### PR TITLE
feat(wiki): produce findings and measure whether they pay (#204, part 2 of 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,22 @@ None of that is in your repository. It exists only because an agent once burned
 tokens finding it out — and every other tool throws it away at the end of the
 session.
 
+**What a default install actually produces.** The structural graph — files,
+symbols, tasks, and the edges between them — is captured from ordinary tool
+traffic with no configuration at all. Findings are produced two ways. At session
+end, `derive` reads evidence already on disk (command outcomes and exit codes,
+red-to-green transitions, corrections, re-read churn) and writes findings from
+it: no model call, no credential, nothing sent anywhere. And the active model
+records durable conclusions itself through `wiki_write`.
+
+The **model-based semantic harvest** is the third path, and the only one that
+needs something you do not already have. It is **not opt-in** —
+`TOKEN_OPTIMIZER_HARVEST=0` turns it *off* — but its real gate is a credential:
+with none it reports `off:no-key`, which is the state on CI, corporate machines,
+and subscription-only logins. Point `TOKEN_OPTIMIZER_HARVEST_ENDPOINT` at a
+local model and it runs **free and private, with nothing leaving the machine**.
+`npx token-optimizer-doctor` states which of these is live.
+
 ### Why this is not RAG
 
 | Classic RAG                                                    | This                                                                          |

--- a/docs/WIKI_GRAPH.md
+++ b/docs/WIKI_GRAPH.md
@@ -81,10 +81,12 @@ being disputed.
 deliberately narrow: absent an explicit task id, the target is derived by
 session-scoped traversal that requires the task to have touched *every* one of
 the finding's anchors, and only when an authoritative session id is present.
-**It does not fire on a default install.** `wiki_write` never supplies an
-authoritative session id, so the model-invoked path never produces the edge; the
-only producer today is the harvest worker, which runs only when the semantic
-harvest is enabled (`hooks-core/harvest-write.mjs`).
+`wiki_write` never supplies an authoritative session id, so the model-invoked
+path never produces the edge. It used to fire nowhere on a default install for
+that reason — its only other producer was the harvest worker, which needs a
+credential. `derive` is now a second producer that needs none: it runs in the
+Stop hook, where the session id comes from the hook payload rather than from a
+model (`hooks-core/derive.mjs`, `hooks-core/harvest-write.mjs`).
 
 ## Harvest — structural free, semantic at boundaries
 
@@ -99,18 +101,32 @@ dead ends. It runs **out-of-band** — a separate cheap-model call that never
 enters the working context, so the harvest cost is not paid by the session doing
 the work.
 
-Model-invoked `wiki_write` exists for the agent to record something deliberately,
-but nothing depends on it. The lesson of the enforcement redesign is that
-anything opt-in does not happen.
+**Local (zero cost, no credential, always on).** At `Stop`,
+[`hooks-core/derive.mjs`](../hooks-core/derive.mjs) reads evidence that is
+already on disk — command outcomes and their exit codes, red-to-green
+transitions, user corrections, re-read churn — and writes findings from it. No
+model call, no credential, nothing sent anywhere. Precision is capped rather
+than claimed: each detector carries a confidence ceiling, claims say only what
+was *observed* ("succeeded where", never "fixes"), and candidates pass through
+`selectForConsolidation` so one long session cannot spend every later session's
+retrieval budget.
 
-**What a default install actually produces is the structural graph.** The
-semantic pass needs a model to call: it is off with no credential
-(`off:no-key`), runs against a local endpoint if one is configured, and is
-disabled outright by `TOKEN_OPTIMIZER_HARVEST=0` or `TOKEN_OPTIMIZER_MODE=off`
-(`hooks-core/harvest.mjs`, `harvestMode`). So findings — and everything that
-depends on them, including the `answers` edge and the hit-rate numbers below —
-accrue only where the harvest or a local model endpoint is in play. Nothing
-below should be read as describing verdicts that accrue on their own.
+Model-invoked `wiki_write` exists for the agent to record something
+deliberately. It is the primary semantic path and the standing-rules block asks
+for it by name, but nothing depends on it.
+
+**What a default install actually produces: the structural graph plus locally
+derived findings.** The model-based semantic harvest is the part that needs
+more. It is **not opt-in** — `harvestMode()` is opt-*out* since #296, and
+`TOKEN_OPTIMIZER_HARVEST=0` (or `TOKEN_OPTIMIZER_MODE=off`) is what turns it off.
+Its real gate is a **credential**: with none it reports `off:no-key`, which is
+the state on CI, corporate machines and subscription-only logins. Point
+`TOKEN_OPTIMIZER_HARVEST_ENDPOINT` at a local model and it runs free and
+private, with nothing leaving the machine
+(`hooks-core/harvest.mjs`, `harvestMode`). The hit-rate numbers below describe a
+graph that has verdicts in it; a machine with neither a credential nor a local
+endpoint gets the structural layer and whatever `derive` could establish
+locally.
 
 ## Retrieval — traversal and lexical, no embeddings
 

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
@@ -1216,7 +1216,48 @@ defects found in my own work by mutation: an **unfalsifiable** publication gate 
 `costObservations` (deleted -- with all-zero costs p is exactly 1, so it could not change a
 verdict; the disclosure in `looNote` took over its job) and **exploration wired but unproven**
 (a new test shows a tight budget serving the never-served finding). See `task-7-report.md`. |
-| 8 | Not started. Depends on 6 and 7. |
+| 8 -- calibration loop | **Complete.** `hooks-core/crosslayer.mjs` (new) -- `calibration`,
+`calibrationNote`, `consolidation`, `graphBalanceSheet`, `labelsByFinding`,
+`MIN_FINDINGS_PER_ARM`, `MIN_GAP_TOKENS`; `audit.mjs` headline + one wiring point;
+`get-optimization-report.ts` serves a `graph` field and a rendered graph block. 29 tests; **30
+mutations, 30 killed, all 29 new tests killed by at least one mutation.** Full suite 224 suites /
+2,849 passed, twice green, no flakiness. Allowlist **5 -> 4**.
+**Three of the task's premises were stale and are resolved rather than papered over.** (a)
+`approxCost` and the hardcoded `$3/1M` **do not exist anywhere in the repo** -- only in the plan
+and the design spec; `pricing.mjs` and `provider-pricing.ts` were already correct, so nothing was
+manufactured. What was open was the RULE, now enforced against the rendered text with a rate
+configured: currency appears on the measured-counterfactual line and on no line saying
+"estimate" (M20/M21/M24 pin it both ways). (b) `hasOutstandingContradiction` is already the
+dispute gate at `staleness.mjs:497`, and **no promotion path exists to gate** -- every
+`confidence` write in `hooks-core` is at CREATION and `utility.mjs` reads it into an ephemeral
+`netUtility` only. So `mayPromote` was NOT added; the invariant is enforced instead, behaviourally
+(a contradicted finding with a large measured effect keeps its stored confidence through
+`graphBalanceSheet`/`calibrationNote`/`renderAudit`) and structurally (`crosslayer`/`loo`/`usage`
+contain zero `confidence` in code), with M26 adding a real promotion to prove the guard bites.
+(c) `consolidationRatio` was the real allowlist item and is wired through
+`consolidation()` -> `graphBalanceSheet` -> the report; its excuse was doubly stale, since
+`expand.promote` DOES persist `derivedCost` and `src/server/disclosure.ts` calls it.
+**`calibration()` REFUSES on this machine and that is the whole point**: Layer 1 publishes no rate
+(0 classifiable observations, 0 reference events) and Layer 2 has 0 observations, so the verdict
+names BOTH insufficient inputs and there is **no `gap` key at all** -- not `gap: 0`, which would
+read as "measured, and they agree". Seven distinct refusals, each tested and each killed by its
+own mutation. Independence preserved by construction -- only Layer 1's categorical LABEL and only
+Layer 2's effect MAGNITUDE, joined on the finding key -- and proven from both sides: flipping the
+labels over identical Layer 2 data flips the gap's sign, and moving Layer 1's rate without moving
+a label leaves the gap byte-identical (M16 injects the circularity and is killed).
+**One production defect found by my own mutation run:** the publication gate was `gap > 0`, and
+two arms of equal means produce a gap of ~1e-13 after floating point, which would have published
+`calibrated: referenced findings suppress 0 more tokens/touch` -- a calibration resting on
+arithmetic noise, leaning the project's own way. `MIN_GAP_TOKENS = 1`, tied to the unit the
+verdict prints, closes it. **`renderAudit`'s headline is fixed** (Task 7 left it): "Nothing
+addressable found." is now scoped to the remediation queue, so it can no longer be a false
+negative printed above a published Layer 2 verdict. `calibration()` lives in a NEW module rather
+than `metrics.mjs` as the plan said, because `metrics.mjs` is the BASE of the import graph and the
+plan's placement would have created `metrics -> loo -> {utility,curate,wiki} -> metrics`;
+`balanceSheet` is untouched and the four new sections are composed one level up in
+`graphBalanceSheet`, which is the shape the plan's interface specifies. Cost: `balanceSheet`
+81.7 ms -> `graphBalanceSheet` 185.1 ms on this machine's real 2 MB log, on an on-demand report
+path. See `task-8-report.md`. |
 | 9, 10 | Not started. |
 | 11 -- transcript reader | **Complete.** `failedResultsFromTranscript` in
 `hooks-core/transcript.mjs`, read-only, tail-bounded, redacted at the boundary. Yield on
@@ -1309,6 +1350,15 @@ this project's own numbers **in its own favour**:
 
 None was the kind of defect a test suite notices: the code works and the *number* lies. Tasks
 6, 7 and 8 are entirely measurement, so this is the class to hunt there.
+
+**Two further instances were found and fixed by Task 8's own mutation run**, both in its own new
+code and both flattering to the project: a publication gate of `gap > 0`, which would have
+published a calibration resting on a ~1e-13 floating-point gap as "referenced findings suppress
+0 more tokens/touch" (fixed with `MIN_GAP_TOKENS = 1`, tied to the unit the verdict prints); and
+a rendered re-read-waste line that printed the confirmed figure without the count of repeats the
+classifier could not judge, which `rereadWaste`'s own docstring says must be reported rather than
+hidden. Neither was visible by reading. **The running total for this class across both plans is
+now eight.**
 
 **A fourth instance is known and unfixed**, found while closing the third: `mutationSucceeded`'s
 status read omits the `postToolUse` envelope, so `postToolUse: { status: 'error' }` falls through

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
@@ -1104,6 +1104,51 @@ mutation reads as survived when it was never applied. Sync between mutation and 
 
 ---
 
+## Task 12: `attemptKey` groups unrelated commands together
+
+**Added mid-plan. This is a correctness bug, not an unlock.**
+
+`attemptKey` groups by up to three non-flag tokens. A leading `cd <repo> &&` therefore
+consumes the whole key, and Task 11 measured the consequence in this repository: **539
+distinct commands share one key.**
+
+That is not only a Claude Code problem. On the ten clients where the detectors *do* receive
+failures, the command detector can pair a failure with a success from a completely unrelated
+command and emit a claim at **0.90** — the highest confidence any detector is permitted. The
+claim would be false about both halves.
+
+**Files:** Modify `hooks-core/derive.mjs`; Test `tests/hooks/derive.test.mjs`
+
+**Requirements**
+
+- Skip a leading directory-change prefix before computing the key — `cd <path> &&`, and any
+  similar shell preamble that carries no information about *what* was run. Report which
+  prefixes you chose to skip and why that set and no wider.
+- **The two existing refusals must survive.** Identical command text either side of a failure
+  still emits nothing, and pairing still uses the nearest preceding failure. A better key must
+  not become a licence to pair more loosely.
+- **Keys must still agree across sources.** Task 11 established that the transcript reader and
+  `recordToolOutcome` agree on 266/266 attempt keys only because both apply the same 120-char
+  truncation. Whatever you change must be applied identically on both paths, and verified on a
+  real session rather than a fixture.
+
+**Measure it, do not assert it.** This changes grouping for all eleven clients, which is the
+kind of shared-behaviour change that has twice needed its own per-client evidence on these
+plans. Report, from real transcripts:
+
+- the number of distinct commands sharing the most-populated key, before and after
+- how many command/test candidates are produced, before and after
+- whether any candidate produced after the change pairs two commands that a reader would
+  agree are the same attempt — inspect them, do not just count them
+
+A larger candidate count is **not** success on its own. The question is whether the pairs are
+true. If the change produces pairs that are still wrong, say so.
+
+**Mutation bar as elsewhere**, plus: sync `hooks-core/` between mutation and test, or
+spawn-based tests run the old copy and a mutation reads as survived.
+
+---
+
 # Execution state and corrections
 
 **Read this before starting or resuming. It is authoritative over the task text above,

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
@@ -1149,6 +1149,42 @@ spawn-based tests run the old copy and a mutation reads as survived.
 
 ---
 
+## Task 13: Hold the cross-layer headline to its own causal test
+
+**Added after Task 10's final audit found one more measurement-bias instance.**
+
+`calibration()` currently publishes whenever the referenced arm's mean shrunk effect is at
+least one token larger than the not-referenced arm's and *some* Layer 2 row published. That
+does not test the cross-layer claim itself. With three findings per arm, a favourable 2:1
+split of real and null effects against an unfavourable 1:2 split produces a positive gap even
+though a two-sided permutation test reads `p = 1`. The existing code calls that partition
+"calibrated".
+
+**Files:** Modify `hooks-core/loo.mjs`, `hooks-core/crosslayer.mjs`; Test
+`tests/hooks/loo.test.mjs`, `tests/hooks/calibration-loop.test.mjs`
+
+**Requirements**
+
+- Reuse Layer 2's exact-or-sampled two-sided permutation statistic. Do not implement a second
+  statistic whose tolerance, enumeration cutoff, or sidedness can drift.
+- Preserve Layer 2's historical fixed sampled sequence when it does not supply a seed.
+- For the cross-layer caller, canonicalise both arms and derive the sampled seed from their
+  data. The result must be invariant to event order and to swapping the two semantic labels.
+- A positive gap publishes only at `p <= 0.10`. The boundary is inclusive: at the existing
+  three-per-arm floor, complete separation has exact two-sided `p = 2/20 = 0.10`; using `<`
+  would make the floor impossible to clear.
+- Carry `p`, `alpha`, and the test name in measured output and print `p` in both the published
+  and refused verdicts. Before both arms clear the floor, no `p` field exists; absence of a
+  test is not `p = 0`.
+- Fail open and preserve every pre-existing calibration refusal, independence invariant,
+  policy-version guard, and report/audit reader.
+
+**Mutation bar as elsewhere.** At minimum mutate away the gate, flip `>` to `>=`, ignore the
+caller's seed, remove canonical ordering, make the exact result one-sided, hide `p` from the
+result or verdict, and inject a permanent `p: 0` into unmeasured refusals.
+
+---
+
 # Execution state and corrections
 
 **Read this before starting or resuming. It is authoritative over the task text above,
@@ -1364,6 +1400,17 @@ constraint is `quotable`, not the key. The identical-text refusal was WIDENED to
 `commandBody` both sides, or the better key would have claimed `npm test` succeeded where
 `cd repo && npm test` failed. Environment assignments, `time`, `bash -c` and `||` are
 deliberately NOT stripped, each for a measured reason. See `task-12-report.md`. |
+| 13 -- cross-layer significance | **Complete.** The final calibration headline now reuses
+Layer 2's exact-or-sampled two-sided `permutationP`; a positive mean gap alone no longer
+publishes. Cross-layer sampling canonicalises both arms and derives its seed from their data,
+while Layer 2's omitted-seed default stays byte-identical. Publication requires `gap >= 1`
+and `p <= 0.10`; equality is deliberate because complete separation at the three-per-arm
+floor is exactly `2/20 = 0.10`. Four new tests, **9 mutations / 9 killed**, every new test
+killed by at least one mutation. Focused 69/69; cross-file regression 103/103; full suite
+225 suites / **2,896 passed**, 5 skipped, 0 failed on the clean rerun. The first full run had
+one unrelated 5-second doctor timeout; that 13-test suite passed immediately in isolation and
+inside the clean rerun. Real graph remains honestly dormant: 0/0 layer observations, with no
+`gap` and no `p`. See `task-13-report.md`. |
 
 ## Corrections to the task text above
 
@@ -1467,6 +1514,16 @@ so a mutation shrinking the RANKING corpus -- making retrieval easier, in this p
 could not move the number the test read. Fixed in the production code rather than the test, so
 the published size IS the ranking corpus. **The running total for this class across both plans is
 now twelve, and every single one flattered this project's own numbers.**
+
+**Task 13 added the thirteenth, in the cross-layer headline itself.** Task 8 required a
+positive difference between the two label-arm means but never tested that difference. A
+2-real/1-null versus 1-real/2-null split clears the one-token gap and had at least one
+published Layer 2 row, so the old code printed `calibrated`; its exact two-sided permutation
+result is **p = 1.0**. The headline now reuses Layer 2's exact-or-sampled statistic and
+publishes only at `p <= 0.10`. Sampling is canonical and data-seeded, while Layer 2's default
+seed remains byte-identical. Complete separation at the three-per-arm floor is `2/20 = 0.10`,
+so the boundary is inclusive or the declared floor would be impossible to clear. The running
+total is now **thirteen**, and all thirteen flattered this project's own numbers.
 
 **The ninth was found by Task 9 and is the first one avoided by declining to wire something.**
 `recordRefresh` has no honest call site because nothing in this repository issues a refresh —

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
@@ -1168,7 +1168,21 @@ injection join — it cannot compile against `master` until #315 merges.
 | 3 — The four extractors | Not started. Depends on 2 and 3b. |
 | 4 | **Complete.** `derive` routes candidates through `selectForConsolidation` (budget 1000 tokens, `TOKEN_OPTIMIZER_DERIVE_BUDGET`) into `writeHarvested` as `ORIGIN_HARVESTED`. `contentAnchor` deleted (issue #319); allowlist 7 -> 5. Three defects fixed on the way: the scorer read `entry.summary` where every other layer writes `claim`, so the budget admitted everything; candidates anchored to the project ROOT, which `indexFile` cannot read, so storage would have been zero; and `derive`'s own evidence boilerplate said "flaky", which `irrecoverability` scores in its top tier. `derive` stays SYNC -- no import cycle, so the brief's async rewrite was unnecessary. See `task-4-report.md`. |
 | 5 | Not started. |
-| 6 — Layer 1 | Not started. |
+| 6 — Layer 1 | **Complete.** `hooks-core/usage.mjs` -- `classify`, `referenceRate`,
+`referenceNote`; 24 tests; 21/21 mutations killed. Keyed on explicit reference, never on
+read-suppression. Two determinations answered against real data: **`expand` does not name a
+finding** (`recordExpansion` writes a truncation-capture `ref`, and all 64 live expand
+events carry `sessionId: null`), so it counts as opportunity only and the brief's "query or
+expand" is wrong; and **2,994 of 2,995 live `tool-outcome` rows report `joinMethod: 'none'`
+because no injection existed for that tool call**, not because the join failed -- there are
+2 `inject` events in 16,387 rows. Denominator 1, `rate: null`, and the audit prints nothing
+rather than 0%. The 2 MB read window, not the join, is the binding constraint: both injects
+have aged out, so the windowed denominator is 0. A measurement-bias defect was found in the
+first draft and is recorded -- keying "the join failed" on `episodeId` (which IS the session
+id) scored 2,559 tool calls of one session as failed joins where the truth is 0. Wired to a
+real reader (`renderAudit` -> `referenceNote`) so the allowlist stays at 5. Also outstanding:
+`wiki_query`'s `sessionId` is an optional input the model must volunteer, so the numerator is
+structurally weak until it records the ambient session. See `task-6-report.md`. |
 | 7 — Layer 2 | Not started. The heaviest task in the plan. |
 | 8 | Not started. Depends on 6 and 7. |
 | 9, 10 | Not started. |

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
@@ -1172,6 +1172,19 @@ injection join — it cannot compile against `master` until #315 merges.
 | 7 — Layer 2 | Not started. The heaviest task in the plan. |
 | 8 | Not started. Depends on 6 and 7. |
 | 9, 10 | Not started. |
+| 11 -- transcript reader | **Complete.** `failedResultsFromTranscript` in
+`hooks-core/transcript.mjs`, read-only, tail-bounded, redacted at the boundary. Yield on
+this machine is **0** and that is measured, not shrugged at: 8 of 571 command failures
+across 163 transcripts are quotable. Two refusals shipped with it -- `quotable` and
+`hasAttemptIdentity`. See `task-11-report.md`. |
+| 12 -- `attemptKey` | **Complete.** `commandBody` skips a leading `cd <path>` up to `&&`,
+`;` or a newline, applied inside `attemptKey` so both sources get it identically. The
+most-populated key fell from **547 distinct commands to 76**; the false-pair exposure a real
+quotable failure sat in fell from **222 to 0**. Candidates 0 -> 0, because the binding
+constraint is `quotable`, not the key. The identical-text refusal was WIDENED to compare
+`commandBody` both sides, or the better key would have claimed `npm test` succeeded where
+`cd repo && npm test` failed. Environment assignments, `time`, `bash -c` and `||` are
+deliberately NOT stripped, each for a measured reason. See `task-12-report.md`. |
 
 ## Corrections to the task text above
 

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
@@ -1038,3 +1038,124 @@ nothing measured recall. Now it does."
 | No price on an estimate | the estimated line in `get_optimization_report` | no `$` |
 | Recall measured | `recallProbe(dir).rate` | a number, or null with a reason |
 | Allowlist shrunk | `grep -c "^  \['" tests/hooks/reachability.test.mjs` | 4 (from 9) |
+
+---
+
+# Execution state and corrections
+
+**Read this before starting or resuming. It is authoritative over the task text above,
+which was written before Plan 1 was executed and is wrong in the places named here.**
+
+Plan 1 shipped as **PR #315** (36 commits). Plan 2 runs on `feat/close-wiki-graph-gaps-plan2`,
+stacked on Plan 1 because it imports `hooks-core/lexical.mjs`, `hooks-core/pending.mjs` and the
+injection join — it cannot compile against `master` until #315 merges.
+
+## Where execution stopped
+
+| Task | State |
+|---|---|
+| 1 — Redaction | **Complete.** `hooks-core/redact.mjs`, 10 tests. |
+| 2 — Extend `tool-outcome` | **Complete through fix round 2.** `output` + `exit` on the event, `isError` read by `toolSucceeded` and `mutationSucceeded`. |
+| 3b — `rereadsByAnchor` | Not started. **Run before Task 3** (see ruling). |
+| 3 — The four extractors | Not started. Depends on 2 and 3b. |
+| 4, 5 | Not started. |
+| 6 — Layer 1 | Not started. |
+| 7 — Layer 2 | Not started. The heaviest task in the plan. |
+| 8 | Not started. Depends on 6 and 7. |
+| 9, 10 | Not started. |
+
+## Corrections to the task text above
+
+1. **The harvest is OPT-OUT, not opt-in.** `harvestMode()` in `hooks-core/harvest.mjs` was
+   flipped by #296. `TOKEN_OPTIMIZER_HARVEST` now turns it *off*; the real default gate is
+   credential availability (`off:no-key`). So this plan's framing of `derive.mjs` as
+   necessary "because the harvest is opt-in" is wrong. The correct framing: **`derive.mjs`
+   needs no credential and sends nothing off the machine**, so it is the only finding
+   producer on a machine without an API key — CI, corporate machines, subscription-only
+   auth. Evidence it still matters: after Plan 1 this repository's own graph held 2,965
+   symbol / 904 file / 128 task nodes and **one** finding, because this machine has no key.
+
+2. **`exit` and `output` now exist on `tool-outcome`** (Task 2). They did not when this plan
+   was written. `output` is captured **only on failure**, gated on `outcome.success !== true`
+   so an unclassified outcome keeps its text; it is redacted and capped at 4 KB at the
+   boundary inside `recordToolOutcome`. `exit` is `null` unless the client reports an integer.
+   MCP tools return no exit code, so `exitFrom` returns null for them by design.
+
+3. **`derive.mjs` must pass an authoritative `taskId`.** The `answers` edge fires nowhere on a
+   default install because its only producer is credential-gated. `derive.mjs` runs in the
+   Stop hook where a real session id exists, so it is the producer that finally makes
+   `answers` live by default. `taskForAnchors` **requires** an authoritative id and returns
+   null without one — an unverified string will not work.
+
+4. **Task 3's churn detector consumes `rereadsByAnchor`** (Task 3b), not `rereadWaste().worst`,
+   which does not exist.
+
+5. **Task 2 extends the existing `tool-outcome` event** rather than adding a `kind:'result'`.
+
+## Plan 1 surfaces this plan will collide with
+
+Plan 1 modified every file Plan 2 touches. Read before editing:
+
+- **`hooks-core/staleness.mjs`** — `serve()` emits three disclosures (staleness, dispute,
+  derivation), clears stale flags automatically, and **writes to the graph** on a verified
+  match (`reindexVerifiedAnchors`). `claimTimeVerdict` is the single shared evidence test;
+  do not duplicate it.
+- **`hooks-core/inject.mjs`** — `withPendingApplied` drains at four entry points; `disputeNote`
+  and `derivationNote` render into the head; `sessionContext` orders blocks via `cacheOrdered`.
+  Layer 2 must decide what to withhold *inside* this machinery.
+- **`hooks-core/metrics.mjs`** — `recordToolOutcome` already joins each outcome to its
+  injection with `injectionId` / `findingIds` / `joinMethod` (preferring an exact
+  tool-call-id match). **Layers 1 and 2 build on that join; do not invent another.**
+  Also gained `evidenceTruncated`.
+- **`hooks-core/decide.mjs`** — `normalizeTool` resolves MCP-prefixed names, so this project's
+  own tools now reach the post-tool path; `isReplacementTool` gates the loop hazard;
+  `readCostBytes` returns 0 for a replacement.
+- **New modules:** `hooks-core/pending.mjs`, `hooks-core/lexical.mjs`, `hooks-core/redact.mjs`.
+
+## Rulings that bind future tasks
+
+- **Run Task 3b before Task 3.** Task 3's churn detector consumes what 3b creates, so the
+  plan's numbering would have Task 3 importing something that does not exist. *Cost if wrong:
+  none; only the execution order changes.*
+- **If Task 9 finds no turn-arrival signal, record observations without letting them change
+  the keep-warm decision, and say so.** Do not invent a signal. *Cost if wrong: keep-warm
+  still decides on expected value, with the data visible for a later fix.*
+- **Every task brief restates the corrections above rather than assuming they were read.**
+  Fresh agents per task cannot know them, and Plan 1 lost a round to exactly this. *Cost if
+  wrong: a few extra lines per dispatch.*
+- **Capture `output` only on failure** (overrides the Task 2 text). A successful `smart_read`
+  would otherwise deposit up to 4 KB of file content into the evidence log on every call —
+  megabytes per session, and a privacy surface, for a consumer that does not exist. *Cost if
+  wrong: a future detector wanting success output must re-add it.*
+- **`outputFrom` deliberately still runs on successful calls** with its result discarded by
+  the boundary gate. One gate at the boundary beats a defensive second one that can drift.
+
+## The measurement-bias class — check every task against it
+
+Three defects of one shape were found across these plans, and all three would have inflated
+this project's own numbers **in its own favour**:
+
+- `readCostBytes` would have charged the A/B holdout a whole file for a call returning a diff.
+- `toolSucceeded` ignored MCP `isError`, so every failed `smart_edit` recorded as a success.
+- `mutationSucceeded` did the same, inflating edit counts and harvest pressure on six clients.
+
+None was the kind of defect a test suite notices: the code works and the *number* lies. Tasks
+6, 7 and 8 are entirely measurement, so this is the class to hunt there.
+
+**A fourth instance is known and unfixed**, found while closing the third: `mutationSucceeded`'s
+status read omits the `postToolUse` envelope, so `postToolUse: { status: 'error' }` falls through
+to the allowlist and counts as a success. It changes no verdict today — which is why it was not
+folded into Task 2 rather than widening a shared classifier silently — but it is the same class
+one envelope out, and it wants its own change with its own per-client comparison.
+
+## The verification bar established on Plan 1
+
+Every task on Plan 1 produced at least one test that passed for the wrong reason, and **every
+one was found by mutating rather than reading**. So for each test: mutate what it targets,
+confirm that test *and only that test* fails, restore, and record the matrix. Also confirm no
+pre-existing kill set *shrank* — adding tests to an existing mechanism can silently stop an
+older one discriminating.
+
+A shared-classification change needs a **per-client verdict comparison**, not an assertion
+that nothing changed. Task 2 set the standard: 1,088 verdicts across 16 clients, with every
+change accounted for.

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
@@ -1297,7 +1297,60 @@ exists (M8 kills the eager version). Floor is `OBSERVATION_FLOOR = TRIPWIRE_MIN 
 changes nothing, 1-in-10 still refreshes, 0-in-10 switches it off. Not a Wilson bound — its 95%
 upper limit at 0/10 is 0.28, which could not switch off a policy that missed ten times out of ten.
 See `task-9-report.md`. |
-| 10 | Not started. |
+| 10 -- the recall probe | **Complete, and the plan's own Step 1 test was the defect.**
+`hooks-core/recall.mjs` -- `recallProbe`, `MIN_PROBED`, `MAX_FINDINGS`; wired into
+`graphBalanceSheet` and rendered as one labelled line in `get_optimization_report`. 22 tests
+plus 1 in `optimization-report.test.ts`; **32 mutations, 32 killed**, every new test killed by
+at least one, and Tasks 6/7/8/9's wiring mutations plus the allowlist guard re-run and still
+killed. Allowlist stays at **3**. Full suite 225 suites / 2,892 passed.
+**THE PLAN'S STEP 3 PROBE CANNOT FAIL, and shipping it would have replaced one unfalsifiable
+claim with another.** `findingsFor(graph, A)` walks `derived_from` edges backwards into `A`,
+and the edge `F -> A` is what MAKES `A` an anchor of `F` -- so "retrieve each finding from its
+own anchor" asks whether an edge that exists exists. It is 1.0 for every graph, forever, and
+`rate: 1.0` printed in the savings report reads to a human as "retrieval is perfect,
+embeddings unnecessary". Proved two ways: a test asserts the property of the primitive
+directly, and across four fixtures whose measured rates are **0, 0.5, 1 and null** the
+by-construction check is **1.0 on every one**. It is kept as `integrity`, with its own
+`what` string saying it is NOT a recall rate, and M2 (publish it as the rate) and M14 (delete
+the disclaimer) are both killed.
+What replaced it is **leave-one-edge-out**: delete each anchor edge, then ask whether traversal
+from the anchor's `contains` NEIGHBOURHOOD or BM25 over the anchor's OWN KEY still surfaces the
+finding. Arm B is deliberately not queried with the finding's claim as Step 3 said, because
+both readings are degenerate -- against a corpus INCLUDING the finding, BM25 scores a document
+against its own text and it wins every time; against a corpus EXCLUDING it, a hit means a
+DIFFERENT finding matched, which measures redundancy of storage and rewards a graph for holding
+duplicates.
+**On this machine the probe REFUSES, and n=1 is honoured as Task 8's house style demands.**
+Project graph: `probed 1, retrieved 1, rate: null` -- both anchor edges of the one finding
+recovered by the lexical arm, and the reason ends *"which is a count and not a rate"*. Shared
+graph: **14 active findings, all 14 UNPROBEABLE** -- every one is anchored to a `file:` id with
+no node in the graph (`expand.promote` writes the edge without indexing the anchor), so there
+is no key to query BM25 with. `findingsFor` still returns them, so **integrity is 1.0 while
+every finding is unprobeable** -- which is exactly why the two are reported separately, and the
+probe declines to convert a graph-integrity defect into a recall loss.
+Four refusals, each costing this project its own good news: `MIN_PROBED = 10` (a resolution
+argument, on distinct FINDINGS not anchor edges, since two anchors of one claim are not two
+independent observations); a corpus no larger than the retrieval limit (below it nothing is
+ever cut for budget, so Arm B is more permissive than production and can only overstate);
+a dangling anchor is UNPROBEABLE rather than a miss; and strict aggregation (every probeable
+anchor edge must recover, biasing the rate DOWN).
+**Two of my own tests were vacuous and only the mutation run found them** -- the
+eighth-and-ninth instance of that class. M15 survived because the cap test read `all.length`
+while BM25 ranked over a separate `corpus` variable, so a mutation shrinking the RANKING corpus
+(easier retrieval, in this project's favour) could not move the number; fixed in the production
+code, so the published size IS the ranking corpus. M23 survived because the fail-open test
+passed a nonexistent directory and `load` returns an EMPTY graph for a missing log rather than
+throwing, so the catch never ran; now two tests, one per catch.
+`recall.mjs` imports only `wiki.mjs` and `lexical.mjs`, neither of which imports back -- **no
+cycle**, the same constraint that moved Task 8's `calibration` out of `metrics.mjs`.
+`graphBalanceSheet` 185 ms -> 213 ms on the real graph; the probe is 42 ms and `MAX_FINDINGS`
+caps it. See `task-10-report.md`, which also runs **every row of the Definition of done** and
+reports the four that do not pass: findings-on-a-default-install passes only on the letter
+(the one finding is `origin: 'agent'`, and Task 3 is Not started so the producer is unbuilt);
+the `kind:"result"` row is stale per correction #5 and its substitute also reads 0 (3,031
+outcome rows, zero failures, so zero rows carry `exit`/`output`); Layer 1's denominator has
+regressed 1 -> 0 as the last two injections aged out of the 2 MB window; and Layer 2's refusal
+row passes VACUOUSLY, on an empty set. |
 | 11 -- transcript reader | **Complete.** `failedResultsFromTranscript` in
 `hooks-core/transcript.mjs`, read-only, tail-bounded, redacted at the boundary. Yield on
 this machine is **0** and that is measured, not shrugged at: 8 of 571 command failures
@@ -1396,8 +1449,24 @@ published a calibration resting on a ~1e-13 floating-point gap as "referenced fi
 0 more tokens/touch" (fixed with `MIN_GAP_TOKENS = 1`, tied to the unit the verdict prints); and
 a rendered re-read-waste line that printed the confirmed figure without the count of repeats the
 classifier could not judge, which `rereadWaste`'s own docstring says must be reported rather than
-hidden. Neither was visible by reading. **The running total for this class across both plans is
-now nine.**
+hidden. Neither was visible by reading.
+
+**Task 9 added the tenth, and it is the first found by DECLINING to wire something**:
+`recordRefresh` stays on the reachability allowlist because nothing in this repository issues a
+keep-warm refresh, and calling it at the recommendation site would have computed a hit rate over
+refreshes never bought.
+
+**Task 10 added the eleventh and twelfth, and the eleventh was written into this plan's own task
+text.** The Step 3 recall probe -- take each finding's anchors and run `findingsFor` from each --
+**cannot fail**, because the edge `F -> A` is what makes `A` an anchor of `F`, so its rate is 1.0
+for every graph forever; the plan's Step 1 test asserted exactly that, and `recall: 100%` in the
+savings report reads as "retrieval is perfect, embeddings unnecessary". It ships as `integrity`,
+never as `rate`. The twelfth was in Task 10's own new tests and only its mutation run found it: a
+cap assertion read a reported `all.length` while BM25 ranked over a separate `corpus` variable,
+so a mutation shrinking the RANKING corpus -- making retrieval easier, in this project's favour --
+could not move the number the test read. Fixed in the production code rather than the test, so
+the published size IS the ranking corpus. **The running total for this class across both plans is
+now twelve, and every single one flattered this project's own numbers.**
 
 **The ninth was found by Task 9 and is the first one avoided by declining to wire something.**
 `recordRefresh` has no honest call site because nothing in this repository issues a refresh —

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
@@ -1192,7 +1192,30 @@ denominator can understate: unwindowing only the injection arm (which already ha
 time spans and manufacture a pessimistic rate from the asymmetry, and unwindowing the query
 arm means widening `EVIDENCE_KINDS`, which two consumers read and which needs its own
 per-consumer comparison. 28 tests, 25/25 mutations killed. See `task-6-report.md`. |
-| 7 — Layer 2 | Not started. The heaviest task in the plan. |
+| 7 — Layer 2 | **Complete.** `hooks-core/loo.mjs` -- `withheldFor`, `exploreOrder`,
+`observations`, `effects`, `looNote`, `servingPolicyVersion`, `LOO_ENABLED`; 43 tests; 43/43
+mutations killed and all 43 tests killed by at least one mutation. Estimand is
+**read-suppression**, disjoint from Layer 1's explicit reference: `loo.mjs` contains zero
+occurrences of `query`, `usage.mjs` zero occurrences of `tokens`/`cost`/`bytes`, and a test
+moves each layer while the other stays deeply equal. Gated on `recordToolOutcome`'s existing
+join; no new join. Withholding happens in `forTouch` **after `fit`** (a leave-one-out, not a
+substitution) and the delivered set is **re-priced**, so `tokens` bills only what was sent.
+Five guards bound it: file surface only, never fewer than two kept findings, never inside
+`inHoldout` (passed in and refused), one per touch, **one per session** -- so the user's worst
+case is one extra file read per session (median 6,531 / p90 20,000 tokens measured here)
+against a finding that costs 66-317 tokens to send. `pinned` / `origin: 'human'` are exempt and
+the note says how many. Exact permutation p-values (84 relabellings at the 6/3 floor, so the
+floor and q=0.10 are compatible by arithmetic), BH across every candidate row, empirical-Bayes
+shrinkage with both the prior mean and the weight estimated from the data.
+**On this machine Layer 2 is dormant and reports nothing at all**: 0 file-surface injections in
+16,875 rows across three graphs (both live injections are command-surface) and the graph holds
+one finding with no anchor carrying two -- so `effects()` is `[]`, `looNote()` is `null`, and
+the audit gains no line rather than a zero. Verified on a synthetic graph built with the real
+producers (`record`, `recordToolOutcome`), field-checked against live `metrics.jsonl`. Two
+defects found in my own work by mutation: an **unfalsifiable** publication gate on
+`costObservations` (deleted -- with all-zero costs p is exactly 1, so it could not change a
+verdict; the disclosure in `looNote` took over its job) and **exploration wired but unproven**
+(a new test shows a tight budget serving the never-served finding). See `task-7-report.md`. |
 | 8 | Not started. Depends on 6 and 7. |
 | 9, 10 | Not started. |
 | 11 -- transcript reader | **Complete.** `failedResultsFromTranscript` in

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
@@ -1041,6 +1041,69 @@ nothing measured recall. Now it does."
 
 ---
 
+## Task 11: A transcript reader for failed tool results
+
+**Added mid-plan, after Task 5 measured why the detectors produced nothing.**
+
+Claude Code **never fires PostToolUse for a failed tool call.** Proved with a deliberately
+failing command that produced no event at all, and 2,238 of 2,238 live outcomes on the
+measuring machine were `success: true`. So the two highest-confidence detectors — command
+failed-then-succeeded (0.90) and test/build red-to-green (0.85) — have **no input on the
+primary client**, while working normally on the ten adapter clients.
+
+This task gives them input from the one place the failures do exist: the local transcript
+archive, which the correction detector already reads.
+
+**Files:**
+- Modify: `hooks-core/derive.mjs`
+- Test: `tests/hooks/derive.test.mjs`
+
+**Interfaces:**
+- Produces: `failedResultsFromArchive(turns) => Array<{ command, output, at }>`, fed to the
+  existing command and test detectors alongside `tool-outcome` events.
+
+**Requirements**
+
+- **Read-only, and reuse the archive already in use.** No new capture path, no new hook, no
+  new event kind. The correction detector reads this archive; so does this.
+- **The confidence ceilings do not change.** A failure observed in a transcript is the same
+  evidence as one observed in an event — the ceilings encode how much the evidence supports,
+  not how it arrived. Do not raise or lower them for this source.
+- **Deduplicate against `tool-outcome`.** On the ten clients that *do* report failures, a
+  failure may appear in both sources. The same failure must not produce two candidates, and
+  the pairing must not treat the transcript copy and the event copy as a failed-then-
+  succeeded pair with itself.
+- **Redact.** Transcript text is not redacted upstream — `recordToolOutcome`'s boundary never
+  saw it. Everything derived from it goes through `redact` before storage.
+- **The refusals from Task 3 still hold.** Identical command text either side of a failure
+  emits nothing, and pairing uses the nearest preceding failure. A transcript source does not
+  license a weaker causal claim.
+- **Bound the read.** A long session's archive is large; cap what is scanned the way the
+  correction detector does, and say what the cap is.
+
+**Two things to determine rather than assume**
+
+1. **Does the archive actually contain failed tool results, and in what shape?** Task 5
+   established the archive exists and carries 723 turns on a real session. Confirm that a
+   *failed* result is present and identifiable — a tool result block with an error, a
+   non-zero exit rendered as text, or a refusal — and report the shape you found. **If failed
+   results are not recoverable from the archive, say so plainly and stop**: that would mean
+   this task cannot work, and reporting it is worth more than an extractor that finds nothing.
+2. **How is a command identified?** `tool-outcome` puts the command text in `anchor`. A
+   transcript turn may render it differently. The `attemptKey` grouping (up to three non-flag
+   tokens) must produce the same key from both sources, or a failure from the transcript will
+   never pair with a success from an event.
+
+**Verification — the deliverable is a measurement, not a claim.** After wiring, run a real
+transcript through the Stop path and report how many command and test candidates it yields,
+against the zero it yields today. If the answer is still zero, that is the finding.
+
+**Mutation bar as elsewhere**, plus the harness defect Task 5 recorded: mutating `hooks-core/`
+without `npm run sync:hooks` leaves spawn-based E2E tests running the old synced copy, so a
+mutation reads as survived when it was never applied. Sync between mutation and test.
+
+---
+
 # Execution state and corrections
 
 **Read this before starting or resuming. It is authoritative over the task text above,

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
@@ -1058,7 +1058,8 @@ injection join — it cannot compile against `master` until #315 merges.
 | 2 — Extend `tool-outcome` | **Complete through fix round 2.** `output` + `exit` on the event, `isError` read by `toolSucceeded` and `mutationSucceeded`. |
 | 3b — `rereadsByAnchor` | Not started. **Run before Task 3** (see ruling). |
 | 3 — The four extractors | Not started. Depends on 2 and 3b. |
-| 4, 5 | Not started. |
+| 4 | **Complete.** `derive` routes candidates through `selectForConsolidation` (budget 1000 tokens, `TOKEN_OPTIMIZER_DERIVE_BUDGET`) into `writeHarvested` as `ORIGIN_HARVESTED`. `contentAnchor` deleted (issue #319); allowlist 7 -> 5. Three defects fixed on the way: the scorer read `entry.summary` where every other layer writes `claim`, so the budget admitted everything; candidates anchored to the project ROOT, which `indexFile` cannot read, so storage would have been zero; and `derive`'s own evidence boilerplate said "flaky", which `irrecoverability` scores in its top tier. `derive` stays SYNC -- no import cycle, so the brief's async rewrite was unnecessary. See `task-4-report.md`. |
+| 5 | Not started. |
 | 6 — Layer 1 | Not started. |
 | 7 — Layer 2 | Not started. The heaviest task in the plan. |
 | 8 | Not started. Depends on 6 and 7. |

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
@@ -1037,7 +1037,7 @@ nothing measured recall. Now it does."
 | Calibration refuses when uncalibrated | `calibration(dir).publishable` | false, with a stated reason |
 | No price on an estimate | the estimated line in `get_optimization_report` | no `$` |
 | Recall measured | `recallProbe(dir).rate` | a number, or null with a reason |
-| Allowlist shrunk | `grep -c "^  \['" tests/hooks/reachability.test.mjs` | 4 (from 9) |
+| Allowlist shrunk | `grep -c "^  \['" tests/hooks/reachability.test.mjs` | 3 (from 9; Task 9 took it 4 -> 3, and `recordRefresh` stays because nothing issues a refresh) |
 
 ---
 
@@ -1258,7 +1258,46 @@ plan's placement would have created `metrics -> loo -> {utility,curate,wiki} -> 
 `graphBalanceSheet`, which is the shape the plan's interface specifies. Cost: `balanceSheet`
 81.7 ms -> `graphBalanceSheet` 185.1 ms on this machine's real 2 MB log, on an on-demand report
 path. See `task-8-report.md`. |
-| 9, 10 | Not started. |
+| 9 — keep-warm loop | **Complete, with one recorder deliberately left unwired.**
+`hooks-core/keepwarm.mjs` — `scoreRefreshes`, `observedHitRates`, `OBSERVATION_FLOOR`,
+`TURN_GAP_MS`; `keepWarmDecision` / `ttlTier` gained an `observed` option; `adapter.mjs` calls
+`scoreRefreshes(dir)` on the **Stop** path. 22 tests; **25 mutations, 25 killed**, every new test
+killed by at least one, and Tasks 6/7/8's `audit.mjs` wiring mutations re-run and still killed.
+Allowlist **4 -> 3**.
+**A REAL TURN-ARRIVAL SIGNAL EXISTS, so the ruling was not needed**: `gapDistribution` is fitted
+to inter-turn gaps from `metrics.jsonl`, so the same log answers the outcome question directly — a
+`5m` refresh was used if a turn of the same session arrived within five minutes of it. The ruling's
+*spirit* is enforced anyway by four refusals, every one costing this project its own good news:
+`pending` (the TTL has not elapsed — scoring a hit the instant it lands while a miss waits out the
+window is **right-censoring**, biased upward and invisible to any test), `uncovered` (the firehose
+no longer reaches back to the refresh, so absence of arrival is absence of evidence and **not** a
+miss), `unattributable` (no `sessionId`, so no arrival can be shown to belong to it), and
+already-scored.
+**The plan's Step 1 test could not run and its Step 4 was a units error.** The signature is
+`keepWarmDecision({ prefixTokens, gaps, tier })` — no `dir` — so observations are passed in the
+options object and `keepWarmDecision` stays pure; `shouldKeepWarm` computes them from the outcome
+array **the tripwire has already read**, so the loop costs no extra I/O and the decision and its
+backstop cannot see different evidence. And a recorded `hit` is NOT the quantity
+`keepWarmDecision` models: its probability is the narrow ping window
+`P(tier.ms < gap < 2·tier.ms)`, while `hit` is `P(gap < tier.ms)` — 0.19% against 99.5% on this
+machine's real log, so substituting the observation would have recommended refreshing forever.
+So an observation may only ever **lower** a modelled probability, never raise it (`Math.min`),
+and it is `ttlTier` — whose `hit` **is** the same estimand — where it does real work. M11 flips the
+bound to `Math.max` and 6 tests kill it.
+**`recordRefresh` STAYS ON THE ALLOWLIST, and the finding is the deliverable**: nothing in this
+repository issues a refresh. `cache_audit` is the only consumer of the decision and it prints a
+recommendation; the prompt cache belongs to the client, so no code spends the money. Calling it at
+the recommendation site would compute a hit rate over refreshes never bought and make keep-warm
+look self-funding — the ninth instance of the measurement-bias class, and the first found by
+declining to wire something. So the loop is **closed and dormant**: on this machine
+`scoreRefreshes` scores 0 and records nothing, `observedHitRates` is empty, and `shouldKeepWarm`
+still answers `refresh` at `5m` on expected value alone. Dormant cost on the Stop path is one read
+of the small balance log (17-23 ms); the 2 MB firehose is read **only** if an unscored refresh
+exists (M8 kills the eager version). Floor is `OBSERVATION_FLOOR = TRIPWIRE_MIN = 10`: one miss
+changes nothing, 1-in-10 still refreshes, 0-in-10 switches it off. Not a Wilson bound — its 95%
+upper limit at 0/10 is 0.28, which could not switch off a policy that missed ten times out of ten.
+See `task-9-report.md`. |
+| 10 | Not started. |
 | 11 -- transcript reader | **Complete.** `failedResultsFromTranscript` in
 `hooks-core/transcript.mjs`, read-only, tail-bounded, redacted at the boundary. Yield on
 this machine is **0** and that is measured, not shrugged at: 8 of 571 command failures
@@ -1358,7 +1397,18 @@ published a calibration resting on a ~1e-13 floating-point gap as "referenced fi
 a rendered re-read-waste line that printed the confirmed figure without the count of repeats the
 classifier could not judge, which `rereadWaste`'s own docstring says must be reported rather than
 hidden. Neither was visible by reading. **The running total for this class across both plans is
-now eight.**
+now nine.**
+
+**The ninth was found by Task 9 and is the first one avoided by declining to wire something.**
+`recordRefresh` has no honest call site because nothing in this repository issues a refresh —
+`cache_audit` prints a recommendation and the prompt cache belongs to the client — so calling it at
+the recommendation site would have produced a hit rate computed over refreshes that were never
+bought, and since 99.5% of this machine's gaps fall inside five minutes that rate would have read
+as ~100% and made keep-warm look like it pays for itself. The same task found the inverted form in
+its own design and fixed it before shipping: a recorded `hit` (`P(gap < tier.ms)`) is not the
+quantity `keepWarmDecision` models (`P(tier.ms < gap < 2·tier.ms)`), 99.5% against 0.19% here, so
+an observation may only **lower** a modelled probability and never raise it. Both are the usual
+shape — the code works and the number lies.
 
 **A fourth instance is known and unfixed**, found while closing the third: `mutationSucceeded`'s
 status read omits the `postToolUse` envelope, so `postToolUse: { status: 'error' }` falls through

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
@@ -1180,9 +1180,18 @@ rather than 0%. The 2 MB read window, not the join, is the binding constraint: b
 have aged out, so the windowed denominator is 0. A measurement-bias defect was found in the
 first draft and is recorded -- keying "the join failed" on `episodeId` (which IS the session
 id) scored 2,559 tool calls of one session as failed joins where the truth is 0. Wired to a
-real reader (`renderAudit` -> `referenceNote`) so the allowlist stays at 5. Also outstanding:
-`wiki_query`'s `sessionId` is an optional input the model must volunteer, so the numerator is
-structurally weak until it records the ambient session. See `task-6-report.md`. |
+real reader (`renderAudit` -> `referenceNote`) so the allowlist stays at 5. **Fix round 1:**
+attribution no longer scopes by session -- `wiki_query`'s `sessionId` is an optional input the
+model must volunteer, and an unverifiable model-supplied id is not evidence, so a `query`
+naming key K credits any earlier injection of K and **time order is the only remaining
+guard**. The cost (two concurrent sessions on one repo can cross-attribute) is disclosed in
+`referenceNote` beside the figure, not just in the report; `unscopedReferences` was removed
+rather than zeroed. `referenceRate` now returns **`windowed`** and the note says the
+denominator can understate: unwindowing only the injection arm (which already has
+`BALANCE_KINDS`/`EVIDENCE_KINDS` access, unlike `query`) would make the arms cover different
+time spans and manufacture a pessimistic rate from the asymmetry, and unwindowing the query
+arm means widening `EVIDENCE_KINDS`, which two consumers read and which needs its own
+per-consumer comparison. 28 tests, 25/25 mutations killed. See `task-6-report.md`. |
 | 7 — Layer 2 | Not started. The heaviest task in the plan. |
 | 8 | Not started. Depends on 6 and 7. |
 | 9, 10 | Not started. |

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-3-detector-and-allowlist.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-3-detector-and-allowlist.md
@@ -649,3 +649,88 @@ Never `gh pr create` directly — it bypasses the validation pipeline.
 | Allowlist has no backlog | `grep -c "^  \['" tests/hooks/reachability.test.mjs` | 1 (`policyText`) |
 | Census runs | `npm run wiki:census` | every row non-zero after a session |
 | Full suite green | `npm run build && npx jest && npm run sync:hooks:check` | PASS |
+
+---
+
+# Execution state and corrections
+
+**Read this before starting. It is authoritative over the task text above.**
+
+Plan 3 has **not started**. It runs last: its allowlist-emptying task is incomplete by
+construction until Plans 1 and 2 have removed their entries.
+
+## The allowlist, and who owns what
+
+Plan 1 took it from **16 to 7**. The remaining seven:
+
+| Entry | Owner |
+|---|---|
+| `selectForConsolidation` | Plan 2 Task 4 (wire) |
+| `consolidationRatio` | Plan 2 Task 8 (wire into the balance sheet) |
+| `contentAnchor` | Plan 2 Task 4 (delete — the idea is preserved as issue #319) |
+| `recordRefresh` | Plan 2 Task 9 (wire) |
+| `recordRefreshOutcome` | Plan 2 Task 9 (wire) |
+| `renderStanding` | **Plan 3** (wire into the audit surface) |
+| `manifestSize` | **Plan 3** (wire into doctor output) |
+
+So Plan 3 inherits two entries and must finish at **zero backlog entries**. `policyText` was
+removed during Plan 1 — the ratchet built there found it was genuinely wired, along with
+`forTouch`, so neither needs an exemption any more.
+
+## Five holes in the guard, all found by USING it during Plan 1
+
+The plan text above describes the first two. All five are required work:
+
+1. **Comments count as call sites.** `usedInShippedCode` word-matches over text.
+   `invalidateOnWrite` had 1 raw reference and 0 code references — the reference was prose.
+2. **Exported consts are invisible.** Only `export function` is collected, so 38 declarations
+   go unchecked. `contradicts` and `answers` sat in `EDGE_KINDS` with zero write sites.
+3. **An `import` specifier counts as a use.** Proven by mutation: dropping the `cacheOrdered`
+   *call* while keeping its import left the guard green; only dropping the import too failed
+   it. "Imported" is not "called".
+4. **Unread record *fields* are invisible.** The scan checks exports, not fields.
+   `contradictionReason` — up to 400 characters of human explanation — was written on every
+   `contradict` call and read by nothing, with the guard green throughout. Needs a
+   written-fields-versus-read-fields census. Filed as issue #318 for the instance;
+   the *class* is Plan 3's.
+5. **Tests asserting on holdout-consulting entry points must pin the arm.** `forTouch`,
+   `forCommand`, `forSharedCommand` and `substitutionFor` consult `inHoldout`, so a test
+   asserting on their output fails intermittently when the anchor lands in the withheld arm.
+   The convention is copy-pasted per suite in three variants and nothing enforces it — one
+   newly-added test on Plan 1 omitted it and produced exactly that flake. A guard asserting
+   every such suite pins the arm would close it.
+
+Holes 3, 4 and 5 are additions to the plan text above; treat them as required, not optional.
+
+## Why this plan is load-bearing
+
+Round 1 of this effort built the detector, it found ~21 instances of correct-but-uncalled code,
+four were wired, and **sixteen were moved to an allowlist labelled `TRIAGE BACKLOG`** — in a
+file whose own documentation says a capability with no consumer should be deleted and written
+again the day it is needed. An accurate written description of a defect felt like resolution.
+
+That is the disease this plan treats. Every hole above was found by *using* the guard during
+Plan 1 rather than by reading it, which is the strongest argument for finishing it: the guard
+is the only thing that makes the other two plans' work stay wired.
+
+## The measurement-bias class
+
+Four defects of one shape were found across Plans 1 and 2, all of which would have inflated
+this project's own numbers **in its own favour**: `readCostBytes` charging the A/B holdout a
+whole file for a call returning a diff; `toolSucceeded` and `mutationSucceeded` each ignoring
+MCP `isError` so failed optimizer-tool calls recorded as successes; and `mutationSucceeded`'s
+status read omitting the `postToolUse` envelope (known, unfixed, changes no verdict today).
+
+None is the kind of defect a test suite notices — the code works and the *number* lies. A
+census of written-versus-read fields (hole 4) is the closest mechanical guard against it.
+
+## The verification bar
+
+Every task across Plans 1 and 2 produced at least one test that passed for the wrong reason,
+and **every one was found by mutating rather than reading**. For each test: mutate what it
+targets, confirm that test *and only that test* fails, restore, record the matrix. Also confirm
+no pre-existing kill set *shrank* — adding tests to an existing mechanism can silently stop an
+older one discriminating.
+
+This plan's own tests are the guard itself, so a vacuous test here disables the thing that
+catches everything else. Mutation-check them hardest.

--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -56,6 +56,7 @@ import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { briefing } from './remedy.mjs';
 import { stableText, transcriptFor } from './cache.mjs';
+import { scoreRefreshes } from './keepwarm.mjs';
 import { cachedRoutingBriefing } from './routing.mjs';
 import {
   forCommand,
@@ -1008,6 +1009,26 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE KEEP-WARM FEEDBACK ARM, at the boundary where a turn has just
+      // ended -- which is the only place the arrival question can be answered.
+      // Every refresh whose TTL has since elapsed is scored here as used or
+      // unused; anything the log cannot settle is left unscored rather than
+      // recorded as a miss, because an absent signal is not a miss.
+      //
+      // Nothing in this repository issues a refresh today -- cache_audit only
+      // recommends one -- so this scores nothing, and what it costs while
+      // dormant is one readBalance: median 70 ms on this machine's 3.5 MB log,
+      // against derive's 71-111 ms a few lines below on the same path. The
+      // firehose is read for ARRIVALS only if an unscored refresh exists, so
+      // the dormant case never pays for that. The moment an issuer exists, the
+      // decision starts learning with no second wiring change.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      scoreRefreshes(dir);
+    } catch {
+      // A refresh that cannot be scored costs a measurement, not a session.
     }
     try {
       // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.

--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -70,7 +70,8 @@ import {
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
-import { isArchived } from './transcript.mjs';
+import { archive, isArchived } from './transcript.mjs';
+import { harvestMode } from './harvest.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
@@ -575,6 +576,65 @@ function emit(object) {
   process.stdout.write(serialized);
 }
 
+/**
+ * What will and will not extract findings after this session, in one sentence.
+ *
+ * THE STATE WAS ONLY EVER LEGIBLE FROM THE DOCTOR, and the doctor is a place
+ * someone visits after they already suspect something is wrong. A user watching
+ * a graph fill with structural nodes and no verdicts has no reason to suspect
+ * anything, which is the failure this project has now measured twice.
+ *
+ * IT IS ADDRESSED TO THE MODEL, NOT ONLY TO THE READER, which is why it earns a
+ * place in the prefix rather than a systemMessage. "Nothing else will write this
+ * down in words" changes what the model does with a conclusion it is holding;
+ * "here is a configuration variable" would not.
+ *
+ * CACHE-SAFE: derived from configuration, so it differs between sessions only
+ * when the configuration does -- the same standard the rest of this block is
+ * held to, and it carries no digits for `stableText` to reject.
+ *
+ * A local endpoint is named FIRST in the off case on purpose. It is the option
+ * that costs nothing and sends nothing, and it was the one buried deepest.
+ */
+function extractionNotice() {
+  switch (harvestMode()) {
+    case 'local':
+      return (
+        '\n\nA local model endpoint is configured, so semantic extraction also runs after this ' +
+        'session -- free and private, with nothing leaving this machine.'
+      );
+    case 'remote':
+      return (
+        '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
+        'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
+    case 'off:mode':
+      // The whole optimizer is off and this text is not emitted anyway. Saying
+      // anything here would be noise stacked on an explicit choice.
+      return '';
+    case 'off:opted-out':
+      // A DELIBERATE CHOICE, SO NO PITCH. The consequence is stated because the
+      // model needs it; the setting that would reverse it is not, because
+      // arguing with a configured decision on every session is how a notice
+      // stops being read. doctor.mjs draws the same line for the same reason.
+      return (
+        '\n\nFallback extraction is off by configuration, so a conclusion you do not record is ' +
+        'not written down in words anywhere. Findings are still derived locally from exit codes, ' +
+        'red-to-green transitions and corrections.'
+      );
+    default:
+      // off:no-key, and any mode a future harvest adds: no extractor is running
+      // and nobody chose that, so the free option is worth naming.
+      return (
+        '\n\nNo separate extractor will run after this session, so a conclusion you do not record ' +
+        'is not written down in words anywhere. Findings are still derived locally from exit ' +
+        'codes, red-to-green transitions and corrections. Pointing ' +
+        'TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model adds semantic extraction, free and ' +
+        'private.'
+      );
+  }
+}
+
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
 export function policyText(
   canDeny,
@@ -633,7 +693,7 @@ export function policyText(
     .filter(Boolean)
     .join(' ');
   const recording = tools.has('wiki_write')
-    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.`
+    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.${extractionNotice()}`
     : '\n\nStructural graph capture remains active through lifecycle hooks. Durable semantic MCP writes are not requested because the writer schema is not proven available.';
 
   return `# Token optimization is active\n\nLive graph capture is active through the lifecycle adapter.\n\n${connection}${routing}${enforcement}${utilities ? `\n\n${utilities}` : ''}${recording}${projectBriefing()}`;
@@ -948,6 +1008,27 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.
+      //
+      // This was lost rather than retired. `plugin/hooks/stop-harvest.mjs` called
+      // `archive()` at Stop, and #300 replaced that entry in `hooks.json` with the
+      // generated `stop.mjs`, which routes here -- so on Claude Code no session has
+      // been archived since. Nothing failed loudly: `readArchive` simply returns an
+      // empty list, so `derive`'s correction detector fell through to the live
+      // transcript (present only for a client that reports one) and `lessons.mjs`
+      // lost the only corpus it can verify a verbatim quote against, which is the
+      // single test that grants a feedback finding human origin.
+      //
+      // BEFORE `derive`, deliberately: the correction detector reads the archive
+      // first and treats the live transcript as the fallback, and the archive is
+      // the copy that survives into later sessions.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      if (agentScope) archive(dir, agentScope, { sessionId });
+    } catch {
+      // The archive is a record, not a result. A session still ends.
     }
     try {
       // ZERO-COST DERIVATION, on every client, with no credential. The semantic

--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -143,11 +143,43 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because three readers depend on it -- success
+ * classification, output capture and exit-code capture -- and clients disagree
+ * on the envelope name and on nothing else. Letting each reader name its own
+ * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
+    return false;
+  // MCP'S OWN FAILURE FLAG, which this function did not read for as long as it
+  // existed. It did not matter while `normalizeTool` dropped MCP names before
+  // any accounting ran; it matters now that `mcp__<server>__smart_edit` and
+  // `smart_write` reach the post-tool path, because an MCP result carries no
+  // `error` field and no `status` -- only `isError` -- so a failed smart_edit
+  // fell through to the optimistic `return true` below.
+  //
+  // WHY THIS IS A MEASUREMENT BUG AND NOT A COSMETIC ONE: this boolean feeds
+  // episode outcomes and effectiveness accounting, so recording every failed
+  // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
+  // optimizer's favour. A measurement that flatters the thing being measured
+  // is worse than no measurement.
+  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
     return false;
   const status =
     raw?.tool_response?.status ??
@@ -168,23 +200,6 @@ export function toolSucceeded(raw) {
   // that its output proved the task.  `success` here is deliberately scoped to
   // the tool call; task correctness comes only from an eval grader.
   return true;
-}
-
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * The same family `toolSucceeded` reads above, hoisted so the three readers
- * cannot drift apart. Clients disagree on the envelope name and on nothing
- * else, so this is the one place that disagreement is spelled out.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
 }
 
 /** A non-empty string, or null.  Blank output is the same as none. */

--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -38,11 +38,13 @@ import {
   touchedFiles,
 } from './decide.mjs';
 import {
+  record,
   recordRead,
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
 } from './metrics.mjs';
+import { derive } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -946,6 +948,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // ZERO-COST DERIVATION, on every client, with no credential. The semantic
+      // harvest below needs an API key, so on a machine without one the graph
+      // accumulates structure and no verdicts at all. These detectors read only
+      // what is already on disk and send nothing anywhere.
+      //
+      // The COUNT is recorded rather than the candidates: how many findings a
+      // session's own evidence supports is the number that says whether this is
+      // working, and it is measurable before anything is stored. Storage is the
+      // caller's next step, under a budget.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      const dir = wikiDir(projectRoot);
+      const derived = derive(dir, {
+        sessionId,
+        projectRoot,
+        transcriptPath: agentScope,
+        // The hook payload's own identity, not a value a model typed.
+        authoritativeSessionId: sessionId,
+      });
+      record(dir, {
+        kind: 'derive',
+        sessionId,
+        candidates: derived.candidates.length,
+        observations: derived.observations.length,
+      });
+    } catch {
+      // A detector failing must never cost a user the end of their session.
     }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&

--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -101,6 +101,44 @@ const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
 
 /**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because FOUR readers depend on it -- mutation accounting,
+ * success classification, output capture and exit-code capture -- and clients
+ * disagree on the envelope name and on nothing else. Letting each reader name
+ * its own subset is exactly how both classifiers came to miss MCP's failure
+ * flag: `toolSucceeded` listed four envelopes and `mutationSucceeded` listed
+ * three, and neither list mentioned `isError` at all.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/**
+ * Did an MCP result declare itself an error?
+ *
+ * `isError` is the ONLY failure signal an MCP result carries -- there is no
+ * `error` field and no `status` -- and `src/server/index.ts` sets it in seven
+ * places. Shared by both classifiers so they cannot disagree about what a
+ * failed call from this project's own tools looks like.
+ *
+ * `=== true` EXACTLY. A client using the key for anything else must not have
+ * its successful calls silently reclassified, and `isError: false` is a
+ * successful MCP call, not a missing verdict.
+ */
+function reportedMcpError(raw) {
+  return [...responseEnvelopes(raw), raw].some(
+    (envelope) => envelope?.isError === true
+  );
+}
+
+/**
  * A post-tool event is not universally proof of success. Some clients split
  * success and failure into distinct events; others expose a result status.
  * Keep mutation accounting conservative so a failed edit cannot arm Stop.
@@ -110,6 +148,19 @@ export function mutationSucceeded(clientName, raw) {
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
     return false;
+  // BEFORE the status read, the explicit-success read AND the client
+  // allowlist, because all three would otherwise pass a failed MCP write. The
+  // allowlist is the one that actually bit: it returns true for claude-code,
+  // codex, qwen, opencode, kilo and windsurf on any post-tool event with no
+  // error and no status, which is precisely the shape of a failed smart_write.
+  //
+  // WHY THIS IS THE SAME BUG AS THE ONE IN `toolSucceeded` AND NOT A COSMETIC
+  // ECHO OF IT: this function gates edit counting and harvest pressure, so
+  // counting a failed write to THE OPTIMIZER'S OWN TOOLS as a mutation
+  // inflates "the optimizer successfully edited a file". Different consumers
+  // from the effectiveness figures, same direction of bias -- toward
+  // flattering the thing being measured.
+  if (reportedMcpError(raw)) return false;
 
   const status =
     raw?.tool_response?.status ??
@@ -143,24 +194,6 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * Spelled out ONCE because three readers depend on it -- success
- * classification, output capture and exit-code capture -- and clients disagree
- * on the envelope name and on nothing else. Letting each reader name its own
- * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
-}
-
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
@@ -179,8 +212,7 @@ export function toolSucceeded(raw) {
   // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
   // optimizer's favour. A measurement that flatters the thing being measured
   // is worse than no measurement.
-  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
-    return false;
+  if (reportedMcpError(raw)) return false;
   const status =
     raw?.tool_response?.status ??
     raw?.toolResponse?.status ??

--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -955,10 +955,12 @@ async function runHook(clientName, event, invocation) {
       // accumulates structure and no verdicts at all. These detectors read only
       // what is already on disk and send nothing anywhere.
       //
-      // The COUNT is recorded rather than the candidates: how many findings a
-      // session's own evidence supports is the number that says whether this is
-      // working, and it is measurable before anything is stored. Storage is the
-      // caller's next step, under a budget.
+      // COUNTS are recorded rather than the candidates, and BOTH counts: how
+      // many findings a session's own evidence supports, and how many of them
+      // survived the storage budget and the anchor discipline. The gap between
+      // the two is the number that says whether the bound is doing anything --
+      // one figure alone cannot distinguish "nothing to derive" from "derived
+      // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
       const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
       const dir = wikiDir(projectRoot);
@@ -974,6 +976,7 @@ async function runHook(clientName, event, invocation) {
         sessionId,
         candidates: derived.candidates.length,
         observations: derived.observations.length,
+        written: derived.written.length,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -170,6 +170,136 @@ export function toolSucceeded(raw) {
   return true;
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * The same family `toolSucceeded` reads above, hoisted so the three readers
+ * cannot drift apart. Clients disagree on the envelope name and on nothing
+ * else, so this is the one place that disagreement is spelled out.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/** A non-empty string, or null.  Blank output is the same as none. */
+function nonEmpty(value) {
+  const text = String(value ?? '');
+  return text.trim() ? text : null;
+}
+
+/**
+ * The human-readable result text inside one envelope, or null.
+ *
+ * RETURNS NULL RATHER THAN GUESSING. An envelope shape nobody here has seen
+ * produces no capture at all, which costs one finding. Stringifying it instead
+ * would put `[object Object]` or a wall of JSON metadata into a claim that gets
+ * injected into model context -- a wrong observation, which is strictly worse
+ * than a missing one.
+ */
+function resultText(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'string') return nonEmpty(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return null;
+
+  // MCP content blocks, which is how THIS PROJECT'S OWN tools now arrive:
+  // `normalizeTool` resolves `mcp__<server>__smart_edit`, so smart_edit and
+  // smart_write reach the post-tool path for the first time and their results
+  // are `{ content: [{ type: 'text', text }], isError }` rather than a shell
+  // result. Both the bare array and the wrapping object are accepted because
+  // hosts differ on whether they hand the hook the result or its content.
+  if (Array.isArray(value)) {
+    const blocks = value
+      .map((block) =>
+        typeof block === 'string' ? block : nonEmpty(block?.text)
+      )
+      .filter(Boolean);
+    return blocks.length ? nonEmpty(blocks.join('\n')) : null;
+  }
+  if (typeof value !== 'object') return null;
+
+  // STDERR FIRST, and not because that is the order it was produced in. The
+  // cap can only ever cut the tail, and the diagnostic that explains a failure
+  // is almost always on stderr while the volume is almost always on stdout --
+  // so appending stderr would let a 3 MB build log push the one line worth
+  // capturing out of the window.
+  const streams = [nonEmpty(value.stderr), nonEmpty(value.stdout)].filter(
+    Boolean
+  );
+  if (streams.length) return streams.join('\n');
+
+  if (Array.isArray(value.content)) {
+    const inner = resultText(value.content);
+    if (inner) return inner;
+  }
+
+  const error = value.error;
+  if (error) {
+    const message =
+      typeof error === 'string' ? error : nonEmpty(error.message ?? error.msg);
+    if (message) return message;
+  }
+
+  return (
+    nonEmpty(value.output) ??
+    nonEmpty(value.text) ??
+    nonEmpty(value.message) ??
+    (typeof value.result === 'string' ? nonEmpty(value.result) : null)
+  );
+}
+
+/**
+ * The result text of a completed tool call, or null when the client reports
+ * none.  Redaction and the size cap are NOT applied here -- they belong at the
+ * `recordToolOutcome` boundary, which is the only place every caller passes.
+ */
+export function outputFrom(raw) {
+  for (const envelope of responseEnvelopes(raw)) {
+    const text = resultText(envelope);
+    if (text) return text;
+  }
+  return resultText(raw?.output) ?? resultText(raw?.stdout) ?? null;
+}
+
+/**
+ * Key names that mean "process exit code" and nothing else.
+ *
+ * `code` is deliberately ABSENT. JSON-RPC errors (`code: -32602`), Node errno
+ * objects (`code: 'ENOENT'`) and HTTP wrappers all reuse that name, so reading
+ * it would record a confident exit code for calls that never had one. A null
+ * here is honest; a -32602 claiming to be an exit status is not.
+ */
+const EXIT_KEYS = [
+  'exit_code',
+  'exitCode',
+  'exit',
+  'exit_status',
+  'exitStatus',
+  'return_code',
+  'returncode',
+];
+
+/** The numeric exit code a client reported, or null when it reported none. */
+export function exitFrom(raw) {
+  for (const envelope of [...responseEnvelopes(raw), raw]) {
+    if (!envelope || typeof envelope !== 'object') continue;
+    for (const key of EXIT_KEYS) {
+      const value = envelope[key];
+      if (Number.isInteger(value)) return value;
+      // A client that serializes the code as a digit string still reported it.
+      // Bounded so a hash or an id cannot be mistaken for a status.
+      if (typeof value === 'string' && /^-?\d{1,5}$/.test(value.trim()))
+        return Number(value.trim());
+    }
+  }
+  return null;
+}
+
 function contextOutput(client, eventName, additionalContext) {
   if (client.contextStyle === 'top-level') return { additionalContext };
   if (client.contextStyle === 'cline') {
@@ -888,6 +1018,11 @@ async function runHook(clientName, event, invocation) {
         anchor,
         toolName: payload.tool_name,
         success: toolSucceeded(raw),
+        // The two fields a boolean cannot carry: which KIND of failure this
+        // was. Read through the same normalisers as `success`, never off `raw`
+        // at this call site.
+        output: outputFrom(raw),
+        exit: exitFrom(raw),
         durationMs:
           Number(
             raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs

--- a/hooks-core/audit.mjs
+++ b/hooks-core/audit.mjs
@@ -31,6 +31,7 @@
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
 import { looNote } from './loo.mjs';
+import { calibrationNote } from './crosslayer.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -242,9 +243,15 @@ export function renderAudit(
     lines.push(text);
   }
 
+  // SCOPED TO THE QUEUE, because that is all it ever described. The bare
+  // sentence "Nothing addressable found." was printed directly above a Layer 1
+  // reference note and a published Layer 2 causal verdict -- so a reader was
+  // told nothing had been found immediately before being shown a finding. The
+  // headline is about the remediation queue and nothing else, and saying so
+  // costs four words and removes a false negative shown to a human.
   const head = shown.length
     ? ['What to do next, most expensive first:', ...lines]
-    : ['Nothing addressable found.'];
+    : ['Nothing addressable found in the remediation queue.'];
 
   const body = [...head];
 
@@ -410,6 +417,16 @@ export function renderAudit(
   // is the one that most needs to be absent when it is not earned.
   const causal = looNote(dir);
   if (causal) body.push('', causal);
+
+  // WHETHER LAYER 1'S CHEAP LABEL PREDICTS LAYER 2'S EXPENSIVE EFFECT.
+  //
+  // The reason this is printed rather than kept for a dashboard: the reference
+  // rate is the number a reader is most likely to quote as a saving, and it is
+  // not one until this comparison says so. `calibrationNote` returns null while
+  // both layers are silent, and otherwise prints the refusal -- naming which
+  // input was insufficient -- rather than a gap of zero.
+  const calibrated = calibrationNote(dir);
+  if (calibrated) body.push('', calibrated);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/hooks-core/audit.mjs
+++ b/hooks-core/audit.mjs
@@ -30,6 +30,7 @@
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
+import { looNote } from './loo.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -399,6 +400,16 @@ export function renderAudit(
   // project with no injections and no queries gains no line at all.
   const reference = referenceNote(dir);
   if (reference) body.push('', reference);
+
+  // WHAT ONE FINDING IS CAUSALLY WORTH (Layer 2).
+  //
+  // The same reasoning as above, and the same refusal: `looNote` returns null
+  // until the leave-one-out experiment has collected an observation, and says
+  // NOT MEASURABLE YET rather than printing a mean until it clears the floor.
+  // A causal number is the most quotable thing this project can produce, so it
+  // is the one that most needs to be absent when it is not earned.
+  const causal = looNote(dir);
+  if (causal) body.push('', causal);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/hooks-core/audit.mjs
+++ b/hooks-core/audit.mjs
@@ -59,6 +59,28 @@ export function declines(dir, { events = readMetrics(dir) } = {}) {
   return counts;
 }
 
+/**
+ * What the local Stop-time derivation path produced in the visible event log.
+ *
+ * The producer records all three counts because any one of them alone is
+ * ambiguous: zero stored can mean no evidence, no candidates, or a binding
+ * storage/anchor filter. This reader keeps those states distinct and prevents
+ * the telemetry itself from becoming an unobserved cost.
+ */
+export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
+  const runs = events.filter((event) => event.kind === 'derive');
+  if (!runs.length) return null;
+
+  const sum = (field) =>
+    runs.reduce((total, event) => total + Math.max(0, Number(event[field]) || 0), 0);
+  const candidates = sum('candidates');
+  const observations = sum('observations');
+  const written = sum('written');
+  return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
+    `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
+    `across ${runs.length.toLocaleString()} Stop run(s).`;
+}
+
 const idOf = (finding) =>
   finding.remedy
     ? `${finding.remedy.type}:${finding.remedy.anchor || finding.remedy.file || (finding.remedy.anchors || []).join(',')}`
@@ -397,6 +419,15 @@ export function renderAudit(
       );
     }
   }
+
+  // WHAT THE DEFAULT, LOCAL DERIVATION PATH ACTUALLY PRODUCED.
+  //
+  // This event used to have a producer and no reader. Keep its three states
+  // together: evidence seen, candidates derived, and findings that survived
+  // selection/storage. A lone stored count would turn every earlier refusal
+  // into an apparent "nothing found" result.
+  const derived = derivationNote(dir);
+  if (derived) body.push('', derived);
 
   // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
   //

--- a/hooks-core/audit.mjs
+++ b/hooks-core/audit.mjs
@@ -29,6 +29,7 @@
  */
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
+import { referenceNote } from './usage.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -388,6 +389,16 @@ export function renderAudit(
       );
     }
   }
+
+  // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
+  //
+  // Printed here because this is the report that already asks "did the advice
+  // change anything", and because a measurement with no reader is how this
+  // project shipped two metrics whose only consumer was their own test suite.
+  // `referenceNote` returns null when it has nothing honest to say, so a
+  // project with no injections and no queries gains no line at all.
+  const reference = referenceNote(dir);
+  if (reference) body.push('', reference);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/hooks-core/consolidate.mjs
+++ b/hooks-core/consolidate.mjs
@@ -140,7 +140,8 @@ const ALWAYS_KEEP = new Set(['failure', 'decision']);
  * Chooses what to promote into the graph, under a token budget.
  *
  * @param {object} graph      Loaded wiki graph, for reuse probability.
- * @param {Array}  candidates Extracted conclusions, each { type, summary, anchors, evidence, at }.
+ * @param {Array}  candidates Extracted conclusions, each { type, claim (or summary),
+ *                              anchors, evidence, at }.
  * @param {object} options    budget: tokens available for promoted findings.
  */
 export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}) {
@@ -219,4 +220,3 @@ export function aggregateConsolidation(findings) {
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
-

--- a/hooks-core/crosslayer.mjs
+++ b/hooks-core/crosslayer.mjs
@@ -52,7 +52,13 @@
 
 import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
-import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import {
+  effects,
+  observations,
+  servingPolicyVersion,
+  permutationP,
+  FDR_Q,
+} from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
 import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
@@ -104,6 +110,32 @@ export function labelsByFinding(rows) {
 }
 
 const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * A deterministic, label-symmetric permutation test for the headline gap.
+ *
+ * Layer 2 only publishes a per-finding row after a two-sided permutation test.
+ * The calibration headline summarises those rows, so a positive difference of
+ * arm means must clear the same evidential bar rather than being promoted just
+ * because it points in this project's favour.
+ *
+ * Sorting within each arm and then sorting the two arms makes the sampled path
+ * invariant to event order and to swapping the labels. The seed is derived
+ * from that canonical data instead of shared globally, so two different
+ * datasets do not reuse one arbitrary sequence of sampled relabellings.
+ */
+export function calibrationP(referenced, notReferenced) {
+  const arms = [referenced, notReferenced]
+    .map((values) => [...values].sort((a, b) => a - b))
+    .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  const encoded = JSON.stringify(arms);
+  let seed = 2166136261;
+  for (const char of encoded) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return permutationP(arms[0], arms[1], { seed: seed >>> 0 });
+}
 
 /**
  * Does Layer 1's label predict Layer 2's effect?
@@ -242,7 +274,16 @@ export function calibration(dir, options = {}) {
     const referencedMean = mean(arms.referenced);
     const notReferencedMean = mean(arms.notReferenced);
     const gap = referencedMean - notReferencedMean;
-    const measured = { ...context, gap, referencedMean, notReferencedMean };
+    const p = calibrationP(arms.referenced, arms.notReferenced);
+    const measured = {
+      ...context,
+      gap,
+      referencedMean,
+      notReferencedMean,
+      p,
+      alpha: FDR_Q,
+      test: 'two-sided permutation',
+    };
 
     if (!(gap >= MIN_GAP_TOKENS))
       return refuse(
@@ -253,11 +294,20 @@ export function calibration(dir, options = {}) {
         measured
       );
 
+    if (p === null || p > FDR_Q)
+      return refuse(
+        `not calibrated: the positive Layer 1/Layer 2 gap is not statistically resolved by the ` +
+          `two-sided permutation test (p=${p === null ? 'unavailable' : p.toFixed(3)}, ` +
+          `alpha=${FDR_Q.toFixed(3)}). Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
     return {
       publishable: true,
       verdict:
         `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
-        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, ` +
+        `shrunk estimates, two-sided permutation p=${p.toFixed(3)}). ` +
         `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
       ...measured,
     };

--- a/hooks-core/crosslayer.mjs
+++ b/hooks-core/crosslayer.mjs
@@ -54,6 +54,7 @@ import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
 import { effects, observations, servingPolicyVersion } from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
 
 /**
@@ -307,11 +308,19 @@ export function consolidation(dir, { graph = null } = {}) {
 }
 
 /**
- * The balance sheet with the graph's own three measurements attached.
+ * The balance sheet with the graph's own measurements attached.
  *
  * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
  * imports, so it cannot import them back. This is where the two meet, and it
  * is the shape `get_optimization_report` serves.
+ *
+ * `recall` joins them as an OFFLINE PROBE, and that label travels in the data
+ * (`recall.basis`) as well as in the rendered line. It is not an observation of
+ * anything a session did: it deletes an anchor edge in memory and re-runs the
+ * real retrieval primitives over the graph as it stands right now. `recall.mjs`
+ * imports only `wiki.mjs` and `lexical.mjs`, neither of which imports anything
+ * in this direction, so no cycle -- the same reason `calibration` had to live
+ * here rather than in `metrics.mjs`.
  */
 export function graphBalanceSheet(dir, options = {}) {
   const sheet = balanceSheet(dir);
@@ -323,6 +332,7 @@ export function graphBalanceSheet(dir, options = {}) {
     layer2,
     calibration: cal,
     consolidation: consolidation(dir, options),
+    recall: recallProbe(dir, options),
   };
 }
 

--- a/hooks-core/crosslayer.mjs
+++ b/hooks-core/crosslayer.mjs
@@ -1,0 +1,349 @@
+/**
+ * The calibration loop: does Layer 1's LABEL predict Layer 2's EFFECT?
+ *
+ * Layer 1 (`usage.mjs`) classifies an injected finding by whether the model
+ * later NAMED it. Layer 2 (`loo.mjs`) measures, by leave-one-out, how many
+ * tokens of reading a finding actually SUPPRESSED. Those are two different
+ * quantities, and the whole point of putting them side by side is that the
+ * cheap one (a label, available on every injection) might stand in for the
+ * expensive one (a causal effect, costing three withheld sessions per finding).
+ *
+ * WHY THIS IS A REAL QUESTION AND NOT A TAUTOLOGY. Task 7 established the
+ * independence three ways -- statically (`loo.mjs` contains no `query` or
+ * `reference`; `usage.mjs` contains no `tokens`, `cost` or `bytes`),
+ * behaviourally in both directions, and by naming the one overlap that does
+ * exist (`recordToolOutcome`'s join, which supplies ATTRIBUTABILITY to both and
+ * the measured quantity to neither). This module is built to preserve that:
+ *
+ *   - from Layer 1 it takes ONLY the categorical label per finding key. No
+ *     rate, no count, no magnitude -- Layer 1 has no magnitude to give.
+ *   - from Layer 2 it takes ONLY the effect magnitude per finding key.
+ *   - the join is the finding key, which is a graph identity and not a
+ *     measurement.
+ *
+ * If a magnitude common to both ever entered, this would correlate a quantity
+ * with itself and report a strong result that means nothing. Two tests pin the
+ * separation from opposite sides: flipping the labels while holding the effects
+ * fixed must move the gap, and changing Layer 1's rate WITHOUT changing any
+ * label must leave the gap byte-identical.
+ *
+ * MEASURED UTILITY RANKS A FINDING. IT MUST NEVER RAISE ITS CONFIDENCE.
+ * A confidently WRONG finding suppresses reads better than a hedged true one,
+ * so utility alone optimises directly against "wrong findings are worse than
+ * none". The plan called for a `mayPromote` gate over
+ * `hasOutstandingContradiction` here. There is nothing to gate: every write of
+ * `confidence` in `hooks-core` happens at CREATION (a per-producer constant in
+ * `derive.mjs` / `lessons.mjs` / `harvest.mjs`, or a human's own number in
+ * `curate.mjs`), and no code path updates a stored finding's confidence
+ * afterwards. `assessFindings` in `utility.mjs` READS confidence into an
+ * ephemeral `netUtility` used for ordering and writes nothing back. So a gate
+ * here would be unreachable, and an unreachable gate is the exact defect class
+ * this work exists to close. `hasOutstandingContradiction` already has its
+ * real consumer -- `staleness.mjs` calls it as the dispute gate on serve.
+ * What is enforceable is the invariant itself, and it is: this module never
+ * writes to the graph, and `tests/hooks/calibration-loop.test.mjs` asserts that
+ * neither it nor either layer under it can move a stored confidence.
+ *
+ * NOTHING HERE IS PRICED. A calibration verdict, a holdout estimate and a
+ * consolidation ratio are all estimates; currency belongs only on a measured
+ * counterfactual, and `balanceSheet`'s `measuredCounterfactual` is the one
+ * section in the sheet below that qualifies.
+ */
+
+import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
+import { classify, referenceRate } from './usage.mjs';
+import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Distinct findings needed in EACH arm before a gap is reported at all.
+ *
+ * Two findings per arm is a difference of two numbers; the comparison would be
+ * dominated by whichever finding happened to sit on a big file. Three is still
+ * small, and the refusal says so rather than implying the gap is solid.
+ */
+export const MIN_FINDINGS_PER_ARM = 3;
+
+/**
+ * The smallest gap that may be PUBLISHED, in tokens per touch.
+ *
+ * Not an effect-size convention: it is tied to the unit the verdict prints. The
+ * published sentence rounds the gap to whole tokens, so a gap of 1e-13 -- which
+ * is what two arms of equal means produce once floating point has had its say --
+ * would publish as "referenced findings suppress 0 more tokens/touch". That is a
+ * calibration claim resting on arithmetic noise, and it leans the only direction
+ * a measurement of this project by this project must never lean.
+ */
+export const MIN_GAP_TOKENS = 1;
+
+/**
+ * The per-finding Layer 1 label, folded from per-injection rows.
+ *
+ * ANY reference wins. `classify` emits one row per (injection, finding) because
+ * one reference must not excuse every later injection -- that is the right unit
+ * for a RATE. For a label the question is different: did the model ever name
+ * this finding? A finding referenced once and ignored nine times is a finding
+ * the model reads, and averaging it into `not-referenced` would put it in the
+ * arm whose mean effect it is meant to predict.
+ *
+ * `unknown` rows are dropped rather than defaulted, exactly as Layer 1 drops
+ * them from its own denominator.
+ */
+export function labelsByFinding(rows) {
+  const labels = new Map();
+  for (const row of rows || []) {
+    const key = row?.findingKey;
+    if (typeof key !== 'string' || !key) continue;
+    if (row.label === 'referenced') labels.set(key, 'referenced');
+    else if (row.label === 'not-referenced' && !labels.has(key))
+      labels.set(key, 'not-referenced');
+  }
+  return labels;
+}
+
+const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * Does Layer 1's label predict Layer 2's effect?
+ *
+ * Returns `publishable`, a `verdict` in English, and `gap` ONLY when a gap was
+ * actually computed. There is no `gap: 0` for the unmeasured case, and that is
+ * deliberate: a permanent zero reads as "measured, and the two agree", which is
+ * the opposite of "nothing was measured". Task 7 deleted a field rather than
+ * zero it for the same reason.
+ *
+ * FAILS OPEN. This runs on report paths that must not break a tool call.
+ */
+export function calibration(dir, options = {}) {
+  const refuse = (verdict, extra = {}) => ({
+    publishable: false,
+    verdict,
+    ...extra,
+  });
+
+  try {
+    // ONE READ for both layers, so the two arms of the comparison cannot cover
+    // different spans of the log. `referenceRate` reports `windowed: false`
+    // when the caller supplies events -- correctly, since the bounds are then
+    // the caller's -- so the truncation flag is taken here, from the read that
+    // actually set it, and republished.
+    const supplied = options.events || null;
+    const events = supplied || readMetrics(dir);
+    const truncation = supplied ? null : readTruncation();
+    const truncated = Boolean(
+      truncation && (truncation.byBytes || truncation.byEvents)
+    );
+
+    const layer1 = referenceRate(dir, { events });
+    const labels = labelsByFinding(classify(dir, { events }));
+
+    const obs = observations(dir, { ...options, events });
+    const rows = effects(dir, { ...options, events, obs });
+
+    // ONE POLICY VERSION. Layer 2 refuses to pool arms across serving
+    // policies; a calibration that pooled them would undo that guard one level
+    // up. Rows from any other policy are excluded and counted.
+    const policy = servingPolicyVersion();
+    const inPolicy = rows.filter((row) => row.policy === policy);
+
+    const layer2 = {
+      rows: rows.length,
+      inPolicy: inPolicy.length,
+      published: rows.filter((row) => row.published).length,
+      observations: obs.rows.length,
+      policy,
+    };
+    const l1 = {
+      referenced: layer1.referenced,
+      notReferenced: layer1.notReferenced,
+      unknown: layer1.unknown,
+      denominator: layer1.denominator,
+      rate: layer1.rate,
+      referenceEvents: layer1.referenceEvents,
+    };
+
+    const excluded = { layer1Unknown: layer1.unknown, unlabelled: 0, noEffect: 0 };
+    const arms = { referenced: [], notReferenced: [] };
+    for (const row of inPolicy) {
+      // THE SHRUNK ESTIMATE, not the raw one. Shrinkage pulls every finding
+      // toward the population mean, so it pulls the GAP toward zero -- the
+      // bias runs against publishing, which is the only direction a
+      // measurement of this project by this project may lean.
+      if (row.shrunk === null || !Number.isFinite(row.shrunk)) {
+        excluded.noEffect += 1;
+        continue;
+      }
+      const label = labels.get(row.findingKey);
+      if (label === 'referenced') arms.referenced.push(row.shrunk);
+      else if (label === 'not-referenced') arms.notReferenced.push(row.shrunk);
+      else excluded.unlabelled += 1;
+    }
+
+    const context = { layer1: l1, layer2, arms: { referenced: arms.referenced.length, notReferenced: arms.notReferenced.length }, excluded, windowed: truncated };
+    const caveat = truncated
+      ? ' The event log was truncated, so both sides can understate.'
+      : '';
+
+    // WHICH INPUT WAS INSUFFICIENT, named. "Not enough data" tells a reader
+    // nothing about which half of the loop to go and fix.
+    const l1Silent = layer1.rate === null;
+    const l2Silent = layer2.observations === 0;
+    if (l1Silent || l2Silent) {
+      const why = [];
+      if (l1Silent)
+        why.push(
+          `Layer 1 has ${layer1.denominator} classifiable observation(s) and ` +
+            `${layer1.referenceEvents} reference event(s), so it publishes no rate`
+        );
+      if (l2Silent)
+        why.push(
+          `Layer 2 has ${layer2.observations} observation(s), so it publishes no effect`
+        );
+      return refuse(
+        `not calibrated: ${why.join('; and ')}. No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+    }
+
+    // A POLICY CHANGE RESETS THE CALIBRATION, and says so rather than reporting
+    // an empty arm. Layer 2 refuses to pool arms across serving policies, so
+    // rows generated under an older one cannot answer a question about how the
+    // graph serves findings today -- but "0 findings per arm" would send a
+    // reader hunting for missing observations that are right there in the log.
+    if (rows.length > 0 && inPolicy.length === 0)
+      return refuse(
+        `not calibrated: all ${rows.length} Layer 2 effect row(s) were measured under a different serving ` +
+          `policy than the current ${policy}, and arms are never pooled across policies. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (layer2.published === 0)
+      return refuse(
+        `not calibrated: Layer 2 has ${layer2.observations} observation(s) but no published effect at q=0.1, ` +
+          'so its per-finding numbers are noise and a difference between two means of them would be too. ' +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (
+      arms.referenced.length < MIN_FINDINGS_PER_ARM ||
+      arms.notReferenced.length < MIN_FINDINGS_PER_ARM
+    )
+      return refuse(
+        `not calibrated: ${arms.referenced.length} referenced and ${arms.notReferenced.length} not-referenced ` +
+          `finding(s) carry a Layer 2 effect, below the floor of ${MIN_FINDINGS_PER_ARM} per arm. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    const referencedMean = mean(arms.referenced);
+    const notReferencedMean = mean(arms.notReferenced);
+    const gap = referencedMean - notReferencedMean;
+    const measured = { ...context, gap, referencedMean, notReferencedMean };
+
+    if (!(gap >= MIN_GAP_TOKENS))
+      return refuse(
+        `uncalibrated: Layer 1's "referenced" label does not predict a larger Layer 2 effect ` +
+          `(referenced ${Math.round(referencedMean).toLocaleString()} vs not-referenced ` +
+          `${Math.round(notReferencedMean).toLocaleString()} tokens/touch, gap ${Math.round(gap).toLocaleString()}). ` +
+          `Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
+    return {
+      publishable: true,
+      verdict:
+        `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
+      ...measured,
+    };
+  } catch {
+    return refuse(
+      'not calibrated: the calibration inputs could not be read. No gap is reported, which is not the same as a gap of zero.'
+    );
+  }
+}
+
+/**
+ * What the graph cost to build against what it carries -- AN ESTIMATE, and
+ * never priced.
+ *
+ * `consolidationRatio` is the per-finding form and the aggregate is the fold.
+ * Both need `derivedCost`, which `expand.promote` persists onto the finding
+ * node it creates (`src/server/disclosure.ts` is its caller) and which
+ * `harvest-write.mjs` does not yet carry through -- so a graph built only by
+ * the harvest reports nothing here rather than a ratio of one.
+ */
+export function consolidation(dir, { graph = null } = {}) {
+  try {
+    const g = graph || load(dir);
+    const findings = [...g.nodes.values()].filter(
+      (node) => node.kind === 'finding' && !node.retired
+    );
+    const rated = [];
+    for (const finding of findings) {
+      const ratio = consolidationRatio(finding);
+      if (ratio === null) continue;
+      rated.push({ key: finding.key, ratio, derivedCost: finding.derivedCost });
+    }
+    const aggregate = aggregateConsolidation(findings);
+    return {
+      what: 'cost to derive against cost to carry',
+      // SAID IN THE DATA, not only in the prose above it, because this is the
+      // field a dashboard will read and a dashboard will not read a comment.
+      basis: 'estimate',
+      priced: false,
+      findings: findings.length,
+      withDerivedCost: rated.length,
+      aggregate,
+      best: rated.sort((a, b) => b.ratio - a.ratio).slice(0, 5),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The balance sheet with the graph's own three measurements attached.
+ *
+ * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
+ * imports, so it cannot import them back. This is where the two meet, and it
+ * is the shape `get_optimization_report` serves.
+ */
+export function graphBalanceSheet(dir, options = {}) {
+  const sheet = balanceSheet(dir);
+  const cal = calibration(dir, options);
+  const { layer1 = null, layer2 = null } = cal;
+  return {
+    ...sheet,
+    layer1,
+    layer2,
+    calibration: cal,
+    consolidation: consolidation(dir, options),
+  };
+}
+
+/**
+ * One audit line, or null when there is nothing honest to say.
+ *
+ * Silent when NEITHER layer has produced anything: a reader of a graph that has
+ * never injected a finding is owed no paragraph about a loop that has not
+ * started. The moment either side speaks, the refusal is worth printing --
+ * because at that point a reader could otherwise take Layer 1's rate for a
+ * saving, which is precisely what this loop exists to stop.
+ */
+export function calibrationNote(dir, options = {}) {
+  try {
+    const result = calibration(dir, options);
+    const l1 = result.layer1;
+    const l2 = result.layer2;
+    if (!l1 || !l2) return null;
+    if (l1.denominator === 0 && l2.observations === 0) return null;
+    return `Layer 1 against Layer 2: ${result.verdict}`;
+  } catch {
+    return null;
+  }
+}

--- a/hooks-core/derive.mjs
+++ b/hooks-core/derive.mjs
@@ -1,0 +1,383 @@
+/**
+ * Findings from data we already hold, with no model call.
+ *
+ * WHY THIS EXISTS. The semantic harvest is on by default but its real gate is a
+ * credential: `harvestMode()` returns `off:no-key` on any machine without one,
+ * which is CI, corporate laptops, and every subscription-only login. This
+ * repository's own graph is the evidence -- 2,965 symbol nodes, 904 file nodes,
+ * 128 task nodes and ONE finding -- because the structural layer accumulates
+ * from ordinary tool traffic while every verdict needed an API key this machine
+ * does not have.
+ *
+ * Everything here is derived from outcomes, transitions and corrections that are
+ * ALREADY RECORDED LOCALLY. Nothing is sent anywhere, nothing is billed, so
+ * there is nothing to consent to and this runs by default. It is the only
+ * finding producer on a machine without a key.
+ *
+ * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
+ * second command fixed the first -- an intervening edit, a dependency install or
+ * a flaky test explains it just as well. So each detector carries a confidence
+ * ceiling, the claim text says only what was OBSERVED, and the two shapes where
+ * the observation supports no claim at all are refused rather than downgraded
+ * (see `attemptKey` and the identical-text guard below).
+ *
+ * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
+ * budget, belongs to the caller.
+ */
+
+import { readMetrics, rereadsByAnchor } from './metrics.mjs';
+import { readArchive, readTurns } from './transcript.mjs';
+import { redact } from './redact.mjs';
+
+/**
+ * Ceilings, ordered by how much the evidence actually supports.
+ *
+ * A command that succeeded where a DIFFERENT command failed is close to a direct
+ * observation. A test or build going red-to-green is weaker, because the usual
+ * cause is the code changing between the two runs rather than anything about the
+ * command. A correction is a lexical guess about what a human meant. Churn
+ * describes our own reading behaviour and says nothing about the code at all.
+ */
+export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+
+/** Claim text cap. A finding is one sentence; a paragraph is evidence. */
+const CLAIM_MAX = 300;
+const EVIDENCE_MAX = 400;
+
+/** Bounded so a pathological log cannot turn session end into real work. */
+const MAX_CANDIDATES = 200;
+
+/**
+ * Commands whose red-to-green transition is usually explained by the CODE
+ * changing rather than by the command. They get the lower ceiling.
+ */
+const CODE_SENSITIVE = /\b(test|tests|jest|vitest|pytest|mocha|build|compile|tsc|lint|typecheck)\b/i;
+
+/**
+ * Openers that mark a user turn as a correction rather than an instruction.
+ *
+ * DELIBERATELY NARROW, and anchored to the START of the turn. The model-based
+ * extractor in `lessons.mjs` can read intent; this cannot, so it only claims the
+ * shapes where the first few words carry the whole signal. Recall is poor by
+ * design: a missed correction costs one finding, a false one puts words in the
+ * user's mouth at 0.6 confidence.
+ */
+const CORRECTION_OPENER =
+  /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
+
+/**
+ * The prefix that makes two invocations "the same attempt".
+ *
+ * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
+ * through what the alternatives do to real command lines:
+ *
+ *   Two tokens conflates `npm run build` with `npm run test`, and the pair then
+ *   produces "`npm run test` works where `npm run build` failed" -- a claim that
+ *   is simply false.
+ *
+ *   Counting flags splits `deploy` from `deploy --retry`, which is the single
+ *   most useful pair this detector can find, into two groups that never meet.
+ *
+ * Conservative in the remaining direction: `npm run build:prod` and
+ * `npm run build` do not pair. A missed pair costs one finding; a wrong pair
+ * ships a false claim into model context.
+ */
+export function attemptKey(command) {
+  return String(command || '')
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'))
+    .slice(0, 3)
+    .join(' ')
+    .toLowerCase();
+}
+
+/** Normalised claim text, so the same lesson derived twice is one candidate. */
+const claimKey = (type, claim) =>
+  `${type}|${String(claim).toLowerCase().replace(/\s+/g, ' ').trim()}`;
+
+/** 0.95 is reserved for verified; everything here is inference. */
+const labelFor = (confidence) => (confidence >= 0.75 ? 'probable' : 'speculative');
+
+/** A literal command prefix, safe to hand to `safeTrigger`. */
+const triggerFor = (command) =>
+  attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
+
+/**
+ * Derives finding candidates from one project's local evidence.
+ *
+ * @param {string} dir wiki directory.
+ * @param {object} options
+ * @param {string|null} options.sessionId session this ran for, for provenance.
+ * @param {string|null} options.transcriptPath live transcript, read only when the
+ *   archive holds nothing for this session yet.
+ * @param {string|null} options.projectRoot the anchor every derived claim gets.
+ *   Without it nothing is derived: an unanchored finding cannot be invalidated
+ *   and is refused by `writeHarvested` anyway, so emitting one would only spend
+ *   the caller's budget on junk.
+ * @param {string|null} options.authoritativeSessionId the session id as the HOOK
+ *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
+ *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
+ *   edge -- `taskForAnchors` returns null without one, so an unverified string
+ *   would silently produce no edge. Threaded rather than defaulted from
+ *   `sessionId`: defaulting would promote any caller's string to trusted.
+ */
+export function derive(dir, options = {}) {
+  // `options || {}` rather than a destructuring default. A default only fires on
+  // `undefined`, so a caller passing an explicitly null options object -- which
+  // is what a hook does when it has nothing to say -- threw a TypeError out of
+  // the parameter list itself, before any of the try/catch below could fail open.
+  const {
+    sessionId = null,
+    transcriptPath = null,
+    projectRoot = null,
+    authoritativeSessionId = null,
+  } = options || {};
+
+  const result = {
+    candidates: [],
+    observations: [],
+    written: [],
+    sessionId,
+    authoritativeSessionId,
+  };
+
+  let events;
+  try {
+    events = readMetrics(dir);
+  } catch {
+    // Session end must cost nothing. No evidence is not an error.
+    return result;
+  }
+  if (!Array.isArray(events)) return result;
+
+  const seen = new Set();
+  const add = (candidate) => {
+    if (result.candidates.length >= MAX_CANDIDATES) return;
+    const key = claimKey(candidate.type, candidate.claim);
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.candidates.push(candidate);
+  };
+
+  // ---- 1 & 2: a failed attempt followed by a succeeding one ---------------
+  //
+  // The event is `tool-outcome` and THE COMMAND TEXT IS IN `anchor`: there is no
+  // separate command field, because the anchor of a command surface IS the
+  // command. It is capped at 120 characters at the boundary, so a very long
+  // command line is compared and quoted truncated.
+  try {
+    if (projectRoot) {
+      const outcomes = events
+        .filter(
+          (e) =>
+            e &&
+            e.kind === 'tool-outcome' &&
+            e.surface === 'command' &&
+            typeof e.anchor === 'string' &&
+            e.anchor.trim()
+        )
+        .map((e) => ({
+          command: e.anchor.trim(),
+          output: typeof e.output === 'string' ? e.output : '',
+          exit: Number.isInteger(e.exit) ? e.exit : null,
+          at: e.at ?? 0,
+          // `success` FIRST, `exit` only as a refinement. MCP tools report no
+          // numeric code at all, so a classifier keyed on `exit !== 0` would be
+          // inert for most clients -- and `exit` is null rather than 0 precisely
+          // so that absence is not read as a clean exit.
+          failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
+        }))
+        .sort((a, b) => a.at - b.at);
+
+      const byAttempt = new Map();
+      for (const outcome of outcomes) {
+        const key = attemptKey(outcome.command);
+        if (!key) continue;
+        if (!byAttempt.has(key)) byAttempt.set(key, []);
+        byAttempt.get(key).push(outcome);
+      }
+
+      for (const run of byAttempt.values()) {
+        // The NEAREST preceding failure, not the first one in the session. With
+        // `find` over the whole run, a command that failed at 09:00 and
+        // succeeded at 17:00 after nine unrelated attempts is reported as one
+        // story.
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          // One pair per failure: a command that succeeds twice afterwards has
+          // not taught two lessons.
+          lastFailure = null;
+
+          // THE GUARD THAT REMOVES THE LARGEST JUNK CLASS. The commonest shape
+          // in a coding session is `npm run build` failing, the code being
+          // fixed, and `npm run build` succeeding -- identical text. From that
+          // pair the two available claims are "`npm run build` works where
+          // `npm run build` failed", which is incoherent, and "`npm run build`
+          // fails", which the same evidence has just disproved. The observation
+          // is real and supports NEITHER claim, so nothing is emitted. This is
+          // not a confidence question; a ceiling cannot rescue a claim whose
+          // content is wrong.
+          if (failed.command === outcome.command) continue;
+
+          const codeSensitive =
+            CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);
+          const confidence = codeSensitive ? CONFIDENCE.test : CONFIDENCE.command;
+          const derivedBy = codeSensitive ? 'test-transition' : 'command-transition';
+
+          // "SUCCEEDED WHERE", NOT "FIXES". What is observed is two outcomes in
+          // order on the same attempt; that the difference in the command line
+          // CAUSED the difference in outcome is not observed and is not claimed.
+          add({
+            type: 'command',
+            claim: redact(
+              `\`${outcome.command}\` succeeded in this project where \`${failed.command}\` failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
+                'an intervening edit or a flaky run explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: 'when about to run this command in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the failing form later succeeds unchanged'],
+            trigger: triggerFor(outcome.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+
+          // The error text, only when there is error text. Without it the claim
+          // degrades to "`X` failed with:" and nothing after the colon, which
+          // carries no information and still costs budget.
+          const firstLine = failed.output.split('\n').find((line) => line.trim()) || '';
+          if (firstLine.trim().length < 8) continue;
+          add({
+            type: 'failure',
+            claim: redact(`\`${failed.command}\` failed with: ${firstLine.trim()}`, {
+              max: CLAIM_MAX,
+            }),
+            evidence: redact(`captured output of the failing run:\n${failed.output}`, {
+              max: EVIDENCE_MAX,
+            }),
+            applicability: 'when this command is about to be run in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the same command later succeeds unchanged'],
+            trigger: triggerFor(failed.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: failed.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 3: user corrections ------------------------------------------------
+  //
+  // A `feedback` finding -- the one type whose source is a person saying the
+  // agent was wrong. The MODEL-BASED extractor for this lives in `lessons.mjs`
+  // and needs the credential this module exists to do without, so here the
+  // signal is lexical: the opening words of the user's own turn.
+  //
+  // ORIGIN IS NOT PROMOTED. `writeHarvested` grants ORIGIN_HUMAN to a finding
+  // carrying a verified verbatim quote, and the standing-rules layer selects on
+  // that origin to inject a claim on EVERY turn. The quote here would be
+  // verbatim -- it is copied out of the archive -- but whether the turn was a
+  // correction at all is a guess, and a guess must not buy always-on injection.
+  // So no `origin` and no `quote` field: this stays harvested provenance.
+  try {
+    if (projectRoot) {
+      let turns = readArchive(dir, sessionId);
+      // The archive is written by the Stop hook too, and the order of the two is
+      // not this module's to assume, so fall back to the live transcript.
+      if (!turns.length && transcriptPath) turns = readTurns(transcriptPath);
+
+      for (const turn of turns) {
+        if (!turn || turn.role !== 'user') continue;
+        const text = String(turn.text || '').trim();
+        // Long turns are new instructions with a complaint somewhere inside
+        // them; truncating one into a claim would misquote the user.
+        if (text.length < 12 || text.length > 300) continue;
+        if (!CORRECTION_OPENER.test(text)) continue;
+        add({
+          type: 'feedback',
+          claim: redact(text, { max: CLAIM_MAX }),
+          evidence: redact(`the user opened a turn with a correction: "${text}"`, {
+            max: EVIDENCE_MAX,
+          }),
+          applicability: 'when working in this project, before repeating what was corrected',
+          confidence: CONFIDENCE.correction,
+          confidenceLabel: labelFor(CONFIDENCE.correction),
+          scope: 'project',
+          invalidators: ['the user later asks for the corrected behaviour'],
+          anchors: [projectRoot],
+          derivedBy: 'correction',
+          sessionId,
+          at: Date.parse(turn.at || '') || Date.now(),
+        });
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 4: re-read churn ---------------------------------------------------
+  //
+  // NOT A FINDING, AND THAT IS THE DECISION RATHER THAN AN OMISSION.
+  //
+  // Churn is a claim about OUR OWN reading behaviour: "this file was read three
+  // times unchanged". Every finding type available is a claim about the work --
+  // `map` describes how an area of the codebase is laid out, and is
+  // content-dependent, so a churn claim filed as `map` would be checked for
+  // staleness against contents it makes no claim about and flip stale on the
+  // first edit to a file it never described. Worse, the anchors it would take
+  // are by construction the HOTTEST files in the project, which are exactly the
+  // files that already carry real findings, so a 0.4-confidence row saying
+  // nothing actionable would sit in the injection budget beside them and render
+  // on the same reads. Nothing a future agent could DO differently follows from
+  // it: it does not say what the file contains, so it cannot substitute for
+  // reading it.
+  //
+  // The signal is still worth having -- as the measurement it already is.
+  // `rereadWaste` reports it on the balance sheet, `rereadsByAnchor` names the
+  // offenders, and this returns those rows as OBSERVATIONS: computed, carried,
+  // and deliberately not competing for context. Three detectors produce
+  // findings; the fourth produces a number.
+  try {
+    for (const row of rereadsByAnchor(events).slice(0, 3)) {
+      if (!row.anchor || row.wasteful < 2) continue;
+      result.observations.push({
+        kind: 'churn',
+        anchor: row.anchor,
+        repeats: row.repeats,
+        wasteful: row.wasteful,
+        tokens: row.tokens,
+        confidence: CONFIDENCE.churn,
+        derivedBy: 'churn',
+        note: `re-read ${row.repeats} times, ${row.wasteful} of them unchanged`,
+      });
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  return result;
+}

--- a/hooks-core/derive.mjs
+++ b/hooks-core/derive.mjs
@@ -137,17 +137,19 @@ const quotable = (command) => {
  * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
  * found across 163 transcripts on this machine it refuses 2 and keeps 6.
  *
- * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
- * building the key, so the claim is about `npm test` rather than about the `cd`.
- * That changes `attemptKey` for every client and every finding already derived
- * from it, so it belongs in its own change with its own comparison.
+ * `commandBody` below now skips a leading `cd <path> &&`, so those two are
+ * recovered and this guard is left holding only the keys that reached a
+ * separator which is NOT a directory change -- `git fetch && <anything>`, a
+ * pipeline, a `;`-joined pair. Those still name no single attempt.
  */
 const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
 
 /**
  * Did `attemptKey` actually capture a command, or only how one was chained?
  *
- * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart --
+ * which now means AFTER `commandBody` has removed any leading `cd`, so this no
+ * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
 const hasAttemptIdentity = (command) =>
@@ -175,6 +177,81 @@ const CORRECTION_OPENER =
   /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
 
 /**
+ * A leading directory change, stripped before the key is built.
+ *
+ * THE MEASURED CASE, AND ONLY THE MEASURED CASE. `attemptKey` spends up to
+ * three non-flag tokens on identity and the habit on this machine is
+ * `cd <absolute path> && <the real command>`, which spends all three on `cd`,
+ * the path and the separator. This repository's own corpus: 1,400 of 2,243
+ * command outcomes open with a `cd`, and the single key
+ * `cd c:/users/.../token-optimizer-mcp &&` covered 547 distinct command lines.
+ * A `cd` says WHERE a command ran; it says nothing about WHAT ran, so it cannot
+ * be part of the identity of an attempt.
+ *
+ * THE SEPARATOR SET IS THE ONE THAT WAS OBSERVED: `&&` (1,147), a newline (204)
+ * and `;` (38) after a leading `cd`. All three mean "then run this". `||` is
+ * DELIBERATELY EXCLUDED even though it costs one line to add: `cd x || echo
+ * failed` puts an error branch after the separator, not the next step, so
+ * stripping there would key the attempt on a failure handler. It occurred zero
+ * times.
+ *
+ * AND NOTHING WIDER, each refusal for a reason from the same corpus:
+ *
+ *   Environment assignments (`FOO=bar cmd`) DO carry information about what
+ *   ran. The one true instance here is
+ *   `TOKEN_OPTIMIZER_HOLDOUT=1 node ... jest.js ...`, and the holdout arm is a
+ *   genuinely different attempt from the same command without it. The other 20
+ *   are shell variable assignments joined by `;` -- statements, not prefixes --
+ *   whose value is usually a 120-character path that would be stripped down to
+ *   nothing useful.
+ *
+ *   `time`, `env`, `nice`, `sudo`, `bash -c`, `pushd`, `Set-Location`: ZERO
+ *   occurrences in 2,243 commands. Code for an unmeasured prefix is a way to
+ *   over-strip that no evidence asked for, and over-stripping merges commands
+ *   that genuinely differ -- the same bug in the other direction. `bash -c` is
+ *   worse than unmeasured: the command sits inside a quoted string, so stripping
+ *   the wrapper leaves a key beginning with a quote character.
+ *
+ *   `cd /d C:\path &&` and `cd "C:/a b" &&` need no extra rule -- the match runs
+ *   to the separator rather than counting tokens, so flags and quoted paths
+ *   containing spaces are consumed for free. Neither appears here, so neither is
+ *   claimed as tested behaviour beyond its unit test.
+ *
+ * A `cd` with NO separator is left alone: `cd <path>` on its own ran no command,
+ * and its key is as meaningless afterwards as before -- there is nothing to
+ * recover. Stripping is repeated up to `MAX_DIR_PREFIXES` times so
+ * `cd a && cd b && cmd` reaches `cmd`; the bound exists only so a pathological
+ * line cannot loop, since each pass must consume a whole `cd ... <sep>`.
+ *
+ * APPLIED IDENTICALLY TO BOTH SOURCES because it is applied INSIDE `attemptKey`,
+ * which is the single function both the event path and the transcript reader's
+ * output pass through. The 120-character anchor cap that makes the two agree on
+ * 266 of 266 keys is untouched and still applied on both sides before this runs.
+ */
+const DIR_PREFIX = /^\s*cd\s[^\r\n;&|]*?(?:&&|;|\r?\n)\s*/i;
+const MAX_DIR_PREFIXES = 4;
+
+/**
+ * The command text with any leading directory change removed.
+ *
+ * Used for the key AND for the identical-text refusal, which is the half that
+ * keeps this from becoming a licence to pair more loosely: without it,
+ * `cd repo && npm test` failing and `npm test` succeeding would emit
+ * "`npm test` succeeded where `cd repo && npm test` failed" at 0.90 -- two
+ * spellings of one attempt, dressed up as a difference that mattered. The
+ * claim itself still quotes the RAW command, because that is what ran.
+ */
+export function commandBody(command) {
+  let text = String(command || '');
+  for (let i = 0; i < MAX_DIR_PREFIXES; i++) {
+    const stripped = text.replace(DIR_PREFIX, '');
+    if (stripped === text) break;
+    text = stripped;
+  }
+  return text;
+}
+
+/**
  * The prefix that makes two invocations "the same attempt".
  *
  * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
@@ -192,7 +269,7 @@ const CORRECTION_OPENER =
  * ships a false claim into model context.
  */
 export function attemptKey(command) {
-  return String(command || '')
+  return commandBody(command)
     .trim()
     .split(/\s+/)
     .filter((token) => token && !token.startsWith('-'))
@@ -492,7 +569,14 @@ export function derive(dir, options = {}) {
           // is real and supports NEITHER claim, so nothing is emitted. This is
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
-          if (failed.command === outcome.command) continue;
+          // COMPARED WITH THE DIRECTORY CHANGE REMOVED, for the same reason
+          // the key is. `cd repo && npm test` and `npm test` are one attempt
+          // spelled two ways; before `commandBody` they landed in different
+          // groups and never met, and letting them meet without widening this
+          // guard would emit "`npm test` succeeded where `cd repo && npm test`
+          // failed" at 0.90 -- a difference in the claim that is not a
+          // difference in what ran. Same for two `cd`s to different paths.
+          if (commandBody(failed.command) === commandBody(outcome.command)) continue;
 
           // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
           // client both sides of almost every pair are truncated multi-line
@@ -500,10 +584,12 @@ export function derive(dir, options = {}) {
           // spending the retrieval budget of every later session.
           if (!quotable(failed.command) || !quotable(outcome.command)) continue;
 
-          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
-          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
-          // command lines in this repository alone, and any pair drawn from that
-          // group is a false claim about both halves.
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`. The
+          // `cd <path> &&` case that grouped 547 unrelated command lines in this
+          // repository is now handled earlier by `commandBody`; what is left
+          // here is every OTHER separator -- `git fetch && <anything>`, a
+          // pipeline, a `;`-joined pair -- where the key still names no single
+          // attempt and any pair drawn from it is false about both halves.
           if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =

--- a/hooks-core/derive.mjs
+++ b/hooks-core/derive.mjs
@@ -14,6 +14,13 @@
  * there is nothing to consent to and this runs by default. It is the only
  * finding producer on a machine without a key.
  *
+ * THREE SOURCES, NOT TWO. `tool-outcome` events, the transcript archive, and --
+ * since the transition detectors were measured to have no input at all on the
+ * primary client -- the raw transcript's FAILED tool results, which is the only
+ * place a Claude Code failure is recorded (`failedResultsFromTranscript` in
+ * transcript.mjs, and the note above `quotable` for what that measurement
+ * actually yielded).
+ *
  * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
  * second command fixed the first -- an intervening edit, a dependency install or
  * a flaky test explains it just as well. So each detector carries a confidence
@@ -30,7 +37,11 @@
 import { readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
-import { readArchive, readTurns } from './transcript.mjs';
+import {
+  readArchive,
+  readTurns,
+  failedResultsFromTranscript,
+} from './transcript.mjs';
 import { redact } from './redact.mjs';
 import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
@@ -54,6 +65,96 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * The anchor cap a command surface is stored under, restated here as a TEST.
+ *
+ * `recordToolOutcome` truncates `anchor` to 120 characters, so a command at or
+ * over that length reached this module already cut -- and `quotable` below
+ * refuses to build a claim out of the fragment.
+ */
+const COMMAND_ANCHOR_MAX = 120;
+
+/**
+ * Can this command text be QUOTED in a claim a reader could act on?
+ *
+ * THE SECOND REFUSAL OF ITS KIND, and it exists because measurement forced it.
+ * Wiring the transcript reader gave the transition detectors their first real
+ * input on this client and immediately produced four candidates at 0.9
+ * confidence whose claim text read:
+ *
+ *   `cd /c/Users/.../token-optimizer-mcp\ncat >> docs/superpowers/plans/2026-` succeeded
+ *   in this project where `cd /c/Users/.../token-optimizer-mcp\ncat > /tmp/probe3.mjs
+ *   <<'EOF'\nimport { readdirSync, readFileSync, sta` failed
+ *
+ * -- two truncated fragments of throwaway shell scripts, grouped together only
+ * because `attemptKey`'s three tokens were spent on `cd`, the absolute path, and
+ * the verb. Then measured properly across three real transcripts: **0 of 83**
+ * captured command failures are single-line and inside the cap. 65% of this
+ * project's 2,178 successful command outcomes are not either. On this client a
+ * "command" is usually a whole shell script, so the attempt identity the
+ * transition detectors are built on does not fit most of the traffic.
+ *
+ * This is the same judgement as the identical-text guard below rather than a
+ * confidence question: a claim whose subject is a truncated fragment of a
+ * program is not a weaker claim, it is not a claim. A raised cap would not
+ * rescue it -- quoting the whole 500-character heredoc is no more actionable.
+ *
+ * What survives is exactly what the detector was designed for: `npm test`,
+ * `dotnet build X`, `deploy --retry` -- a repeatable command someone could run
+ * again. This machine captured none failing, which is why the honest yield here
+ * is zero and why that is reported rather than dressed up.
+ *
+ * Applied to BOTH sources. Where the evidence arrived from has no bearing on
+ * whether the resulting sentence says anything, and a rule that let events
+ * through would ship the junk on the ten clients that do report failures.
+ */
+const quotable = (command) => {
+  const text = String(command || '');
+  return (
+    text.trim().length > 0 &&
+    !/[\r\n]/.test(text) &&
+    text.length < COMMAND_ANCHOR_MAX
+  );
+};
+
+/**
+ * Tokens that separate one command from the next rather than naming one.
+ *
+ * MEASURED, LIKE EVERY OTHER REFUSAL HERE. `attemptKey` spends up to three
+ * non-flag tokens on identity, and the habit on this machine is
+ * `cd <absolute path> && <the real command>` -- which spends all three on `cd`,
+ * the path and `&&`, so the real command never enters the key. This project's
+ * own evidence: the single key `cd c:/users/.../token-optimizer-mcp &&` covers
+ * **539 distinct command lines**. One quotable failure in that group would pair
+ * with an arbitrary unrelated success and claim "`cd repo && grep -n ...`
+ * succeeded where `cd repo && git merge ...` failed", which is false about both.
+ *
+ * A KEY THAT REACHED A SEPARATOR NEVER REACHED A COMMAND, so there is no attempt
+ * to compare and nothing to claim -- the same judgement as the identical-text
+ * guard rather than a lower ceiling. Narrow on purpose: `2>&1` and `/F` are not
+ * separators and do not trip this, so `cat commitlint.config.mjs 2>&1` and
+ * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
+ * found across 163 transcripts on this machine it refuses 2 and keeps 6.
+ *
+ * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
+ * building the key, so the claim is about `npm test` rather than about the `cd`.
+ * That changes `attemptKey` for every client and every finding already derived
+ * from it, so it belongs in its own change with its own comparison.
+ */
+const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
+
+/**
+ * Did `attemptKey` actually capture a command, or only how one was chained?
+ *
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * One check per pair is enough: both halves share the key by construction.
+ */
+const hasAttemptIdentity = (command) =>
+  attemptKey(command)
+    .split(' ')
+    .filter(Boolean)
+    .every((token) => !COMMAND_SEPARATORS.has(token));
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -272,6 +373,17 @@ export function derive(dir, options = {}) {
   // separate command field, because the anchor of a command surface IS the
   // command. It is capped at 120 characters at the boundary, so a very long
   // command line is compared and quoted truncated.
+  //
+  // TWO SOURCES OF FAILURE, ONE PAIRING LOOP. Claude Code never fires
+  // PostToolUse for a failed tool call -- 2,238 of 2,238 live `tool-outcome`
+  // events on the measuring machine carry `success: true`, and a deliberately
+  // failing command produced no event at all -- so on the primary client these
+  // two detectors had NO INPUT WHATSOEVER while working normally on the ten
+  // adapter clients. `failedResultsFromTranscript` supplies the missing half
+  // from the only place it exists. The successes still come from events only:
+  // a transcript failure that pairs with nothing stays unclaimed, which is also
+  // what keeps a failure from ANOTHER project's directory out of this project's
+  // graph -- a candidate cannot be emitted without a success recorded HERE.
   try {
     if (projectRoot) {
       const outcomes = events
@@ -288,6 +400,9 @@ export function derive(dir, options = {}) {
           output: typeof e.output === 'string' ? e.output : '',
           exit: Number.isInteger(e.exit) ? e.exit : null,
           at: e.at ?? 0,
+          // Carried purely so the transcript merge below can recognise the same
+          // tool call arriving from the other source.
+          toolCallId: e.toolCallId ? String(e.toolCallId) : null,
           // `success` FIRST, `exit` only as a refinement. MCP tools report no
           // numeric code at all, so a classifier keyed on `exit !== 0` would be
           // inert for most clients -- and `exit` is null rather than 0 precisely
@@ -295,6 +410,53 @@ export function derive(dir, options = {}) {
           failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
         }))
         .sort((a, b) => a.at - b.at);
+
+      // DEDUPLICATED ON `toolCallId`, which is the SAME STRING in both sources:
+      // `episodeMeta` reads `raw.tool_use_id` into `toolCallId`, and that is the
+      // transcript's `tool_use_id` verbatim -- verified against live evidence
+      // (`toolu_01L4Nwr...` in metrics.jsonl, the same ids in the transcript).
+      // So on the ten clients that DO report failures, the event copy wins and
+      // the transcript copy is dropped before grouping. Without this the two
+      // copies of one failure would sit in the same run and the second of them
+      // would be paired against the first as a failed-then-succeeded story about
+      // itself.
+      //
+      // The fallback covers a client that reports a failure with no call id:
+      // identical command text within two seconds is one failure recorded twice,
+      // not two failures, because nothing re-runs a command that fast.
+      const eventIds = new Set(
+        outcomes.map((o) => o.toolCallId).filter(Boolean)
+      );
+      const eventFailures = outcomes.filter((o) => o.failed);
+      const alreadyRecorded = (failure) => {
+        if (failure.toolCallId && eventIds.has(failure.toolCallId)) return true;
+        return eventFailures.some(
+          (o) =>
+            o.command === failure.command &&
+            Math.abs((o.at || 0) - (failure.at || 0)) <= 2000
+        );
+      };
+
+      let transcriptFailures = [];
+      try {
+        transcriptFailures = failedResultsFromTranscript(transcriptPath).filter(
+          (failure) => failure.command.trim() && !alreadyRecorded(failure)
+        );
+      } catch {
+        // The reader is an extra source, never a reason the detector stops.
+      }
+      for (const failure of transcriptFailures) {
+        outcomes.push({
+          command: failure.command.trim(),
+          output: failure.output,
+          exit: failure.exit,
+          at: failure.at,
+          toolCallId: failure.toolCallId,
+          // Read from `Exit code N`, which is the only shape the reader admits.
+          failed: true,
+        });
+      }
+      if (transcriptFailures.length) outcomes.sort((a, b) => a.at - b.at);
 
       const byAttempt = new Map();
       for (const outcome of outcomes) {
@@ -331,6 +493,18 @@ export function derive(dir, options = {}) {
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
           if (failed.command === outcome.command) continue;
+
+          // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
+          // client both sides of almost every pair are truncated multi-line
+          // shell scripts, and a claim quoting a fragment of one is noise
+          // spending the retrieval budget of every later session.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
+          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
+          // command lines in this repository alone, and any pair drawn from that
+          // group is a false claim about both halves.
+          if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =
             CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);

--- a/hooks-core/derive.mjs
+++ b/hooks-core/derive.mjs
@@ -21,13 +21,21 @@
  * the observation supports no claim at all are refused rather than downgraded
  * (see `attemptKey` and the identical-text guard below).
  *
- * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
- * budget, belongs to the caller.
+ * WHAT IS STORED IS BOUNDED. Candidates go through `selectForConsolidation`
+ * before `writeHarvested`, so a long session cannot spend the whole retrieval
+ * budget of every later session on one afternoon's exit codes. Nothing enters
+ * the graph unbudgeted, and nothing enters it wearing a human origin.
  */
 
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
 import { readArchive, readTurns } from './transcript.mjs';
 import { redact } from './redact.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { load } from './wiki.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -104,6 +112,92 @@ const triggerFor = (command) =>
   attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
 
 /**
+ * Literal root-level files that define how a project is BUILT, RUN and TESTED,
+ * best first. A `command` claim is a claim about this project's commands, and
+ * this is the file those commands are declared in.
+ */
+const PROJECT_MARKERS = [
+  'package.json', 'pyproject.toml', 'Cargo.toml', 'go.mod', 'pom.xml',
+  'build.gradle.kts', 'build.gradle', 'build.sbt', 'mix.exs', 'composer.json',
+  'Gemfile', 'Package.swift', 'CMakeLists.txt', 'Makefile', 'Taskfile.yml',
+  'requirements.txt', 'setup.py', 'deno.json', 'bun.lockb',
+];
+
+/** .NET has no single literal marker; the solution or project file is one. */
+const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
+
+/**
+ * A REAL FILE to anchor a derived claim to, inside the project root.
+ *
+ * WHY NOT THE PROJECT ROOT ITSELF, which is what the extraction step reaches
+ * for and what `promoteToShared` uses in the shared tier. Because
+ * `writeHarvested` resolves every anchor through `indexFile`, `indexFile` reads
+ * the path, and reading a DIRECTORY returns null -- so a candidate anchored to
+ * `projectRoot` resolves to nothing, is refused as unanchorable, and the whole
+ * pipeline stores zero findings while reporting a healthy candidate count.
+ * Verified directly: `indexFile(dir, dir)` returns null. That refusal is
+ * correct and must not be weakened -- an anchor that cannot be indexed is an
+ * anchor that can never be invalidated -- so the anchor has to be a file.
+ *
+ * STALENESS DOES NOT MISFIRE ON THIS. `command`, `failure` and `feedback` are
+ * all outside `CONTENT_DEPENDENT` (staleness.mjs), so the anchor is a RETRIEVAL
+ * AND EXISTENCE hook rather than a contents claim: editing the manifest does
+ * not mark these findings stale. staleness.mjs names this exact case in its own
+ * comment -- "a claim about `npm test` anchored to package.json" -- and calls
+ * missing that invalidation the better error.
+ *
+ * A project with no recognisable marker gets the root back, which will not
+ * resolve, so its candidates are derived and then refused rather than stored
+ * against a fabricated anchor. That is the fail-open direction: no finding
+ * beats a finding anchored to something that is not what the claim is about.
+ */
+export function projectAnchor(projectRoot) {
+  if (!projectRoot) return null;
+  let entries;
+  try {
+    entries = readdirSync(projectRoot);
+  } catch {
+    return projectRoot;
+  }
+  const present = new Set(entries);
+  for (const marker of PROJECT_MARKERS) {
+    if (!present.has(marker)) continue;
+    const path = join(projectRoot, marker);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // A marker that cannot be stat'ed is not a marker.
+    }
+  }
+  // Sorted so two sessions in the same repository pick the SAME solution file:
+  // readdir order is not guaranteed stable across hosts, and an anchor that
+  // varies by host splits one finding into two nodes.
+  for (const entry of [...entries].sort()) {
+    if (!DOTNET_MARKER.test(entry)) continue;
+    const path = join(projectRoot, entry);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // Same.
+    }
+  }
+  return projectRoot;
+}
+
+/**
+ * Tokens of claim text one session may add to the graph.
+ *
+ * SCALED TO THE RETRIEVAL BUDGET IT COMPETES FOR, not picked round. A single
+ * command's injection budget is 500 tokens (`TOKEN_OPTIMIZER_TOUCH_BUDGET`),
+ * and everything stored here is competing for that budget on every later
+ * command, forever. Two touch-budgets per session is the bound: enough for a
+ * few dozen real claims, and short of one session's exit codes crowding out
+ * every finding a human or a model ever wrote.
+ */
+const storageBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_DERIVE_BUDGET) || 1000;
+
+/**
  * Derives finding candidates from one project's local evidence.
  *
  * @param {string} dir wiki directory.
@@ -116,11 +210,18 @@ const triggerFor = (command) =>
  *   and is refused by `writeHarvested` anyway, so emitting one would only spend
  *   the caller's budget on junk.
  * @param {string|null} options.authoritativeSessionId the session id as the HOOK
- *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
- *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
- *   edge -- `taskForAnchors` returns null without one, so an unverified string
- *   would silently produce no edge. Threaded rather than defaulted from
- *   `sessionId`: defaulting would promote any caller's string to trusted.
+ *   PAYLOAD reported it, never a value a model typed. Passed straight to
+ *   `writeHarvested`, which needs it to resolve the `answers` edge --
+ *   `taskForAnchors` returns null without one, so an unverified string would
+ *   silently produce no edge. Threaded rather than defaulted from `sessionId`:
+ *   defaulting would promote any caller's string to trusted. Also returned, so a
+ *   caller can see what it handed over.
+ * @returns {object} `{ candidates, observations, written, selected, dropped,
+ *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
+ *   everything derived; `written` is the subset of keys the graph actually
+ *   holds, which is smaller for three independent reasons -- the budget, the
+ *   anchor discipline, and the duplicate collapse that returns an EXISTING key
+ *   when a later session derives the same claim again.
  */
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
@@ -150,6 +251,11 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // ONE anchor for the whole run, so every candidate from this session points at
+  // the same node and the duplicate collapse in `writeHarvested` can recognise
+  // the same lesson across sessions.
+  const anchorPath = projectAnchor(projectRoot);
 
   const seen = new Set();
   const add = (candidate) => {
@@ -244,7 +350,7 @@ export function derive(dir, options = {}) {
               `observed in one session: \`${failed.command}\` failed` +
                 `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
                 `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
-                'an intervening edit or a flaky run explains the same pair.',
+                'an intervening edit or an unrelated environment change explains the same pair.',
               { max: EVIDENCE_MAX }
             ),
             applicability: 'when about to run this command in this project',
@@ -253,7 +359,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the failing form later succeeds unchanged'],
             trigger: triggerFor(outcome.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: outcome.at || Date.now(),
@@ -278,7 +384,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the same command later succeeds unchanged'],
             trigger: triggerFor(failed.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: failed.at || Date.now(),
@@ -328,7 +434,7 @@ export function derive(dir, options = {}) {
           confidenceLabel: labelFor(CONFIDENCE.correction),
           scope: 'project',
           invalidators: ['the user later asks for the corrected behaviour'],
-          anchors: [projectRoot],
+          anchors: [anchorPath],
           derivedBy: 'correction',
           sessionId,
           at: Date.parse(turn.at || '') || Date.now(),
@@ -377,6 +483,48 @@ export function derive(dir, options = {}) {
     }
   } catch {
     // One detector, never the session.
+  }
+
+  // ---- storage, under a budget -------------------------------------------
+  //
+  // NOTHING ENTERS THE GRAPH UNBUDGETED. `selectForConsolidation` existed for
+  // exactly this and had no caller, which meant that until now nothing bounded
+  // what a session could add. It admits `failure` and `decision` on a FLOOR
+  // before ranking -- a dead end exists nowhere else and is small, and cheap to
+  // find is not cheap to find again -- then fills the remainder by
+  // cost x irrecoverability x reuse-probability.
+  //
+  // ORIGIN_HARVESTED, EXPLICITLY, never ORIGIN_HUMAN. These are machine
+  // derivations; `curate.mjs` states the reason in its own header -- "a
+  // hand-written assertion and a machine guess look identical three months
+  // later, which quietly destroys the reader's ability to calibrate trust".
+  // `writeHarvested` would refuse a batch-wide human origin anyway, and a
+  // candidate here carries neither `origin` nor `quote`, so it cannot earn one
+  // per finding either. That is deliberate: whether a turn was a correction at
+  // all is a lexical guess, and the standing-rules layer selects on human
+  // origin to inject on EVERY turn.
+  try {
+    if (result.candidates.length) {
+      const selected = selectForConsolidation(load(dir), result.candidates, {
+        budget: storageBudget(),
+      });
+      result.selected = selected.kept.length;
+      result.dropped = selected.dropped;
+      result.selectedTokens = selected.tokens;
+      result.written = writeHarvested(dir, selected.kept, {
+        sessionId,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        // The hook payload's own identity, passed through untouched. Without it
+        // `taskForAnchors` returns null and the `answers` edge never fires --
+        // which is the state a default install has been in, because its only
+        // other producer is credential-gated.
+        authoritativeSessionId,
+      });
+    }
+  } catch {
+    // Storage is the last step and the session is already over. A graph write
+    // that fails must not turn a completed session into a hook error.
   }
 
   return result;

--- a/hooks-core/doctor.mjs
+++ b/hooks-core/doctor.mjs
@@ -195,7 +195,8 @@ function hooksDirFor({ hooksDir, install, root }) {
  * identical from outside: a graph that fills with structural nodes either way.
  *
  * Measured on a real 5.4.0 install: 484 symbol, 286 file and 122 task nodes and
- * ZERO findings, because harvestMode() was 'off:not-opted-in'. Fifteen checks
+ * ZERO findings, because harvestMode() then returned an opt-in refusal (the mode has
+ * since been renamed: it is 'off:no-key' now, and opting in is no longer the gate). Fifteen checks
  * passed and none mentioned harvest. stop-harvest.mjs names this exact gap --
  * "nothing in doctor, audit or waste mentions harvest, so a user sees a graph
  * filling with structural nodes and no findings and has no way to learn why" --
@@ -219,9 +220,15 @@ export function probeHarvest() {
   // optimizer is off" is noise, which is why stop-harvest maps it to no notice.
   if (mode === 'off:mode') return [];
 
+  // SAID PLAINLY, because this is the configuration a user would choose if they
+  // knew it existed and the previous wording buried it in machinery. A local
+  // endpoint is the only setting under which the semantic harvest runs with no
+  // credential, no billing and no digest leaving the machine -- so the two facts
+  // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
     return [ok('finding extraction is available',
-      'active-model wiki_write is primary; local endpoint also enables fallback extraction')];
+      'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
+      'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
@@ -231,10 +238,19 @@ export function probeHarvest() {
 
   // No second-model credential is required for the primary path. The Codex/agent session that
   // already paid to derive the conclusion is the extractor and wiki_write is local.
+  // NAME THE TRADE, not just the missing variable. This is the default state on
+  // every machine without a credential, so it is the text most users will read,
+  // and "unavailable" alone tells them neither what they are missing nor that
+  // the free option exists. Local findings still accumulate: derive.mjs reads
+  // exit codes, red-to-green transitions, corrections and churn out of evidence
+  // already on disk and sends nothing anywhere.
   if (mode === 'off:no-key') {
     return [ok('finding extraction is available',
-      'active model records durable conclusions through local wiki_write; no separate-model ' +
-      'credential is configured, so fallback transcript extraction is unavailable')];
+      'active model records durable conclusions through local wiki_write, and derive runs at ' +
+      'session end with no credential. No separate-model credential is configured, so fallback ' +
+      'transcript extraction is unavailable: point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local ' +
+      'model to run it free and private, or set TOKEN_OPTIMIZER_API_KEY to run it from a bounded ' +
+      'digest of paths, commands, prompts and conclusions -- never file contents')];
   }
 
   // off:opted-out -- a deliberate choice, reported as one. Nagging about a setting somebody chose

--- a/hooks-core/inject.mjs
+++ b/hooks-core/inject.mjs
@@ -1132,10 +1132,25 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // injected more than the budget allowed and recorded fewer tokens than it
   // spent -- in a block whose entire justification is that it is tightly
   // bounded and measured against the control arm.
+  // THE LAST LINE IS HOW THE NEXT RULE GETS HERE, and it is one line because
+  // this block is charged on every session forever. A rule reaches this list
+  // only by being pinned or by being a person's verified correction, and both
+  // start as a `wiki_write` -- so a model reading a set of standing rules with
+  // no idea how they were produced has no way to add to it. Stated at the point
+  // of the evidence rather than as a separate always-on block: the reader is
+  // already looking at the output of the mechanism being described.
+  //
+  // THE COLD GRAPH IS COVERED ELSEWHERE, deliberately. Nothing here renders
+  // until at least one rule qualifies, which is the property the always-on
+  // budget depends on, so this line cannot be the first-session nudge --
+  // `policyText`'s "Record what you work out" section is, and it is emitted at
+  // SessionStart whether or not the graph holds anything.
   const HEADING =
     '# Standing rules for this project' +
     '\n\nEstablished in previous sessions and expected to hold. ' +
-    'These are not suggestions.\n\n';
+    'These are not suggestions.\n\n' +
+    'Record what you work out with wiki_write and a real file anchor; ' +
+    'that is how a rule reaches this list.\n\n';
   const noticeFor = (n) =>
     n
       ? `\n(${n} further standing rule${n === 1 ? '' : 's'} did not fit this budget; ` +

--- a/hooks-core/inject.mjs
+++ b/hooks-core/inject.mjs
@@ -33,6 +33,7 @@ import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
 import { cacheOrdered } from './cache.mjs';
+import { withheldFor, exploreOrder, servingPolicyVersion, LOO_ENABLED } from './loo.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -309,8 +310,38 @@ export function forTouch(
     });
     for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
   }
-  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  // LAYER 2 EXPLORATION, BEFORE the budget decides.
+  //
+  // `assessed.eligible` arrives in net-utility order and `fit` keeps that order
+  // until the budget runs out -- so the ranking decides which findings are ever
+  // served, which decides which ever accumulate observations, which decides
+  // their utility. A tenth of touches therefore promote the least-served
+  // candidate first. This is the only place it can go: after `fit` the choice
+  // has already been made.
+  const ordered = exploreOrder(assessed.eligible, dir, { sessionId, anchor: filePath });
+  const { kept, spent } = fit(ordered.map((item) => item.finding), budget);
   if (!kept.length) return null;
+
+  // LAYER 2 WITHHOLDING, AFTER the budget decides, which is the only ordering
+  // that produces a leave-one-out rather than a substitution: withholding first
+  // would let the next-ranked finding take the freed tokens, so the withheld
+  // arm would differ from the served arm by two findings instead of one and the
+  // effect would belong to neither.
+  //
+  // `holdout` is passed so the two experiments cannot compose into "withhold
+  // everything and call it a leave-one-out": that arm already serves nothing.
+  const withheld = withheldFor(kept.map((finding) => finding.key), sessionId, graph, dir, {
+    surface: 'file',
+    anchor: filePath,
+    holdout,
+  });
+  const delivered = withheld ? kept.filter((finding) => finding.key !== withheld) : kept;
+  // RE-PRICED, because `fit` priced what it KEPT and this delivers less. Using
+  // `spent` would bill the injection-cost side of the balance sheet for text
+  // the model never received.
+  const deliveredSpent = withheld
+    ? delivered.reduce((sum, finding) => sum + estimate(render(finding)), 0)
+    : spent;
 
   record(dir, {
     kind: 'inject',
@@ -319,15 +350,20 @@ export function forTouch(
     surface: 'file',
     anchor: filePath,
     holdout,
-    tokens: holdout ? 0 : spent,
-    deliveredTokens: holdout ? 0 : spent,
+    tokens: holdout ? 0 : deliveredSpent,
+    deliveredTokens: holdout ? 0 : deliveredSpent,
     shadowTokens: spent,
-    count: holdout ? 0 : kept.length,
+    count: holdout ? 0 : delivered.length,
     candidateCount: kept.length,
-    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    findingIds: holdout ? [] : delivered.map((finding) => finding.key),
     shadowFindingIds: kept.map((finding) => finding.key),
-    stale: kept.some((f) => f.stale),
+    stale: delivered.some((f) => f.stale),
     sessionId,
+    // ON EVERY RECORD, not only the withheld ones. A served observation needs
+    // the policy version as much as a withheld one does, or `effects` cannot
+    // keep the two arms of one comparison inside one policy.
+    ...(LOO_ENABLED() ? { looPolicy: servingPolicyVersion() } : {}),
+    ...(withheld ? { loo: withheld } : {}),
   });
 
   // MARKED SEEN IN BOTH ARMS, for the same reason as the command path: a file
@@ -337,11 +373,16 @@ export function forTouch(
   // grow faster purely from repetition.
   //
   // This is the identical defect that was fixed in `forCommand` and not here.
+  //
+  // THE WITHHELD KEY IS MARKED TOO, and that is load-bearing rather than tidy:
+  // an unmarked one would be a candidate again on the next touch of this file,
+  // where the one-per-touch tiebreak could serve it -- flipping its arm inside
+  // the very session the arm hash exists to pin it for.
   for (const f of kept) alreadyInjected.add(f.key);
 
-  if (holdout || !kept.length) return null;
+  if (holdout || !delivered.length) return null;
 
-  return `Known about ${filePath} (from previous sessions):\n${kept.map(render).join('\n')}`;
+  return `Known about ${filePath} (from previous sessions):\n${delivered.map(render).join('\n')}`;
 }
 
 /**

--- a/hooks-core/keepwarm.mjs
+++ b/hooks-core/keepwarm.mjs
@@ -28,6 +28,15 @@ import { record, readMetrics, readBalance } from './metrics.mjs';
 import { WRITE_MULTIPLIER, READ_MULTIPLIER } from './cache.mjs';
 
 /**
+ * The shortest gap that counts as a NEW turn rather than a burst inside one.
+ *
+ * Shared by the gap distribution and by the hit test, because they have to
+ * agree about what a turn is. Two copies of this number would let the decision
+ * be fitted to one definition of a turn and scored against another.
+ */
+export const TURN_GAP_MS = 250;
+
+/**
  * TTL tiers, with what a WRITE costs at each.
  *
  * A five-minute entry is written at 1.25x a plain input token; the one-hour
@@ -83,7 +92,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
     for (let i = 1; i < session.length; i++) {
       const gap = session[i] - session[i - 1];
       // A burst of events inside one turn is not a gap between turns.
-      if (gap > 250) gaps.push(gap);
+      if (gap > TURN_GAP_MS) gaps.push(gap);
     }
   }
   if (gaps.length < 6) return null;
@@ -103,10 +112,91 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
 }
 
 /**
+ * Refreshes to observe at a tier before the observation may bound the decision.
+ *
+ * THE SAME NUMBER THE BACKSTOP DEMANDS, deliberately. The decision and the
+ * tripwire read the same ledger, so letting them disagree about when there is
+ * enough evidence would mean one of them acting on a sample the other calls too
+ * small. Below the floor the decision keeps its expected-value answer, so a
+ * single unlucky miss changes nothing at all.
+ *
+ * NOT A CONFIDENCE INTERVAL, and the reason is arithmetic rather than taste. A
+ * Wilson 95% upper bound at ten refreshes and zero hits is 0.28 -- so a policy
+ * that missed ten times out of ten would still be recommended, which is exactly
+ * the case the loop exists to catch. The point estimate is safe here because of
+ * the bound below: an observation may only ever LOWER the modelled probability,
+ * so sampling noise cannot manufacture a refresh, and the tripwire's realised
+ * ledger is a second guard underneath.
+ */
+export const OBSERVATION_FLOOR = TRIPWIRE_MIN;
+
+/**
+ * The measured hit rate per tier, from recorded outcomes.
+ *
+ * Tiers below the floor are ABSENT rather than present with a small n, because
+ * a rate carrying no weight is the thing most likely to be used as though it
+ * did.
+ */
+export function observedHitRates(outcomes = []) {
+  const byTier = new Map();
+  for (const event of outcomes) {
+    if (event?.kind !== 'keepwarm' || event.action !== 'outcome') continue;
+    const name = TIERS.some((t) => t.name === event.tier) ? event.tier : TIERS[0].name;
+    const row = byTier.get(name) || { refreshes: 0, hits: 0 };
+    row.refreshes += 1;
+    if (event.hit) row.hits += 1;
+    byTier.set(name, row);
+  }
+
+  const qualified = new Map();
+  for (const [name, row] of byTier) {
+    if (row.refreshes < OBSERVATION_FLOOR) continue;
+    qualified.set(name, { ...row, rate: row.hits / row.refreshes });
+  }
+  return qualified;
+}
+
+/**
+ * What the refreshes at this tier actually did, if enough of them have.
+ *
+ * Tolerates being handed anything -- null, a plain object, a Map -- because the
+ * callers are two public functions whose options object is assembled by other
+ * people's code.
+ */
+function observationsFor(observed, tierName) {
+  const row = observed instanceof Map ? observed.get(tierName) : null;
+  return row && Number.isFinite(row.rate) ? row : null;
+}
+
+/**
+ * The modelled probability, BOUNDED BY what was observed and never raised by it.
+ *
+ * The asymmetry is the whole point and runs against this project's interest. A
+ * recorded `hit` says only that a turn arrived before the entry expired; it
+ * cannot say the refresh is what kept the entry alive, because a turn arriving
+ * one minute after a five-minute ping would have found the entry warm anyway.
+ * So the observed rate is an UPPER bound on a refresh's value, and substituting
+ * it for the model would flatter keep-warm badly: on the machine this was
+ * written on, the modelled ping probability is 0.2% and the observable
+ * before-expiry rate is 99.5%, so the substitution would recommend refreshing
+ * forever. A low rate, by contrast, is real evidence against: if turns do not
+ * even arrive inside the TTL, the refresh certainly bought nothing.
+ */
+function bounded(modelled, seen) {
+  return seen ? Math.min(modelled, seen.rate) : modelled;
+}
+
+/**
  * Should we refresh this prefix now?
  *
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
+ *
+ * `observed` is passed IN rather than read from disk here: this function is
+ * pure, its purity is what lets the tests build a distribution by hand, and
+ * `shouldKeepWarm` has already read the outcome log for the tripwire -- so
+ * threading the reader in here would be a second read of the same file and a
+ * second place for the window discipline to be got wrong.
  */
 export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
@@ -123,42 +213,30 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
   const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
-
-  // MEASURED BEATS MODELLED, once there is enough of it.
-  //
-  // The module header already commits to this -- "an expected-value decision is
-  // only as good as the distribution it was fitted to, and distributions
-  // shift" -- and the tripwire underneath was the only thing acting on it, as
-  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
-  // entirely" there was nothing, because the observed hit rate was never
-  // computed: both recording halves had no call site, so ten refreshes that
-  // bought nothing would keep recommending refresh right up to the moment the
-  // tripwire cut the whole feature off.
-  //
-  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
-  // handful of samples would swing the decision harder than the distribution
-  // they replace.
-  const probability = observed ? observed.rate : modelled;
+  const seen = observationsFor(observed, tier.name);
+  const probability = bounded(modelled, seen);
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
-  const basis = observed
-    ? `measured over ${observed.observations} refreshes`
-    : 'modelled from the gap distribution';
+  const note = seen && probability < modelled
+    ? `; bounded by ${seen.refreshes} observed refreshes, ` +
+      `${Math.round(seen.rate * 100)}% used before expiry`
+    : '';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
     modelledProbability: modelled,
-    basis,
+    observedHitRate: seen ? seen.rate : null,
+    observedRefreshes: seen ? seen.refreshes : 0,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
-    reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
+    reason: (ev > 0
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
-        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`) + note,
   };
 }
 
@@ -169,7 +247,12 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
  * long enough that the short tier keeps missing. Returns null when neither tier
  * pays, which is a real answer and the one a default-on product never gives.
  */
-export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS }) {
+export function ttlTier({
+  prefixTokens,
+  gaps,
+  turnsPerSession = DEFAULT_TURNS,
+  observed = null,
+}) {
   if (!prefixTokens || !gaps) return null;
 
   // Expected cost of a turn under each tier, as a multiple of what the prefix
@@ -177,7 +260,16 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   // again; and the FIRST write is amortised over the session, which is what
   // stops the expensive tier from looking free whenever gaps are short.
   const costOf = (tier) => {
-    const hit = gaps.probabilityWithin(tier.ms);
+    // THE SAME QUANTITY THE OUTCOMES RECORD, which is what makes the
+    // observation admissible here at all. `hit` is P(a turn arrives before the
+    // entry expires) and `recordRefreshOutcome`'s `hit` is exactly that event,
+    // measured -- unlike keepWarmDecision, whose probability is the narrower
+    // ping window and for which the same observation is only an upper bound.
+    // Bounded rather than replaced even so: a sample drawn only from moments we
+    // CHOSE to refresh is not a sample of gaps, and its bias runs our way.
+    const modelled = gaps.probabilityWithin(tier.ms);
+    const seen = observationsFor(observed, tier.name);
+    const hit = bounded(modelled, seen);
     const perTurn = hit * READ_MULTIPLIER + (1 - hit) * tier.writeMultiplier;
     // THE SUPPLIED VALUE, not only the computed one. Math.max(1, NaN) is NaN -- Math.max
     // propagates it rather than clamping -- so perTurn became NaN, the `perTurn >= 1` guard below
@@ -190,6 +282,8 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     return {
       tier,
       hit,
+      seen,
+      boundedByObservation: Boolean(seen) && hit < modelled,
       perTurn: (tier.writeMultiplier + (turns - 1) * perTurn) / turns,
     };
   };
@@ -206,99 +300,53 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     action: 'refresh',
     tier: best.tier.name,
     hitProbability: best.hit,
+    observedHitRate: best.seen ? best.seen.rate : null,
+    observedRefreshes: best.seen ? best.seen.refreshes : 0,
     expectedCostPerTurn: Number(best.perTurn.toFixed(3)),
     expectedValue: Math.round((1 - best.perTurn) * prefixTokens),
     reason: `${Math.round(best.hit * 100)}% of gaps land inside ${best.tier.name}; ` +
-      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached`,
+      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached` +
+      (best.boundedByObservation
+        ? `, bounded by ${best.seen.refreshes} observed refreshes ` +
+          `(${Math.round(best.seen.rate * 100)}% used before expiry)`
+        : ''),
   };
 }
 
-/** Observations of a tier before its measured hit rate may override the model. */
-export const OBSERVATION_FLOOR = 5;
-
-/** Records a refresh so its outcome can be scored. */
-export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
-  record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
-}
-
 /**
- * Scores every refresh whose window has since resolved.
+ * Records a refresh so its outcome can be scored.
  *
- * THE MISSING HALF, and it was missing because nobody could see where the
- * signal would come from. `recordRefreshOutcome` needs to know whether a real
- * turn arrived before the entry expired -- and that is not a thing anyone has
- * to instrument, because the event log already records when every turn
- * happened. The answer was in the data the whole time.
+ * `sessionId` IS REQUIRED FOR THE REFRESH TO BE SCOREABLE, and is not defaulted
+ * to anything. The hit test asks whether a turn of THIS conversation arrived
+ * before expiry; pooling arrivals across sessions would let a second concurrent
+ * session's turn pay for this one's ping, which manufactures hits. A refresh
+ * recorded without one is kept in the ledger and reported as unattributable
+ * rather than guessed at.
  *
- * For each unscored refresh at time T on a tier with TTL `ms`:
- *
- *   - a later event within `ms`            -> HIT, observed
- *   - a later event after `ms`             -> MISS, observed
- *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
- *                                             demonstrably closed unused
- *   - no later event, window still open    -> NOTHING RECORDED
- *
- * That last line is the important one and it is Plan 2's own instruction: "if
- * no signal is available for a tier, record nothing rather than guessing
- * `hit: false`". A refresh whose window has not closed yet is not a miss, and
- * scoring it as one would drive the tripwire negative on the newest and least
- * informative records.
- *
- * DRAINED AT READ TIME, which is the pattern this codebase already uses for
- * staleness: the producer cannot know the outcome at the moment it acts, so the
- * next reader resolves what has become knowable since.
+ * Returns the stored record, whose `id` is what `scoreRefreshes` pairs the
+ * outcome to, so an issuer can hold onto it.
  */
-export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
-  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
-  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
-  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
-
-  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
-  // so everything past the number already scored is outstanding. Pairing by
-  // timestamp instead would double-count two refreshes recorded in the same
-  // millisecond, which is reachable: a tool run twice in a loop.
-  const outstanding = refreshes.slice(scored);
-  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
-
-  let recorded = 0;
-  for (const refresh of outstanding) {
-    const at = Number(refresh.at) || 0;
-    if (!at) continue;
-    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
-    const next = timeline.find((t) => t > at);
-
-    let hit;
-    if (next !== undefined) hit = next - at <= tierSpec.ms;
-    else if (now - at > tierSpec.ms) hit = false;
-    else continue; // window still open: not yet knowable
-
-    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
-    recorded += 1;
-  }
-  return { outstanding: outstanding.length, recorded };
-}
-
-/**
- * The measured hit rate for a tier, or null below the observation floor.
- *
- * Null rather than a small-sample number, because the caller substitutes it for
- * a modelled probability and three observations would swing the decision harder
- * than the model they replace.
- */
-export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
-  const relevant = outcomes.filter(
-    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
-  );
-  if (relevant.length < OBSERVATION_FLOOR) return null;
-  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
+export function recordRefresh(dir, { tier, prefixTokens, expectedValue, sessionId, at }) {
+  return record(dir, {
+    kind: 'keepwarm',
+    action: 'refresh',
+    tier,
+    prefixTokens,
+    expectedValue,
+    sessionId,
+    at,
+  });
 }
 
 /**
  * Records whether the refresh was used.
  *
  * `hit` means a real turn arrived before expiry, so the write bought a read.
+ * `refreshId` names the refresh this scores, so the same one cannot be scored
+ * twice -- once per turn for the rest of the session, which is what an
+ * unpaired outcome would become.
  */
-export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
+export function recordRefreshOutcome(dir, { tier, prefixTokens, hit, refreshId = null }) {
   const tierSpec = TIERS.find((t) => t.name === tier) || TIERS[0];
   // THE SAME LEDGER keepWarmDecision BUYS THE REFRESH WITH. That function is explicit that a
   // refresh is a PING, which READS the prefix -- costOfPing = prefixTokens * READ_MULTIPLIER --
@@ -315,7 +363,125 @@ export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
   const realised = hit
     ? prefixTokens * (tierSpec.writeMultiplier - READ_MULTIPLIER) - prefixTokens * READ_MULTIPLIER
     : -prefixTokens * READ_MULTIPLIER;
-  record(dir, { kind: 'keepwarm', action: 'outcome', tier, prefixTokens, hit: Boolean(hit), realised: Math.round(realised) });
+  record(dir, {
+    kind: 'keepwarm',
+    action: 'outcome',
+    tier,
+    prefixTokens,
+    hit: Boolean(hit),
+    refreshId,
+    realised: Math.round(realised),
+  });
+}
+
+/**
+ * Scores every recorded refresh whose window has closed -- and NOTHING ELSE.
+ *
+ * This is the arm that was missing. `recordRefresh` and `recordRefreshOutcome`
+ * were both correct and both called by nothing, so the decision spent money on
+ * refreshes and could never find out whether one bought a read.
+ *
+ * THE SIGNAL IS REAL, not invented. `gapDistribution` already treats this log's
+ * timestamps as turn arrivals -- that is the distribution the whole decision is
+ * fitted to -- so the same log answers the outcome question directly: a refresh
+ * at tier `5m` was used if a turn of the same session arrived within five
+ * minutes of it. Four cases refuse to answer rather than guess, and every one
+ * of them refuses in the direction that costs this project its own good news:
+ *
+ *   - `pending`: the window has not closed yet. A hit could be scored the
+ *     instant it arrives while a miss must wait out the whole TTL, so scoring
+ *     early would mean the recorded hits are always complete and the recorded
+ *     misses always lagging -- right-censoring, biased upward, invisible in any
+ *     test. So a hit waits exactly as long as a miss.
+ *   - `uncovered`: the arrival log no longer reaches back to the refresh, so
+ *     absence of an arrival is absence of evidence. RECORDING `hit: false` HERE
+ *     WOULD BE THE INVENTION THIS IS FORBIDDEN TO MAKE: an absent signal is not
+ *     a miss, and treating it as one biases every rate downward and would
+ *     eventually switch keep-warm off on no evidence at all.
+ *   - `unattributable`: the refresh names no session, so no arrival can be
+ *     shown to belong to it.
+ *   - already scored: an outcome already names this refresh.
+ *
+ * The firehose is READ LAZILY, and only when there is something to score. On a
+ * machine where nothing issues refreshes -- which is every machine today, since
+ * nothing in this repository issues one -- the whole cost is the outcome-log
+ * read: median 70 ms on a 3.5 MB log, of which readBalance is 49 ms, because
+ * that reader also scans the firehose tail for pre-split records.
+ */
+export function scoreRefreshes(dir, {
+  refreshes = readBalance(dir),
+  arrivals = null,
+  now = Date.now(),
+} = {}) {
+  const summary = { scored: 0, hits: 0, pending: 0, uncovered: 0, unattributable: 0 };
+  const keepwarm = refreshes.filter((event) => event?.kind === 'keepwarm');
+  const alreadyScored = new Set(
+    keepwarm
+      .filter((event) => event.action === 'outcome' && event.refreshId)
+      .map((event) => event.refreshId)
+  );
+  const unscored = keepwarm.filter(
+    (event) =>
+      event.action === 'refresh' &&
+      Number.isFinite(event.at) &&
+      event.id &&
+      !alreadyScored.has(event.id)
+  );
+
+  // A refresh with no id cannot be paired, so scoring it would write a fresh
+  // outcome on every turn forever. Reported, not silently dropped.
+  summary.unattributable += keepwarm.filter(
+    (event) => event.action === 'refresh' && (!event.id || !Number.isFinite(event.at))
+  ).length;
+
+  if (!unscored.length) return summary;
+
+  const events = (arrivals ? arrivals() : readMetrics(dir)).filter((event) =>
+    Number.isFinite(event?.at)
+  );
+  // Coverage is judged over EVERY event, including our own bookkeeping: the
+  // refresh's own copy in the firehose is what proves the window is still
+  // inside the read. Arrivals are judged over everything else, because a record
+  // keep-warm wrote about itself is not a turn -- and counting one would
+  // manufacture a hit out of the act of measuring.
+  const earliest = events.reduce((min, event) => Math.min(min, event.at), Infinity);
+  const turns = events.filter((event) => event.kind !== 'keepwarm');
+
+  for (const refresh of unscored) {
+    const tier = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    if (now - refresh.at < tier.ms) {
+      summary.pending += 1;
+      continue;
+    }
+    const session = refresh.sessionId;
+    if (!session) {
+      summary.unattributable += 1;
+      continue;
+    }
+    if (!(earliest <= refresh.at)) {
+      summary.uncovered += 1;
+      continue;
+    }
+
+    const opens = refresh.at + TURN_GAP_MS;
+    const closes = refresh.at + tier.ms;
+    const hit = turns.some(
+      (event) =>
+        (event.sessionId ?? event.episodeId) === session &&
+        event.at > opens &&
+        event.at <= closes
+    );
+    recordRefreshOutcome(dir, {
+      tier: refresh.tier,
+      prefixTokens: refresh.prefixTokens,
+      hit,
+      refreshId: refresh.id,
+    });
+    summary.scored += 1;
+    if (hit) summary.hits += 1;
+  }
+
+  return summary;
 }
 
 /**
@@ -370,23 +536,15 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
-  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
-  // becomes evidence now, so the decision below and the tripwire above both see
-  // the most that is currently knowable -- the same read-time drain the
-  // staleness path uses, and for the same reason: the producer cannot know the
-  // outcome at the moment it acts.
-  try {
-    scoreOutstandingRefreshes(dir, { events, outcomes });
-    outcomes = readBalance(dir);
-  } catch {
-    /* scoring is evidence, never a reason to refuse a decision */
-  }
-
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
+  // THE SAME ARRAY THE TRIPWIRE JUST READ, so closing the loop costs no extra
+  // I/O -- and so the decision and its backstop cannot be looking at different
+  // evidence about the same refreshes.
+  const observed = observedHitRates(outcomes);
   const gaps = gapDistribution(dir, { events });
-  const best = ttlTier({ prefixTokens, gaps });
+  const best = ttlTier({ prefixTokens, gaps, observed });
   if (!best) {
     // THE TWO MODELS ANSWER DIFFERENT QUESTIONS, so they may legitimately disagree. ttlTier asks
     // whether holding a cache beats not caching at all; keepWarmDecision asks whether ONE ping
@@ -395,11 +553,7 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({
-      prefixTokens,
-      gaps,
-      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
-    });
+    const decision = keepWarmDecision({ prefixTokens, gaps, observed });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/hooks-core/loo.mjs
+++ b/hooks-core/loo.mjs
@@ -1,0 +1,786 @@
+/**
+ * LAYER 2 -- what one finding is actually worth, measured by withholding it.
+ *
+ * Layer 1 asks whether the model went back and named a finding. This asks the
+ * harder question and answers it causally: WITHHOLD ONE FINDING while serving
+ * every other finding for the same touch, and compare what the session spent
+ * READING that anchor afterwards. Nobody in this space measures per-item value
+ * this way in production; the state of the art is an offline evaluation set.
+ * That is also why this file is more refusal than statistics -- a causal claim
+ * from four observations is worse than no claim, because it is a number and
+ * numbers get quoted.
+ *
+ * THE ESTIMAND IS READ-SUPPRESSION, and it is deliberately DISJOINT from Layer
+ * 1. Layer 1 keys on an explicit `query` naming a finding key. This keys on
+ * `read` events against the injection's anchor. Neither signal appears in the
+ * other's arithmetic: no `query` event is consulted here, and `usage.mjs`
+ * consults no `read` event. Task 8 calibrates one against the other, and if
+ * both derived from the same channel that calibration would report a strong
+ * correlation between two spellings of one quantity and mean nothing.
+ *
+ * IT INVENTS NO JOIN. `recordToolOutcome` already joins each post-tool result
+ * back to the injection that preceded it, recording `injectionId`,
+ * `findingIds` and a `joinMethod` of `tool-call-id` / `episode-anchor` /
+ * `none`. Every observation here is GATED on that join: an injection with no
+ * joined outcome is unattributable and enters neither arm, exactly as Layer 1
+ * treats `joinMethod: 'none'`. An earlier draft of this plan proposed a fresh
+ * `(sessionId, findingKey)` join; it was rejected and is not here.
+ *
+ * WHAT IT COSTS THE USER, because an experiment that degrades a turn owes an
+ * accounting. One withheld finding means the model may re-derive what it was
+ * told last time, and the worst case is one read of that anchor: measured on
+ * this machine, a median read is 3,769 tokens and the 90th percentile is
+ * 14,082. Five guards bound that exposure, and they are the reason the numbers
+ * below are as small as they are:
+ *
+ *   1. only on a FILE touch, because a command injection has no anchor a read
+ *      event can be joined to -- withholding there would cost a user a finding
+ *      and buy no observation at all (see `buildReport`, which excludes command
+ *      injections from the holdout balance for the same reason);
+ *   2. never when fewer than two findings were kept, so "leave one out" always
+ *      leaves something in -- otherwise it degenerates into `inHoldout`, which
+ *      withholds EVERY finding for an anchor and is a different experiment;
+ *   3. never in the same breath as `inHoldout`: if that arm already withheld
+ *      everything, there is nothing to leave out and a Layer 2 arm recorded
+ *      there would be a fabricated observation;
+ *   4. at most ONE finding per touch, or the effect is attributable to neither;
+ *   5. at most ONE withheld finding per SESSION, so the worst case a user can
+ *      experience is a single re-read -- not one per file they open.
+ *
+ * AND IT NEVER OVERRIDES A PERSON. A `pinned` or `origin: 'human'` finding is
+ * an explicit human decision to keep something in front of the model.
+ * Withholding it to run an experiment would overrule that decision for the
+ * convenience of the measurement, so those findings are exempt: they are
+ * always served, they get no causal score, and `looNote` says so rather than
+ * leaving a reader to wonder why they are missing from the table.
+ */
+
+import { createHash } from 'node:crypto';
+import { readEvidence, readMetrics, readTruncation, isFixtureAnchor } from './metrics.mjs';
+import { retrievalPolicy } from './utility.mjs';
+import { ORIGIN_HUMAN } from './curate.mjs';
+import { canonicalPath } from './paths.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Injections of a finding before it may enter the experiment.
+ *
+ * A finding nobody has served yet has no established value to measure the
+ * absence of, and withholding it would be measuring the cold start rather than
+ * the finding. Four is also what makes the ratio below reachable: at a quarter
+ * of (key, session) pairs armed, a key needs roughly a dozen enrolled
+ * injections before it can reach a verdict at all.
+ */
+export const MIN_PRIOR_INJECTIONS = 4;
+
+/** The observation floor. Below this there is no verdict -- and NOT a zero. */
+export const MIN_SERVED = 6;
+export const MIN_WITHHELD = 3;
+
+/** Benjamini-Hochberg false-discovery rate for published verdicts. */
+export const FDR_Q = 0.1;
+
+/**
+ * Exploration rate.
+ *
+ * Without this, utility feeds the ranking, the ranking feeds injection
+ * frequency, injection frequency feeds the observation count, and a low score
+ * becomes self-fulfilling: the finding is never served often enough to earn a
+ * better one. A tenth of touches therefore ignore the utility order and
+ * promote the LEAST-served candidate instead.
+ */
+export const EPSILON = 0.1;
+
+/**
+ * The share of (finding, session) pairs assigned to the withheld arm.
+ *
+ * Chosen against the floors rather than picked: MIN_SERVED / MIN_WITHHELD is
+ * 2:1, so a quarter withheld reaches both floors at about the same time while
+ * leaving three touches in four undamaged.
+ */
+export const WITHHOLD_FRACTION = 0.25;
+
+/**
+ * Withheld findings allowed per session. ONE.
+ *
+ * The per-touch cap alone bounds nothing across a session: a session that
+ * opens twelve files with enrolled findings could have withheld twelve. This
+ * makes the worst case a user can experience one re-read, at the price of a
+ * mild confound that is stated rather than hidden -- when the cap binds, the
+ * other armed findings in that session are served, so the served arm is
+ * slightly enriched by sessions that touch many enrolled findings.
+ */
+export const MAX_WITHHELD_PER_SESSION = 1;
+
+/**
+ * Fallback shrinkage weight when the between-finding variance cannot be
+ * estimated (fewer than two findings with both arms, or no dispersion at all).
+ *
+ * MIN_SERVED + MIN_WITHHELD, deliberately: a finding's own data outweighs the
+ * population prior only once it has reached the publication floor.
+ */
+export const SHRINKAGE_K = MIN_SERVED + MIN_WITHHELD;
+
+/** Bounds on the estimated shrinkage weight, so a degenerate variance ratio cannot run away. */
+const K_MIN = 1;
+const K_MAX = 100;
+
+/**
+ * Bumped BY HAND when the serving code changes in a way that could move a
+ * finding's measured effect. It is the part of the policy version a hash of the
+ * configuration cannot see.
+ */
+export const LOO_POLICY_GENERATION = 1;
+
+/** Permutation budget before the exact null distribution is sampled instead of enumerated. */
+const MAX_EXACT_PERMUTATIONS = 20_000;
+const SAMPLED_PERMUTATIONS = 10_000;
+
+/**
+ * On by default, off by `TOKEN_OPTIMIZER_LOO=off`.
+ *
+ * Read per call rather than at module load, for the reason `holdoutFraction`
+ * gives: a long-lived process started before the setting changed would
+ * otherwise honour the old value forever with no way to tell.
+ */
+export function LOO_ENABLED() {
+  return String(process.env.TOKEN_OPTIMIZER_LOO || '').trim().toLowerCase() !== 'off';
+}
+
+/**
+ * The serving policy an observation was collected under.
+ *
+ * WHY EVERY OBSERVATION CARRIES ONE. An effect is only meaningful against a
+ * fixed policy. Halve the touch budget or move the minimum net utility and the
+ * same finding is served in different company, at a different rank, against a
+ * different counterfactual -- so pooling observations from before and after
+ * that change would average two different experiments and call the result
+ * causal. `effects()` therefore groups by (finding, policy) and never across.
+ *
+ * IT IS DELIBERATELY ABSENT FROM THE ARM HASH. Including it would reassign
+ * arms the moment a setting changed, which is precisely the mid-session flip
+ * the arm hash exists to prevent. Configuration decides which experiment an
+ * observation belongs to; it must never decide which arm.
+ */
+export function servingPolicyVersion() {
+  const policy = retrievalPolicy();
+  const parts = [
+    `g${LOO_POLICY_GENERATION}`,
+    `touch=${Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500}`,
+    `benefit=${policy.baseBenefitTokens}`,
+    `minutility=${policy.minimumNetUtility}`,
+    `cooldown=${policy.cooldownMs}`,
+    `quarantine=${policy.quarantineHarmCount}`,
+    `holdout=${process.env.TOKEN_OPTIMIZER_HOLDOUT ?? 'default'}`,
+    `withhold=${WITHHOLD_FRACTION}`,
+    `prior=${MIN_PRIOR_INJECTIONS}`,
+    `epsilon=${EPSILON}`,
+  ];
+  const digest = createHash('sha256').update(parts.join('|')).digest('hex');
+  return `${LOO_POLICY_GENERATION}-${digest.slice(0, 8)}`;
+}
+
+/**
+ * A stable number in [0, 1) from a string.
+ *
+ * SHA-256 rather than SHA-1 for the same reason `inHoldout` uses it: this is a
+ * bucketing hash and nothing here is secret, but arguing that a CodeQL finding
+ * is benign is a worse habit than paying a cost that rounds to nothing.
+ */
+function bucket(text) {
+  return createHash('sha256').update(String(text)).digest().readUInt32BE(0) / 4_294_967_296;
+}
+
+/**
+ * The arm of one finding in one session.
+ *
+ * Keyed on (findingKey, sessionId) AND NOTHING ELSE, so a finding cannot
+ * change arms partway through a session: not when the candidate set changes,
+ * not when the budget changes, not when the graph grows. The measurement is a
+ * comparison between sessions, and an arm that flips inside one contaminates
+ * both sides of it.
+ */
+function armed(findingKey, sessionId) {
+  return bucket(`loo-arm:${findingKey}:${sessionId}`) < WITHHOLD_FRACTION;
+}
+
+/** Deterministic tiebreak among armed candidates: lowest bucket, then key order. */
+function armRank(findingKey, sessionId) {
+  return bucket(`loo-rank:${findingKey}:${sessionId}`);
+}
+
+/** The graph node for a finding key, or null. Keys are unique per graph. */
+function findingNode(graph, key) {
+  const nodes = graph?.nodes;
+  if (!nodes || typeof nodes.values !== 'function') return null;
+  for (const node of nodes.values()) {
+    if (node?.kind === 'finding' && node.key === key) return node;
+    // A fixture graph may omit `kind`; key identity is what this needs.
+    if (node?.key === key && node.kind === undefined) return node;
+  }
+  return null;
+}
+
+/**
+ * May this finding ever be withheld?
+ *
+ * FAILS CLOSED ON AN UNKNOWN KEY, which is the opposite of how the rest of
+ * this module fails. Everywhere else a missing input costs a measurement; here
+ * it could cost a human their explicit decision, because a key whose node
+ * cannot be read is a key whose `pinned` and `origin` cannot be checked.
+ */
+function withholdable(graph, key) {
+  const node = findingNode(graph, key);
+  if (!node) return false;
+  if (node.pinned) return false;
+  if (node.origin === ORIGIN_HUMAN) return false;
+  if (node.retired) return false;
+  return true;
+}
+
+/** Prior SERVED injections per finding key, and withheld injections per session. */
+function history(dir, { evidence = null } = {}) {
+  const priorServed = new Map();
+  const withheldPerSession = new Map();
+  const events = evidence || readEvidence(dir);
+  for (const event of events) {
+    if (event.kind !== 'inject') continue;
+    if (typeof event.loo === 'string' && event.loo) {
+      const session = typeof event.sessionId === 'string' ? event.sessionId : '';
+      withheldPerSession.set(session, (withheldPerSession.get(session) || 0) + 1);
+    }
+    if (event.holdout) continue;
+    const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+    for (const raw of keys) {
+      const key = String(raw);
+      priorServed.set(key, (priorServed.get(key) || 0) + 1);
+    }
+  }
+  return { priorServed, withheldPerSession };
+}
+
+/**
+ * Which single finding to withhold from this touch, or null.
+ *
+ * Called from `forTouch` AFTER `fit` has decided what would have been served,
+ * which is the only ordering that produces a true leave-one-out. Withholding
+ * BEFORE the budget runs would let a lower-ranked finding take the freed
+ * tokens, so the withheld arm would receive different company as well as one
+ * fewer finding, and the comparison would confound the two.
+ *
+ * @param {string[]} findingKeys keys that would otherwise be delivered
+ * @param {string} sessionId the session, which pins the arm
+ * @param {object} graph the loaded graph, for `pinned` / `origin`
+ * @param {string|null} dir graph directory, for the injection history
+ */
+export function withheldFor(findingKeys, sessionId, graph, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return null;
+
+    // Every guard that needs no I/O runs first: this is the PreToolUse path,
+    // and on a project with one finding per anchor the answer is null before
+    // anything is read.
+    const keys = [...new Set((findingKeys || []).map((k) => String(k)).filter(Boolean))];
+    if (keys.length < 2) return null;
+    if (!sessionId || typeof sessionId !== 'string') return null;
+
+    // FILE SURFACE ONLY. A command injection's anchor is the command text, and
+    // no read event will ever match it -- so both arms would score zero
+    // downstream and the finding would be scored on nothing.
+    const { surface = 'file', anchor = '', holdout = false } = options;
+    if (surface !== 'file' || !anchor) return null;
+    // The all-findings holdout already withheld everything for this anchor.
+    if (holdout) return null;
+
+    const eligible = keys.filter((key) => withholdable(graph, key));
+    if (!eligible.length) return null;
+
+    const { priorServed, withheldPerSession } = history(dir, options);
+    if ((withheldPerSession.get(sessionId) || 0) >= MAX_WITHHELD_PER_SESSION) return null;
+
+    const enrolled = eligible.filter(
+      (key) => (priorServed.get(key) || 0) >= MIN_PRIOR_INJECTIONS
+    );
+    if (!enrolled.length) return null;
+
+    const candidates = enrolled.filter((key) => armed(key, sessionId));
+    if (!candidates.length) return null;
+
+    // AT MOST ONE. Sorted deterministically so the same touch always yields the
+    // same choice; the findings that lose the tiebreak are SERVED, and the
+    // observation records what actually happened rather than what the arm hash
+    // intended.
+    candidates.sort(
+      (a, b) => armRank(a, sessionId) - armRank(b, sessionId) || (a < b ? -1 : a > b ? 1 : 0)
+    );
+    return candidates[0];
+  } catch {
+    // An experiment must never break a tool call. Failing open here means
+    // serving everything, which is the undegraded behaviour.
+    return null;
+  }
+}
+
+/**
+ * Reorders candidates so exploration can break the feedback loop.
+ *
+ * A tenth of touches -- deterministic in (session, anchor), not random, so the
+ * same touch behaves the same way twice -- promote the LEAST-served candidate
+ * ahead of the utility order, giving it a chance to survive `fit` and accrue
+ * the observations it needs to earn a score. The other nine tenths are
+ * untouched.
+ *
+ * @param {Array<{finding:{key:string}}>} items assessed candidates, best first
+ */
+export function exploreOrder(items, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return items;
+    const list = Array.isArray(items) ? items : [];
+    if (list.length < 2) return list;
+    const { sessionId = '', anchor = '' } = options;
+    if (bucket(`loo-explore:${sessionId}:${anchor}`) >= EPSILON) return list;
+
+    const keyOf = (item) => String(item?.finding?.key ?? item?.key ?? '');
+    const { priorServed } = history(dir, options);
+    let promoted = 0;
+    for (let i = 1; i < list.length; i += 1) {
+      const a = priorServed.get(keyOf(list[i])) || 0;
+      const b = priorServed.get(keyOf(list[promoted])) || 0;
+      if (a < b || (a === b && keyOf(list[i]) < keyOf(list[promoted]))) promoted = i;
+    }
+    if (promoted === 0) return list;
+    return [list[promoted], ...list.filter((_, i) => i !== promoted)];
+  } catch {
+    return Array.isArray(items) ? items : [];
+  }
+}
+
+const mean = (values) =>
+  values.length ? values.reduce((sum, v) => sum + v, 0) / values.length : 0;
+
+/** Sample variance (n-1). Zero for a single observation: dispersion is unknown, not large. */
+function variance(values) {
+  if (values.length < 2) return 0;
+  const m = mean(values);
+  return values.reduce((sum, v) => sum + (v - m) * (v - m), 0) / (values.length - 1);
+}
+
+/**
+ * Every attributable Layer 2 observation, one per (injection, finding, arm).
+ *
+ * THREE THINGS ARE REPORTED SEPARATELY RATHER THAN FOLDED IN, because each of
+ * them would otherwise turn an absence into a zero:
+ *
+ *   `unattributable`  the outcome join could not attach a tool call to the
+ *                     injection, so nothing is known about what followed it.
+ *   `excluded`        the injection could never produce a read-join at all
+ *                     (command surface, session-start, fixture anchor) or was
+ *                     already in the all-findings holdout.
+ *   `costObservations` how many observations saw a non-zero read cost. If this
+ *                     is zero, "withholding changed nothing" and "the read
+ *                     channel never fired" are the same picture, and only one
+ *                     of them is a finding about findings.
+ */
+export function observations(dir, { events = null, evidence = null } = {}) {
+  const empty = {
+    rows: [],
+    unattributable: 0,
+    unattributableOutcomes: 0,
+    excluded: { command: 0, holdout: 0, fixture: 0, unanchored: 0 },
+    injections: 0,
+    withheldInjections: 0,
+    costObservations: 0,
+    policies: [],
+    windowed: false,
+  };
+  try {
+    const causal = evidence || readEvidence(dir);
+    const all = events || readMetrics(dir);
+    // OUT OF BAND and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` describes the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
+
+    // THE JOIN THIS MODULE CONSUMES AND DOES NOT REPLACE.
+    const joined = new Set();
+    let unattributableOutcomes = 0;
+    for (const event of causal) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) {
+        unattributableOutcomes += 1;
+        continue;
+      }
+      joined.add(String(event.injectionId));
+    }
+
+    // Read cost, grouped the way `buildReport` groups it: (session, anchor),
+    // canonicalised on both sides so two spellings of one file are one anchor.
+    // A mismatch here would make every read invisible and report a clean zero
+    // effect in both arms -- correct code, absent measurement.
+    const reads = new Map();
+    for (const event of all) {
+      if (event.kind !== 'read' || !event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      if (!reads.has(key)) reads.set(key, []);
+      reads.get(key).push(event);
+    }
+
+    const injects = causal
+      .filter((event) => event.kind === 'inject')
+      .map((event, index) => ({ event, index }))
+      .sort((a, b) => (a.event.at || 0) - (b.event.at || 0) || a.index - b.index)
+      .map((row) => row.event);
+
+    // How many injections share each (session, anchor), so a key's read total
+    // is SPLIT between them rather than charged in full to each -- the same
+    // correction `buildReport` applies, and for the same reason: without it the
+    // arm means scale with injections-per-anchor instead of per-touch cost.
+    const perKey = new Map();
+    for (const event of injects) {
+      if (!event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      perKey.set(key, (perKey.get(key) || 0) + 1);
+    }
+
+    const rows = [];
+    const excluded = { command: 0, holdout: 0, fixture: 0, unanchored: 0 };
+    const priorServed = new Map();
+    const policies = new Set();
+    let unattributable = 0;
+    let considered = 0;
+    let withheldInjections = 0;
+
+    for (const event of injects) {
+      const served = (Array.isArray(event.findingIds) ? event.findingIds : []).map(String);
+      const withheldKey = typeof event.loo === 'string' && event.loo ? event.loo : null;
+      const bump = () => {
+        for (const key of served) priorServed.set(key, (priorServed.get(key) || 0) + 1);
+      };
+
+      const isCommand =
+        event.surface === 'command' ||
+        event.trigger === 'command' ||
+        event.surface === 'session-start';
+      if (isCommand) {
+        excluded.command += 1;
+        bump();
+        continue;
+      }
+      if (!event.anchor) {
+        excluded.unanchored += 1;
+        bump();
+        continue;
+      }
+      if (isFixtureAnchor(event.anchor)) {
+        excluded.fixture += 1;
+        bump();
+        continue;
+      }
+      if (event.holdout) {
+        excluded.holdout += 1;
+        bump();
+        continue;
+      }
+
+      considered += 1;
+      if (withheldKey) withheldInjections += 1;
+      const policy = typeof event.looPolicy === 'string' && event.looPolicy
+        ? event.looPolicy
+        : 'unversioned';
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const attributable = Boolean(injectionId && joined.has(injectionId));
+
+      // DOWNSTREAM MEANS AFTER, STRICTLY. The read that triggered the touch is
+      // not caused by the advice; it happened before the advice existed.
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      const at = event.at || 0;
+      const total = (reads.get(key) || []).reduce(
+        (sum, read) => sum + ((read.at || 0) > at ? read.tokens || 0 : 0),
+        0
+      );
+      const cost = total / Math.max(1, perKey.get(key) || 1);
+
+      const observe = (findingKey, arm) => {
+        // ENROLMENT IS RE-DERIVED FROM THE LOG rather than trusted from the
+        // serving decision. It is the one field an old or hand-written record
+        // could contradict, and a served observation from before a finding was
+        // enrolled would compare an established finding against its own cold
+        // start.
+        //
+        // CHECKED BEFORE ATTRIBUTABILITY, so `unattributable` counts only
+        // observations the experiment actually wanted. Counting the rest there
+        // would report a join failure for every finding that was never in the
+        // experiment to begin with -- the same shape as the 2,559-row
+        // measurement-bias defect Layer 1 found in its own first draft.
+        if ((priorServed.get(findingKey) || 0) < MIN_PRIOR_INJECTIONS) return;
+        if (!attributable) {
+          unattributable += 1;
+          return;
+        }
+        policies.add(policy);
+        rows.push({ findingKey, arm, cost, policy, injectionId, anchor: event.anchor });
+      };
+
+      if (withheldKey) observe(withheldKey, 'withheld');
+      for (const findingKey of served) observe(findingKey, 'served');
+      bump();
+    }
+
+    return {
+      rows,
+      unattributable,
+      unattributableOutcomes,
+      excluded,
+      injections: considered,
+      withheldInjections,
+      costObservations: rows.filter((row) => row.cost > 0).length,
+      policies: [...policies].sort(),
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
+function permutationP(servedCosts, withheldCosts) {
+  const pooled = [...servedCosts, ...withheldCosts];
+  const n = pooled.length;
+  const k = withheldCosts.length;
+  if (!k || k === n) return null;
+  const observed = Math.abs(mean(withheldCosts) - mean(servedCosts));
+  const total = pooled.reduce((sum, v) => sum + v, 0);
+  // Mean difference from the withheld-arm sum alone: the served sum is the
+  // complement, so one number decides the statistic.
+  const diffFrom = (withheldSum) =>
+    Math.abs(withheldSum / k - (total - withheldSum) / (n - k));
+
+  const choose = (a, b) => {
+    let out = 1;
+    for (let i = 1; i <= b; i += 1) out = (out * (a - b + i)) / i;
+    return out;
+  };
+
+  const tolerance = 1e-9;
+  if (choose(n, k) <= MAX_EXACT_PERMUTATIONS) {
+    let extreme = 0;
+    let count = 0;
+    const walk = (start, chosen, sum) => {
+      if (chosen === k) {
+        count += 1;
+        if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+        return;
+      }
+      for (let i = start; i <= n - (k - chosen); i += 1) walk(i + 1, chosen + 1, sum + pooled[i]);
+    };
+    walk(0, 0, 0);
+    return count ? extreme / count : null;
+  }
+
+  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
+  // the same p-value and a verdict cannot flicker between two audit runs.
+  let state = 0x9e3779b9;
+  const random = () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4_294_967_296;
+  };
+  let extreme = 0;
+  const order = [...pooled];
+  for (let round = 0; round < SAMPLED_PERMUTATIONS; round += 1) {
+    for (let i = order.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(random() * (i + 1));
+      [order[i], order[j]] = [order[j], order[i]];
+    }
+    let sum = 0;
+    for (let i = 0; i < k; i += 1) sum += order[i];
+    if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+  }
+  return (extreme + 1) / (SAMPLED_PERMUTATIONS + 1);
+}
+
+/**
+ * The per-finding causal effect, shrunk, and whether it may be published.
+ *
+ * `raw` is `mean(withheld) - mean(served)`: POSITIVE means the session read the
+ * anchor more when the finding was withheld, which is the finding earning its
+ * place. `shrunk` is the number a reader should use.
+ *
+ * EMPIRICAL BAYES, and both halves of it come from the data. The prior mean is
+ * the population effect across findings; the weight `k` is the ratio of
+ * within-finding noise to between-finding spread, so a population where every
+ * finding behaves alike shrinks hard and one where they genuinely differ
+ * shrinks little. `SHRINKAGE_K` is the fallback when that spread cannot be
+ * estimated at all. Two observations therefore cannot post a wild score.
+ *
+ * PUBLICATION IS NOT THE SAME QUESTION as having an estimate. A row is
+ * published only if it clears the observation floor AND its permutation
+ * p-value survives Benjamini-Hochberg at q = 0.10 across every candidate row.
+ * Everything else gets `published: false` -- which is not a zero effect, and
+ * `looNote` says which of the two it is. An all-zero-cost population needs no
+ * separate guard: p is exactly 1 there, so nothing can publish anyway.
+ *
+ * NEVER POOLED ACROSS POLICY VERSIONS: rows are keyed on (findingKey, policy).
+ */
+export function effects(dir, options = {}) {
+  try {
+    // `obs` is accepted so `looNote` can read the logs once for both.
+    const obs = options.obs || observations(dir, options);
+    const groups = new Map();
+    for (const row of obs.rows) {
+      const id = JSON.stringify([row.findingKey, row.policy]);
+      if (!groups.has(id))
+        groups.set(id, { findingKey: row.findingKey, policy: row.policy, served: [], withheld: [] });
+      groups.get(id)[row.arm === 'withheld' ? 'withheld' : 'served'].push(row.cost);
+    }
+
+    const raws = [];
+    const withinVars = [];
+    for (const group of groups.values()) {
+      if (!group.served.length || !group.withheld.length) continue;
+      raws.push(mean(group.withheld) - mean(group.served));
+      withinVars.push(
+        variance(group.withheld) / group.withheld.length +
+          variance(group.served) / group.served.length
+      );
+    }
+    const prior = raws.length ? mean(raws) : 0;
+    const within = withinVars.length ? mean(withinVars) : 0;
+    const between = raws.length > 1 ? Math.max(0, variance(raws) - within) : 0;
+    const weight =
+      between > 0 && within > 0
+        ? Math.min(K_MAX, Math.max(K_MIN, within / between))
+        : SHRINKAGE_K;
+
+    const rows = [...groups.values()]
+      .map((group) => {
+        const served = group.served.length;
+        const withheld = group.withheld.length;
+        const both = served > 0 && withheld > 0;
+        const raw = both ? mean(group.withheld) - mean(group.served) : null;
+        const n = served + withheld;
+        const shrunk = raw === null ? null : (n * raw + weight * prior) / (n + weight);
+        const eligible = served >= MIN_SERVED && withheld >= MIN_WITHHELD;
+        return {
+          findingKey: group.findingKey,
+          policy: group.policy,
+          served,
+          withheld,
+          servedMean: mean(group.served),
+          withheldMean: mean(group.withheld),
+          raw,
+          shrunk,
+          p: eligible ? permutationP(group.served, group.withheld) : null,
+          published: false,
+        };
+      })
+      .sort((a, b) =>
+        a.findingKey < b.findingKey ? -1 : a.findingKey > b.findingKey ? 1 : a.policy < b.policy ? -1 : 1
+      );
+
+    // BENJAMINI-HOCHBERG at q = 0.10 over every row that cleared the floor.
+    // One finding tested in isolation would publish at p < 0.10; a hundred
+    // would publish ten false ones, and this module's whole claim is that its
+    // numbers can be quoted.
+    //
+    // THERE IS NO SEPARATE "WAS ANY READ COST OBSERVED" GATE HERE, and its
+    // absence is deliberate rather than an omission. One was written, and
+    // mutation testing showed it could not change a single verdict: if every
+    // observation has zero cost then both arm means are zero, the permutation
+    // statistic is zero for every relabelling, and p is exactly 1 -- which no
+    // BH threshold can pass. The guard was unfalsifiable, and an unfalsifiable
+    // guard is worse than none because it reads as protection nobody can test.
+    // `costObservations` survives as what it can honestly be: a DISCLOSURE, so
+    // `looNote` can say the read channel never fired instead of letting a
+    // reader take an arithmetic zero for a measured one.
+    const candidates = rows
+      .filter((row) => row.p !== null)
+      .sort((a, b) => a.p - b.p);
+    const m = candidates.length;
+    let cutoff = 0;
+    for (let i = 0; i < m; i += 1) {
+      if (candidates[i].p <= ((i + 1) / m) * FDR_Q) cutoff = i + 1;
+    }
+    for (let i = 0; i < cutoff; i += 1) candidates[i].published = true;
+
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * One or two lines for the audit, or nothing at all.
+ *
+ * THE REFUSAL IS THE PRODUCT HERE. On a machine with two injections in sixteen
+ * thousand events, the only honest output is that nothing is measurable yet,
+ * and this says so with the counts that make it checkable rather than printing
+ * a mean of nothing. It returns `null` when Layer 2 has not collected a single
+ * observation, so an idle experiment costs the reader no line at all -- the
+ * same standard `referenceNote` holds itself to.
+ */
+export function looNote(dir, options = {}) {
+  try {
+    const obs = options.obs || observations(dir, options);
+    const rows = effects(dir, { ...options, obs });
+    if (!obs.rows.length && !obs.withheldInjections) return null;
+
+    let graph = options.graph;
+    if (graph === undefined) {
+      try {
+        graph = load(dir);
+      } catch {
+        graph = null;
+      }
+    }
+    let exempt = 0;
+    if (graph?.nodes?.values) {
+      for (const node of graph.nodes.values()) {
+        if (node?.kind !== 'finding' || node.retired) continue;
+        if (node.pinned || node.origin === ORIGIN_HUMAN) exempt += 1;
+      }
+    }
+
+    const published = rows.filter((row) => row.published);
+    const head = published.length
+      ? `Per-finding causal value (leave-one-out): ${published.length} of ${rows.length} ` +
+        `findings show a verdict at q=${FDR_Q}` +
+        published
+          .slice(0, 3)
+          .map(
+            (row) =>
+              `; ${row.findingKey} saves ~${Math.round(row.shrunk)} tokens/touch ` +
+              `(${row.served} served, ${row.withheld} withheld, p=${row.p.toFixed(3)})`
+          )
+          .join('') +
+        '.'
+      : `Per-finding causal value (leave-one-out): NOT MEASURABLE YET -- ` +
+        `${obs.rows.length} attributable observations across ${rows.length} findings, ` +
+        `${obs.withheldInjections} withheld touches; the floor is ${MIN_SERVED} served ` +
+        `and ${MIN_WITHHELD} withheld per finding` +
+        (obs.costObservations ? '' : ', and no read cost has been observed in either arm') +
+        '. No effect is reported, which is not the same as an effect of zero.';
+
+    const caveats = [];
+    if (obs.unattributable)
+      caveats.push(
+        `${obs.unattributable} observations were unattributable (no joined tool outcome) and are in neither arm`
+      );
+    if (exempt)
+      caveats.push(
+        `${exempt} pinned or human-origin findings are exempt from withholding and get no causal score`
+      );
+    if (obs.policies.length > 1)
+      caveats.push(
+        `observations span ${obs.policies.length} serving-policy versions and are never pooled across them`
+      );
+    if (obs.windowed)
+      caveats.push('the read log was truncated, so downstream cost can understate');
+    return caveats.length ? `${head} ${caveats.join('; ')}.` : head;
+  } catch {
+    return null;
+  }
+}

--- a/hooks-core/loo.mjs
+++ b/hooks-core/loo.mjs
@@ -543,8 +543,22 @@ export function observations(dir, { events = null, evidence = null } = {}) {
   }
 }
 
-/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
-function permutationP(servedCosts, withheldCosts) {
+/**
+ * Enumerates or samples arm relabellings and returns a two-sided p-value.
+ *
+ * EXPORTED so the cross-layer headline can be held to the same standard as the
+ * per-finding rows it summarises. `crosslayer.mjs` runs this over the two ARMS
+ * of shrunk effect estimates; the statistic, the enumerate-or-sample switch and the
+ * tolerance are therefore shared rather than reimplemented, and there is one
+ * place where "two-sided" is decided.
+ *
+ * `seed` exists for that caller. The default reproduces the fixed seed this
+ * function has always used, so Layer 2's own p-values are byte-identical; the
+ * cross-layer caller passes a seed DERIVED FROM ITS DATA, because a verdict
+ * printed to a human must not depend on `Math.random()` or on which module
+ * happened to call first.
+ */
+export function permutationP(servedCosts, withheldCosts, { seed = 0x9e3779b9 } = {}) {
   const pooled = [...servedCosts, ...withheldCosts];
   const n = pooled.length;
   const k = withheldCosts.length;
@@ -578,9 +592,10 @@ function permutationP(servedCosts, withheldCosts) {
     return count ? extreme / count : null;
   }
 
-  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
-  // the same p-value and a verdict cannot flicker between two audit runs.
-  let state = 0x9e3779b9;
+  // Mulberry32 off the caller's seed: reproducible, so the same data always
+  // yields the same p-value and a verdict cannot flicker between two audit
+  // runs.
+  let state = seed | 0;
   const random = () => {
     state = (state + 0x6d2b79f5) | 0;
     let t = state;

--- a/hooks-core/metrics.mjs
+++ b/hooks-core/metrics.mjs
@@ -29,6 +29,7 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { createHash, randomBytes } from 'node:crypto';
+import { redact } from './redact.mjs';
 
 /**
  * Read per call, not once at module load.
@@ -515,6 +516,15 @@ export function readEvidence(dir) {
 }
 
 /**
+ * The captured-output budget, in characters.
+ *
+ * Small enough that a 3 MB test log cannot bloat the evidence log or a single
+ * injected claim, large enough to hold the stack trace or compiler diagnostic
+ * that makes a failure finding worth anything.
+ */
+const OUTPUT_MAX_BYTES = 4096;
+
+/**
  * Joins a post-tool result to the most recent matching injection.  The exact
  * tool-call id wins; clients that omit it fall back to episode + surface +
  * anchor, in timestamp order, and the report states the weaker join method.
@@ -543,10 +553,31 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
+  // text is INJECTED into model context and EXPORTED to markdown, so the
+  // boundary is the only place that can guarantee it: a second caller added
+  // later would otherwise have to remember, and the one that forgot would leak
+  // a secret into two more places than the terminal it came from. `undefined`
+  // rather than `''` when nothing was captured, so JSON.stringify omits the
+  // key entirely and an absent capture is distinguishable from an empty one.
+  const output =
+    outcome.output === undefined || outcome.output === null
+      ? undefined
+      : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
+  // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric
+  // code at all, and 0 is the success value -- defaulting to it would claim
+  // every unreported call exited cleanly, which is a fabricated observation
+  // rather than a missing one.
+  const exit = Number.isInteger(outcome.exit) ? outcome.exit : null;
+
   return record(dir, {
     kind: 'tool-outcome',
     ...outcome,
     anchor,
+    // AFTER the spread, so a caller cannot smuggle raw text past the boundary
+    // by setting the field itself.
+    output,
+    exit,
     injectionId: injection?.injectionId || null,
     findingIds: injection?.findingIds || [],
     joinMethod,

--- a/hooks-core/metrics.mjs
+++ b/hooks-core/metrics.mjs
@@ -661,6 +661,89 @@ export function isFixtureAnchor(anchor) {
  * Fixture anchors are excluded from both.
  */
 /**
+ * Re-reads grouped by anchor -- the one place that decides what "wasteful" means.
+ *
+ * `rereadWaste` needed only the totals, so the grouping lived inside it and the
+ * per-anchor rows were thrown away. `derive.mjs`'s churn detector needs the
+ * rows, and re-deriving them there would put TWO definitions of "a repeat read
+ * of an unchanged file is waste" in the codebase, free to drift apart -- the
+ * exact divergence `npm run sync:hooks` exists to prevent between hooks-core and
+ * its generated copies. So the grouping lives here and both consumers read it.
+ *
+ * A re-read is only a re-read INSIDE ONE SESSION: grouping is keyed on
+ * session + canonical anchor, and rows are then merged per anchor so a file
+ * re-read across three sessions reports as one anchor with the sum of its
+ * repeats rather than three rows the caller has to add up. Merging cannot move
+ * the totals -- a sum of sums -- which is what makes it safe for `rereadWaste`.
+ *
+ * `tokens` is the WASTEFUL token count, not the total: it is the only one of the
+ * three that names something recoverable, and a row whose headline number
+ * included legitimate re-reads would overstate exactly the way the first
+ * version of this measurement did.
+ *
+ * @returns {Array<{anchor: string, repeats: number, wasteful: number,
+ *   tokens: number, legitimate: number, legitimateTokens: number,
+ *   undecidable: number, undecidableTokens: number}>} descending by `wasteful`,
+ *   then by `repeats`.
+ */
+export function rereadsByAnchor(events = [], { includeFixtures = false } = {}) {
+  const groups = new Map();
+  for (const e of events) {
+    if (!e || e.kind !== 'read' || !e.anchor) continue;
+    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
+    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(e);
+  }
+
+  const rows = new Map();
+  for (const list of groups.values()) {
+    if (list.length < 2) continue;
+    list.sort((a, b) => (a.at || 0) - (b.at || 0));
+
+    const anchorKey = canonicalKeyish(list[0].anchor);
+    let row = rows.get(anchorKey);
+    if (!row) {
+      row = {
+        anchor: list[0].anchor,
+        repeats: 0,
+        wasteful: 0,
+        tokens: 0,
+        legitimate: 0,
+        legitimateTokens: 0,
+        undecidable: 0,
+        undecidableTokens: 0,
+      };
+      rows.set(anchorKey, row);
+    }
+
+    for (let i = 1; i < list.length; i++) {
+      const prev = list[i - 1];
+      const cur = list[i];
+      const tokens = cur.tokens || 0;
+      row.repeats += 1;
+      // THE JUDGEMENT, in one place. A repeat read of a file that CHANGED is
+      // correct behaviour, not waste; a read written before fingerprints
+      // existed cannot be judged at all and says so.
+      if (!prev.fp || !cur.fp) {
+        row.undecidable += 1;
+        row.undecidableTokens += tokens;
+      } else if (prev.fp === cur.fp) {
+        row.wasteful += 1;
+        row.tokens += tokens;
+      } else {
+        row.legitimate += 1;
+        row.legitimateTokens += tokens;
+      }
+    }
+  }
+
+  return [...rows.values()].sort(
+    (a, b) => b.wasteful - a.wasteful || b.repeats - a.repeats
+  );
+}
+
+/**
  * Re-read waste, split into what is KNOWN and what is not.
  *
  * The question is narrow on purpose: how often does one session read the same
@@ -675,6 +758,9 @@ export function isFixtureAnchor(anchor) {
  * `undecidable` is reported rather than hidden. Reads written before the
  * fingerprint existed cannot be classified, and a measurement that quietly
  * counted them either way would be inventing its own answer.
+ *
+ * The aggregate fields are UNCHANGED -- `balanceSheet` reads them -- and are now
+ * a fold over `rereadsByAnchor`'s rows. `worst` is purely additive.
  */
 export function rereadWaste(
   dir,
@@ -683,14 +769,7 @@ export function rereadWaste(
   // excludes by design, making the real path untestable.
   { events = readMetrics(dir), includeFixtures = false } = {}
 ) {
-  const groups = new Map();
-  for (const e of events) {
-    if (e.kind !== 'read' || !e.anchor) continue;
-    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
-    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key).push(e);
-  }
+  const rows = rereadsByAnchor(events, { includeFixtures });
 
   const out = {
     repeats: 0,
@@ -702,29 +781,21 @@ export function rereadWaste(
     undecidableTokens: 0,
   };
 
-  for (const list of groups.values()) {
-    if (list.length < 2) continue;
-    list.sort((a, b) => (a.at || 0) - (b.at || 0));
-    for (let i = 1; i < list.length; i++) {
-      const prev = list[i - 1];
-      const cur = list[i];
-      const tokens = cur.tokens || 0;
-      out.repeats += 1;
-      if (!prev.fp || !cur.fp) {
-        out.undecidable += 1;
-        out.undecidableTokens += tokens;
-      } else if (prev.fp === cur.fp) {
-        out.wasteful += 1;
-        out.wastefulTokens += tokens;
-      } else {
-        out.legitimate += 1;
-        out.legitimateTokens += tokens;
-      }
-    }
+  for (const row of rows) {
+    out.repeats += row.repeats;
+    out.wasteful += row.wasteful;
+    out.wastefulTokens += row.tokens;
+    out.legitimate += row.legitimate;
+    out.legitimateTokens += row.legitimateTokens;
+    out.undecidable += row.undecidable;
+    out.undecidableTokens += row.undecidableTokens;
   }
 
   const decided = out.wasteful + out.legitimate;
   out.coverage = out.repeats ? decided / out.repeats : null;
+  // The offenders behind the totals, bounded: a report needs the handful worth
+  // acting on, not one row per file the session touched twice.
+  out.worst = rows.slice(0, 10);
   return out;
 }
 

--- a/hooks-core/metrics.mjs
+++ b/hooks-core/metrics.mjs
@@ -553,6 +553,22 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // FAILURES ONLY, and that is a deliberate override of the original plan.
+  // The plan predates MCP tool names reaching this path, so it never
+  // considered that a SUCCESSFUL `smart_read` would deposit 4 KB of file
+  // content into the evidence log on every call -- the log would grow with
+  // file text and the privacy surface would be every file the session opened.
+  //
+  // Nothing downstream loses anything. A failure claim quotes the error text;
+  // a "this command works" claim needs only the fact that it worked, which
+  // `success` and `exit` already carry. So the stored text narrows to text
+  // that is already an error message.
+  //
+  // GATED ON `success === true`, not on `!== false`: an outcome that never
+  // said whether it worked is unclassified, not successful, and dropping its
+  // text would lose exactly the failures a client too terse to report status
+  // produces.
+  const captureOutput = outcome.success !== true;
   // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
   // text is INJECTED into model context and EXPORTED to markdown, so the
   // boundary is the only place that can guarantee it: a second caller added
@@ -561,7 +577,7 @@ export function recordToolOutcome(dir, outcome) {
   // rather than `''` when nothing was captured, so JSON.stringify omits the
   // key entirely and an absent capture is distinguishable from an empty one.
   const output =
-    outcome.output === undefined || outcome.output === null
+    !captureOutput || outcome.output === undefined || outcome.output === null
       ? undefined
       : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
   // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric

--- a/hooks-core/recall.mjs
+++ b/hooks-core/recall.mjs
@@ -1,0 +1,388 @@
+/**
+ * Does retrieval FIND a finding, or does it only find what it was told where
+ * to look?
+ *
+ * `docs/WIKI_GRAPH.md` says embeddings get added "if measurement shows real
+ * recall loss". Nothing measured recall, so the no-embeddings stance was
+ * unfalsifiable -- a claim with no observation that could contradict it. This
+ * module is the observation.
+ *
+ * ---------------------------------------------------------------------------
+ * THE TAUTOLOGY THIS DELIBERATELY DOES NOT SHIP, AND WHY IT IS RECORDED HERE
+ * ---------------------------------------------------------------------------
+ * The obvious probe -- for each finding, take its anchors and ask whether
+ * `findingsFor` returns it from each -- CANNOT FAIL. `findingsFor(graph, A)`
+ * walks `derived_from` edges backwards into A, and the edge F -> A is the very
+ * thing that makes A an anchor of F. So F is in the result by CONSTRUCTION, not
+ * by retrieval quality, for every graph, forever. Its rate is 1.0 always, and a
+ * permanent 1.0 published as a recall rate reads to a human as "retrieval is
+ * perfect, embeddings unnecessary" -- one unfalsifiable claim swapped for
+ * another, leaning the one direction a measurement of this project by this
+ * project must never lean.
+ *
+ * That check is still worth running -- if it ever fails, traversal is broken
+ * rather than merely lossy -- so it is kept, and reported as `integrity` with
+ * its own `what` string saying it is not a recall rate. It is NEVER `rate`.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT IS MEASURED INSTEAD: LEAVE-ONE-EDGE-OUT
+ * ---------------------------------------------------------------------------
+ * For each active finding F and each anchor A of F, delete the edge F -> A and
+ * ask whether touching A would STILL surface F. Two independent arms, both of
+ * which can genuinely miss, which is what makes this a measurement:
+ *
+ *   Arm A -- TRAVERSAL FROM THE NEIGHBOURHOOD. Run the real `findingsFor` over
+ *   the edge-deleted graph from A itself and from A's `contains` parents. This
+ *   hits only when F has some OTHER structural route in: a second anchor on the
+ *   same file, or an anchor on a sibling symbol under the same parent. A's
+ *   `contains` children need no separate call because `findingsFor` expands
+ *   them itself -- calling the parent therefore covers every sibling, which is
+ *   why the neighbour list is `[A, ...parents(A)]` and not a hop-counted
+ *   frontier. The REAL primitive is used rather than an equivalent inlined
+ *   here, because a probe that reimplements the thing it measures drifts from
+ *   it and then measures itself.
+ *
+ *   Arm B -- BM25 FROM THE ANCHOR'S OWN KEY. Rank the whole active corpus with
+ *   `lexical.rank`, querying with A's key -- the file path or symbol name the
+ *   user actually touched -- and hit if F comes back inside `limit`.
+ *
+ * WHY ARM B IS NOT QUERIED WITH THE FINDING'S OWN CLAIM. The plan's literal
+ * form was "the finding's claim terms against the rest of the corpus", and both
+ * readings of it are degenerate. Querying F's claim against a corpus that
+ * INCLUDES F is the tautology again: BM25 scores a document against its own
+ * text, so F wins its own query every time. Querying F's claim against a corpus
+ * that EXCLUDES F cannot return F at all, so a "hit" would mean some DIFFERENT
+ * finding matched -- that is redundancy of storage, not recall of F, and it
+ * would score a graph better for holding duplicates. The anchor's key is the
+ * one query text that is available offline, is not derived from F, and matches
+ * the production question: a session touches a file, and the only lexical
+ * handle on it is its own path. It misses exactly when a finding's claim never
+ * names the code it is about, which is the recall gap embeddings are supposed
+ * to close.
+ *
+ * ---------------------------------------------------------------------------
+ * REFUSALS -- four, and each costs this project its own good news
+ * ---------------------------------------------------------------------------
+ *  1. TOO FEW OBSERVATIONS -> `rate: null` with a reason. See `MIN_PROBED`.
+ *  2. A CORPUS NO LARGER THAN THE RETRIEVAL LIMIT -> `rate: null`. Arm B is
+ *     recall@`limit`, and below the limit NO FINDING IS EVER CUT FOR BUDGET:
+ *     every document scoring above zero is returned, so the arm measures
+ *     whether a token matched, which is a strictly weaker bar than the one
+ *     production applies when `forTouch` fills a token budget from a ranked
+ *     list. A probe more permissive than the system it measures can only
+ *     overstate recall, so the rate is withheld in that band and the counts are
+ *     published instead. It bites between `MIN_PROBED` and `limit` findings --
+ *     on this machine's project graph, whose one finding had both anchor edges
+ *     "recovered" that way, the observation-count refusal fires first.
+ *  3. NO ANCHOR NODE -> the pair is UNPROBEABLE, not a miss. Reported and
+ *     excluded from the denominator; see `probeEdge`.
+ *  4. STRICT AGGREGATION -> a finding counts as retrieved only if EVERY one of
+ *     its probeable anchor edges is recoverable. A finding reachable from one
+ *     anchor and lost from another is a miss, with the losing anchor named.
+ *     This biases the rate DOWN, which is the safe direction here.
+ *
+ * FAILS OPEN. It runs on a report path; a graph it cannot read must cost a
+ * section, not the report.
+ */
+
+import { load, findingsFor } from './wiki.mjs';
+import { rank } from './lexical.mjs';
+
+/**
+ * Distinct findings that must be probeable before a RATE is published at all.
+ *
+ * NOT AN EFFECT-SIZE CONVENTION -- it is a resolution argument. A proportion
+ * over n observations has a resolution of 1/n, so below ten findings the
+ * published figure moves in steps coarser than ten percentage points, and the
+ * two extremes a small graph actually produces (`1.0` and `0.0`) are the two a
+ * reader is most likely to mistake for a finding about retrieval. At n = 10 and
+ * zero misses the exact binomial 95% upper bound on the true miss rate is still
+ * 1 - 0.05^(1/10) = 0.26, so even a clean sweep here bounds recall loss only
+ * below about a quarter -- which is why the refusal reason says what the number
+ * would and would not have supported rather than just naming the floor.
+ *
+ * THE FLOOR IS ON DISTINCT FINDINGS, NOT ANCHOR EDGES. Two anchors of one
+ * finding are two edges of the same claim, not two independent observations;
+ * counting them would let a single multi-anchored finding unlock a rate.
+ */
+export const MIN_PROBED = 10;
+
+/**
+ * The most findings probed in one call.
+ *
+ * Each probed anchor edge costs a graph-sized edge filter plus one or two real
+ * `findingsFor` walks plus one BM25 pass over the corpus, and this runs on the
+ * on-demand report path. The cap is deterministic (findings sorted by key) and
+ * `truncated` says when it bit, so a large graph gets a smaller, honestly
+ * labelled sample rather than a slow report.
+ */
+export const MAX_FINDINGS = 200;
+
+/** Active findings only. A retired claim is withdrawn; recalling it is not a win. */
+function activeFindings(graph) {
+  return [...graph.nodes.values()]
+    .filter((node) => node && node.kind === 'finding' && !node.retired)
+    .sort((a, b) => String(a.key || '').localeCompare(String(b.key || '')));
+}
+
+/** The `contains` parents of every node, indexed once for the whole probe. */
+function parentIndex(graph) {
+  const parents = new Map();
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contains') continue;
+    const list = parents.get(edge.to);
+    if (list) list.push(edge.from);
+    else parents.set(edge.to, [edge.from]);
+  }
+  return parents;
+}
+
+/** The anchors of one finding: the targets of its own `derived_from` edges. */
+function anchorsOf(graph, findingId) {
+  const out = new Set();
+  for (const edge of graph.edges) {
+    if (edge.edge === 'derived_from' && edge.from === findingId) out.add(edge.to);
+  }
+  return [...out];
+}
+
+/**
+ * The graph minus exactly one anchor edge.
+ *
+ * `nodes` is shared rather than copied: nothing here mutates it, and a
+ * 2,600-node Map copied once per anchor edge is the difference between a probe
+ * and a stall.
+ */
+function withoutAnchorEdge(graph, findingId, anchorId) {
+  return {
+    nodes: graph.nodes,
+    edges: graph.edges.filter(
+      (edge) =>
+        !(
+          edge.edge === 'derived_from' &&
+          edge.from === findingId &&
+          edge.to === anchorId
+        )
+    ),
+  };
+}
+
+/**
+ * One anchor edge, hidden, then asked after. Returns `recovered` with the arm
+ * that found it, or a reason -- and `probeable: false` when the question could
+ * not be put at all.
+ */
+function probeEdge(graph, parents, finding, anchorId, corpus, limit) {
+  const hidden = withoutAnchorEdge(graph, finding.id, anchorId);
+
+  // Arm A. `findingsFor` expands `contains` children itself, so the parent call
+  // covers every sibling of the anchor.
+  const neighbours = [anchorId, ...(parents.get(anchorId) || [])];
+  for (const neighbour of neighbours) {
+    const got = findingsFor(hidden, neighbour, { limit });
+    if (got.some((node) => node.id === finding.id)) {
+      return { recovered: true, arm: 'traversal', anchorId };
+    }
+  }
+
+  // Arm B needs a query, and the query is the anchor's own key. A dangling
+  // anchor edge -- an edge whose target node was never indexed, which
+  // `expand.promote` produces -- leaves nothing to query with. That is a
+  // question that could not be asked, NOT an observed miss: scoring it a miss
+  // would manufacture a recall loss out of a graph-integrity defect.
+  const anchor = graph.nodes.get(anchorId);
+  const key = anchor && typeof anchor.key === 'string' ? anchor.key : '';
+  if (!key) {
+    return {
+      recovered: false,
+      probeable: false,
+      anchorId,
+      reason: `anchor ${anchorId} has no node in the graph, so there is no anchor key to query BM25 with`,
+    };
+  }
+
+  const hits = rank(key, corpus, { limit });
+  if (hits.some((hit) => hit.finding && hit.finding.id === finding.id)) {
+    return { recovered: true, arm: 'lexical', anchorId };
+  }
+
+  return {
+    recovered: false,
+    probeable: true,
+    anchorId,
+    reason: `no neighbouring anchor reaches it and BM25 over ${key} does not rank it in the top ${limit}`,
+  };
+}
+
+/**
+ * The probe. An OFFLINE measurement over the graph as it stands -- it reads,
+ * ranks and traverses, and writes nothing.
+ */
+export function recallProbe(
+  dir,
+  {
+    limit = 20,
+    graph = null,
+    minProbed = MIN_PROBED,
+    maxFindings = MAX_FINDINGS,
+  } = {}
+) {
+  const refuse = (reason) => ({
+    basis: 'offline probe over the current graph',
+    probed: 0,
+    retrieved: 0,
+    rate: null,
+    reason,
+    misses: [],
+    unprobeable: [],
+  });
+
+  let g;
+  try {
+    g = graph || load(dir);
+  } catch {
+    return refuse('the graph could not be read, so recall was not measured.');
+  }
+
+  try {
+    const all = activeFindings(g);
+    const truncated = all.length > maxFindings;
+    const findings = truncated ? all.slice(0, maxFindings) : all;
+    const parents = parentIndex(g);
+    // The corpus BM25 ranks over is the ACTIVE graph, uncapped: the sample is
+    // which findings are probed, not what they compete against. Every reported
+    // figure below reads `corpus.length` rather than `all.length`, so the
+    // published size IS the ranking corpus rather than a parallel claim about
+    // it. The distinction is not pedantry: a mutation that shrank the ranking
+    // corpus to the probed sample -- making retrieval easier, in this project's
+    // favour -- SURVIVED the first mutation run precisely because the reported
+    // number came from the other variable and could not move.
+    const corpus = all;
+
+    const misses = [];
+    const unprobeable = [];
+    const integrityFailures = [];
+    let probed = 0;
+    let retrieved = 0;
+    let integrityOk = 0;
+    let probedEdges = 0;
+    let recoveredEdges = 0;
+    const byArm = { traversal: 0, lexical: 0 };
+
+    for (const finding of findings) {
+      const anchors = anchorsOf(g, finding.id);
+
+      // INTEGRITY, run on the UNTOUCHED graph: the by-construction check. Its
+      // only honest use is as a smoke test, and it is reported as one.
+      if (!anchors.length) {
+        integrityFailures.push({
+          key: finding.key,
+          reason:
+            'active finding with no anchor -- writeHarvested refuses to create one',
+        });
+      } else if (
+        anchors.every((anchorId) =>
+          findingsFor(g, anchorId, { limit }).some((node) => node.id === finding.id)
+        )
+      ) {
+        integrityOk += 1;
+      } else {
+        integrityFailures.push({
+          key: finding.key,
+          reason: `not returned by findingsFor from one of its own anchors at limit ${limit}`,
+        });
+      }
+
+      // An unanchored finding is a definite miss, not an unaskable question:
+      // nothing traverses to it and there is no anchor key to query from, so
+      // the anchor-driven path that serves findings on a file touch can never
+      // surface it. Only an explicit wiki_query naming its own terms would.
+      if (!anchors.length) {
+        probed += 1;
+        misses.push({
+          key: finding.key,
+          reason:
+            'no anchor: nothing traverses to it and there is no anchor key to query with, so only an explicit wiki_query of its own terms would surface it',
+        });
+        continue;
+      }
+
+      const results = anchors.map((anchorId) =>
+        probeEdge(g, parents, finding, anchorId, corpus, limit)
+      );
+      const askable = results.filter((result) => result.probeable !== false);
+      probedEdges += askable.length;
+      recoveredEdges += askable.filter((result) => result.recovered).length;
+      for (const result of askable) {
+        if (result.recovered) byArm[result.arm] += 1;
+      }
+
+      if (!askable.length) {
+        unprobeable.push({ key: finding.key, reason: results[0].reason });
+        continue;
+      }
+
+      probed += 1;
+      const lost = askable.filter((result) => !result.recovered);
+      if (!lost.length) retrieved += 1;
+      else misses.push({ key: finding.key, reason: lost[0].reason });
+    }
+
+    const integrity = {
+      what:
+        'BY CONSTRUCTION: a finding is returned by findingsFor from its own anchor because that edge is what makes it an anchor. Expected 1 for every graph. NOT a recall rate.',
+      probed: findings.length,
+      retrieved: integrityOk,
+      rate: findings.length ? integrityOk / findings.length : null,
+      ok: integrityFailures.length === 0,
+      failures: integrityFailures,
+    };
+
+    // Arm B is recall@`limit`. Over a corpus of at most `limit` findings nothing
+    // is ever cut for budget, so the arm asks only whether a token matched --
+    // weaker than the bar production applies under a token budget, and a probe
+    // more permissive than the system it measures can only overstate recall.
+    const discriminating = corpus.length > limit;
+
+    const common = {
+      basis: 'offline probe over the current graph',
+      probed,
+      retrieved,
+      misses,
+      unprobeable,
+      probedEdges,
+      recoveredEdges,
+      byArm,
+      corpus: corpus.length,
+      discriminating,
+      truncated,
+      minProbed,
+      integrity,
+    };
+
+    if (probed < minProbed) {
+      return {
+        ...common,
+        rate: null,
+        reason:
+          probed === 0
+            ? `no probeable finding: ${unprobeable.length} of ${findings.length} active finding(s) have no anchor node to query from, so recall was not measured. No rate is reported, which is not the same as a rate of zero.`
+            : `${probed} probeable finding(s), below the floor of ${minProbed}: a proportion over ${probed} has a resolution of ${Math.round(
+                100 / probed
+              )} percentage points, so no rate is published. ${retrieved} of ${probed} were recovered without their own anchor edge, which is a count and not a rate.`,
+      };
+    }
+
+    if (!discriminating) {
+      return {
+        ...common,
+        rate: null,
+        reason: `the active corpus holds ${corpus.length} finding(s) and the retrieval limit is ${limit}, so nothing is ever cut for budget and the lexical arm asks only whether a token matched -- a weaker bar than production applies. No rate is published off a probe more permissive than the system it measures; ${retrieved} of ${probed} were recovered, which is a count and not a rate.`,
+      };
+    }
+
+    return { ...common, rate: retrieved / probed, reason: null };
+  } catch {
+    return refuse('the probe failed, so recall was not measured.');
+  }
+}

--- a/hooks-core/redact.mjs
+++ b/hooks-core/redact.mjs
@@ -22,7 +22,21 @@ const PATTERNS = [
 ];
 
 export function redact(text, { max = 400 } = {}) {
+  // `?? ''` matters even though String(null)/String(undefined) never throw:
+  // without it a missing value becomes the literal 4-11 character string
+  // "null"/"undefined" -- a garbage claim that silently reaches the graph
+  // and model context instead of surfacing as an error.
   let out = String(text ?? '');
   for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  // Redact BEFORE truncating, never the reverse. Several patterns above rely
+  // on a minimum-length quantifier (e.g. `{10,}`, `{12,}`) plus a prefix.
+  // Truncating first can cut a match down to fewer characters than that
+  // quantifier requires, so the shortened fragment no longer satisfies the
+  // pattern and a live partial secret would pass through in cleartext. By
+  // redacting the full, untruncated string first, every pattern always sees
+  // the complete secret and removes it before any character budget is
+  // spent; the cap below can then only ever cut into already-redacted text
+  // (a label, or the "[redacted]" placeholder itself), never into raw
+  // secret bytes.
   return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
 }

--- a/hooks-core/redact.mjs
+++ b/hooks-core/redact.mjs
@@ -1,0 +1,28 @@
+// hooks-core/redact.mjs
+/**
+ * Redaction for anything derived from captured output.
+ *
+ * WHY THIS IS MANDATORY RATHER THAN PRUDENT. derive.mjs builds claims out of
+ * command stderr. A claim is INJECTED into model context and EXPORTED to
+ * markdown, so a secret that reaches a claim reaches two more places than the
+ * terminal it came from. Pattern matching is imperfect and that is stated in the
+ * spec, but "imperfect" beats "absent" by a wide margin here.
+ */
+
+const PATTERNS = [
+  // Bearer / API-key shaped tokens.
+  [/\b(bearer\s+)[A-Za-z0-9._~+/-]{12,}/gi, '$1[redacted]'],
+  [/\b(sk|pk|ghp|gho|github_pat|xox[baprs])[-_][A-Za-z0-9._-]{10,}/gi, '[redacted]'],
+  // KEY=value where the key name suggests a secret.
+  [/\b([A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|APIKEY|API_KEY|PRIVATE_KEY|CREDENTIAL)[A-Z0-9_]*)\s*[=:]\s*\S+/g, '$1=[redacted]'],
+  // Credentials inside a URL.
+  [/\b([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+):[^\s@]+@/gi, '$1:[redacted]@'],
+  // PEM blocks.
+  [/-----BEGIN[^-]*PRIVATE KEY-----[\s\S]*?-----END[^-]*PRIVATE KEY-----/g, '[redacted key]'],
+];
+
+export function redact(text, { max = 400 } = {}) {
+  let out = String(text ?? '');
+  for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
+}

--- a/hooks-core/transcript.mjs
+++ b/hooks-core/transcript.mjs
@@ -17,9 +17,11 @@
  */
 
 import {
-  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, unlinkSync,
+  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync,
+  unlinkSync, openSync, readSync, closeSync,
 } from 'node:fs';
 import { join } from 'node:path';
+import { redact } from './redact.mjs';
 
 /** Where a project's transcripts live, under the graph it belongs to. */
 export const transcriptDir = (dir) => join(dir, 'transcripts');
@@ -208,4 +210,204 @@ export function readArchive(dir, sessionId) {
   } catch {
     return [];
   }
+}
+
+/**
+ * How much of a transcript's TAIL is scanned for failed tool results.
+ *
+ * A transcript is the largest file this project reads: the three real ones on
+ * the measuring machine are 5.8 MB, 22 MB and 45 MB. `archive()` above already
+ * reads the whole thing once at Stop, so an unbounded second pass doubles the
+ * most expensive read on the session-end path for evidence that is, by
+ * construction, mostly old. The tail is the right half to keep for the same
+ * reason `buildFeedbackDigest` keeps the end: what a session learned is
+ * concentrated where the work went wrong, which is later rather than sooner.
+ */
+const FAILED_SCAN_BYTES = () =>
+  Number(process.env.TOKEN_OPTIMIZER_TRANSCRIPT_SCAN_BYTES) || 8 * 1024 * 1024;
+
+/** Failed results kept, most recent first. The pairing detector needs a handful. */
+const FAILED_MAX = 50;
+
+/** Same 4 KB cap `recordToolOutcome` applies to `output`, for the same reason. */
+const FAILED_OUTPUT_MAX = 4096;
+
+/**
+ * The same 120-character truncation `recordToolOutcome` applies to `anchor`.
+ *
+ * ONE COMMAND MUST PRODUCE ONE KEY FROM EITHER SOURCE. A `tool-outcome` stores
+ * the command as `String(tool_input.command).slice(0, 120)`, and `attemptKey`
+ * reads up to three non-flag tokens off whatever it is handed. A long first
+ * token -- a quoted grep pattern, an absolute Windows path, a heredoc -- is cut
+ * by that cap INSIDE those three tokens, so the untruncated transcript copy of
+ * the same command lands in a DIFFERENT group. Measured against one real
+ * session's own evidence: 266 commands present in both sources, and truncating
+ * here made 266 of 266 keys agree where the untruncated text agreed on only
+ * 240.
+ *
+ * WHAT THAT ACTUALLY BUYS, stated precisely rather than generously. `derive`
+ * refuses to build a claim out of a command at or over the cap at all (see
+ * `quotable` there), so agreement on a TRUNCATED key never produces a finding
+ * on its own. It buys two things that still matter: a transcript failure lands
+ * in the same run as the event outcomes of the same command, so the
+ * nearest-preceding-failure rule sees the real sequence rather than a sparse
+ * one; and the no-call-id fallback in `derive`'s deduplication compares command
+ * TEXT against an already-truncated anchor, which cannot match unless this side
+ * is truncated identically.
+ */
+const ANCHOR_MAX = 120;
+
+/**
+ * A tool result that reports a command that RAN and exited non-zero.
+ *
+ * A POSITIVE ALLOWLIST, and the measurement is why. Claude Code sets
+ * `is_error: true` on every kind of unhappy tool result, and across three real
+ * transcripts 214 of them fell into four shapes:
+ *
+ *   83  `Exit code N` + stderr    -- a command ran and failed. THIS ONE.
+ *   109 hook and policy denials   -- overwhelmingly THIS optimizer's own
+ *                                    PreToolUse text ("Recursive shell searches
+ *                                    return unbounded output. Call the
+ *                                    token-optimizer MCP tool smart_grep
+ *                                    instead"), plus `Remove-Item on system
+ *                                    path` blocks.
+ *   18  `<tool_use_error>...`     -- protocol errors: `String to replace not
+ *                                    found`, `File has not been read yet`,
+ *                                    `Blocked: ...`.
+ *   4   a person declined the call.
+ *
+ * Only the first shape is a command failing. In every other shape THE COMMAND
+ * NEVER RAN, so "`X` failed with: ..." would be a false claim about X, and a
+ * later success would pair with a failure that never happened. The 109 are the
+ * dangerous ones: ingesting them would have this tool derive findings from its
+ * own advice, at 0.9 confidence, and serve them back as observations about the
+ * project -- a self-referential loop that also inflates its own finding count.
+ * That is the measurement-bias class this plan tracks, and a denylist would
+ * have let every future denial string through by default.
+ */
+const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
+
+/** Reads at most `bytes` from the END of a file, without loading the rest. */
+function readTail(path, bytes) {
+  let fd;
+  try {
+    const size = statSync(path).size;
+    const length = Math.min(size, bytes);
+    if (!length) return '';
+    fd = openSync(path, 'r');
+    const buffer = Buffer.allocUnsafe(length);
+    readSync(fd, buffer, 0, length, size - length);
+    const text = buffer.toString('utf8');
+    // A tail almost never starts on a line boundary, and half a JSON object is
+    // not a parse failure worth reporting -- it is a partial record. Drop it.
+    return length < size ? text.slice(text.indexOf('\n') + 1) : text;
+  } catch {
+    return '';
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+}
+
+/**
+ * The failed COMMAND results a transcript holds, which no hook event carries.
+ *
+ * WHY THIS READER EXISTS. Claude Code never fires PostToolUse for a failed tool
+ * call: a deliberately failing command produced no event at all, and 2,238 of
+ * 2,238 live `tool-outcome` events on the measuring machine carry
+ * `success: true`. So `derive.mjs`'s two strongest detectors -- command
+ * failed-then-succeeded at 0.90 and test/build red-to-green at 0.85 -- have no
+ * input whatsoever on the primary client, while working normally on the ten
+ * adapter clients. The failures exist; they exist only here.
+ *
+ * WHY NOT THE ARCHIVE, which the plan for this reader assumed. `readTurns`
+ * DROPS tool results by design -- that is where whole file contents would enter
+ * the record -- so `readArchive` returns no failure, ever, and an extractor over
+ * archived turns would find nothing however well it was written. Making the
+ * archive carry them would also push command stderr into `buildFeedbackDigest`,
+ * which is the one code path in this project that sends anything to a model
+ * endpoint. So this reads the transcript and STORES NOTHING NEW: read-only, no
+ * capture path, no new event kind, and no widening of what leaves the machine.
+ *
+ * REDACTED HERE, at this boundary, exactly as `recordToolOutcome` redacts
+ * `output`. Transcript text has never passed a redaction boundary -- that one
+ * never saw it -- and everything returned from here is destined for a claim that
+ * is injected into model context and exported to markdown.
+ *
+ * @returns {Array<{command: string, output: string, exit: number|null,
+ *   at: number, toolCallId: string|null}>} in transcript order, so a caller can
+ *   sort it beside `tool-outcome` events without re-ordering.
+ */
+export function failedResultsFromTranscript(transcriptPath, options = {}) {
+  const { max = FAILED_MAX, scanBytes = FAILED_SCAN_BYTES() } = options || {};
+  if (!transcriptPath) return [];
+  const text = readTail(transcriptPath, scanBytes);
+  if (!text) return [];
+
+  // tool_use_id -> the command that was attempted. The join is EXACT and it is
+  // the only one available: the result block carries no command of its own, and
+  // the id is the same string `episodeMeta` reads into `toolCallId`, so the same
+  // key also deduplicates against events on clients that do report failures.
+  const commands = new Map();
+  const failures = [];
+
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const message = entry.message || entry;
+    const role = message.role || entry.type;
+    const content = message.content;
+    if (!Array.isArray(content)) continue;
+
+    if (role === 'assistant') {
+      for (const block of content) {
+        if (!block || block.type !== 'tool_use' || !block.id) continue;
+        const command = block.input?.command;
+        if (typeof command !== 'string' || !command.trim()) continue;
+        commands.set(String(block.id), command.slice(0, ANCHOR_MAX));
+      }
+      continue;
+    }
+
+    if (role !== 'user') continue;
+    for (const block of content) {
+      if (!block || block.type !== 'tool_result' || block.is_error !== true) continue;
+      // Only a STRING result can be an exit-code report; every failed Claude
+      // Code result observed was one, and a structured body is a shape this
+      // classifier has not measured, so it is refused rather than guessed at.
+      if (typeof block.content !== 'string') continue;
+      const match = EXIT_CODE_RESULT.exec(block.content);
+      if (!match) continue;
+      const command = commands.get(String(block.tool_use_id || ''));
+      // No command means no claim. The result says something failed; without
+      // the text of what failed there is nothing to say about it, and nothing
+      // to group it with.
+      if (!command) continue;
+      failures.push({
+        command,
+        // The exit line itself is stripped: `exit` carries it structurally, and
+        // leaving it in makes every failure claim read "failed with: Exit code 1".
+        output: redact(block.content.slice(match[0].length).trim(), {
+          max: FAILED_OUTPUT_MAX,
+        }),
+        exit: Number(match[1]),
+        at: Date.parse(entry.timestamp || '') || 0,
+        toolCallId: block.tool_use_id ? String(block.tool_use_id) : null,
+      });
+    }
+  }
+
+  // The MOST RECENT `max`, keeping chronological order. A session that failed
+  // two hundred times teaches its last lessons, not its first.
+  return failures.slice(-max);
 }

--- a/hooks-core/usage.mjs
+++ b/hooks-core/usage.mjs
@@ -40,7 +40,7 @@
  * was referenced" and "nothing could be measured" are different answers and
  * this module gives different answers for them.
  */
-import { readMetrics } from './metrics.mjs';
+import { readMetrics, readTruncation } from './metrics.mjs';
 
 /**
  * The events that name a finding, and it is ONE kind, not the two the plan
@@ -127,17 +127,30 @@ export function classify(dir, { events = null } = {}) {
   try {
     const all = inTimeOrder(events || readMetrics(dir));
 
-    // Every reference, keyed on the finding it names. Only references carrying
-    // a session id are usable -- see `unscopedReferences` in `referenceRate`
-    // for the ones this drops and why they are counted rather than credited.
+    // Every reference, keyed on the finding it names and on nothing else.
+    //
+    // NOT SCOPED BY SESSION, and that is a deliberate reversal. Scoping needs
+    // the query's `sessionId`, which `wiki_query` takes as an OPTIONAL input
+    // the model has to volunteer (`options.sessionId ?? null`) -- so the
+    // numerator depended on the model choosing to identify itself, and an
+    // unverifiable model-supplied id is not evidence. Plan 1 settled that for
+    // the `answers` edge and it settles it here: stop depending on the field
+    // rather than hope for cooperation. The finding key is the specific part
+    // anyway; a key is a graph identity, not a guess.
+    //
+    // THE COST, disclosed here and in `referenceNote` because a reader of the
+    // number has to see it: TWO CONCURRENT SESSIONS ON ONE REPOSITORY CAN
+    // CROSS-ATTRIBUTE. Session A's injection of K plus session B's later query
+    // for K reads as a reference. Nothing in the log can separate them once the
+    // session id is gone, so the exposure is real and is stated rather than
+    // priced.
     const references = new Map();
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       const key = referencedKey(event);
-      const session = sessionOf(event);
-      if (!key || !session) continue;
+      if (!key) continue;
       if (!references.has(key)) references.set(key, []);
-      references.get(key).push({ at: event.at || 0, session });
+      references.get(key).push(event.at || 0);
     }
 
     // Which injections the existing outcome join could attribute. An outcome
@@ -168,9 +181,8 @@ export function classify(dir, { events = null } = {}) {
       const injectionId = event.injectionId ? String(event.injectionId) : null;
       const at = event.at || 0;
       const session = sessionOf(event);
-      // STRICTLY AFTER. A query that PRECEDED the injection is the model
-      // asking on its own initiative; crediting it would let the metric take
-      // the credit for a lookup it had nothing to do with.
+      // STRICTLY AFTER here too: activity that predates the injection is not
+      // an opportunity to have used it.
       const followed = (times) => times.some((t) => t > at);
       const continued =
         (injectionId && attributed.has(injectionId)) ||
@@ -179,9 +191,11 @@ export function classify(dir, { events = null } = {}) {
       for (const raw of keys) {
         const findingKey = String(raw);
         const hits = references.get(findingKey) || [];
-        const referenced = session
-          ? hits.some((hit) => hit.session === session && hit.at > at)
-          : false;
+        // TIME ORDER IS THE ONLY REMAINING GUARD, so it carries the whole
+        // weight of the attribution: a query that PRECEDED the injection is
+        // the model asking on its own initiative, and crediting it would let
+        // the metric take the credit for a lookup it had nothing to do with.
+        const referenced = hits.some((hitAt) => hitAt > at);
         rows.push({
           findingKey,
           injectionId,
@@ -202,9 +216,27 @@ export function classify(dir, { events = null } = {}) {
 /**
  * The rate, with everything needed to tell a real 0 from an absent one.
  *
- * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
- * `unattributable` and `unscopedReferences` are reported beside it, never
- * inside it.
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown` and
+ * `unattributable` are reported beside it, never inside it.
+ *
+ * `windowed` SAYS WHETHER THE DENOMINATOR CAN UNDERSTATE, and it is not
+ * decoration. `readMetrics` reads a 2 MB / 5,000-event TAIL of the firehose,
+ * and injections are rare enough on a real project to age out of it: measured
+ * on this repository, both `inject` events sit at lines 502 and 883 of 6,871
+ * and have scrolled away behind ~6,000 later `read` and `tool-outcome` rows,
+ * so the windowed denominator is 0 where the whole-file truth is 1.
+ *
+ * IT IS REPORTED RATHER THAN FIXED, deliberately. `inject` already gets
+ * unwindowed access through `BALANCE_KINDS` / `EVIDENCE_KINDS`, but `query`
+ * does not -- and reading only the INJECTION arm unwindowed would be worse
+ * than the windowing: every old injection would enter the denominator with no
+ * chance of a matching query in the window and score `not-referenced`,
+ * manufacturing a pessimistic rate out of the asymmetry. Making the query arm
+ * unwindowed means adding `query` to `EVIDENCE_KINDS`, which two other
+ * consumers read, and this project's own standard says a shared-classifier
+ * change needs a per-consumer verdict comparison. So the honest move is to
+ * publish the flag: a caller that needs the unwindowed truth passes its own
+ * `events`, which is exactly what the live measurement in the task report did.
  */
 export function referenceRate(dir, { events = null } = {}) {
   const empty = {
@@ -216,10 +248,15 @@ export function referenceRate(dir, { events = null } = {}) {
     unattributable: 0,
     unattributableWithInjectedToolCall: 0,
     referenceEvents: 0,
-    unscopedReferences: 0,
+    windowed: false,
   };
   try {
     const all = events || readMetrics(dir);
+    // OUT OF BAND, and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` reports on the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
     const rows = classify(dir, { events: all });
     const count = (label) => rows.filter((row) => row.label === label).length;
     const referenced = count('referenced');
@@ -229,17 +266,17 @@ export function referenceRate(dir, { events = null } = {}) {
     // Usable reference events in the window: the numerator's producer. If this
     // is zero the channel never fired, and a 0% rate would be measuring the
     // absence of a producer rather than the uselessness of findings.
+    //
+    // NO SESSION REQUIREMENT, matching the attribution above. The former
+    // `unscopedReferences` counted queries dropped for want of a session id;
+    // nothing is dropped for that reason any more, so the field is GONE rather
+    // than kept at a permanent zero that a later reader would misread as
+    // evidence the loss had been fixed.
     let referenceEvents = 0;
-    let unscopedReferences = 0;
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       if (!referencedKey(event)) continue;
-      if (sessionOf(event)) referenceEvents += 1;
-      // Names a finding but cannot be scoped to one injection. `sessionId` is
-      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
-      // is the expected loss rather than an edge case -- counted here so it is
-      // visible instead of silently deflating the numerator.
-      else unscopedReferences += 1;
+      referenceEvents += 1;
     }
 
     // The tool calls that DID receive findings, keyed the way
@@ -290,7 +327,7 @@ export function referenceRate(dir, { events = null } = {}) {
       unattributable,
       unattributableWithInjectedToolCall,
       referenceEvents,
-      unscopedReferences,
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
     };
   } catch {
     return empty;
@@ -298,11 +335,18 @@ export function referenceRate(dir, { events = null } = {}) {
 }
 
 /**
- * One line for the audit, or nothing at all.
+ * One or two lines for the audit, or nothing at all.
  *
  * Says which of the three things is true -- a measured rate, a live channel
  * with no opportunities yet, or no channel at all -- rather than printing a
  * figure and letting the reader assume the first.
+ *
+ * AND IT CARRIES THE CAVEATS, because this is the only place a human meets the
+ * number. A rate attributed on (finding key, time order) can cross-attribute
+ * between two concurrent sessions on one repository, and a windowed read can
+ * understate the denominator. Both are stated beside the figure they qualify.
+ * Putting them only in a task report would be publishing a clean number and
+ * filing the asterisk somewhere nobody quoting it will look.
  */
 export function referenceNote(dir, { events = null } = {}) {
   const r = referenceRate(dir, { events });
@@ -315,6 +359,11 @@ export function referenceNote(dir, { events = null } = {}) {
   }
   return (
     `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
-    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded. ` +
+    'Matched on finding key and time order, so concurrent sessions on this ' +
+    'repository can cross-attribute' +
+    (r.windowed
+      ? '; and the event log was truncated, so the denominator can understate.'
+      : '.')
   );
 }

--- a/hooks-core/usage.mjs
+++ b/hooks-core/usage.mjs
@@ -1,0 +1,320 @@
+/**
+ * LAYER 1 -- did the model actually go back and use what we injected?
+ *
+ * The cheap behavioural label. One question, answered from the event log alone:
+ * after we put a finding in front of the model, did the model later ASK FOR
+ * THAT FINDING BY NAME?
+ *
+ * WHY EXPLICIT REFERENCE, AND NOT READ-SUPPRESSION. Read-suppression -- "the
+ * file was not re-read, so the finding must have helped" -- is Layer 2's
+ * estimand, measured causally by withholding a finding and comparing. Layer 1
+ * exists to be calibrated AGAINST that. If both layers derived from
+ * suppression, the calibration would compare two spellings of one quantity,
+ * report a strong correlation, and mean nothing. So Layer 1 is deliberately
+ * built on a signal Layer 2 does not touch: an explicit `query` naming the
+ * finding key.
+ *
+ * WHAT THIS DOES NOT DO. It does not invent a join. `recordToolOutcome`
+ * already joins each post-tool result back to the injection that preceded it,
+ * recording `injectionId`, `findingIds` and a `joinMethod` of `tool-call-id`,
+ * `episode-anchor` or `none` -- preferring an exact tool-call id, which is
+ * strictly better evidence than the `(sessionId, findingKey)` approximation an
+ * earlier draft of this plan proposed. This module consumes that join and adds
+ * none of its own. `inject.mjs` needed no change: it has written `findingIds`
+ * at every call site all along.
+ *
+ * WHAT `unknown` IS FOR, and it is the whole reason this file is careful. An
+ * injection whose session simply stopped afterwards is not a miss. Nothing
+ * happened, so nothing can be concluded, and counting it against the finding
+ * would make the metric read worse the more often sessions end -- a number
+ * that moves with session length rather than with usefulness. `unknown` is
+ * therefore EXCLUDED from the denominator rather than scored zero, and
+ * outcomes the join could not attribute at all are reported as
+ * `unattributable` rather than folded into either arm.
+ *
+ * AND WHY THE RATE CAN BE `null`. This project has already shipped two metrics
+ * whose only producer was their own test suite. A rate of 0% that actually
+ * means "no data" is worse than a refusal, because it is a number and numbers
+ * get quoted. So `rate` is null unless there is a denominator AND the
+ * reference channel produced at least one usable event in the window. "Nothing
+ * was referenced" and "nothing could be measured" are different answers and
+ * this module gives different answers for them.
+ */
+import { readMetrics } from './metrics.mjs';
+
+/**
+ * The events that name a finding, and it is ONE kind, not the two the plan
+ * assumed.
+ *
+ * The brief said "a later `query` or `expand` event". Checked against the code
+ * and against every metrics log on this machine, `expand` does not qualify and
+ * cannot be made to:
+ *
+ *   - `recordExpansion` writes `{ ref, tool, shape, asked, sessionId }`. `ref`
+ *     is a TRUNCATION CAPTURE id (a 16-hex digest of captured tool output),
+ *     not a finding key, and `asked` is free text naming a section of that
+ *     output. Neither is a graph key, and no code path ever puts one there.
+ *   - measured: 64 live `expand` events exist on this machine and all 64 carry
+ *     `sessionId: null`, so they could not be scoped to an injection even if
+ *     they did name one.
+ *
+ * Keying the classifier on `expand` would therefore have added a branch that
+ * can never fire -- a metric with no producer, which is the exact defect this
+ * whole effort exists to close. So it is excluded, deliberately and with the
+ * measurement recorded, rather than included for symmetry with the brief.
+ */
+const REFERENCE_KINDS = new Set(['query']);
+
+/**
+ * What counts as the session having CONTINUED past the injection.
+ *
+ * The distinction between `not-referenced` and `unknown` rests entirely on
+ * this, so the set is explicit rather than "any later event". These are the
+ * kinds a tool call produces: if one of them follows the injection in the same
+ * session, the model had the opportunity to ask and did not. If none does, the
+ * session ended and there was no opportunity.
+ *
+ * `inject` is in the set because a later injection means a later tool call
+ * happened. `forecast`, `mcp-client` and `mcp-tool` are NOT: they are written
+ * by session bookkeeping rather than by the model doing something, and
+ * treating them as opportunity would convert `unknown` rows into misses on
+ * bookkeeping alone.
+ */
+const ACTIVITY_KINDS = new Set([
+  'tool-outcome',
+  'read',
+  'query',
+  'expand',
+  'substitute',
+  'inject',
+]);
+
+/** A usable session id: a non-empty string. `null == null` is not a match. */
+const sessionOf = (event) => {
+  const id = event?.sessionId;
+  return typeof id === 'string' && id ? id : null;
+};
+
+/** The finding key a reference event names, or null if it names none. */
+const referencedKey = (event) => {
+  const key = event?.key;
+  return typeof key === 'string' && key ? key : null;
+};
+
+/** Ordering by the caller's timestamp, with log order breaking ties. */
+function inTimeOrder(events) {
+  return events
+    .map((event, index) => ({ event, index }))
+    .sort(
+      (a, b) =>
+        (a.event.at || 0) - (b.event.at || 0) || a.index - b.index
+    )
+    .map((row) => row.event);
+}
+
+/**
+ * One row per (injection, finding) pair, labelled.
+ *
+ * Per injection rather than per finding: the same finding injected twice is two
+ * separate opportunities, and collapsing them would let one reference excuse
+ * every later injection of that key.
+ *
+ * FAILS OPEN. A malformed log yields an empty classification, never a throw:
+ * this runs on report paths that must not break a tool call.
+ */
+export function classify(dir, { events = null } = {}) {
+  let rows = [];
+  try {
+    const all = inTimeOrder(events || readMetrics(dir));
+
+    // Every reference, keyed on the finding it names. Only references carrying
+    // a session id are usable -- see `unscopedReferences` in `referenceRate`
+    // for the ones this drops and why they are counted rather than credited.
+    const references = new Map();
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      const key = referencedKey(event);
+      const session = sessionOf(event);
+      if (!key || !session) continue;
+      if (!references.has(key)) references.set(key, []);
+      references.get(key).push({ at: event.at || 0, session });
+    }
+
+    // Which injections the existing outcome join could attribute. An outcome
+    // carrying our injectionId is proof the tool call completed, which is
+    // opportunity even when the session id is missing from the log.
+    const attributed = new Set();
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) continue;
+      attributed.add(String(event.injectionId));
+    }
+
+    // Activity per session, so "did anything follow?" is one lookup rather
+    // than a scan per injection.
+    const activity = new Map();
+    for (const event of all) {
+      if (!ACTIVITY_KINDS.has(event.kind)) continue;
+      const session = sessionOf(event);
+      if (!session) continue;
+      if (!activity.has(session)) activity.set(session, []);
+      activity.get(session).push(event.at || 0);
+    }
+
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+      if (!keys.length) continue;
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const at = event.at || 0;
+      const session = sessionOf(event);
+      // STRICTLY AFTER. A query that PRECEDED the injection is the model
+      // asking on its own initiative; crediting it would let the metric take
+      // the credit for a lookup it had nothing to do with.
+      const followed = (times) => times.some((t) => t > at);
+      const continued =
+        (injectionId && attributed.has(injectionId)) ||
+        (session ? followed(activity.get(session) || []) : false);
+
+      for (const raw of keys) {
+        const findingKey = String(raw);
+        const hits = references.get(findingKey) || [];
+        const referenced = session
+          ? hits.some((hit) => hit.session === session && hit.at > at)
+          : false;
+        rows.push({
+          findingKey,
+          injectionId,
+          label: referenced
+            ? 'referenced'
+            : continued
+              ? 'not-referenced'
+              : 'unknown',
+        });
+      }
+    }
+  } catch {
+    rows = [];
+  }
+  return rows;
+}
+
+/**
+ * The rate, with everything needed to tell a real 0 from an absent one.
+ *
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
+ * `unattributable` and `unscopedReferences` are reported beside it, never
+ * inside it.
+ */
+export function referenceRate(dir, { events = null } = {}) {
+  const empty = {
+    referenced: 0,
+    notReferenced: 0,
+    unknown: 0,
+    denominator: 0,
+    rate: null,
+    unattributable: 0,
+    unattributableWithInjectedToolCall: 0,
+    referenceEvents: 0,
+    unscopedReferences: 0,
+  };
+  try {
+    const all = events || readMetrics(dir);
+    const rows = classify(dir, { events: all });
+    const count = (label) => rows.filter((row) => row.label === label).length;
+    const referenced = count('referenced');
+    const notReferenced = count('not-referenced');
+    const denominator = referenced + notReferenced;
+
+    // Usable reference events in the window: the numerator's producer. If this
+    // is zero the channel never fired, and a 0% rate would be measuring the
+    // absence of a producer rather than the uselessness of findings.
+    let referenceEvents = 0;
+    let unscopedReferences = 0;
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      if (!referencedKey(event)) continue;
+      if (sessionOf(event)) referenceEvents += 1;
+      // Names a finding but cannot be scoped to one injection. `sessionId` is
+      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
+      // is the expected loss rather than an edge case -- counted here so it is
+      // visible instead of silently deflating the numerator.
+      else unscopedReferences += 1;
+    }
+
+    // The tool calls that DID receive findings, keyed the way
+    // `recordToolOutcome` keys its own primary join: the tool-call id. An
+    // unattributable outcome for one of these is a join that FAILED. An
+    // unattributable outcome for any other tool call had nothing to join to.
+    //
+    // KEYED ON THE TOOL CALL, NOT THE EPISODE, and the first draft of this
+    // got it wrong in a way worth recording because it is the exact
+    // measurement-bias class this plan hunts. `episodeId` equals the SESSION
+    // id, so "unattributable outcomes in an episode that had an injection"
+    // scored all 2,559 tool calls of a session in which ONE injection
+    // happened. It would have published 2,559 join failures where the true
+    // number is zero -- correct code, lying number, and biased pessimistic
+    // rather than flattering, which is no better.
+    const injectedToolCalls = new Set();
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      if (!Array.isArray(event.findingIds) || !event.findingIds.length)
+        continue;
+      if (event.toolCallId) injectedToolCalls.add(String(event.toolCallId));
+    }
+    let unattributable = 0;
+    let unattributableWithInjectedToolCall = 0;
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome' || event.joinMethod !== 'none')
+        continue;
+      unattributable += 1;
+      // BOTH FIGURES, because the raw one alone lies in the pessimistic
+      // direction. Measured on this machine: 2,991 of 2,992 live outcomes
+      // report `joinMethod: 'none'`, and every one of them because NO
+      // INJECTION EXISTED for that tool call -- the graph holds one finding.
+      // Quoting only the raw count would read as a join that fails 99.97% of
+      // the time, which is a different and false claim.
+      if (event.toolCallId && injectedToolCalls.has(String(event.toolCallId)))
+        unattributableWithInjectedToolCall += 1;
+    }
+
+    return {
+      referenced,
+      notReferenced,
+      unknown: count('unknown'),
+      denominator,
+      rate:
+        denominator > 0 && referenceEvents > 0
+          ? referenced / denominator
+          : null,
+      unattributable,
+      unattributableWithInjectedToolCall,
+      referenceEvents,
+      unscopedReferences,
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/**
+ * One line for the audit, or nothing at all.
+ *
+ * Says which of the three things is true -- a measured rate, a live channel
+ * with no opportunities yet, or no channel at all -- rather than printing a
+ * figure and letting the reader assume the first.
+ */
+export function referenceNote(dir, { events = null } = {}) {
+  const r = referenceRate(dir, { events });
+  if (!r.denominator && !r.unknown && !r.referenceEvents) return null;
+  if (r.rate == null) {
+    const why = !r.referenceEvents
+      ? 'no finding was ever queried by key in this window'
+      : `no injection had a chance to be referenced yet (${r.unknown} unknown)`;
+    return `Injected findings referenced later: not measurable -- ${why}.`;
+  }
+  return (
+    `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+  );
+}

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -103,6 +103,44 @@ const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
 
 /**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because FOUR readers depend on it -- mutation accounting,
+ * success classification, output capture and exit-code capture -- and clients
+ * disagree on the envelope name and on nothing else. Letting each reader name
+ * its own subset is exactly how both classifiers came to miss MCP's failure
+ * flag: `toolSucceeded` listed four envelopes and `mutationSucceeded` listed
+ * three, and neither list mentioned `isError` at all.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/**
+ * Did an MCP result declare itself an error?
+ *
+ * `isError` is the ONLY failure signal an MCP result carries -- there is no
+ * `error` field and no `status` -- and `src/server/index.ts` sets it in seven
+ * places. Shared by both classifiers so they cannot disagree about what a
+ * failed call from this project's own tools looks like.
+ *
+ * `=== true` EXACTLY. A client using the key for anything else must not have
+ * its successful calls silently reclassified, and `isError: false` is a
+ * successful MCP call, not a missing verdict.
+ */
+function reportedMcpError(raw) {
+  return [...responseEnvelopes(raw), raw].some(
+    (envelope) => envelope?.isError === true
+  );
+}
+
+/**
  * A post-tool event is not universally proof of success. Some clients split
  * success and failure into distinct events; others expose a result status.
  * Keep mutation accounting conservative so a failed edit cannot arm Stop.
@@ -112,6 +150,19 @@ export function mutationSucceeded(clientName, raw) {
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
     return false;
+  // BEFORE the status read, the explicit-success read AND the client
+  // allowlist, because all three would otherwise pass a failed MCP write. The
+  // allowlist is the one that actually bit: it returns true for claude-code,
+  // codex, qwen, opencode, kilo and windsurf on any post-tool event with no
+  // error and no status, which is precisely the shape of a failed smart_write.
+  //
+  // WHY THIS IS THE SAME BUG AS THE ONE IN `toolSucceeded` AND NOT A COSMETIC
+  // ECHO OF IT: this function gates edit counting and harvest pressure, so
+  // counting a failed write to THE OPTIMIZER'S OWN TOOLS as a mutation
+  // inflates "the optimizer successfully edited a file". Different consumers
+  // from the effectiveness figures, same direction of bias -- toward
+  // flattering the thing being measured.
+  if (reportedMcpError(raw)) return false;
 
   const status =
     raw?.tool_response?.status ??
@@ -145,24 +196,6 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * Spelled out ONCE because three readers depend on it -- success
- * classification, output capture and exit-code capture -- and clients disagree
- * on the envelope name and on nothing else. Letting each reader name its own
- * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
-}
-
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
@@ -181,8 +214,7 @@ export function toolSucceeded(raw) {
   // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
   // optimizer's favour. A measurement that flatters the thing being measured
   // is worse than no measurement.
-  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
-    return false;
+  if (reportedMcpError(raw)) return false;
   const status =
     raw?.tool_response?.status ??
     raw?.toolResponse?.status ??

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -957,10 +957,12 @@ async function runHook(clientName, event, invocation) {
       // accumulates structure and no verdicts at all. These detectors read only
       // what is already on disk and send nothing anywhere.
       //
-      // The COUNT is recorded rather than the candidates: how many findings a
-      // session's own evidence supports is the number that says whether this is
-      // working, and it is measurable before anything is stored. Storage is the
-      // caller's next step, under a budget.
+      // COUNTS are recorded rather than the candidates, and BOTH counts: how
+      // many findings a session's own evidence supports, and how many of them
+      // survived the storage budget and the anchor discipline. The gap between
+      // the two is the number that says whether the bound is doing anything --
+      // one figure alone cannot distinguish "nothing to derive" from "derived
+      // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
       const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
       const dir = wikiDir(projectRoot);
@@ -976,6 +978,7 @@ async function runHook(clientName, event, invocation) {
         sessionId,
         candidates: derived.candidates.length,
         observations: derived.observations.length,
+        written: derived.written.length,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -172,6 +172,136 @@ export function toolSucceeded(raw) {
   return true;
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * The same family `toolSucceeded` reads above, hoisted so the three readers
+ * cannot drift apart. Clients disagree on the envelope name and on nothing
+ * else, so this is the one place that disagreement is spelled out.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/** A non-empty string, or null.  Blank output is the same as none. */
+function nonEmpty(value) {
+  const text = String(value ?? '');
+  return text.trim() ? text : null;
+}
+
+/**
+ * The human-readable result text inside one envelope, or null.
+ *
+ * RETURNS NULL RATHER THAN GUESSING. An envelope shape nobody here has seen
+ * produces no capture at all, which costs one finding. Stringifying it instead
+ * would put `[object Object]` or a wall of JSON metadata into a claim that gets
+ * injected into model context -- a wrong observation, which is strictly worse
+ * than a missing one.
+ */
+function resultText(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'string') return nonEmpty(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return null;
+
+  // MCP content blocks, which is how THIS PROJECT'S OWN tools now arrive:
+  // `normalizeTool` resolves `mcp__<server>__smart_edit`, so smart_edit and
+  // smart_write reach the post-tool path for the first time and their results
+  // are `{ content: [{ type: 'text', text }], isError }` rather than a shell
+  // result. Both the bare array and the wrapping object are accepted because
+  // hosts differ on whether they hand the hook the result or its content.
+  if (Array.isArray(value)) {
+    const blocks = value
+      .map((block) =>
+        typeof block === 'string' ? block : nonEmpty(block?.text)
+      )
+      .filter(Boolean);
+    return blocks.length ? nonEmpty(blocks.join('\n')) : null;
+  }
+  if (typeof value !== 'object') return null;
+
+  // STDERR FIRST, and not because that is the order it was produced in. The
+  // cap can only ever cut the tail, and the diagnostic that explains a failure
+  // is almost always on stderr while the volume is almost always on stdout --
+  // so appending stderr would let a 3 MB build log push the one line worth
+  // capturing out of the window.
+  const streams = [nonEmpty(value.stderr), nonEmpty(value.stdout)].filter(
+    Boolean
+  );
+  if (streams.length) return streams.join('\n');
+
+  if (Array.isArray(value.content)) {
+    const inner = resultText(value.content);
+    if (inner) return inner;
+  }
+
+  const error = value.error;
+  if (error) {
+    const message =
+      typeof error === 'string' ? error : nonEmpty(error.message ?? error.msg);
+    if (message) return message;
+  }
+
+  return (
+    nonEmpty(value.output) ??
+    nonEmpty(value.text) ??
+    nonEmpty(value.message) ??
+    (typeof value.result === 'string' ? nonEmpty(value.result) : null)
+  );
+}
+
+/**
+ * The result text of a completed tool call, or null when the client reports
+ * none.  Redaction and the size cap are NOT applied here -- they belong at the
+ * `recordToolOutcome` boundary, which is the only place every caller passes.
+ */
+export function outputFrom(raw) {
+  for (const envelope of responseEnvelopes(raw)) {
+    const text = resultText(envelope);
+    if (text) return text;
+  }
+  return resultText(raw?.output) ?? resultText(raw?.stdout) ?? null;
+}
+
+/**
+ * Key names that mean "process exit code" and nothing else.
+ *
+ * `code` is deliberately ABSENT. JSON-RPC errors (`code: -32602`), Node errno
+ * objects (`code: 'ENOENT'`) and HTTP wrappers all reuse that name, so reading
+ * it would record a confident exit code for calls that never had one. A null
+ * here is honest; a -32602 claiming to be an exit status is not.
+ */
+const EXIT_KEYS = [
+  'exit_code',
+  'exitCode',
+  'exit',
+  'exit_status',
+  'exitStatus',
+  'return_code',
+  'returncode',
+];
+
+/** The numeric exit code a client reported, or null when it reported none. */
+export function exitFrom(raw) {
+  for (const envelope of [...responseEnvelopes(raw), raw]) {
+    if (!envelope || typeof envelope !== 'object') continue;
+    for (const key of EXIT_KEYS) {
+      const value = envelope[key];
+      if (Number.isInteger(value)) return value;
+      // A client that serializes the code as a digit string still reported it.
+      // Bounded so a hash or an id cannot be mistaken for a status.
+      if (typeof value === 'string' && /^-?\d{1,5}$/.test(value.trim()))
+        return Number(value.trim());
+    }
+  }
+  return null;
+}
+
 function contextOutput(client, eventName, additionalContext) {
   if (client.contextStyle === 'top-level') return { additionalContext };
   if (client.contextStyle === 'cline') {
@@ -890,6 +1020,11 @@ async function runHook(clientName, event, invocation) {
         anchor,
         toolName: payload.tool_name,
         success: toolSucceeded(raw),
+        // The two fields a boolean cannot carry: which KIND of failure this
+        // was. Read through the same normalisers as `success`, never off `raw`
+        // at this call site.
+        output: outputFrom(raw),
+        exit: exitFrom(raw),
         durationMs:
           Number(
             raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -145,11 +145,43 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because three readers depend on it -- success
+ * classification, output capture and exit-code capture -- and clients disagree
+ * on the envelope name and on nothing else. Letting each reader name its own
+ * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
+    return false;
+  // MCP'S OWN FAILURE FLAG, which this function did not read for as long as it
+  // existed. It did not matter while `normalizeTool` dropped MCP names before
+  // any accounting ran; it matters now that `mcp__<server>__smart_edit` and
+  // `smart_write` reach the post-tool path, because an MCP result carries no
+  // `error` field and no `status` -- only `isError` -- so a failed smart_edit
+  // fell through to the optimistic `return true` below.
+  //
+  // WHY THIS IS A MEASUREMENT BUG AND NOT A COSMETIC ONE: this boolean feeds
+  // episode outcomes and effectiveness accounting, so recording every failed
+  // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
+  // optimizer's favour. A measurement that flatters the thing being measured
+  // is worse than no measurement.
+  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
     return false;
   const status =
     raw?.tool_response?.status ??
@@ -170,23 +202,6 @@ export function toolSucceeded(raw) {
   // that its output proved the task.  `success` here is deliberately scoped to
   // the tool call; task correctness comes only from an eval grader.
   return true;
-}
-
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * The same family `toolSucceeded` reads above, hoisted so the three readers
- * cannot drift apart. Clients disagree on the envelope name and on nothing
- * else, so this is the one place that disagreement is spelled out.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
 }
 
 /** A non-empty string, or null.  Blank output is the same as none. */

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -58,6 +58,7 @@ import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { briefing } from './remedy.mjs';
 import { stableText, transcriptFor } from './cache.mjs';
+import { scoreRefreshes } from './keepwarm.mjs';
 import { cachedRoutingBriefing } from './routing.mjs';
 import {
   forCommand,
@@ -1010,6 +1011,26 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE KEEP-WARM FEEDBACK ARM, at the boundary where a turn has just
+      // ended -- which is the only place the arrival question can be answered.
+      // Every refresh whose TTL has since elapsed is scored here as used or
+      // unused; anything the log cannot settle is left unscored rather than
+      // recorded as a miss, because an absent signal is not a miss.
+      //
+      // Nothing in this repository issues a refresh today -- cache_audit only
+      // recommends one -- so this scores nothing, and what it costs while
+      // dormant is one readBalance: median 70 ms on this machine's 3.5 MB log,
+      // against derive's 71-111 ms a few lines below on the same path. The
+      // firehose is read for ARRIVALS only if an unscored refresh exists, so
+      // the dormant case never pays for that. The moment an issuer exists, the
+      // decision starts learning with no second wiring change.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      scoreRefreshes(dir);
+    } catch {
+      // A refresh that cannot be scored costs a measurement, not a session.
     }
     try {
       // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -40,11 +40,13 @@ import {
   touchedFiles,
 } from './decide.mjs';
 import {
+  record,
   recordRead,
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
 } from './metrics.mjs';
+import { derive } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -948,6 +950,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // ZERO-COST DERIVATION, on every client, with no credential. The semantic
+      // harvest below needs an API key, so on a machine without one the graph
+      // accumulates structure and no verdicts at all. These detectors read only
+      // what is already on disk and send nothing anywhere.
+      //
+      // The COUNT is recorded rather than the candidates: how many findings a
+      // session's own evidence supports is the number that says whether this is
+      // working, and it is measurable before anything is stored. Storage is the
+      // caller's next step, under a budget.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      const dir = wikiDir(projectRoot);
+      const derived = derive(dir, {
+        sessionId,
+        projectRoot,
+        transcriptPath: agentScope,
+        // The hook payload's own identity, not a value a model typed.
+        authoritativeSessionId: sessionId,
+      });
+      record(dir, {
+        kind: 'derive',
+        sessionId,
+        candidates: derived.candidates.length,
+        observations: derived.observations.length,
+      });
+    } catch {
+      // A detector failing must never cost a user the end of their session.
     }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -72,7 +72,8 @@ import {
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
-import { isArchived } from './transcript.mjs';
+import { archive, isArchived } from './transcript.mjs';
+import { harvestMode } from './harvest.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
@@ -577,6 +578,65 @@ function emit(object) {
   process.stdout.write(serialized);
 }
 
+/**
+ * What will and will not extract findings after this session, in one sentence.
+ *
+ * THE STATE WAS ONLY EVER LEGIBLE FROM THE DOCTOR, and the doctor is a place
+ * someone visits after they already suspect something is wrong. A user watching
+ * a graph fill with structural nodes and no verdicts has no reason to suspect
+ * anything, which is the failure this project has now measured twice.
+ *
+ * IT IS ADDRESSED TO THE MODEL, NOT ONLY TO THE READER, which is why it earns a
+ * place in the prefix rather than a systemMessage. "Nothing else will write this
+ * down in words" changes what the model does with a conclusion it is holding;
+ * "here is a configuration variable" would not.
+ *
+ * CACHE-SAFE: derived from configuration, so it differs between sessions only
+ * when the configuration does -- the same standard the rest of this block is
+ * held to, and it carries no digits for `stableText` to reject.
+ *
+ * A local endpoint is named FIRST in the off case on purpose. It is the option
+ * that costs nothing and sends nothing, and it was the one buried deepest.
+ */
+function extractionNotice() {
+  switch (harvestMode()) {
+    case 'local':
+      return (
+        '\n\nA local model endpoint is configured, so semantic extraction also runs after this ' +
+        'session -- free and private, with nothing leaving this machine.'
+      );
+    case 'remote':
+      return (
+        '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
+        'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
+    case 'off:mode':
+      // The whole optimizer is off and this text is not emitted anyway. Saying
+      // anything here would be noise stacked on an explicit choice.
+      return '';
+    case 'off:opted-out':
+      // A DELIBERATE CHOICE, SO NO PITCH. The consequence is stated because the
+      // model needs it; the setting that would reverse it is not, because
+      // arguing with a configured decision on every session is how a notice
+      // stops being read. doctor.mjs draws the same line for the same reason.
+      return (
+        '\n\nFallback extraction is off by configuration, so a conclusion you do not record is ' +
+        'not written down in words anywhere. Findings are still derived locally from exit codes, ' +
+        'red-to-green transitions and corrections.'
+      );
+    default:
+      // off:no-key, and any mode a future harvest adds: no extractor is running
+      // and nobody chose that, so the free option is worth naming.
+      return (
+        '\n\nNo separate extractor will run after this session, so a conclusion you do not record ' +
+        'is not written down in words anywhere. Findings are still derived locally from exit ' +
+        'codes, red-to-green transitions and corrections. Pointing ' +
+        'TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model adds semantic extraction, free and ' +
+        'private.'
+      );
+  }
+}
+
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
 export function policyText(
   canDeny,
@@ -635,7 +695,7 @@ export function policyText(
     .filter(Boolean)
     .join(' ');
   const recording = tools.has('wiki_write')
-    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.`
+    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.${extractionNotice()}`
     : '\n\nStructural graph capture remains active through lifecycle hooks. Durable semantic MCP writes are not requested because the writer schema is not proven available.';
 
   return `# Token optimization is active\n\nLive graph capture is active through the lifecycle adapter.\n\n${connection}${routing}${enforcement}${utilities ? `\n\n${utilities}` : ''}${recording}${projectBriefing()}`;
@@ -950,6 +1010,27 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.
+      //
+      // This was lost rather than retired. `plugin/hooks/stop-harvest.mjs` called
+      // `archive()` at Stop, and #300 replaced that entry in `hooks.json` with the
+      // generated `stop.mjs`, which routes here -- so on Claude Code no session has
+      // been archived since. Nothing failed loudly: `readArchive` simply returns an
+      // empty list, so `derive`'s correction detector fell through to the live
+      // transcript (present only for a client that reports one) and `lessons.mjs`
+      // lost the only corpus it can verify a verbatim quote against, which is the
+      // single test that grants a feedback finding human origin.
+      //
+      // BEFORE `derive`, deliberately: the correction detector reads the archive
+      // first and treats the live transcript as the fallback, and the archive is
+      // the copy that survives into later sessions.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      if (agentScope) archive(dir, agentScope, { sessionId });
+    } catch {
+      // The archive is a record, not a result. A session still ends.
     }
     try {
       // ZERO-COST DERIVATION, on every client, with no credential. The semantic

--- a/integrations/cline/hooks/token-optimizer/lib/audit.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/audit.mjs
@@ -32,6 +32,7 @@
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
+import { looNote } from './loo.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -401,6 +402,16 @@ export function renderAudit(
   // project with no injections and no queries gains no line at all.
   const reference = referenceNote(dir);
   if (reference) body.push('', reference);
+
+  // WHAT ONE FINDING IS CAUSALLY WORTH (Layer 2).
+  //
+  // The same reasoning as above, and the same refusal: `looNote` returns null
+  // until the leave-one-out experiment has collected an observation, and says
+  // NOT MEASURABLE YET rather than printing a mean until it clears the floor.
+  // A causal number is the most quotable thing this project can produce, so it
+  // is the one that most needs to be absent when it is not earned.
+  const causal = looNote(dir);
+  if (causal) body.push('', causal);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/cline/hooks/token-optimizer/lib/audit.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
 import { looNote } from './loo.mjs';
+import { calibrationNote } from './crosslayer.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -244,9 +245,15 @@ export function renderAudit(
     lines.push(text);
   }
 
+  // SCOPED TO THE QUEUE, because that is all it ever described. The bare
+  // sentence "Nothing addressable found." was printed directly above a Layer 1
+  // reference note and a published Layer 2 causal verdict -- so a reader was
+  // told nothing had been found immediately before being shown a finding. The
+  // headline is about the remediation queue and nothing else, and saying so
+  // costs four words and removes a false negative shown to a human.
   const head = shown.length
     ? ['What to do next, most expensive first:', ...lines]
-    : ['Nothing addressable found.'];
+    : ['Nothing addressable found in the remediation queue.'];
 
   const body = [...head];
 
@@ -412,6 +419,16 @@ export function renderAudit(
   // is the one that most needs to be absent when it is not earned.
   const causal = looNote(dir);
   if (causal) body.push('', causal);
+
+  // WHETHER LAYER 1'S CHEAP LABEL PREDICTS LAYER 2'S EXPENSIVE EFFECT.
+  //
+  // The reason this is printed rather than kept for a dashboard: the reference
+  // rate is the number a reader is most likely to quote as a saving, and it is
+  // not one until this comparison says so. `calibrationNote` returns null while
+  // both layers are silent, and otherwise prints the refusal -- naming which
+  // input was insufficient -- rather than a gap of zero.
+  const calibrated = calibrationNote(dir);
+  if (calibrated) body.push('', calibrated);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/cline/hooks/token-optimizer/lib/audit.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/audit.mjs
@@ -61,6 +61,28 @@ export function declines(dir, { events = readMetrics(dir) } = {}) {
   return counts;
 }
 
+/**
+ * What the local Stop-time derivation path produced in the visible event log.
+ *
+ * The producer records all three counts because any one of them alone is
+ * ambiguous: zero stored can mean no evidence, no candidates, or a binding
+ * storage/anchor filter. This reader keeps those states distinct and prevents
+ * the telemetry itself from becoming an unobserved cost.
+ */
+export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
+  const runs = events.filter((event) => event.kind === 'derive');
+  if (!runs.length) return null;
+
+  const sum = (field) =>
+    runs.reduce((total, event) => total + Math.max(0, Number(event[field]) || 0), 0);
+  const candidates = sum('candidates');
+  const observations = sum('observations');
+  const written = sum('written');
+  return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
+    `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
+    `across ${runs.length.toLocaleString()} Stop run(s).`;
+}
+
 const idOf = (finding) =>
   finding.remedy
     ? `${finding.remedy.type}:${finding.remedy.anchor || finding.remedy.file || (finding.remedy.anchors || []).join(',')}`
@@ -399,6 +421,15 @@ export function renderAudit(
       );
     }
   }
+
+  // WHAT THE DEFAULT, LOCAL DERIVATION PATH ACTUALLY PRODUCED.
+  //
+  // This event used to have a producer and no reader. Keep its three states
+  // together: evidence seen, candidates derived, and findings that survived
+  // selection/storage. A lone stored count would turn every earlier refusal
+  // into an apparent "nothing found" result.
+  const derived = derivationNote(dir);
+  if (derived) body.push('', derived);
 
   // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
   //

--- a/integrations/cline/hooks/token-optimizer/lib/audit.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/audit.mjs
@@ -31,6 +31,7 @@
  */
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
+import { referenceNote } from './usage.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -390,6 +391,16 @@ export function renderAudit(
       );
     }
   }
+
+  // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
+  //
+  // Printed here because this is the report that already asks "did the advice
+  // change anything", and because a measurement with no reader is how this
+  // project shipped two metrics whose only consumer was their own test suite.
+  // `referenceNote` returns null when it has nothing honest to say, so a
+  // project with no injections and no queries gains no line at all.
+  const reference = referenceNote(dir);
+  if (reference) body.push('', reference);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/cline/hooks/token-optimizer/lib/consolidate.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/consolidate.mjs
@@ -142,7 +142,8 @@ const ALWAYS_KEEP = new Set(['failure', 'decision']);
  * Chooses what to promote into the graph, under a token budget.
  *
  * @param {object} graph      Loaded wiki graph, for reuse probability.
- * @param {Array}  candidates Extracted conclusions, each { type, summary, anchors, evidence, at }.
+ * @param {Array}  candidates Extracted conclusions, each { type, claim (or summary),
+ *                              anchors, evidence, at }.
  * @param {object} options    budget: tokens available for promoted findings.
  */
 export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}) {
@@ -221,4 +222,3 @@ export function aggregateConsolidation(findings) {
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
-

--- a/integrations/cline/hooks/token-optimizer/lib/crosslayer.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/crosslayer.mjs
@@ -1,0 +1,351 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/crosslayer.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The calibration loop: does Layer 1's LABEL predict Layer 2's EFFECT?
+ *
+ * Layer 1 (`usage.mjs`) classifies an injected finding by whether the model
+ * later NAMED it. Layer 2 (`loo.mjs`) measures, by leave-one-out, how many
+ * tokens of reading a finding actually SUPPRESSED. Those are two different
+ * quantities, and the whole point of putting them side by side is that the
+ * cheap one (a label, available on every injection) might stand in for the
+ * expensive one (a causal effect, costing three withheld sessions per finding).
+ *
+ * WHY THIS IS A REAL QUESTION AND NOT A TAUTOLOGY. Task 7 established the
+ * independence three ways -- statically (`loo.mjs` contains no `query` or
+ * `reference`; `usage.mjs` contains no `tokens`, `cost` or `bytes`),
+ * behaviourally in both directions, and by naming the one overlap that does
+ * exist (`recordToolOutcome`'s join, which supplies ATTRIBUTABILITY to both and
+ * the measured quantity to neither). This module is built to preserve that:
+ *
+ *   - from Layer 1 it takes ONLY the categorical label per finding key. No
+ *     rate, no count, no magnitude -- Layer 1 has no magnitude to give.
+ *   - from Layer 2 it takes ONLY the effect magnitude per finding key.
+ *   - the join is the finding key, which is a graph identity and not a
+ *     measurement.
+ *
+ * If a magnitude common to both ever entered, this would correlate a quantity
+ * with itself and report a strong result that means nothing. Two tests pin the
+ * separation from opposite sides: flipping the labels while holding the effects
+ * fixed must move the gap, and changing Layer 1's rate WITHOUT changing any
+ * label must leave the gap byte-identical.
+ *
+ * MEASURED UTILITY RANKS A FINDING. IT MUST NEVER RAISE ITS CONFIDENCE.
+ * A confidently WRONG finding suppresses reads better than a hedged true one,
+ * so utility alone optimises directly against "wrong findings are worse than
+ * none". The plan called for a `mayPromote` gate over
+ * `hasOutstandingContradiction` here. There is nothing to gate: every write of
+ * `confidence` in `hooks-core` happens at CREATION (a per-producer constant in
+ * `derive.mjs` / `lessons.mjs` / `harvest.mjs`, or a human's own number in
+ * `curate.mjs`), and no code path updates a stored finding's confidence
+ * afterwards. `assessFindings` in `utility.mjs` READS confidence into an
+ * ephemeral `netUtility` used for ordering and writes nothing back. So a gate
+ * here would be unreachable, and an unreachable gate is the exact defect class
+ * this work exists to close. `hasOutstandingContradiction` already has its
+ * real consumer -- `staleness.mjs` calls it as the dispute gate on serve.
+ * What is enforceable is the invariant itself, and it is: this module never
+ * writes to the graph, and `tests/hooks/calibration-loop.test.mjs` asserts that
+ * neither it nor either layer under it can move a stored confidence.
+ *
+ * NOTHING HERE IS PRICED. A calibration verdict, a holdout estimate and a
+ * consolidation ratio are all estimates; currency belongs only on a measured
+ * counterfactual, and `balanceSheet`'s `measuredCounterfactual` is the one
+ * section in the sheet below that qualifies.
+ */
+
+import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
+import { classify, referenceRate } from './usage.mjs';
+import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Distinct findings needed in EACH arm before a gap is reported at all.
+ *
+ * Two findings per arm is a difference of two numbers; the comparison would be
+ * dominated by whichever finding happened to sit on a big file. Three is still
+ * small, and the refusal says so rather than implying the gap is solid.
+ */
+export const MIN_FINDINGS_PER_ARM = 3;
+
+/**
+ * The smallest gap that may be PUBLISHED, in tokens per touch.
+ *
+ * Not an effect-size convention: it is tied to the unit the verdict prints. The
+ * published sentence rounds the gap to whole tokens, so a gap of 1e-13 -- which
+ * is what two arms of equal means produce once floating point has had its say --
+ * would publish as "referenced findings suppress 0 more tokens/touch". That is a
+ * calibration claim resting on arithmetic noise, and it leans the only direction
+ * a measurement of this project by this project must never lean.
+ */
+export const MIN_GAP_TOKENS = 1;
+
+/**
+ * The per-finding Layer 1 label, folded from per-injection rows.
+ *
+ * ANY reference wins. `classify` emits one row per (injection, finding) because
+ * one reference must not excuse every later injection -- that is the right unit
+ * for a RATE. For a label the question is different: did the model ever name
+ * this finding? A finding referenced once and ignored nine times is a finding
+ * the model reads, and averaging it into `not-referenced` would put it in the
+ * arm whose mean effect it is meant to predict.
+ *
+ * `unknown` rows are dropped rather than defaulted, exactly as Layer 1 drops
+ * them from its own denominator.
+ */
+export function labelsByFinding(rows) {
+  const labels = new Map();
+  for (const row of rows || []) {
+    const key = row?.findingKey;
+    if (typeof key !== 'string' || !key) continue;
+    if (row.label === 'referenced') labels.set(key, 'referenced');
+    else if (row.label === 'not-referenced' && !labels.has(key))
+      labels.set(key, 'not-referenced');
+  }
+  return labels;
+}
+
+const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * Does Layer 1's label predict Layer 2's effect?
+ *
+ * Returns `publishable`, a `verdict` in English, and `gap` ONLY when a gap was
+ * actually computed. There is no `gap: 0` for the unmeasured case, and that is
+ * deliberate: a permanent zero reads as "measured, and the two agree", which is
+ * the opposite of "nothing was measured". Task 7 deleted a field rather than
+ * zero it for the same reason.
+ *
+ * FAILS OPEN. This runs on report paths that must not break a tool call.
+ */
+export function calibration(dir, options = {}) {
+  const refuse = (verdict, extra = {}) => ({
+    publishable: false,
+    verdict,
+    ...extra,
+  });
+
+  try {
+    // ONE READ for both layers, so the two arms of the comparison cannot cover
+    // different spans of the log. `referenceRate` reports `windowed: false`
+    // when the caller supplies events -- correctly, since the bounds are then
+    // the caller's -- so the truncation flag is taken here, from the read that
+    // actually set it, and republished.
+    const supplied = options.events || null;
+    const events = supplied || readMetrics(dir);
+    const truncation = supplied ? null : readTruncation();
+    const truncated = Boolean(
+      truncation && (truncation.byBytes || truncation.byEvents)
+    );
+
+    const layer1 = referenceRate(dir, { events });
+    const labels = labelsByFinding(classify(dir, { events }));
+
+    const obs = observations(dir, { ...options, events });
+    const rows = effects(dir, { ...options, events, obs });
+
+    // ONE POLICY VERSION. Layer 2 refuses to pool arms across serving
+    // policies; a calibration that pooled them would undo that guard one level
+    // up. Rows from any other policy are excluded and counted.
+    const policy = servingPolicyVersion();
+    const inPolicy = rows.filter((row) => row.policy === policy);
+
+    const layer2 = {
+      rows: rows.length,
+      inPolicy: inPolicy.length,
+      published: rows.filter((row) => row.published).length,
+      observations: obs.rows.length,
+      policy,
+    };
+    const l1 = {
+      referenced: layer1.referenced,
+      notReferenced: layer1.notReferenced,
+      unknown: layer1.unknown,
+      denominator: layer1.denominator,
+      rate: layer1.rate,
+      referenceEvents: layer1.referenceEvents,
+    };
+
+    const excluded = { layer1Unknown: layer1.unknown, unlabelled: 0, noEffect: 0 };
+    const arms = { referenced: [], notReferenced: [] };
+    for (const row of inPolicy) {
+      // THE SHRUNK ESTIMATE, not the raw one. Shrinkage pulls every finding
+      // toward the population mean, so it pulls the GAP toward zero -- the
+      // bias runs against publishing, which is the only direction a
+      // measurement of this project by this project may lean.
+      if (row.shrunk === null || !Number.isFinite(row.shrunk)) {
+        excluded.noEffect += 1;
+        continue;
+      }
+      const label = labels.get(row.findingKey);
+      if (label === 'referenced') arms.referenced.push(row.shrunk);
+      else if (label === 'not-referenced') arms.notReferenced.push(row.shrunk);
+      else excluded.unlabelled += 1;
+    }
+
+    const context = { layer1: l1, layer2, arms: { referenced: arms.referenced.length, notReferenced: arms.notReferenced.length }, excluded, windowed: truncated };
+    const caveat = truncated
+      ? ' The event log was truncated, so both sides can understate.'
+      : '';
+
+    // WHICH INPUT WAS INSUFFICIENT, named. "Not enough data" tells a reader
+    // nothing about which half of the loop to go and fix.
+    const l1Silent = layer1.rate === null;
+    const l2Silent = layer2.observations === 0;
+    if (l1Silent || l2Silent) {
+      const why = [];
+      if (l1Silent)
+        why.push(
+          `Layer 1 has ${layer1.denominator} classifiable observation(s) and ` +
+            `${layer1.referenceEvents} reference event(s), so it publishes no rate`
+        );
+      if (l2Silent)
+        why.push(
+          `Layer 2 has ${layer2.observations} observation(s), so it publishes no effect`
+        );
+      return refuse(
+        `not calibrated: ${why.join('; and ')}. No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+    }
+
+    // A POLICY CHANGE RESETS THE CALIBRATION, and says so rather than reporting
+    // an empty arm. Layer 2 refuses to pool arms across serving policies, so
+    // rows generated under an older one cannot answer a question about how the
+    // graph serves findings today -- but "0 findings per arm" would send a
+    // reader hunting for missing observations that are right there in the log.
+    if (rows.length > 0 && inPolicy.length === 0)
+      return refuse(
+        `not calibrated: all ${rows.length} Layer 2 effect row(s) were measured under a different serving ` +
+          `policy than the current ${policy}, and arms are never pooled across policies. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (layer2.published === 0)
+      return refuse(
+        `not calibrated: Layer 2 has ${layer2.observations} observation(s) but no published effect at q=0.1, ` +
+          'so its per-finding numbers are noise and a difference between two means of them would be too. ' +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (
+      arms.referenced.length < MIN_FINDINGS_PER_ARM ||
+      arms.notReferenced.length < MIN_FINDINGS_PER_ARM
+    )
+      return refuse(
+        `not calibrated: ${arms.referenced.length} referenced and ${arms.notReferenced.length} not-referenced ` +
+          `finding(s) carry a Layer 2 effect, below the floor of ${MIN_FINDINGS_PER_ARM} per arm. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    const referencedMean = mean(arms.referenced);
+    const notReferencedMean = mean(arms.notReferenced);
+    const gap = referencedMean - notReferencedMean;
+    const measured = { ...context, gap, referencedMean, notReferencedMean };
+
+    if (!(gap >= MIN_GAP_TOKENS))
+      return refuse(
+        `uncalibrated: Layer 1's "referenced" label does not predict a larger Layer 2 effect ` +
+          `(referenced ${Math.round(referencedMean).toLocaleString()} vs not-referenced ` +
+          `${Math.round(notReferencedMean).toLocaleString()} tokens/touch, gap ${Math.round(gap).toLocaleString()}). ` +
+          `Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
+    return {
+      publishable: true,
+      verdict:
+        `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
+      ...measured,
+    };
+  } catch {
+    return refuse(
+      'not calibrated: the calibration inputs could not be read. No gap is reported, which is not the same as a gap of zero.'
+    );
+  }
+}
+
+/**
+ * What the graph cost to build against what it carries -- AN ESTIMATE, and
+ * never priced.
+ *
+ * `consolidationRatio` is the per-finding form and the aggregate is the fold.
+ * Both need `derivedCost`, which `expand.promote` persists onto the finding
+ * node it creates (`src/server/disclosure.ts` is its caller) and which
+ * `harvest-write.mjs` does not yet carry through -- so a graph built only by
+ * the harvest reports nothing here rather than a ratio of one.
+ */
+export function consolidation(dir, { graph = null } = {}) {
+  try {
+    const g = graph || load(dir);
+    const findings = [...g.nodes.values()].filter(
+      (node) => node.kind === 'finding' && !node.retired
+    );
+    const rated = [];
+    for (const finding of findings) {
+      const ratio = consolidationRatio(finding);
+      if (ratio === null) continue;
+      rated.push({ key: finding.key, ratio, derivedCost: finding.derivedCost });
+    }
+    const aggregate = aggregateConsolidation(findings);
+    return {
+      what: 'cost to derive against cost to carry',
+      // SAID IN THE DATA, not only in the prose above it, because this is the
+      // field a dashboard will read and a dashboard will not read a comment.
+      basis: 'estimate',
+      priced: false,
+      findings: findings.length,
+      withDerivedCost: rated.length,
+      aggregate,
+      best: rated.sort((a, b) => b.ratio - a.ratio).slice(0, 5),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The balance sheet with the graph's own three measurements attached.
+ *
+ * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
+ * imports, so it cannot import them back. This is where the two meet, and it
+ * is the shape `get_optimization_report` serves.
+ */
+export function graphBalanceSheet(dir, options = {}) {
+  const sheet = balanceSheet(dir);
+  const cal = calibration(dir, options);
+  const { layer1 = null, layer2 = null } = cal;
+  return {
+    ...sheet,
+    layer1,
+    layer2,
+    calibration: cal,
+    consolidation: consolidation(dir, options),
+  };
+}
+
+/**
+ * One audit line, or null when there is nothing honest to say.
+ *
+ * Silent when NEITHER layer has produced anything: a reader of a graph that has
+ * never injected a finding is owed no paragraph about a loop that has not
+ * started. The moment either side speaks, the refusal is worth printing --
+ * because at that point a reader could otherwise take Layer 1's rate for a
+ * saving, which is precisely what this loop exists to stop.
+ */
+export function calibrationNote(dir, options = {}) {
+  try {
+    const result = calibration(dir, options);
+    const l1 = result.layer1;
+    const l2 = result.layer2;
+    if (!l1 || !l2) return null;
+    if (l1.denominator === 0 && l2.observations === 0) return null;
+    return `Layer 1 against Layer 2: ${result.verdict}`;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/cline/hooks/token-optimizer/lib/crosslayer.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/crosslayer.mjs
@@ -54,7 +54,13 @@
 
 import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
-import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import {
+  effects,
+  observations,
+  servingPolicyVersion,
+  permutationP,
+  FDR_Q,
+} from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
 import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
@@ -106,6 +112,32 @@ export function labelsByFinding(rows) {
 }
 
 const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * A deterministic, label-symmetric permutation test for the headline gap.
+ *
+ * Layer 2 only publishes a per-finding row after a two-sided permutation test.
+ * The calibration headline summarises those rows, so a positive difference of
+ * arm means must clear the same evidential bar rather than being promoted just
+ * because it points in this project's favour.
+ *
+ * Sorting within each arm and then sorting the two arms makes the sampled path
+ * invariant to event order and to swapping the labels. The seed is derived
+ * from that canonical data instead of shared globally, so two different
+ * datasets do not reuse one arbitrary sequence of sampled relabellings.
+ */
+export function calibrationP(referenced, notReferenced) {
+  const arms = [referenced, notReferenced]
+    .map((values) => [...values].sort((a, b) => a - b))
+    .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  const encoded = JSON.stringify(arms);
+  let seed = 2166136261;
+  for (const char of encoded) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return permutationP(arms[0], arms[1], { seed: seed >>> 0 });
+}
 
 /**
  * Does Layer 1's label predict Layer 2's effect?
@@ -244,7 +276,16 @@ export function calibration(dir, options = {}) {
     const referencedMean = mean(arms.referenced);
     const notReferencedMean = mean(arms.notReferenced);
     const gap = referencedMean - notReferencedMean;
-    const measured = { ...context, gap, referencedMean, notReferencedMean };
+    const p = calibrationP(arms.referenced, arms.notReferenced);
+    const measured = {
+      ...context,
+      gap,
+      referencedMean,
+      notReferencedMean,
+      p,
+      alpha: FDR_Q,
+      test: 'two-sided permutation',
+    };
 
     if (!(gap >= MIN_GAP_TOKENS))
       return refuse(
@@ -255,11 +296,20 @@ export function calibration(dir, options = {}) {
         measured
       );
 
+    if (p === null || p > FDR_Q)
+      return refuse(
+        `not calibrated: the positive Layer 1/Layer 2 gap is not statistically resolved by the ` +
+          `two-sided permutation test (p=${p === null ? 'unavailable' : p.toFixed(3)}, ` +
+          `alpha=${FDR_Q.toFixed(3)}). Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
     return {
       publishable: true,
       verdict:
         `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
-        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, ` +
+        `shrunk estimates, two-sided permutation p=${p.toFixed(3)}). ` +
         `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
       ...measured,
     };

--- a/integrations/cline/hooks/token-optimizer/lib/crosslayer.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/crosslayer.mjs
@@ -56,6 +56,7 @@ import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
 import { effects, observations, servingPolicyVersion } from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
 
 /**
@@ -309,11 +310,19 @@ export function consolidation(dir, { graph = null } = {}) {
 }
 
 /**
- * The balance sheet with the graph's own three measurements attached.
+ * The balance sheet with the graph's own measurements attached.
  *
  * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
  * imports, so it cannot import them back. This is where the two meet, and it
  * is the shape `get_optimization_report` serves.
+ *
+ * `recall` joins them as an OFFLINE PROBE, and that label travels in the data
+ * (`recall.basis`) as well as in the rendered line. It is not an observation of
+ * anything a session did: it deletes an anchor edge in memory and re-runs the
+ * real retrieval primitives over the graph as it stands right now. `recall.mjs`
+ * imports only `wiki.mjs` and `lexical.mjs`, neither of which imports anything
+ * in this direction, so no cycle -- the same reason `calibration` had to live
+ * here rather than in `metrics.mjs`.
  */
 export function graphBalanceSheet(dir, options = {}) {
   const sheet = balanceSheet(dir);
@@ -325,6 +334,7 @@ export function graphBalanceSheet(dir, options = {}) {
     layer2,
     calibration: cal,
     consolidation: consolidation(dir, options),
+    recall: recallProbe(dir, options),
   };
 }
 

--- a/integrations/cline/hooks/token-optimizer/lib/derive.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/derive.mjs
@@ -23,13 +23,21 @@
  * the observation supports no claim at all are refused rather than downgraded
  * (see `attemptKey` and the identical-text guard below).
  *
- * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
- * budget, belongs to the caller.
+ * WHAT IS STORED IS BOUNDED. Candidates go through `selectForConsolidation`
+ * before `writeHarvested`, so a long session cannot spend the whole retrieval
+ * budget of every later session on one afternoon's exit codes. Nothing enters
+ * the graph unbudgeted, and nothing enters it wearing a human origin.
  */
 
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
 import { readArchive, readTurns } from './transcript.mjs';
 import { redact } from './redact.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { load } from './wiki.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -106,6 +114,92 @@ const triggerFor = (command) =>
   attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
 
 /**
+ * Literal root-level files that define how a project is BUILT, RUN and TESTED,
+ * best first. A `command` claim is a claim about this project's commands, and
+ * this is the file those commands are declared in.
+ */
+const PROJECT_MARKERS = [
+  'package.json', 'pyproject.toml', 'Cargo.toml', 'go.mod', 'pom.xml',
+  'build.gradle.kts', 'build.gradle', 'build.sbt', 'mix.exs', 'composer.json',
+  'Gemfile', 'Package.swift', 'CMakeLists.txt', 'Makefile', 'Taskfile.yml',
+  'requirements.txt', 'setup.py', 'deno.json', 'bun.lockb',
+];
+
+/** .NET has no single literal marker; the solution or project file is one. */
+const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
+
+/**
+ * A REAL FILE to anchor a derived claim to, inside the project root.
+ *
+ * WHY NOT THE PROJECT ROOT ITSELF, which is what the extraction step reaches
+ * for and what `promoteToShared` uses in the shared tier. Because
+ * `writeHarvested` resolves every anchor through `indexFile`, `indexFile` reads
+ * the path, and reading a DIRECTORY returns null -- so a candidate anchored to
+ * `projectRoot` resolves to nothing, is refused as unanchorable, and the whole
+ * pipeline stores zero findings while reporting a healthy candidate count.
+ * Verified directly: `indexFile(dir, dir)` returns null. That refusal is
+ * correct and must not be weakened -- an anchor that cannot be indexed is an
+ * anchor that can never be invalidated -- so the anchor has to be a file.
+ *
+ * STALENESS DOES NOT MISFIRE ON THIS. `command`, `failure` and `feedback` are
+ * all outside `CONTENT_DEPENDENT` (staleness.mjs), so the anchor is a RETRIEVAL
+ * AND EXISTENCE hook rather than a contents claim: editing the manifest does
+ * not mark these findings stale. staleness.mjs names this exact case in its own
+ * comment -- "a claim about `npm test` anchored to package.json" -- and calls
+ * missing that invalidation the better error.
+ *
+ * A project with no recognisable marker gets the root back, which will not
+ * resolve, so its candidates are derived and then refused rather than stored
+ * against a fabricated anchor. That is the fail-open direction: no finding
+ * beats a finding anchored to something that is not what the claim is about.
+ */
+export function projectAnchor(projectRoot) {
+  if (!projectRoot) return null;
+  let entries;
+  try {
+    entries = readdirSync(projectRoot);
+  } catch {
+    return projectRoot;
+  }
+  const present = new Set(entries);
+  for (const marker of PROJECT_MARKERS) {
+    if (!present.has(marker)) continue;
+    const path = join(projectRoot, marker);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // A marker that cannot be stat'ed is not a marker.
+    }
+  }
+  // Sorted so two sessions in the same repository pick the SAME solution file:
+  // readdir order is not guaranteed stable across hosts, and an anchor that
+  // varies by host splits one finding into two nodes.
+  for (const entry of [...entries].sort()) {
+    if (!DOTNET_MARKER.test(entry)) continue;
+    const path = join(projectRoot, entry);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // Same.
+    }
+  }
+  return projectRoot;
+}
+
+/**
+ * Tokens of claim text one session may add to the graph.
+ *
+ * SCALED TO THE RETRIEVAL BUDGET IT COMPETES FOR, not picked round. A single
+ * command's injection budget is 500 tokens (`TOKEN_OPTIMIZER_TOUCH_BUDGET`),
+ * and everything stored here is competing for that budget on every later
+ * command, forever. Two touch-budgets per session is the bound: enough for a
+ * few dozen real claims, and short of one session's exit codes crowding out
+ * every finding a human or a model ever wrote.
+ */
+const storageBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_DERIVE_BUDGET) || 1000;
+
+/**
  * Derives finding candidates from one project's local evidence.
  *
  * @param {string} dir wiki directory.
@@ -118,11 +212,18 @@ const triggerFor = (command) =>
  *   and is refused by `writeHarvested` anyway, so emitting one would only spend
  *   the caller's budget on junk.
  * @param {string|null} options.authoritativeSessionId the session id as the HOOK
- *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
- *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
- *   edge -- `taskForAnchors` returns null without one, so an unverified string
- *   would silently produce no edge. Threaded rather than defaulted from
- *   `sessionId`: defaulting would promote any caller's string to trusted.
+ *   PAYLOAD reported it, never a value a model typed. Passed straight to
+ *   `writeHarvested`, which needs it to resolve the `answers` edge --
+ *   `taskForAnchors` returns null without one, so an unverified string would
+ *   silently produce no edge. Threaded rather than defaulted from `sessionId`:
+ *   defaulting would promote any caller's string to trusted. Also returned, so a
+ *   caller can see what it handed over.
+ * @returns {object} `{ candidates, observations, written, selected, dropped,
+ *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
+ *   everything derived; `written` is the subset of keys the graph actually
+ *   holds, which is smaller for three independent reasons -- the budget, the
+ *   anchor discipline, and the duplicate collapse that returns an EXISTING key
+ *   when a later session derives the same claim again.
  */
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
@@ -152,6 +253,11 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // ONE anchor for the whole run, so every candidate from this session points at
+  // the same node and the duplicate collapse in `writeHarvested` can recognise
+  // the same lesson across sessions.
+  const anchorPath = projectAnchor(projectRoot);
 
   const seen = new Set();
   const add = (candidate) => {
@@ -246,7 +352,7 @@ export function derive(dir, options = {}) {
               `observed in one session: \`${failed.command}\` failed` +
                 `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
                 `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
-                'an intervening edit or a flaky run explains the same pair.',
+                'an intervening edit or an unrelated environment change explains the same pair.',
               { max: EVIDENCE_MAX }
             ),
             applicability: 'when about to run this command in this project',
@@ -255,7 +361,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the failing form later succeeds unchanged'],
             trigger: triggerFor(outcome.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: outcome.at || Date.now(),
@@ -280,7 +386,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the same command later succeeds unchanged'],
             trigger: triggerFor(failed.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: failed.at || Date.now(),
@@ -330,7 +436,7 @@ export function derive(dir, options = {}) {
           confidenceLabel: labelFor(CONFIDENCE.correction),
           scope: 'project',
           invalidators: ['the user later asks for the corrected behaviour'],
-          anchors: [projectRoot],
+          anchors: [anchorPath],
           derivedBy: 'correction',
           sessionId,
           at: Date.parse(turn.at || '') || Date.now(),
@@ -379,6 +485,48 @@ export function derive(dir, options = {}) {
     }
   } catch {
     // One detector, never the session.
+  }
+
+  // ---- storage, under a budget -------------------------------------------
+  //
+  // NOTHING ENTERS THE GRAPH UNBUDGETED. `selectForConsolidation` existed for
+  // exactly this and had no caller, which meant that until now nothing bounded
+  // what a session could add. It admits `failure` and `decision` on a FLOOR
+  // before ranking -- a dead end exists nowhere else and is small, and cheap to
+  // find is not cheap to find again -- then fills the remainder by
+  // cost x irrecoverability x reuse-probability.
+  //
+  // ORIGIN_HARVESTED, EXPLICITLY, never ORIGIN_HUMAN. These are machine
+  // derivations; `curate.mjs` states the reason in its own header -- "a
+  // hand-written assertion and a machine guess look identical three months
+  // later, which quietly destroys the reader's ability to calibrate trust".
+  // `writeHarvested` would refuse a batch-wide human origin anyway, and a
+  // candidate here carries neither `origin` nor `quote`, so it cannot earn one
+  // per finding either. That is deliberate: whether a turn was a correction at
+  // all is a lexical guess, and the standing-rules layer selects on human
+  // origin to inject on EVERY turn.
+  try {
+    if (result.candidates.length) {
+      const selected = selectForConsolidation(load(dir), result.candidates, {
+        budget: storageBudget(),
+      });
+      result.selected = selected.kept.length;
+      result.dropped = selected.dropped;
+      result.selectedTokens = selected.tokens;
+      result.written = writeHarvested(dir, selected.kept, {
+        sessionId,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        // The hook payload's own identity, passed through untouched. Without it
+        // `taskForAnchors` returns null and the `answers` edge never fires --
+        // which is the state a default install has been in, because its only
+        // other producer is credential-gated.
+        authoritativeSessionId,
+      });
+    }
+  } catch {
+    // Storage is the last step and the session is already over. A graph write
+    // that fails must not turn a completed session into a hook error.
   }
 
   return result;

--- a/integrations/cline/hooks/token-optimizer/lib/derive.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/derive.mjs
@@ -139,17 +139,19 @@ const quotable = (command) => {
  * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
  * found across 163 transcripts on this machine it refuses 2 and keeps 6.
  *
- * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
- * building the key, so the claim is about `npm test` rather than about the `cd`.
- * That changes `attemptKey` for every client and every finding already derived
- * from it, so it belongs in its own change with its own comparison.
+ * `commandBody` below now skips a leading `cd <path> &&`, so those two are
+ * recovered and this guard is left holding only the keys that reached a
+ * separator which is NOT a directory change -- `git fetch && <anything>`, a
+ * pipeline, a `;`-joined pair. Those still name no single attempt.
  */
 const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
 
 /**
  * Did `attemptKey` actually capture a command, or only how one was chained?
  *
- * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart --
+ * which now means AFTER `commandBody` has removed any leading `cd`, so this no
+ * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
 const hasAttemptIdentity = (command) =>
@@ -177,6 +179,81 @@ const CORRECTION_OPENER =
   /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
 
 /**
+ * A leading directory change, stripped before the key is built.
+ *
+ * THE MEASURED CASE, AND ONLY THE MEASURED CASE. `attemptKey` spends up to
+ * three non-flag tokens on identity and the habit on this machine is
+ * `cd <absolute path> && <the real command>`, which spends all three on `cd`,
+ * the path and the separator. This repository's own corpus: 1,400 of 2,243
+ * command outcomes open with a `cd`, and the single key
+ * `cd c:/users/.../token-optimizer-mcp &&` covered 547 distinct command lines.
+ * A `cd` says WHERE a command ran; it says nothing about WHAT ran, so it cannot
+ * be part of the identity of an attempt.
+ *
+ * THE SEPARATOR SET IS THE ONE THAT WAS OBSERVED: `&&` (1,147), a newline (204)
+ * and `;` (38) after a leading `cd`. All three mean "then run this". `||` is
+ * DELIBERATELY EXCLUDED even though it costs one line to add: `cd x || echo
+ * failed` puts an error branch after the separator, not the next step, so
+ * stripping there would key the attempt on a failure handler. It occurred zero
+ * times.
+ *
+ * AND NOTHING WIDER, each refusal for a reason from the same corpus:
+ *
+ *   Environment assignments (`FOO=bar cmd`) DO carry information about what
+ *   ran. The one true instance here is
+ *   `TOKEN_OPTIMIZER_HOLDOUT=1 node ... jest.js ...`, and the holdout arm is a
+ *   genuinely different attempt from the same command without it. The other 20
+ *   are shell variable assignments joined by `;` -- statements, not prefixes --
+ *   whose value is usually a 120-character path that would be stripped down to
+ *   nothing useful.
+ *
+ *   `time`, `env`, `nice`, `sudo`, `bash -c`, `pushd`, `Set-Location`: ZERO
+ *   occurrences in 2,243 commands. Code for an unmeasured prefix is a way to
+ *   over-strip that no evidence asked for, and over-stripping merges commands
+ *   that genuinely differ -- the same bug in the other direction. `bash -c` is
+ *   worse than unmeasured: the command sits inside a quoted string, so stripping
+ *   the wrapper leaves a key beginning with a quote character.
+ *
+ *   `cd /d C:\path &&` and `cd "C:/a b" &&` need no extra rule -- the match runs
+ *   to the separator rather than counting tokens, so flags and quoted paths
+ *   containing spaces are consumed for free. Neither appears here, so neither is
+ *   claimed as tested behaviour beyond its unit test.
+ *
+ * A `cd` with NO separator is left alone: `cd <path>` on its own ran no command,
+ * and its key is as meaningless afterwards as before -- there is nothing to
+ * recover. Stripping is repeated up to `MAX_DIR_PREFIXES` times so
+ * `cd a && cd b && cmd` reaches `cmd`; the bound exists only so a pathological
+ * line cannot loop, since each pass must consume a whole `cd ... <sep>`.
+ *
+ * APPLIED IDENTICALLY TO BOTH SOURCES because it is applied INSIDE `attemptKey`,
+ * which is the single function both the event path and the transcript reader's
+ * output pass through. The 120-character anchor cap that makes the two agree on
+ * 266 of 266 keys is untouched and still applied on both sides before this runs.
+ */
+const DIR_PREFIX = /^\s*cd\s[^\r\n;&|]*?(?:&&|;|\r?\n)\s*/i;
+const MAX_DIR_PREFIXES = 4;
+
+/**
+ * The command text with any leading directory change removed.
+ *
+ * Used for the key AND for the identical-text refusal, which is the half that
+ * keeps this from becoming a licence to pair more loosely: without it,
+ * `cd repo && npm test` failing and `npm test` succeeding would emit
+ * "`npm test` succeeded where `cd repo && npm test` failed" at 0.90 -- two
+ * spellings of one attempt, dressed up as a difference that mattered. The
+ * claim itself still quotes the RAW command, because that is what ran.
+ */
+export function commandBody(command) {
+  let text = String(command || '');
+  for (let i = 0; i < MAX_DIR_PREFIXES; i++) {
+    const stripped = text.replace(DIR_PREFIX, '');
+    if (stripped === text) break;
+    text = stripped;
+  }
+  return text;
+}
+
+/**
  * The prefix that makes two invocations "the same attempt".
  *
  * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
@@ -194,7 +271,7 @@ const CORRECTION_OPENER =
  * ships a false claim into model context.
  */
 export function attemptKey(command) {
-  return String(command || '')
+  return commandBody(command)
     .trim()
     .split(/\s+/)
     .filter((token) => token && !token.startsWith('-'))
@@ -494,7 +571,14 @@ export function derive(dir, options = {}) {
           // is real and supports NEITHER claim, so nothing is emitted. This is
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
-          if (failed.command === outcome.command) continue;
+          // COMPARED WITH THE DIRECTORY CHANGE REMOVED, for the same reason
+          // the key is. `cd repo && npm test` and `npm test` are one attempt
+          // spelled two ways; before `commandBody` they landed in different
+          // groups and never met, and letting them meet without widening this
+          // guard would emit "`npm test` succeeded where `cd repo && npm test`
+          // failed" at 0.90 -- a difference in the claim that is not a
+          // difference in what ran. Same for two `cd`s to different paths.
+          if (commandBody(failed.command) === commandBody(outcome.command)) continue;
 
           // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
           // client both sides of almost every pair are truncated multi-line
@@ -502,10 +586,12 @@ export function derive(dir, options = {}) {
           // spending the retrieval budget of every later session.
           if (!quotable(failed.command) || !quotable(outcome.command)) continue;
 
-          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
-          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
-          // command lines in this repository alone, and any pair drawn from that
-          // group is a false claim about both halves.
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`. The
+          // `cd <path> &&` case that grouped 547 unrelated command lines in this
+          // repository is now handled earlier by `commandBody`; what is left
+          // here is every OTHER separator -- `git fetch && <anything>`, a
+          // pipeline, a `;`-joined pair -- where the key still names no single
+          // attempt and any pair drawn from it is false about both halves.
           if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =

--- a/integrations/cline/hooks/token-optimizer/lib/derive.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/derive.mjs
@@ -1,0 +1,385 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/derive.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Findings from data we already hold, with no model call.
+ *
+ * WHY THIS EXISTS. The semantic harvest is on by default but its real gate is a
+ * credential: `harvestMode()` returns `off:no-key` on any machine without one,
+ * which is CI, corporate laptops, and every subscription-only login. This
+ * repository's own graph is the evidence -- 2,965 symbol nodes, 904 file nodes,
+ * 128 task nodes and ONE finding -- because the structural layer accumulates
+ * from ordinary tool traffic while every verdict needed an API key this machine
+ * does not have.
+ *
+ * Everything here is derived from outcomes, transitions and corrections that are
+ * ALREADY RECORDED LOCALLY. Nothing is sent anywhere, nothing is billed, so
+ * there is nothing to consent to and this runs by default. It is the only
+ * finding producer on a machine without a key.
+ *
+ * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
+ * second command fixed the first -- an intervening edit, a dependency install or
+ * a flaky test explains it just as well. So each detector carries a confidence
+ * ceiling, the claim text says only what was OBSERVED, and the two shapes where
+ * the observation supports no claim at all are refused rather than downgraded
+ * (see `attemptKey` and the identical-text guard below).
+ *
+ * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
+ * budget, belongs to the caller.
+ */
+
+import { readMetrics, rereadsByAnchor } from './metrics.mjs';
+import { readArchive, readTurns } from './transcript.mjs';
+import { redact } from './redact.mjs';
+
+/**
+ * Ceilings, ordered by how much the evidence actually supports.
+ *
+ * A command that succeeded where a DIFFERENT command failed is close to a direct
+ * observation. A test or build going red-to-green is weaker, because the usual
+ * cause is the code changing between the two runs rather than anything about the
+ * command. A correction is a lexical guess about what a human meant. Churn
+ * describes our own reading behaviour and says nothing about the code at all.
+ */
+export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+
+/** Claim text cap. A finding is one sentence; a paragraph is evidence. */
+const CLAIM_MAX = 300;
+const EVIDENCE_MAX = 400;
+
+/** Bounded so a pathological log cannot turn session end into real work. */
+const MAX_CANDIDATES = 200;
+
+/**
+ * Commands whose red-to-green transition is usually explained by the CODE
+ * changing rather than by the command. They get the lower ceiling.
+ */
+const CODE_SENSITIVE = /\b(test|tests|jest|vitest|pytest|mocha|build|compile|tsc|lint|typecheck)\b/i;
+
+/**
+ * Openers that mark a user turn as a correction rather than an instruction.
+ *
+ * DELIBERATELY NARROW, and anchored to the START of the turn. The model-based
+ * extractor in `lessons.mjs` can read intent; this cannot, so it only claims the
+ * shapes where the first few words carry the whole signal. Recall is poor by
+ * design: a missed correction costs one finding, a false one puts words in the
+ * user's mouth at 0.6 confidence.
+ */
+const CORRECTION_OPENER =
+  /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
+
+/**
+ * The prefix that makes two invocations "the same attempt".
+ *
+ * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
+ * through what the alternatives do to real command lines:
+ *
+ *   Two tokens conflates `npm run build` with `npm run test`, and the pair then
+ *   produces "`npm run test` works where `npm run build` failed" -- a claim that
+ *   is simply false.
+ *
+ *   Counting flags splits `deploy` from `deploy --retry`, which is the single
+ *   most useful pair this detector can find, into two groups that never meet.
+ *
+ * Conservative in the remaining direction: `npm run build:prod` and
+ * `npm run build` do not pair. A missed pair costs one finding; a wrong pair
+ * ships a false claim into model context.
+ */
+export function attemptKey(command) {
+  return String(command || '')
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'))
+    .slice(0, 3)
+    .join(' ')
+    .toLowerCase();
+}
+
+/** Normalised claim text, so the same lesson derived twice is one candidate. */
+const claimKey = (type, claim) =>
+  `${type}|${String(claim).toLowerCase().replace(/\s+/g, ' ').trim()}`;
+
+/** 0.95 is reserved for verified; everything here is inference. */
+const labelFor = (confidence) => (confidence >= 0.75 ? 'probable' : 'speculative');
+
+/** A literal command prefix, safe to hand to `safeTrigger`. */
+const triggerFor = (command) =>
+  attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
+
+/**
+ * Derives finding candidates from one project's local evidence.
+ *
+ * @param {string} dir wiki directory.
+ * @param {object} options
+ * @param {string|null} options.sessionId session this ran for, for provenance.
+ * @param {string|null} options.transcriptPath live transcript, read only when the
+ *   archive holds nothing for this session yet.
+ * @param {string|null} options.projectRoot the anchor every derived claim gets.
+ *   Without it nothing is derived: an unanchored finding cannot be invalidated
+ *   and is refused by `writeHarvested` anyway, so emitting one would only spend
+ *   the caller's budget on junk.
+ * @param {string|null} options.authoritativeSessionId the session id as the HOOK
+ *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
+ *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
+ *   edge -- `taskForAnchors` returns null without one, so an unverified string
+ *   would silently produce no edge. Threaded rather than defaulted from
+ *   `sessionId`: defaulting would promote any caller's string to trusted.
+ */
+export function derive(dir, options = {}) {
+  // `options || {}` rather than a destructuring default. A default only fires on
+  // `undefined`, so a caller passing an explicitly null options object -- which
+  // is what a hook does when it has nothing to say -- threw a TypeError out of
+  // the parameter list itself, before any of the try/catch below could fail open.
+  const {
+    sessionId = null,
+    transcriptPath = null,
+    projectRoot = null,
+    authoritativeSessionId = null,
+  } = options || {};
+
+  const result = {
+    candidates: [],
+    observations: [],
+    written: [],
+    sessionId,
+    authoritativeSessionId,
+  };
+
+  let events;
+  try {
+    events = readMetrics(dir);
+  } catch {
+    // Session end must cost nothing. No evidence is not an error.
+    return result;
+  }
+  if (!Array.isArray(events)) return result;
+
+  const seen = new Set();
+  const add = (candidate) => {
+    if (result.candidates.length >= MAX_CANDIDATES) return;
+    const key = claimKey(candidate.type, candidate.claim);
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.candidates.push(candidate);
+  };
+
+  // ---- 1 & 2: a failed attempt followed by a succeeding one ---------------
+  //
+  // The event is `tool-outcome` and THE COMMAND TEXT IS IN `anchor`: there is no
+  // separate command field, because the anchor of a command surface IS the
+  // command. It is capped at 120 characters at the boundary, so a very long
+  // command line is compared and quoted truncated.
+  try {
+    if (projectRoot) {
+      const outcomes = events
+        .filter(
+          (e) =>
+            e &&
+            e.kind === 'tool-outcome' &&
+            e.surface === 'command' &&
+            typeof e.anchor === 'string' &&
+            e.anchor.trim()
+        )
+        .map((e) => ({
+          command: e.anchor.trim(),
+          output: typeof e.output === 'string' ? e.output : '',
+          exit: Number.isInteger(e.exit) ? e.exit : null,
+          at: e.at ?? 0,
+          // `success` FIRST, `exit` only as a refinement. MCP tools report no
+          // numeric code at all, so a classifier keyed on `exit !== 0` would be
+          // inert for most clients -- and `exit` is null rather than 0 precisely
+          // so that absence is not read as a clean exit.
+          failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
+        }))
+        .sort((a, b) => a.at - b.at);
+
+      const byAttempt = new Map();
+      for (const outcome of outcomes) {
+        const key = attemptKey(outcome.command);
+        if (!key) continue;
+        if (!byAttempt.has(key)) byAttempt.set(key, []);
+        byAttempt.get(key).push(outcome);
+      }
+
+      for (const run of byAttempt.values()) {
+        // The NEAREST preceding failure, not the first one in the session. With
+        // `find` over the whole run, a command that failed at 09:00 and
+        // succeeded at 17:00 after nine unrelated attempts is reported as one
+        // story.
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          // One pair per failure: a command that succeeds twice afterwards has
+          // not taught two lessons.
+          lastFailure = null;
+
+          // THE GUARD THAT REMOVES THE LARGEST JUNK CLASS. The commonest shape
+          // in a coding session is `npm run build` failing, the code being
+          // fixed, and `npm run build` succeeding -- identical text. From that
+          // pair the two available claims are "`npm run build` works where
+          // `npm run build` failed", which is incoherent, and "`npm run build`
+          // fails", which the same evidence has just disproved. The observation
+          // is real and supports NEITHER claim, so nothing is emitted. This is
+          // not a confidence question; a ceiling cannot rescue a claim whose
+          // content is wrong.
+          if (failed.command === outcome.command) continue;
+
+          const codeSensitive =
+            CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);
+          const confidence = codeSensitive ? CONFIDENCE.test : CONFIDENCE.command;
+          const derivedBy = codeSensitive ? 'test-transition' : 'command-transition';
+
+          // "SUCCEEDED WHERE", NOT "FIXES". What is observed is two outcomes in
+          // order on the same attempt; that the difference in the command line
+          // CAUSED the difference in outcome is not observed and is not claimed.
+          add({
+            type: 'command',
+            claim: redact(
+              `\`${outcome.command}\` succeeded in this project where \`${failed.command}\` failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
+                'an intervening edit or a flaky run explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: 'when about to run this command in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the failing form later succeeds unchanged'],
+            trigger: triggerFor(outcome.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+
+          // The error text, only when there is error text. Without it the claim
+          // degrades to "`X` failed with:" and nothing after the colon, which
+          // carries no information and still costs budget.
+          const firstLine = failed.output.split('\n').find((line) => line.trim()) || '';
+          if (firstLine.trim().length < 8) continue;
+          add({
+            type: 'failure',
+            claim: redact(`\`${failed.command}\` failed with: ${firstLine.trim()}`, {
+              max: CLAIM_MAX,
+            }),
+            evidence: redact(`captured output of the failing run:\n${failed.output}`, {
+              max: EVIDENCE_MAX,
+            }),
+            applicability: 'when this command is about to be run in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the same command later succeeds unchanged'],
+            trigger: triggerFor(failed.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: failed.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 3: user corrections ------------------------------------------------
+  //
+  // A `feedback` finding -- the one type whose source is a person saying the
+  // agent was wrong. The MODEL-BASED extractor for this lives in `lessons.mjs`
+  // and needs the credential this module exists to do without, so here the
+  // signal is lexical: the opening words of the user's own turn.
+  //
+  // ORIGIN IS NOT PROMOTED. `writeHarvested` grants ORIGIN_HUMAN to a finding
+  // carrying a verified verbatim quote, and the standing-rules layer selects on
+  // that origin to inject a claim on EVERY turn. The quote here would be
+  // verbatim -- it is copied out of the archive -- but whether the turn was a
+  // correction at all is a guess, and a guess must not buy always-on injection.
+  // So no `origin` and no `quote` field: this stays harvested provenance.
+  try {
+    if (projectRoot) {
+      let turns = readArchive(dir, sessionId);
+      // The archive is written by the Stop hook too, and the order of the two is
+      // not this module's to assume, so fall back to the live transcript.
+      if (!turns.length && transcriptPath) turns = readTurns(transcriptPath);
+
+      for (const turn of turns) {
+        if (!turn || turn.role !== 'user') continue;
+        const text = String(turn.text || '').trim();
+        // Long turns are new instructions with a complaint somewhere inside
+        // them; truncating one into a claim would misquote the user.
+        if (text.length < 12 || text.length > 300) continue;
+        if (!CORRECTION_OPENER.test(text)) continue;
+        add({
+          type: 'feedback',
+          claim: redact(text, { max: CLAIM_MAX }),
+          evidence: redact(`the user opened a turn with a correction: "${text}"`, {
+            max: EVIDENCE_MAX,
+          }),
+          applicability: 'when working in this project, before repeating what was corrected',
+          confidence: CONFIDENCE.correction,
+          confidenceLabel: labelFor(CONFIDENCE.correction),
+          scope: 'project',
+          invalidators: ['the user later asks for the corrected behaviour'],
+          anchors: [projectRoot],
+          derivedBy: 'correction',
+          sessionId,
+          at: Date.parse(turn.at || '') || Date.now(),
+        });
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 4: re-read churn ---------------------------------------------------
+  //
+  // NOT A FINDING, AND THAT IS THE DECISION RATHER THAN AN OMISSION.
+  //
+  // Churn is a claim about OUR OWN reading behaviour: "this file was read three
+  // times unchanged". Every finding type available is a claim about the work --
+  // `map` describes how an area of the codebase is laid out, and is
+  // content-dependent, so a churn claim filed as `map` would be checked for
+  // staleness against contents it makes no claim about and flip stale on the
+  // first edit to a file it never described. Worse, the anchors it would take
+  // are by construction the HOTTEST files in the project, which are exactly the
+  // files that already carry real findings, so a 0.4-confidence row saying
+  // nothing actionable would sit in the injection budget beside them and render
+  // on the same reads. Nothing a future agent could DO differently follows from
+  // it: it does not say what the file contains, so it cannot substitute for
+  // reading it.
+  //
+  // The signal is still worth having -- as the measurement it already is.
+  // `rereadWaste` reports it on the balance sheet, `rereadsByAnchor` names the
+  // offenders, and this returns those rows as OBSERVATIONS: computed, carried,
+  // and deliberately not competing for context. Three detectors produce
+  // findings; the fourth produces a number.
+  try {
+    for (const row of rereadsByAnchor(events).slice(0, 3)) {
+      if (!row.anchor || row.wasteful < 2) continue;
+      result.observations.push({
+        kind: 'churn',
+        anchor: row.anchor,
+        repeats: row.repeats,
+        wasteful: row.wasteful,
+        tokens: row.tokens,
+        confidence: CONFIDENCE.churn,
+        derivedBy: 'churn',
+        note: `re-read ${row.repeats} times, ${row.wasteful} of them unchanged`,
+      });
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  return result;
+}

--- a/integrations/cline/hooks/token-optimizer/lib/derive.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/derive.mjs
@@ -16,6 +16,13 @@
  * there is nothing to consent to and this runs by default. It is the only
  * finding producer on a machine without a key.
  *
+ * THREE SOURCES, NOT TWO. `tool-outcome` events, the transcript archive, and --
+ * since the transition detectors were measured to have no input at all on the
+ * primary client -- the raw transcript's FAILED tool results, which is the only
+ * place a Claude Code failure is recorded (`failedResultsFromTranscript` in
+ * transcript.mjs, and the note above `quotable` for what that measurement
+ * actually yielded).
+ *
  * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
  * second command fixed the first -- an intervening edit, a dependency install or
  * a flaky test explains it just as well. So each detector carries a confidence
@@ -32,7 +39,11 @@
 import { readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
-import { readArchive, readTurns } from './transcript.mjs';
+import {
+  readArchive,
+  readTurns,
+  failedResultsFromTranscript,
+} from './transcript.mjs';
 import { redact } from './redact.mjs';
 import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
@@ -56,6 +67,96 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * The anchor cap a command surface is stored under, restated here as a TEST.
+ *
+ * `recordToolOutcome` truncates `anchor` to 120 characters, so a command at or
+ * over that length reached this module already cut -- and `quotable` below
+ * refuses to build a claim out of the fragment.
+ */
+const COMMAND_ANCHOR_MAX = 120;
+
+/**
+ * Can this command text be QUOTED in a claim a reader could act on?
+ *
+ * THE SECOND REFUSAL OF ITS KIND, and it exists because measurement forced it.
+ * Wiring the transcript reader gave the transition detectors their first real
+ * input on this client and immediately produced four candidates at 0.9
+ * confidence whose claim text read:
+ *
+ *   `cd /c/Users/.../token-optimizer-mcp\ncat >> docs/superpowers/plans/2026-` succeeded
+ *   in this project where `cd /c/Users/.../token-optimizer-mcp\ncat > /tmp/probe3.mjs
+ *   <<'EOF'\nimport { readdirSync, readFileSync, sta` failed
+ *
+ * -- two truncated fragments of throwaway shell scripts, grouped together only
+ * because `attemptKey`'s three tokens were spent on `cd`, the absolute path, and
+ * the verb. Then measured properly across three real transcripts: **0 of 83**
+ * captured command failures are single-line and inside the cap. 65% of this
+ * project's 2,178 successful command outcomes are not either. On this client a
+ * "command" is usually a whole shell script, so the attempt identity the
+ * transition detectors are built on does not fit most of the traffic.
+ *
+ * This is the same judgement as the identical-text guard below rather than a
+ * confidence question: a claim whose subject is a truncated fragment of a
+ * program is not a weaker claim, it is not a claim. A raised cap would not
+ * rescue it -- quoting the whole 500-character heredoc is no more actionable.
+ *
+ * What survives is exactly what the detector was designed for: `npm test`,
+ * `dotnet build X`, `deploy --retry` -- a repeatable command someone could run
+ * again. This machine captured none failing, which is why the honest yield here
+ * is zero and why that is reported rather than dressed up.
+ *
+ * Applied to BOTH sources. Where the evidence arrived from has no bearing on
+ * whether the resulting sentence says anything, and a rule that let events
+ * through would ship the junk on the ten clients that do report failures.
+ */
+const quotable = (command) => {
+  const text = String(command || '');
+  return (
+    text.trim().length > 0 &&
+    !/[\r\n]/.test(text) &&
+    text.length < COMMAND_ANCHOR_MAX
+  );
+};
+
+/**
+ * Tokens that separate one command from the next rather than naming one.
+ *
+ * MEASURED, LIKE EVERY OTHER REFUSAL HERE. `attemptKey` spends up to three
+ * non-flag tokens on identity, and the habit on this machine is
+ * `cd <absolute path> && <the real command>` -- which spends all three on `cd`,
+ * the path and `&&`, so the real command never enters the key. This project's
+ * own evidence: the single key `cd c:/users/.../token-optimizer-mcp &&` covers
+ * **539 distinct command lines**. One quotable failure in that group would pair
+ * with an arbitrary unrelated success and claim "`cd repo && grep -n ...`
+ * succeeded where `cd repo && git merge ...` failed", which is false about both.
+ *
+ * A KEY THAT REACHED A SEPARATOR NEVER REACHED A COMMAND, so there is no attempt
+ * to compare and nothing to claim -- the same judgement as the identical-text
+ * guard rather than a lower ceiling. Narrow on purpose: `2>&1` and `/F` are not
+ * separators and do not trip this, so `cat commitlint.config.mjs 2>&1` and
+ * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
+ * found across 163 transcripts on this machine it refuses 2 and keeps 6.
+ *
+ * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
+ * building the key, so the claim is about `npm test` rather than about the `cd`.
+ * That changes `attemptKey` for every client and every finding already derived
+ * from it, so it belongs in its own change with its own comparison.
+ */
+const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
+
+/**
+ * Did `attemptKey` actually capture a command, or only how one was chained?
+ *
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * One check per pair is enough: both halves share the key by construction.
+ */
+const hasAttemptIdentity = (command) =>
+  attemptKey(command)
+    .split(' ')
+    .filter(Boolean)
+    .every((token) => !COMMAND_SEPARATORS.has(token));
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -274,6 +375,17 @@ export function derive(dir, options = {}) {
   // separate command field, because the anchor of a command surface IS the
   // command. It is capped at 120 characters at the boundary, so a very long
   // command line is compared and quoted truncated.
+  //
+  // TWO SOURCES OF FAILURE, ONE PAIRING LOOP. Claude Code never fires
+  // PostToolUse for a failed tool call -- 2,238 of 2,238 live `tool-outcome`
+  // events on the measuring machine carry `success: true`, and a deliberately
+  // failing command produced no event at all -- so on the primary client these
+  // two detectors had NO INPUT WHATSOEVER while working normally on the ten
+  // adapter clients. `failedResultsFromTranscript` supplies the missing half
+  // from the only place it exists. The successes still come from events only:
+  // a transcript failure that pairs with nothing stays unclaimed, which is also
+  // what keeps a failure from ANOTHER project's directory out of this project's
+  // graph -- a candidate cannot be emitted without a success recorded HERE.
   try {
     if (projectRoot) {
       const outcomes = events
@@ -290,6 +402,9 @@ export function derive(dir, options = {}) {
           output: typeof e.output === 'string' ? e.output : '',
           exit: Number.isInteger(e.exit) ? e.exit : null,
           at: e.at ?? 0,
+          // Carried purely so the transcript merge below can recognise the same
+          // tool call arriving from the other source.
+          toolCallId: e.toolCallId ? String(e.toolCallId) : null,
           // `success` FIRST, `exit` only as a refinement. MCP tools report no
           // numeric code at all, so a classifier keyed on `exit !== 0` would be
           // inert for most clients -- and `exit` is null rather than 0 precisely
@@ -297,6 +412,53 @@ export function derive(dir, options = {}) {
           failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
         }))
         .sort((a, b) => a.at - b.at);
+
+      // DEDUPLICATED ON `toolCallId`, which is the SAME STRING in both sources:
+      // `episodeMeta` reads `raw.tool_use_id` into `toolCallId`, and that is the
+      // transcript's `tool_use_id` verbatim -- verified against live evidence
+      // (`toolu_01L4Nwr...` in metrics.jsonl, the same ids in the transcript).
+      // So on the ten clients that DO report failures, the event copy wins and
+      // the transcript copy is dropped before grouping. Without this the two
+      // copies of one failure would sit in the same run and the second of them
+      // would be paired against the first as a failed-then-succeeded story about
+      // itself.
+      //
+      // The fallback covers a client that reports a failure with no call id:
+      // identical command text within two seconds is one failure recorded twice,
+      // not two failures, because nothing re-runs a command that fast.
+      const eventIds = new Set(
+        outcomes.map((o) => o.toolCallId).filter(Boolean)
+      );
+      const eventFailures = outcomes.filter((o) => o.failed);
+      const alreadyRecorded = (failure) => {
+        if (failure.toolCallId && eventIds.has(failure.toolCallId)) return true;
+        return eventFailures.some(
+          (o) =>
+            o.command === failure.command &&
+            Math.abs((o.at || 0) - (failure.at || 0)) <= 2000
+        );
+      };
+
+      let transcriptFailures = [];
+      try {
+        transcriptFailures = failedResultsFromTranscript(transcriptPath).filter(
+          (failure) => failure.command.trim() && !alreadyRecorded(failure)
+        );
+      } catch {
+        // The reader is an extra source, never a reason the detector stops.
+      }
+      for (const failure of transcriptFailures) {
+        outcomes.push({
+          command: failure.command.trim(),
+          output: failure.output,
+          exit: failure.exit,
+          at: failure.at,
+          toolCallId: failure.toolCallId,
+          // Read from `Exit code N`, which is the only shape the reader admits.
+          failed: true,
+        });
+      }
+      if (transcriptFailures.length) outcomes.sort((a, b) => a.at - b.at);
 
       const byAttempt = new Map();
       for (const outcome of outcomes) {
@@ -333,6 +495,18 @@ export function derive(dir, options = {}) {
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
           if (failed.command === outcome.command) continue;
+
+          // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
+          // client both sides of almost every pair are truncated multi-line
+          // shell scripts, and a claim quoting a fragment of one is noise
+          // spending the retrieval budget of every later session.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
+          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
+          // command lines in this repository alone, and any pair drawn from that
+          // group is a false claim about both halves.
+          if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =
             CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);

--- a/integrations/cline/hooks/token-optimizer/lib/doctor.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/doctor.mjs
@@ -197,7 +197,8 @@ function hooksDirFor({ hooksDir, install, root }) {
  * identical from outside: a graph that fills with structural nodes either way.
  *
  * Measured on a real 5.4.0 install: 484 symbol, 286 file and 122 task nodes and
- * ZERO findings, because harvestMode() was 'off:not-opted-in'. Fifteen checks
+ * ZERO findings, because harvestMode() then returned an opt-in refusal (the mode has
+ * since been renamed: it is 'off:no-key' now, and opting in is no longer the gate). Fifteen checks
  * passed and none mentioned harvest. stop-harvest.mjs names this exact gap --
  * "nothing in doctor, audit or waste mentions harvest, so a user sees a graph
  * filling with structural nodes and no findings and has no way to learn why" --
@@ -221,9 +222,15 @@ export function probeHarvest() {
   // optimizer is off" is noise, which is why stop-harvest maps it to no notice.
   if (mode === 'off:mode') return [];
 
+  // SAID PLAINLY, because this is the configuration a user would choose if they
+  // knew it existed and the previous wording buried it in machinery. A local
+  // endpoint is the only setting under which the semantic harvest runs with no
+  // credential, no billing and no digest leaving the machine -- so the two facts
+  // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
     return [ok('finding extraction is available',
-      'active-model wiki_write is primary; local endpoint also enables fallback extraction')];
+      'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
+      'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
@@ -233,10 +240,19 @@ export function probeHarvest() {
 
   // No second-model credential is required for the primary path. The Codex/agent session that
   // already paid to derive the conclusion is the extractor and wiki_write is local.
+  // NAME THE TRADE, not just the missing variable. This is the default state on
+  // every machine without a credential, so it is the text most users will read,
+  // and "unavailable" alone tells them neither what they are missing nor that
+  // the free option exists. Local findings still accumulate: derive.mjs reads
+  // exit codes, red-to-green transitions, corrections and churn out of evidence
+  // already on disk and sends nothing anywhere.
   if (mode === 'off:no-key') {
     return [ok('finding extraction is available',
-      'active model records durable conclusions through local wiki_write; no separate-model ' +
-      'credential is configured, so fallback transcript extraction is unavailable')];
+      'active model records durable conclusions through local wiki_write, and derive runs at ' +
+      'session end with no credential. No separate-model credential is configured, so fallback ' +
+      'transcript extraction is unavailable: point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local ' +
+      'model to run it free and private, or set TOKEN_OPTIMIZER_API_KEY to run it from a bounded ' +
+      'digest of paths, commands, prompts and conclusions -- never file contents')];
   }
 
   // off:opted-out -- a deliberate choice, reported as one. Nagging about a setting somebody chose

--- a/integrations/cline/hooks/token-optimizer/lib/inject.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/inject.mjs
@@ -1134,10 +1134,25 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // injected more than the budget allowed and recorded fewer tokens than it
   // spent -- in a block whose entire justification is that it is tightly
   // bounded and measured against the control arm.
+  // THE LAST LINE IS HOW THE NEXT RULE GETS HERE, and it is one line because
+  // this block is charged on every session forever. A rule reaches this list
+  // only by being pinned or by being a person's verified correction, and both
+  // start as a `wiki_write` -- so a model reading a set of standing rules with
+  // no idea how they were produced has no way to add to it. Stated at the point
+  // of the evidence rather than as a separate always-on block: the reader is
+  // already looking at the output of the mechanism being described.
+  //
+  // THE COLD GRAPH IS COVERED ELSEWHERE, deliberately. Nothing here renders
+  // until at least one rule qualifies, which is the property the always-on
+  // budget depends on, so this line cannot be the first-session nudge --
+  // `policyText`'s "Record what you work out" section is, and it is emitted at
+  // SessionStart whether or not the graph holds anything.
   const HEADING =
     '# Standing rules for this project' +
     '\n\nEstablished in previous sessions and expected to hold. ' +
-    'These are not suggestions.\n\n';
+    'These are not suggestions.\n\n' +
+    'Record what you work out with wiki_write and a real file anchor; ' +
+    'that is how a rule reaches this list.\n\n';
   const noticeFor = (n) =>
     n
       ? `\n(${n} further standing rule${n === 1 ? '' : 's'} did not fit this budget; ` +

--- a/integrations/cline/hooks/token-optimizer/lib/inject.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/inject.mjs
@@ -35,6 +35,7 @@ import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
 import { cacheOrdered } from './cache.mjs';
+import { withheldFor, exploreOrder, servingPolicyVersion, LOO_ENABLED } from './loo.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -311,8 +312,38 @@ export function forTouch(
     });
     for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
   }
-  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  // LAYER 2 EXPLORATION, BEFORE the budget decides.
+  //
+  // `assessed.eligible` arrives in net-utility order and `fit` keeps that order
+  // until the budget runs out -- so the ranking decides which findings are ever
+  // served, which decides which ever accumulate observations, which decides
+  // their utility. A tenth of touches therefore promote the least-served
+  // candidate first. This is the only place it can go: after `fit` the choice
+  // has already been made.
+  const ordered = exploreOrder(assessed.eligible, dir, { sessionId, anchor: filePath });
+  const { kept, spent } = fit(ordered.map((item) => item.finding), budget);
   if (!kept.length) return null;
+
+  // LAYER 2 WITHHOLDING, AFTER the budget decides, which is the only ordering
+  // that produces a leave-one-out rather than a substitution: withholding first
+  // would let the next-ranked finding take the freed tokens, so the withheld
+  // arm would differ from the served arm by two findings instead of one and the
+  // effect would belong to neither.
+  //
+  // `holdout` is passed so the two experiments cannot compose into "withhold
+  // everything and call it a leave-one-out": that arm already serves nothing.
+  const withheld = withheldFor(kept.map((finding) => finding.key), sessionId, graph, dir, {
+    surface: 'file',
+    anchor: filePath,
+    holdout,
+  });
+  const delivered = withheld ? kept.filter((finding) => finding.key !== withheld) : kept;
+  // RE-PRICED, because `fit` priced what it KEPT and this delivers less. Using
+  // `spent` would bill the injection-cost side of the balance sheet for text
+  // the model never received.
+  const deliveredSpent = withheld
+    ? delivered.reduce((sum, finding) => sum + estimate(render(finding)), 0)
+    : spent;
 
   record(dir, {
     kind: 'inject',
@@ -321,15 +352,20 @@ export function forTouch(
     surface: 'file',
     anchor: filePath,
     holdout,
-    tokens: holdout ? 0 : spent,
-    deliveredTokens: holdout ? 0 : spent,
+    tokens: holdout ? 0 : deliveredSpent,
+    deliveredTokens: holdout ? 0 : deliveredSpent,
     shadowTokens: spent,
-    count: holdout ? 0 : kept.length,
+    count: holdout ? 0 : delivered.length,
     candidateCount: kept.length,
-    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    findingIds: holdout ? [] : delivered.map((finding) => finding.key),
     shadowFindingIds: kept.map((finding) => finding.key),
-    stale: kept.some((f) => f.stale),
+    stale: delivered.some((f) => f.stale),
     sessionId,
+    // ON EVERY RECORD, not only the withheld ones. A served observation needs
+    // the policy version as much as a withheld one does, or `effects` cannot
+    // keep the two arms of one comparison inside one policy.
+    ...(LOO_ENABLED() ? { looPolicy: servingPolicyVersion() } : {}),
+    ...(withheld ? { loo: withheld } : {}),
   });
 
   // MARKED SEEN IN BOTH ARMS, for the same reason as the command path: a file
@@ -339,11 +375,16 @@ export function forTouch(
   // grow faster purely from repetition.
   //
   // This is the identical defect that was fixed in `forCommand` and not here.
+  //
+  // THE WITHHELD KEY IS MARKED TOO, and that is load-bearing rather than tidy:
+  // an unmarked one would be a candidate again on the next touch of this file,
+  // where the one-per-touch tiebreak could serve it -- flipping its arm inside
+  // the very session the arm hash exists to pin it for.
   for (const f of kept) alreadyInjected.add(f.key);
 
-  if (holdout || !kept.length) return null;
+  if (holdout || !delivered.length) return null;
 
-  return `Known about ${filePath} (from previous sessions):\n${kept.map(render).join('\n')}`;
+  return `Known about ${filePath} (from previous sessions):\n${delivered.map(render).join('\n')}`;
 }
 
 /**

--- a/integrations/cline/hooks/token-optimizer/lib/keepwarm.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/keepwarm.mjs
@@ -30,6 +30,15 @@ import { record, readMetrics, readBalance } from './metrics.mjs';
 import { WRITE_MULTIPLIER, READ_MULTIPLIER } from './cache.mjs';
 
 /**
+ * The shortest gap that counts as a NEW turn rather than a burst inside one.
+ *
+ * Shared by the gap distribution and by the hit test, because they have to
+ * agree about what a turn is. Two copies of this number would let the decision
+ * be fitted to one definition of a turn and scored against another.
+ */
+export const TURN_GAP_MS = 250;
+
+/**
  * TTL tiers, with what a WRITE costs at each.
  *
  * A five-minute entry is written at 1.25x a plain input token; the one-hour
@@ -85,7 +94,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
     for (let i = 1; i < session.length; i++) {
       const gap = session[i] - session[i - 1];
       // A burst of events inside one turn is not a gap between turns.
-      if (gap > 250) gaps.push(gap);
+      if (gap > TURN_GAP_MS) gaps.push(gap);
     }
   }
   if (gaps.length < 6) return null;
@@ -105,10 +114,91 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
 }
 
 /**
+ * Refreshes to observe at a tier before the observation may bound the decision.
+ *
+ * THE SAME NUMBER THE BACKSTOP DEMANDS, deliberately. The decision and the
+ * tripwire read the same ledger, so letting them disagree about when there is
+ * enough evidence would mean one of them acting on a sample the other calls too
+ * small. Below the floor the decision keeps its expected-value answer, so a
+ * single unlucky miss changes nothing at all.
+ *
+ * NOT A CONFIDENCE INTERVAL, and the reason is arithmetic rather than taste. A
+ * Wilson 95% upper bound at ten refreshes and zero hits is 0.28 -- so a policy
+ * that missed ten times out of ten would still be recommended, which is exactly
+ * the case the loop exists to catch. The point estimate is safe here because of
+ * the bound below: an observation may only ever LOWER the modelled probability,
+ * so sampling noise cannot manufacture a refresh, and the tripwire's realised
+ * ledger is a second guard underneath.
+ */
+export const OBSERVATION_FLOOR = TRIPWIRE_MIN;
+
+/**
+ * The measured hit rate per tier, from recorded outcomes.
+ *
+ * Tiers below the floor are ABSENT rather than present with a small n, because
+ * a rate carrying no weight is the thing most likely to be used as though it
+ * did.
+ */
+export function observedHitRates(outcomes = []) {
+  const byTier = new Map();
+  for (const event of outcomes) {
+    if (event?.kind !== 'keepwarm' || event.action !== 'outcome') continue;
+    const name = TIERS.some((t) => t.name === event.tier) ? event.tier : TIERS[0].name;
+    const row = byTier.get(name) || { refreshes: 0, hits: 0 };
+    row.refreshes += 1;
+    if (event.hit) row.hits += 1;
+    byTier.set(name, row);
+  }
+
+  const qualified = new Map();
+  for (const [name, row] of byTier) {
+    if (row.refreshes < OBSERVATION_FLOOR) continue;
+    qualified.set(name, { ...row, rate: row.hits / row.refreshes });
+  }
+  return qualified;
+}
+
+/**
+ * What the refreshes at this tier actually did, if enough of them have.
+ *
+ * Tolerates being handed anything -- null, a plain object, a Map -- because the
+ * callers are two public functions whose options object is assembled by other
+ * people's code.
+ */
+function observationsFor(observed, tierName) {
+  const row = observed instanceof Map ? observed.get(tierName) : null;
+  return row && Number.isFinite(row.rate) ? row : null;
+}
+
+/**
+ * The modelled probability, BOUNDED BY what was observed and never raised by it.
+ *
+ * The asymmetry is the whole point and runs against this project's interest. A
+ * recorded `hit` says only that a turn arrived before the entry expired; it
+ * cannot say the refresh is what kept the entry alive, because a turn arriving
+ * one minute after a five-minute ping would have found the entry warm anyway.
+ * So the observed rate is an UPPER bound on a refresh's value, and substituting
+ * it for the model would flatter keep-warm badly: on the machine this was
+ * written on, the modelled ping probability is 0.2% and the observable
+ * before-expiry rate is 99.5%, so the substitution would recommend refreshing
+ * forever. A low rate, by contrast, is real evidence against: if turns do not
+ * even arrive inside the TTL, the refresh certainly bought nothing.
+ */
+function bounded(modelled, seen) {
+  return seen ? Math.min(modelled, seen.rate) : modelled;
+}
+
+/**
  * Should we refresh this prefix now?
  *
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
+ *
+ * `observed` is passed IN rather than read from disk here: this function is
+ * pure, its purity is what lets the tests build a distribution by hand, and
+ * `shouldKeepWarm` has already read the outcome log for the tripwire -- so
+ * threading the reader in here would be a second read of the same file and a
+ * second place for the window discipline to be got wrong.
  */
 export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
@@ -125,42 +215,30 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
   const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
-
-  // MEASURED BEATS MODELLED, once there is enough of it.
-  //
-  // The module header already commits to this -- "an expected-value decision is
-  // only as good as the distribution it was fitted to, and distributions
-  // shift" -- and the tripwire underneath was the only thing acting on it, as
-  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
-  // entirely" there was nothing, because the observed hit rate was never
-  // computed: both recording halves had no call site, so ten refreshes that
-  // bought nothing would keep recommending refresh right up to the moment the
-  // tripwire cut the whole feature off.
-  //
-  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
-  // handful of samples would swing the decision harder than the distribution
-  // they replace.
-  const probability = observed ? observed.rate : modelled;
+  const seen = observationsFor(observed, tier.name);
+  const probability = bounded(modelled, seen);
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
-  const basis = observed
-    ? `measured over ${observed.observations} refreshes`
-    : 'modelled from the gap distribution';
+  const note = seen && probability < modelled
+    ? `; bounded by ${seen.refreshes} observed refreshes, ` +
+      `${Math.round(seen.rate * 100)}% used before expiry`
+    : '';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
     modelledProbability: modelled,
-    basis,
+    observedHitRate: seen ? seen.rate : null,
+    observedRefreshes: seen ? seen.refreshes : 0,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
-    reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
+    reason: (ev > 0
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
-        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`) + note,
   };
 }
 
@@ -171,7 +249,12 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
  * long enough that the short tier keeps missing. Returns null when neither tier
  * pays, which is a real answer and the one a default-on product never gives.
  */
-export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS }) {
+export function ttlTier({
+  prefixTokens,
+  gaps,
+  turnsPerSession = DEFAULT_TURNS,
+  observed = null,
+}) {
   if (!prefixTokens || !gaps) return null;
 
   // Expected cost of a turn under each tier, as a multiple of what the prefix
@@ -179,7 +262,16 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   // again; and the FIRST write is amortised over the session, which is what
   // stops the expensive tier from looking free whenever gaps are short.
   const costOf = (tier) => {
-    const hit = gaps.probabilityWithin(tier.ms);
+    // THE SAME QUANTITY THE OUTCOMES RECORD, which is what makes the
+    // observation admissible here at all. `hit` is P(a turn arrives before the
+    // entry expires) and `recordRefreshOutcome`'s `hit` is exactly that event,
+    // measured -- unlike keepWarmDecision, whose probability is the narrower
+    // ping window and for which the same observation is only an upper bound.
+    // Bounded rather than replaced even so: a sample drawn only from moments we
+    // CHOSE to refresh is not a sample of gaps, and its bias runs our way.
+    const modelled = gaps.probabilityWithin(tier.ms);
+    const seen = observationsFor(observed, tier.name);
+    const hit = bounded(modelled, seen);
     const perTurn = hit * READ_MULTIPLIER + (1 - hit) * tier.writeMultiplier;
     // THE SUPPLIED VALUE, not only the computed one. Math.max(1, NaN) is NaN -- Math.max
     // propagates it rather than clamping -- so perTurn became NaN, the `perTurn >= 1` guard below
@@ -192,6 +284,8 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     return {
       tier,
       hit,
+      seen,
+      boundedByObservation: Boolean(seen) && hit < modelled,
       perTurn: (tier.writeMultiplier + (turns - 1) * perTurn) / turns,
     };
   };
@@ -208,99 +302,53 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     action: 'refresh',
     tier: best.tier.name,
     hitProbability: best.hit,
+    observedHitRate: best.seen ? best.seen.rate : null,
+    observedRefreshes: best.seen ? best.seen.refreshes : 0,
     expectedCostPerTurn: Number(best.perTurn.toFixed(3)),
     expectedValue: Math.round((1 - best.perTurn) * prefixTokens),
     reason: `${Math.round(best.hit * 100)}% of gaps land inside ${best.tier.name}; ` +
-      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached`,
+      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached` +
+      (best.boundedByObservation
+        ? `, bounded by ${best.seen.refreshes} observed refreshes ` +
+          `(${Math.round(best.seen.rate * 100)}% used before expiry)`
+        : ''),
   };
 }
 
-/** Observations of a tier before its measured hit rate may override the model. */
-export const OBSERVATION_FLOOR = 5;
-
-/** Records a refresh so its outcome can be scored. */
-export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
-  record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
-}
-
 /**
- * Scores every refresh whose window has since resolved.
+ * Records a refresh so its outcome can be scored.
  *
- * THE MISSING HALF, and it was missing because nobody could see where the
- * signal would come from. `recordRefreshOutcome` needs to know whether a real
- * turn arrived before the entry expired -- and that is not a thing anyone has
- * to instrument, because the event log already records when every turn
- * happened. The answer was in the data the whole time.
+ * `sessionId` IS REQUIRED FOR THE REFRESH TO BE SCOREABLE, and is not defaulted
+ * to anything. The hit test asks whether a turn of THIS conversation arrived
+ * before expiry; pooling arrivals across sessions would let a second concurrent
+ * session's turn pay for this one's ping, which manufactures hits. A refresh
+ * recorded without one is kept in the ledger and reported as unattributable
+ * rather than guessed at.
  *
- * For each unscored refresh at time T on a tier with TTL `ms`:
- *
- *   - a later event within `ms`            -> HIT, observed
- *   - a later event after `ms`             -> MISS, observed
- *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
- *                                             demonstrably closed unused
- *   - no later event, window still open    -> NOTHING RECORDED
- *
- * That last line is the important one and it is Plan 2's own instruction: "if
- * no signal is available for a tier, record nothing rather than guessing
- * `hit: false`". A refresh whose window has not closed yet is not a miss, and
- * scoring it as one would drive the tripwire negative on the newest and least
- * informative records.
- *
- * DRAINED AT READ TIME, which is the pattern this codebase already uses for
- * staleness: the producer cannot know the outcome at the moment it acts, so the
- * next reader resolves what has become knowable since.
+ * Returns the stored record, whose `id` is what `scoreRefreshes` pairs the
+ * outcome to, so an issuer can hold onto it.
  */
-export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
-  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
-  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
-  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
-
-  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
-  // so everything past the number already scored is outstanding. Pairing by
-  // timestamp instead would double-count two refreshes recorded in the same
-  // millisecond, which is reachable: a tool run twice in a loop.
-  const outstanding = refreshes.slice(scored);
-  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
-
-  let recorded = 0;
-  for (const refresh of outstanding) {
-    const at = Number(refresh.at) || 0;
-    if (!at) continue;
-    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
-    const next = timeline.find((t) => t > at);
-
-    let hit;
-    if (next !== undefined) hit = next - at <= tierSpec.ms;
-    else if (now - at > tierSpec.ms) hit = false;
-    else continue; // window still open: not yet knowable
-
-    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
-    recorded += 1;
-  }
-  return { outstanding: outstanding.length, recorded };
-}
-
-/**
- * The measured hit rate for a tier, or null below the observation floor.
- *
- * Null rather than a small-sample number, because the caller substitutes it for
- * a modelled probability and three observations would swing the decision harder
- * than the model they replace.
- */
-export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
-  const relevant = outcomes.filter(
-    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
-  );
-  if (relevant.length < OBSERVATION_FLOOR) return null;
-  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
+export function recordRefresh(dir, { tier, prefixTokens, expectedValue, sessionId, at }) {
+  return record(dir, {
+    kind: 'keepwarm',
+    action: 'refresh',
+    tier,
+    prefixTokens,
+    expectedValue,
+    sessionId,
+    at,
+  });
 }
 
 /**
  * Records whether the refresh was used.
  *
  * `hit` means a real turn arrived before expiry, so the write bought a read.
+ * `refreshId` names the refresh this scores, so the same one cannot be scored
+ * twice -- once per turn for the rest of the session, which is what an
+ * unpaired outcome would become.
  */
-export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
+export function recordRefreshOutcome(dir, { tier, prefixTokens, hit, refreshId = null }) {
   const tierSpec = TIERS.find((t) => t.name === tier) || TIERS[0];
   // THE SAME LEDGER keepWarmDecision BUYS THE REFRESH WITH. That function is explicit that a
   // refresh is a PING, which READS the prefix -- costOfPing = prefixTokens * READ_MULTIPLIER --
@@ -317,7 +365,125 @@ export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
   const realised = hit
     ? prefixTokens * (tierSpec.writeMultiplier - READ_MULTIPLIER) - prefixTokens * READ_MULTIPLIER
     : -prefixTokens * READ_MULTIPLIER;
-  record(dir, { kind: 'keepwarm', action: 'outcome', tier, prefixTokens, hit: Boolean(hit), realised: Math.round(realised) });
+  record(dir, {
+    kind: 'keepwarm',
+    action: 'outcome',
+    tier,
+    prefixTokens,
+    hit: Boolean(hit),
+    refreshId,
+    realised: Math.round(realised),
+  });
+}
+
+/**
+ * Scores every recorded refresh whose window has closed -- and NOTHING ELSE.
+ *
+ * This is the arm that was missing. `recordRefresh` and `recordRefreshOutcome`
+ * were both correct and both called by nothing, so the decision spent money on
+ * refreshes and could never find out whether one bought a read.
+ *
+ * THE SIGNAL IS REAL, not invented. `gapDistribution` already treats this log's
+ * timestamps as turn arrivals -- that is the distribution the whole decision is
+ * fitted to -- so the same log answers the outcome question directly: a refresh
+ * at tier `5m` was used if a turn of the same session arrived within five
+ * minutes of it. Four cases refuse to answer rather than guess, and every one
+ * of them refuses in the direction that costs this project its own good news:
+ *
+ *   - `pending`: the window has not closed yet. A hit could be scored the
+ *     instant it arrives while a miss must wait out the whole TTL, so scoring
+ *     early would mean the recorded hits are always complete and the recorded
+ *     misses always lagging -- right-censoring, biased upward, invisible in any
+ *     test. So a hit waits exactly as long as a miss.
+ *   - `uncovered`: the arrival log no longer reaches back to the refresh, so
+ *     absence of an arrival is absence of evidence. RECORDING `hit: false` HERE
+ *     WOULD BE THE INVENTION THIS IS FORBIDDEN TO MAKE: an absent signal is not
+ *     a miss, and treating it as one biases every rate downward and would
+ *     eventually switch keep-warm off on no evidence at all.
+ *   - `unattributable`: the refresh names no session, so no arrival can be
+ *     shown to belong to it.
+ *   - already scored: an outcome already names this refresh.
+ *
+ * The firehose is READ LAZILY, and only when there is something to score. On a
+ * machine where nothing issues refreshes -- which is every machine today, since
+ * nothing in this repository issues one -- the whole cost is the outcome-log
+ * read: median 70 ms on a 3.5 MB log, of which readBalance is 49 ms, because
+ * that reader also scans the firehose tail for pre-split records.
+ */
+export function scoreRefreshes(dir, {
+  refreshes = readBalance(dir),
+  arrivals = null,
+  now = Date.now(),
+} = {}) {
+  const summary = { scored: 0, hits: 0, pending: 0, uncovered: 0, unattributable: 0 };
+  const keepwarm = refreshes.filter((event) => event?.kind === 'keepwarm');
+  const alreadyScored = new Set(
+    keepwarm
+      .filter((event) => event.action === 'outcome' && event.refreshId)
+      .map((event) => event.refreshId)
+  );
+  const unscored = keepwarm.filter(
+    (event) =>
+      event.action === 'refresh' &&
+      Number.isFinite(event.at) &&
+      event.id &&
+      !alreadyScored.has(event.id)
+  );
+
+  // A refresh with no id cannot be paired, so scoring it would write a fresh
+  // outcome on every turn forever. Reported, not silently dropped.
+  summary.unattributable += keepwarm.filter(
+    (event) => event.action === 'refresh' && (!event.id || !Number.isFinite(event.at))
+  ).length;
+
+  if (!unscored.length) return summary;
+
+  const events = (arrivals ? arrivals() : readMetrics(dir)).filter((event) =>
+    Number.isFinite(event?.at)
+  );
+  // Coverage is judged over EVERY event, including our own bookkeeping: the
+  // refresh's own copy in the firehose is what proves the window is still
+  // inside the read. Arrivals are judged over everything else, because a record
+  // keep-warm wrote about itself is not a turn -- and counting one would
+  // manufacture a hit out of the act of measuring.
+  const earliest = events.reduce((min, event) => Math.min(min, event.at), Infinity);
+  const turns = events.filter((event) => event.kind !== 'keepwarm');
+
+  for (const refresh of unscored) {
+    const tier = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    if (now - refresh.at < tier.ms) {
+      summary.pending += 1;
+      continue;
+    }
+    const session = refresh.sessionId;
+    if (!session) {
+      summary.unattributable += 1;
+      continue;
+    }
+    if (!(earliest <= refresh.at)) {
+      summary.uncovered += 1;
+      continue;
+    }
+
+    const opens = refresh.at + TURN_GAP_MS;
+    const closes = refresh.at + tier.ms;
+    const hit = turns.some(
+      (event) =>
+        (event.sessionId ?? event.episodeId) === session &&
+        event.at > opens &&
+        event.at <= closes
+    );
+    recordRefreshOutcome(dir, {
+      tier: refresh.tier,
+      prefixTokens: refresh.prefixTokens,
+      hit,
+      refreshId: refresh.id,
+    });
+    summary.scored += 1;
+    if (hit) summary.hits += 1;
+  }
+
+  return summary;
 }
 
 /**
@@ -372,23 +538,15 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
-  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
-  // becomes evidence now, so the decision below and the tripwire above both see
-  // the most that is currently knowable -- the same read-time drain the
-  // staleness path uses, and for the same reason: the producer cannot know the
-  // outcome at the moment it acts.
-  try {
-    scoreOutstandingRefreshes(dir, { events, outcomes });
-    outcomes = readBalance(dir);
-  } catch {
-    /* scoring is evidence, never a reason to refuse a decision */
-  }
-
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
+  // THE SAME ARRAY THE TRIPWIRE JUST READ, so closing the loop costs no extra
+  // I/O -- and so the decision and its backstop cannot be looking at different
+  // evidence about the same refreshes.
+  const observed = observedHitRates(outcomes);
   const gaps = gapDistribution(dir, { events });
-  const best = ttlTier({ prefixTokens, gaps });
+  const best = ttlTier({ prefixTokens, gaps, observed });
   if (!best) {
     // THE TWO MODELS ANSWER DIFFERENT QUESTIONS, so they may legitimately disagree. ttlTier asks
     // whether holding a cache beats not caching at all; keepWarmDecision asks whether ONE ping
@@ -397,11 +555,7 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({
-      prefixTokens,
-      gaps,
-      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
-    });
+    const decision = keepWarmDecision({ prefixTokens, gaps, observed });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/integrations/cline/hooks/token-optimizer/lib/loo.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/loo.mjs
@@ -1,0 +1,788 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/loo.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 2 -- what one finding is actually worth, measured by withholding it.
+ *
+ * Layer 1 asks whether the model went back and named a finding. This asks the
+ * harder question and answers it causally: WITHHOLD ONE FINDING while serving
+ * every other finding for the same touch, and compare what the session spent
+ * READING that anchor afterwards. Nobody in this space measures per-item value
+ * this way in production; the state of the art is an offline evaluation set.
+ * That is also why this file is more refusal than statistics -- a causal claim
+ * from four observations is worse than no claim, because it is a number and
+ * numbers get quoted.
+ *
+ * THE ESTIMAND IS READ-SUPPRESSION, and it is deliberately DISJOINT from Layer
+ * 1. Layer 1 keys on an explicit `query` naming a finding key. This keys on
+ * `read` events against the injection's anchor. Neither signal appears in the
+ * other's arithmetic: no `query` event is consulted here, and `usage.mjs`
+ * consults no `read` event. Task 8 calibrates one against the other, and if
+ * both derived from the same channel that calibration would report a strong
+ * correlation between two spellings of one quantity and mean nothing.
+ *
+ * IT INVENTS NO JOIN. `recordToolOutcome` already joins each post-tool result
+ * back to the injection that preceded it, recording `injectionId`,
+ * `findingIds` and a `joinMethod` of `tool-call-id` / `episode-anchor` /
+ * `none`. Every observation here is GATED on that join: an injection with no
+ * joined outcome is unattributable and enters neither arm, exactly as Layer 1
+ * treats `joinMethod: 'none'`. An earlier draft of this plan proposed a fresh
+ * `(sessionId, findingKey)` join; it was rejected and is not here.
+ *
+ * WHAT IT COSTS THE USER, because an experiment that degrades a turn owes an
+ * accounting. One withheld finding means the model may re-derive what it was
+ * told last time, and the worst case is one read of that anchor: measured on
+ * this machine, a median read is 3,769 tokens and the 90th percentile is
+ * 14,082. Five guards bound that exposure, and they are the reason the numbers
+ * below are as small as they are:
+ *
+ *   1. only on a FILE touch, because a command injection has no anchor a read
+ *      event can be joined to -- withholding there would cost a user a finding
+ *      and buy no observation at all (see `buildReport`, which excludes command
+ *      injections from the holdout balance for the same reason);
+ *   2. never when fewer than two findings were kept, so "leave one out" always
+ *      leaves something in -- otherwise it degenerates into `inHoldout`, which
+ *      withholds EVERY finding for an anchor and is a different experiment;
+ *   3. never in the same breath as `inHoldout`: if that arm already withheld
+ *      everything, there is nothing to leave out and a Layer 2 arm recorded
+ *      there would be a fabricated observation;
+ *   4. at most ONE finding per touch, or the effect is attributable to neither;
+ *   5. at most ONE withheld finding per SESSION, so the worst case a user can
+ *      experience is a single re-read -- not one per file they open.
+ *
+ * AND IT NEVER OVERRIDES A PERSON. A `pinned` or `origin: 'human'` finding is
+ * an explicit human decision to keep something in front of the model.
+ * Withholding it to run an experiment would overrule that decision for the
+ * convenience of the measurement, so those findings are exempt: they are
+ * always served, they get no causal score, and `looNote` says so rather than
+ * leaving a reader to wonder why they are missing from the table.
+ */
+
+import { createHash } from 'node:crypto';
+import { readEvidence, readMetrics, readTruncation, isFixtureAnchor } from './metrics.mjs';
+import { retrievalPolicy } from './utility.mjs';
+import { ORIGIN_HUMAN } from './curate.mjs';
+import { canonicalPath } from './paths.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Injections of a finding before it may enter the experiment.
+ *
+ * A finding nobody has served yet has no established value to measure the
+ * absence of, and withholding it would be measuring the cold start rather than
+ * the finding. Four is also what makes the ratio below reachable: at a quarter
+ * of (key, session) pairs armed, a key needs roughly a dozen enrolled
+ * injections before it can reach a verdict at all.
+ */
+export const MIN_PRIOR_INJECTIONS = 4;
+
+/** The observation floor. Below this there is no verdict -- and NOT a zero. */
+export const MIN_SERVED = 6;
+export const MIN_WITHHELD = 3;
+
+/** Benjamini-Hochberg false-discovery rate for published verdicts. */
+export const FDR_Q = 0.1;
+
+/**
+ * Exploration rate.
+ *
+ * Without this, utility feeds the ranking, the ranking feeds injection
+ * frequency, injection frequency feeds the observation count, and a low score
+ * becomes self-fulfilling: the finding is never served often enough to earn a
+ * better one. A tenth of touches therefore ignore the utility order and
+ * promote the LEAST-served candidate instead.
+ */
+export const EPSILON = 0.1;
+
+/**
+ * The share of (finding, session) pairs assigned to the withheld arm.
+ *
+ * Chosen against the floors rather than picked: MIN_SERVED / MIN_WITHHELD is
+ * 2:1, so a quarter withheld reaches both floors at about the same time while
+ * leaving three touches in four undamaged.
+ */
+export const WITHHOLD_FRACTION = 0.25;
+
+/**
+ * Withheld findings allowed per session. ONE.
+ *
+ * The per-touch cap alone bounds nothing across a session: a session that
+ * opens twelve files with enrolled findings could have withheld twelve. This
+ * makes the worst case a user can experience one re-read, at the price of a
+ * mild confound that is stated rather than hidden -- when the cap binds, the
+ * other armed findings in that session are served, so the served arm is
+ * slightly enriched by sessions that touch many enrolled findings.
+ */
+export const MAX_WITHHELD_PER_SESSION = 1;
+
+/**
+ * Fallback shrinkage weight when the between-finding variance cannot be
+ * estimated (fewer than two findings with both arms, or no dispersion at all).
+ *
+ * MIN_SERVED + MIN_WITHHELD, deliberately: a finding's own data outweighs the
+ * population prior only once it has reached the publication floor.
+ */
+export const SHRINKAGE_K = MIN_SERVED + MIN_WITHHELD;
+
+/** Bounds on the estimated shrinkage weight, so a degenerate variance ratio cannot run away. */
+const K_MIN = 1;
+const K_MAX = 100;
+
+/**
+ * Bumped BY HAND when the serving code changes in a way that could move a
+ * finding's measured effect. It is the part of the policy version a hash of the
+ * configuration cannot see.
+ */
+export const LOO_POLICY_GENERATION = 1;
+
+/** Permutation budget before the exact null distribution is sampled instead of enumerated. */
+const MAX_EXACT_PERMUTATIONS = 20_000;
+const SAMPLED_PERMUTATIONS = 10_000;
+
+/**
+ * On by default, off by `TOKEN_OPTIMIZER_LOO=off`.
+ *
+ * Read per call rather than at module load, for the reason `holdoutFraction`
+ * gives: a long-lived process started before the setting changed would
+ * otherwise honour the old value forever with no way to tell.
+ */
+export function LOO_ENABLED() {
+  return String(process.env.TOKEN_OPTIMIZER_LOO || '').trim().toLowerCase() !== 'off';
+}
+
+/**
+ * The serving policy an observation was collected under.
+ *
+ * WHY EVERY OBSERVATION CARRIES ONE. An effect is only meaningful against a
+ * fixed policy. Halve the touch budget or move the minimum net utility and the
+ * same finding is served in different company, at a different rank, against a
+ * different counterfactual -- so pooling observations from before and after
+ * that change would average two different experiments and call the result
+ * causal. `effects()` therefore groups by (finding, policy) and never across.
+ *
+ * IT IS DELIBERATELY ABSENT FROM THE ARM HASH. Including it would reassign
+ * arms the moment a setting changed, which is precisely the mid-session flip
+ * the arm hash exists to prevent. Configuration decides which experiment an
+ * observation belongs to; it must never decide which arm.
+ */
+export function servingPolicyVersion() {
+  const policy = retrievalPolicy();
+  const parts = [
+    `g${LOO_POLICY_GENERATION}`,
+    `touch=${Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500}`,
+    `benefit=${policy.baseBenefitTokens}`,
+    `minutility=${policy.minimumNetUtility}`,
+    `cooldown=${policy.cooldownMs}`,
+    `quarantine=${policy.quarantineHarmCount}`,
+    `holdout=${process.env.TOKEN_OPTIMIZER_HOLDOUT ?? 'default'}`,
+    `withhold=${WITHHOLD_FRACTION}`,
+    `prior=${MIN_PRIOR_INJECTIONS}`,
+    `epsilon=${EPSILON}`,
+  ];
+  const digest = createHash('sha256').update(parts.join('|')).digest('hex');
+  return `${LOO_POLICY_GENERATION}-${digest.slice(0, 8)}`;
+}
+
+/**
+ * A stable number in [0, 1) from a string.
+ *
+ * SHA-256 rather than SHA-1 for the same reason `inHoldout` uses it: this is a
+ * bucketing hash and nothing here is secret, but arguing that a CodeQL finding
+ * is benign is a worse habit than paying a cost that rounds to nothing.
+ */
+function bucket(text) {
+  return createHash('sha256').update(String(text)).digest().readUInt32BE(0) / 4_294_967_296;
+}
+
+/**
+ * The arm of one finding in one session.
+ *
+ * Keyed on (findingKey, sessionId) AND NOTHING ELSE, so a finding cannot
+ * change arms partway through a session: not when the candidate set changes,
+ * not when the budget changes, not when the graph grows. The measurement is a
+ * comparison between sessions, and an arm that flips inside one contaminates
+ * both sides of it.
+ */
+function armed(findingKey, sessionId) {
+  return bucket(`loo-arm:${findingKey}:${sessionId}`) < WITHHOLD_FRACTION;
+}
+
+/** Deterministic tiebreak among armed candidates: lowest bucket, then key order. */
+function armRank(findingKey, sessionId) {
+  return bucket(`loo-rank:${findingKey}:${sessionId}`);
+}
+
+/** The graph node for a finding key, or null. Keys are unique per graph. */
+function findingNode(graph, key) {
+  const nodes = graph?.nodes;
+  if (!nodes || typeof nodes.values !== 'function') return null;
+  for (const node of nodes.values()) {
+    if (node?.kind === 'finding' && node.key === key) return node;
+    // A fixture graph may omit `kind`; key identity is what this needs.
+    if (node?.key === key && node.kind === undefined) return node;
+  }
+  return null;
+}
+
+/**
+ * May this finding ever be withheld?
+ *
+ * FAILS CLOSED ON AN UNKNOWN KEY, which is the opposite of how the rest of
+ * this module fails. Everywhere else a missing input costs a measurement; here
+ * it could cost a human their explicit decision, because a key whose node
+ * cannot be read is a key whose `pinned` and `origin` cannot be checked.
+ */
+function withholdable(graph, key) {
+  const node = findingNode(graph, key);
+  if (!node) return false;
+  if (node.pinned) return false;
+  if (node.origin === ORIGIN_HUMAN) return false;
+  if (node.retired) return false;
+  return true;
+}
+
+/** Prior SERVED injections per finding key, and withheld injections per session. */
+function history(dir, { evidence = null } = {}) {
+  const priorServed = new Map();
+  const withheldPerSession = new Map();
+  const events = evidence || readEvidence(dir);
+  for (const event of events) {
+    if (event.kind !== 'inject') continue;
+    if (typeof event.loo === 'string' && event.loo) {
+      const session = typeof event.sessionId === 'string' ? event.sessionId : '';
+      withheldPerSession.set(session, (withheldPerSession.get(session) || 0) + 1);
+    }
+    if (event.holdout) continue;
+    const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+    for (const raw of keys) {
+      const key = String(raw);
+      priorServed.set(key, (priorServed.get(key) || 0) + 1);
+    }
+  }
+  return { priorServed, withheldPerSession };
+}
+
+/**
+ * Which single finding to withhold from this touch, or null.
+ *
+ * Called from `forTouch` AFTER `fit` has decided what would have been served,
+ * which is the only ordering that produces a true leave-one-out. Withholding
+ * BEFORE the budget runs would let a lower-ranked finding take the freed
+ * tokens, so the withheld arm would receive different company as well as one
+ * fewer finding, and the comparison would confound the two.
+ *
+ * @param {string[]} findingKeys keys that would otherwise be delivered
+ * @param {string} sessionId the session, which pins the arm
+ * @param {object} graph the loaded graph, for `pinned` / `origin`
+ * @param {string|null} dir graph directory, for the injection history
+ */
+export function withheldFor(findingKeys, sessionId, graph, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return null;
+
+    // Every guard that needs no I/O runs first: this is the PreToolUse path,
+    // and on a project with one finding per anchor the answer is null before
+    // anything is read.
+    const keys = [...new Set((findingKeys || []).map((k) => String(k)).filter(Boolean))];
+    if (keys.length < 2) return null;
+    if (!sessionId || typeof sessionId !== 'string') return null;
+
+    // FILE SURFACE ONLY. A command injection's anchor is the command text, and
+    // no read event will ever match it -- so both arms would score zero
+    // downstream and the finding would be scored on nothing.
+    const { surface = 'file', anchor = '', holdout = false } = options;
+    if (surface !== 'file' || !anchor) return null;
+    // The all-findings holdout already withheld everything for this anchor.
+    if (holdout) return null;
+
+    const eligible = keys.filter((key) => withholdable(graph, key));
+    if (!eligible.length) return null;
+
+    const { priorServed, withheldPerSession } = history(dir, options);
+    if ((withheldPerSession.get(sessionId) || 0) >= MAX_WITHHELD_PER_SESSION) return null;
+
+    const enrolled = eligible.filter(
+      (key) => (priorServed.get(key) || 0) >= MIN_PRIOR_INJECTIONS
+    );
+    if (!enrolled.length) return null;
+
+    const candidates = enrolled.filter((key) => armed(key, sessionId));
+    if (!candidates.length) return null;
+
+    // AT MOST ONE. Sorted deterministically so the same touch always yields the
+    // same choice; the findings that lose the tiebreak are SERVED, and the
+    // observation records what actually happened rather than what the arm hash
+    // intended.
+    candidates.sort(
+      (a, b) => armRank(a, sessionId) - armRank(b, sessionId) || (a < b ? -1 : a > b ? 1 : 0)
+    );
+    return candidates[0];
+  } catch {
+    // An experiment must never break a tool call. Failing open here means
+    // serving everything, which is the undegraded behaviour.
+    return null;
+  }
+}
+
+/**
+ * Reorders candidates so exploration can break the feedback loop.
+ *
+ * A tenth of touches -- deterministic in (session, anchor), not random, so the
+ * same touch behaves the same way twice -- promote the LEAST-served candidate
+ * ahead of the utility order, giving it a chance to survive `fit` and accrue
+ * the observations it needs to earn a score. The other nine tenths are
+ * untouched.
+ *
+ * @param {Array<{finding:{key:string}}>} items assessed candidates, best first
+ */
+export function exploreOrder(items, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return items;
+    const list = Array.isArray(items) ? items : [];
+    if (list.length < 2) return list;
+    const { sessionId = '', anchor = '' } = options;
+    if (bucket(`loo-explore:${sessionId}:${anchor}`) >= EPSILON) return list;
+
+    const keyOf = (item) => String(item?.finding?.key ?? item?.key ?? '');
+    const { priorServed } = history(dir, options);
+    let promoted = 0;
+    for (let i = 1; i < list.length; i += 1) {
+      const a = priorServed.get(keyOf(list[i])) || 0;
+      const b = priorServed.get(keyOf(list[promoted])) || 0;
+      if (a < b || (a === b && keyOf(list[i]) < keyOf(list[promoted]))) promoted = i;
+    }
+    if (promoted === 0) return list;
+    return [list[promoted], ...list.filter((_, i) => i !== promoted)];
+  } catch {
+    return Array.isArray(items) ? items : [];
+  }
+}
+
+const mean = (values) =>
+  values.length ? values.reduce((sum, v) => sum + v, 0) / values.length : 0;
+
+/** Sample variance (n-1). Zero for a single observation: dispersion is unknown, not large. */
+function variance(values) {
+  if (values.length < 2) return 0;
+  const m = mean(values);
+  return values.reduce((sum, v) => sum + (v - m) * (v - m), 0) / (values.length - 1);
+}
+
+/**
+ * Every attributable Layer 2 observation, one per (injection, finding, arm).
+ *
+ * THREE THINGS ARE REPORTED SEPARATELY RATHER THAN FOLDED IN, because each of
+ * them would otherwise turn an absence into a zero:
+ *
+ *   `unattributable`  the outcome join could not attach a tool call to the
+ *                     injection, so nothing is known about what followed it.
+ *   `excluded`        the injection could never produce a read-join at all
+ *                     (command surface, session-start, fixture anchor) or was
+ *                     already in the all-findings holdout.
+ *   `costObservations` how many observations saw a non-zero read cost. If this
+ *                     is zero, "withholding changed nothing" and "the read
+ *                     channel never fired" are the same picture, and only one
+ *                     of them is a finding about findings.
+ */
+export function observations(dir, { events = null, evidence = null } = {}) {
+  const empty = {
+    rows: [],
+    unattributable: 0,
+    unattributableOutcomes: 0,
+    excluded: { command: 0, holdout: 0, fixture: 0, unanchored: 0 },
+    injections: 0,
+    withheldInjections: 0,
+    costObservations: 0,
+    policies: [],
+    windowed: false,
+  };
+  try {
+    const causal = evidence || readEvidence(dir);
+    const all = events || readMetrics(dir);
+    // OUT OF BAND and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` describes the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
+
+    // THE JOIN THIS MODULE CONSUMES AND DOES NOT REPLACE.
+    const joined = new Set();
+    let unattributableOutcomes = 0;
+    for (const event of causal) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) {
+        unattributableOutcomes += 1;
+        continue;
+      }
+      joined.add(String(event.injectionId));
+    }
+
+    // Read cost, grouped the way `buildReport` groups it: (session, anchor),
+    // canonicalised on both sides so two spellings of one file are one anchor.
+    // A mismatch here would make every read invisible and report a clean zero
+    // effect in both arms -- correct code, absent measurement.
+    const reads = new Map();
+    for (const event of all) {
+      if (event.kind !== 'read' || !event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      if (!reads.has(key)) reads.set(key, []);
+      reads.get(key).push(event);
+    }
+
+    const injects = causal
+      .filter((event) => event.kind === 'inject')
+      .map((event, index) => ({ event, index }))
+      .sort((a, b) => (a.event.at || 0) - (b.event.at || 0) || a.index - b.index)
+      .map((row) => row.event);
+
+    // How many injections share each (session, anchor), so a key's read total
+    // is SPLIT between them rather than charged in full to each -- the same
+    // correction `buildReport` applies, and for the same reason: without it the
+    // arm means scale with injections-per-anchor instead of per-touch cost.
+    const perKey = new Map();
+    for (const event of injects) {
+      if (!event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      perKey.set(key, (perKey.get(key) || 0) + 1);
+    }
+
+    const rows = [];
+    const excluded = { command: 0, holdout: 0, fixture: 0, unanchored: 0 };
+    const priorServed = new Map();
+    const policies = new Set();
+    let unattributable = 0;
+    let considered = 0;
+    let withheldInjections = 0;
+
+    for (const event of injects) {
+      const served = (Array.isArray(event.findingIds) ? event.findingIds : []).map(String);
+      const withheldKey = typeof event.loo === 'string' && event.loo ? event.loo : null;
+      const bump = () => {
+        for (const key of served) priorServed.set(key, (priorServed.get(key) || 0) + 1);
+      };
+
+      const isCommand =
+        event.surface === 'command' ||
+        event.trigger === 'command' ||
+        event.surface === 'session-start';
+      if (isCommand) {
+        excluded.command += 1;
+        bump();
+        continue;
+      }
+      if (!event.anchor) {
+        excluded.unanchored += 1;
+        bump();
+        continue;
+      }
+      if (isFixtureAnchor(event.anchor)) {
+        excluded.fixture += 1;
+        bump();
+        continue;
+      }
+      if (event.holdout) {
+        excluded.holdout += 1;
+        bump();
+        continue;
+      }
+
+      considered += 1;
+      if (withheldKey) withheldInjections += 1;
+      const policy = typeof event.looPolicy === 'string' && event.looPolicy
+        ? event.looPolicy
+        : 'unversioned';
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const attributable = Boolean(injectionId && joined.has(injectionId));
+
+      // DOWNSTREAM MEANS AFTER, STRICTLY. The read that triggered the touch is
+      // not caused by the advice; it happened before the advice existed.
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      const at = event.at || 0;
+      const total = (reads.get(key) || []).reduce(
+        (sum, read) => sum + ((read.at || 0) > at ? read.tokens || 0 : 0),
+        0
+      );
+      const cost = total / Math.max(1, perKey.get(key) || 1);
+
+      const observe = (findingKey, arm) => {
+        // ENROLMENT IS RE-DERIVED FROM THE LOG rather than trusted from the
+        // serving decision. It is the one field an old or hand-written record
+        // could contradict, and a served observation from before a finding was
+        // enrolled would compare an established finding against its own cold
+        // start.
+        //
+        // CHECKED BEFORE ATTRIBUTABILITY, so `unattributable` counts only
+        // observations the experiment actually wanted. Counting the rest there
+        // would report a join failure for every finding that was never in the
+        // experiment to begin with -- the same shape as the 2,559-row
+        // measurement-bias defect Layer 1 found in its own first draft.
+        if ((priorServed.get(findingKey) || 0) < MIN_PRIOR_INJECTIONS) return;
+        if (!attributable) {
+          unattributable += 1;
+          return;
+        }
+        policies.add(policy);
+        rows.push({ findingKey, arm, cost, policy, injectionId, anchor: event.anchor });
+      };
+
+      if (withheldKey) observe(withheldKey, 'withheld');
+      for (const findingKey of served) observe(findingKey, 'served');
+      bump();
+    }
+
+    return {
+      rows,
+      unattributable,
+      unattributableOutcomes,
+      excluded,
+      injections: considered,
+      withheldInjections,
+      costObservations: rows.filter((row) => row.cost > 0).length,
+      policies: [...policies].sort(),
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
+function permutationP(servedCosts, withheldCosts) {
+  const pooled = [...servedCosts, ...withheldCosts];
+  const n = pooled.length;
+  const k = withheldCosts.length;
+  if (!k || k === n) return null;
+  const observed = Math.abs(mean(withheldCosts) - mean(servedCosts));
+  const total = pooled.reduce((sum, v) => sum + v, 0);
+  // Mean difference from the withheld-arm sum alone: the served sum is the
+  // complement, so one number decides the statistic.
+  const diffFrom = (withheldSum) =>
+    Math.abs(withheldSum / k - (total - withheldSum) / (n - k));
+
+  const choose = (a, b) => {
+    let out = 1;
+    for (let i = 1; i <= b; i += 1) out = (out * (a - b + i)) / i;
+    return out;
+  };
+
+  const tolerance = 1e-9;
+  if (choose(n, k) <= MAX_EXACT_PERMUTATIONS) {
+    let extreme = 0;
+    let count = 0;
+    const walk = (start, chosen, sum) => {
+      if (chosen === k) {
+        count += 1;
+        if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+        return;
+      }
+      for (let i = start; i <= n - (k - chosen); i += 1) walk(i + 1, chosen + 1, sum + pooled[i]);
+    };
+    walk(0, 0, 0);
+    return count ? extreme / count : null;
+  }
+
+  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
+  // the same p-value and a verdict cannot flicker between two audit runs.
+  let state = 0x9e3779b9;
+  const random = () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4_294_967_296;
+  };
+  let extreme = 0;
+  const order = [...pooled];
+  for (let round = 0; round < SAMPLED_PERMUTATIONS; round += 1) {
+    for (let i = order.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(random() * (i + 1));
+      [order[i], order[j]] = [order[j], order[i]];
+    }
+    let sum = 0;
+    for (let i = 0; i < k; i += 1) sum += order[i];
+    if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+  }
+  return (extreme + 1) / (SAMPLED_PERMUTATIONS + 1);
+}
+
+/**
+ * The per-finding causal effect, shrunk, and whether it may be published.
+ *
+ * `raw` is `mean(withheld) - mean(served)`: POSITIVE means the session read the
+ * anchor more when the finding was withheld, which is the finding earning its
+ * place. `shrunk` is the number a reader should use.
+ *
+ * EMPIRICAL BAYES, and both halves of it come from the data. The prior mean is
+ * the population effect across findings; the weight `k` is the ratio of
+ * within-finding noise to between-finding spread, so a population where every
+ * finding behaves alike shrinks hard and one where they genuinely differ
+ * shrinks little. `SHRINKAGE_K` is the fallback when that spread cannot be
+ * estimated at all. Two observations therefore cannot post a wild score.
+ *
+ * PUBLICATION IS NOT THE SAME QUESTION as having an estimate. A row is
+ * published only if it clears the observation floor AND its permutation
+ * p-value survives Benjamini-Hochberg at q = 0.10 across every candidate row.
+ * Everything else gets `published: false` -- which is not a zero effect, and
+ * `looNote` says which of the two it is. An all-zero-cost population needs no
+ * separate guard: p is exactly 1 there, so nothing can publish anyway.
+ *
+ * NEVER POOLED ACROSS POLICY VERSIONS: rows are keyed on (findingKey, policy).
+ */
+export function effects(dir, options = {}) {
+  try {
+    // `obs` is accepted so `looNote` can read the logs once for both.
+    const obs = options.obs || observations(dir, options);
+    const groups = new Map();
+    for (const row of obs.rows) {
+      const id = JSON.stringify([row.findingKey, row.policy]);
+      if (!groups.has(id))
+        groups.set(id, { findingKey: row.findingKey, policy: row.policy, served: [], withheld: [] });
+      groups.get(id)[row.arm === 'withheld' ? 'withheld' : 'served'].push(row.cost);
+    }
+
+    const raws = [];
+    const withinVars = [];
+    for (const group of groups.values()) {
+      if (!group.served.length || !group.withheld.length) continue;
+      raws.push(mean(group.withheld) - mean(group.served));
+      withinVars.push(
+        variance(group.withheld) / group.withheld.length +
+          variance(group.served) / group.served.length
+      );
+    }
+    const prior = raws.length ? mean(raws) : 0;
+    const within = withinVars.length ? mean(withinVars) : 0;
+    const between = raws.length > 1 ? Math.max(0, variance(raws) - within) : 0;
+    const weight =
+      between > 0 && within > 0
+        ? Math.min(K_MAX, Math.max(K_MIN, within / between))
+        : SHRINKAGE_K;
+
+    const rows = [...groups.values()]
+      .map((group) => {
+        const served = group.served.length;
+        const withheld = group.withheld.length;
+        const both = served > 0 && withheld > 0;
+        const raw = both ? mean(group.withheld) - mean(group.served) : null;
+        const n = served + withheld;
+        const shrunk = raw === null ? null : (n * raw + weight * prior) / (n + weight);
+        const eligible = served >= MIN_SERVED && withheld >= MIN_WITHHELD;
+        return {
+          findingKey: group.findingKey,
+          policy: group.policy,
+          served,
+          withheld,
+          servedMean: mean(group.served),
+          withheldMean: mean(group.withheld),
+          raw,
+          shrunk,
+          p: eligible ? permutationP(group.served, group.withheld) : null,
+          published: false,
+        };
+      })
+      .sort((a, b) =>
+        a.findingKey < b.findingKey ? -1 : a.findingKey > b.findingKey ? 1 : a.policy < b.policy ? -1 : 1
+      );
+
+    // BENJAMINI-HOCHBERG at q = 0.10 over every row that cleared the floor.
+    // One finding tested in isolation would publish at p < 0.10; a hundred
+    // would publish ten false ones, and this module's whole claim is that its
+    // numbers can be quoted.
+    //
+    // THERE IS NO SEPARATE "WAS ANY READ COST OBSERVED" GATE HERE, and its
+    // absence is deliberate rather than an omission. One was written, and
+    // mutation testing showed it could not change a single verdict: if every
+    // observation has zero cost then both arm means are zero, the permutation
+    // statistic is zero for every relabelling, and p is exactly 1 -- which no
+    // BH threshold can pass. The guard was unfalsifiable, and an unfalsifiable
+    // guard is worse than none because it reads as protection nobody can test.
+    // `costObservations` survives as what it can honestly be: a DISCLOSURE, so
+    // `looNote` can say the read channel never fired instead of letting a
+    // reader take an arithmetic zero for a measured one.
+    const candidates = rows
+      .filter((row) => row.p !== null)
+      .sort((a, b) => a.p - b.p);
+    const m = candidates.length;
+    let cutoff = 0;
+    for (let i = 0; i < m; i += 1) {
+      if (candidates[i].p <= ((i + 1) / m) * FDR_Q) cutoff = i + 1;
+    }
+    for (let i = 0; i < cutoff; i += 1) candidates[i].published = true;
+
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * One or two lines for the audit, or nothing at all.
+ *
+ * THE REFUSAL IS THE PRODUCT HERE. On a machine with two injections in sixteen
+ * thousand events, the only honest output is that nothing is measurable yet,
+ * and this says so with the counts that make it checkable rather than printing
+ * a mean of nothing. It returns `null` when Layer 2 has not collected a single
+ * observation, so an idle experiment costs the reader no line at all -- the
+ * same standard `referenceNote` holds itself to.
+ */
+export function looNote(dir, options = {}) {
+  try {
+    const obs = options.obs || observations(dir, options);
+    const rows = effects(dir, { ...options, obs });
+    if (!obs.rows.length && !obs.withheldInjections) return null;
+
+    let graph = options.graph;
+    if (graph === undefined) {
+      try {
+        graph = load(dir);
+      } catch {
+        graph = null;
+      }
+    }
+    let exempt = 0;
+    if (graph?.nodes?.values) {
+      for (const node of graph.nodes.values()) {
+        if (node?.kind !== 'finding' || node.retired) continue;
+        if (node.pinned || node.origin === ORIGIN_HUMAN) exempt += 1;
+      }
+    }
+
+    const published = rows.filter((row) => row.published);
+    const head = published.length
+      ? `Per-finding causal value (leave-one-out): ${published.length} of ${rows.length} ` +
+        `findings show a verdict at q=${FDR_Q}` +
+        published
+          .slice(0, 3)
+          .map(
+            (row) =>
+              `; ${row.findingKey} saves ~${Math.round(row.shrunk)} tokens/touch ` +
+              `(${row.served} served, ${row.withheld} withheld, p=${row.p.toFixed(3)})`
+          )
+          .join('') +
+        '.'
+      : `Per-finding causal value (leave-one-out): NOT MEASURABLE YET -- ` +
+        `${obs.rows.length} attributable observations across ${rows.length} findings, ` +
+        `${obs.withheldInjections} withheld touches; the floor is ${MIN_SERVED} served ` +
+        `and ${MIN_WITHHELD} withheld per finding` +
+        (obs.costObservations ? '' : ', and no read cost has been observed in either arm') +
+        '. No effect is reported, which is not the same as an effect of zero.';
+
+    const caveats = [];
+    if (obs.unattributable)
+      caveats.push(
+        `${obs.unattributable} observations were unattributable (no joined tool outcome) and are in neither arm`
+      );
+    if (exempt)
+      caveats.push(
+        `${exempt} pinned or human-origin findings are exempt from withholding and get no causal score`
+      );
+    if (obs.policies.length > 1)
+      caveats.push(
+        `observations span ${obs.policies.length} serving-policy versions and are never pooled across them`
+      );
+    if (obs.windowed)
+      caveats.push('the read log was truncated, so downstream cost can understate');
+    return caveats.length ? `${head} ${caveats.join('; ')}.` : head;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/cline/hooks/token-optimizer/lib/loo.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/loo.mjs
@@ -545,8 +545,22 @@ export function observations(dir, { events = null, evidence = null } = {}) {
   }
 }
 
-/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
-function permutationP(servedCosts, withheldCosts) {
+/**
+ * Enumerates or samples arm relabellings and returns a two-sided p-value.
+ *
+ * EXPORTED so the cross-layer headline can be held to the same standard as the
+ * per-finding rows it summarises. `crosslayer.mjs` runs this over the two ARMS
+ * of shrunk effect estimates; the statistic, the enumerate-or-sample switch and the
+ * tolerance are therefore shared rather than reimplemented, and there is one
+ * place where "two-sided" is decided.
+ *
+ * `seed` exists for that caller. The default reproduces the fixed seed this
+ * function has always used, so Layer 2's own p-values are byte-identical; the
+ * cross-layer caller passes a seed DERIVED FROM ITS DATA, because a verdict
+ * printed to a human must not depend on `Math.random()` or on which module
+ * happened to call first.
+ */
+export function permutationP(servedCosts, withheldCosts, { seed = 0x9e3779b9 } = {}) {
   const pooled = [...servedCosts, ...withheldCosts];
   const n = pooled.length;
   const k = withheldCosts.length;
@@ -580,9 +594,10 @@ function permutationP(servedCosts, withheldCosts) {
     return count ? extreme / count : null;
   }
 
-  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
-  // the same p-value and a verdict cannot flicker between two audit runs.
-  let state = 0x9e3779b9;
+  // Mulberry32 off the caller's seed: reproducible, so the same data always
+  // yields the same p-value and a verdict cannot flicker between two audit
+  // runs.
+  let state = seed | 0;
   const random = () => {
     state = (state + 0x6d2b79f5) | 0;
     let t = state;

--- a/integrations/cline/hooks/token-optimizer/lib/metrics.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/metrics.mjs
@@ -31,6 +31,7 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { createHash, randomBytes } from 'node:crypto';
+import { redact } from './redact.mjs';
 
 /**
  * Read per call, not once at module load.
@@ -517,6 +518,15 @@ export function readEvidence(dir) {
 }
 
 /**
+ * The captured-output budget, in characters.
+ *
+ * Small enough that a 3 MB test log cannot bloat the evidence log or a single
+ * injected claim, large enough to hold the stack trace or compiler diagnostic
+ * that makes a failure finding worth anything.
+ */
+const OUTPUT_MAX_BYTES = 4096;
+
+/**
  * Joins a post-tool result to the most recent matching injection.  The exact
  * tool-call id wins; clients that omit it fall back to episode + surface +
  * anchor, in timestamp order, and the report states the weaker join method.
@@ -545,10 +555,31 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
+  // text is INJECTED into model context and EXPORTED to markdown, so the
+  // boundary is the only place that can guarantee it: a second caller added
+  // later would otherwise have to remember, and the one that forgot would leak
+  // a secret into two more places than the terminal it came from. `undefined`
+  // rather than `''` when nothing was captured, so JSON.stringify omits the
+  // key entirely and an absent capture is distinguishable from an empty one.
+  const output =
+    outcome.output === undefined || outcome.output === null
+      ? undefined
+      : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
+  // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric
+  // code at all, and 0 is the success value -- defaulting to it would claim
+  // every unreported call exited cleanly, which is a fabricated observation
+  // rather than a missing one.
+  const exit = Number.isInteger(outcome.exit) ? outcome.exit : null;
+
   return record(dir, {
     kind: 'tool-outcome',
     ...outcome,
     anchor,
+    // AFTER the spread, so a caller cannot smuggle raw text past the boundary
+    // by setting the field itself.
+    output,
+    exit,
     injectionId: injection?.injectionId || null,
     findingIds: injection?.findingIds || [],
     joinMethod,

--- a/integrations/cline/hooks/token-optimizer/lib/metrics.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/metrics.mjs
@@ -555,6 +555,22 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // FAILURES ONLY, and that is a deliberate override of the original plan.
+  // The plan predates MCP tool names reaching this path, so it never
+  // considered that a SUCCESSFUL `smart_read` would deposit 4 KB of file
+  // content into the evidence log on every call -- the log would grow with
+  // file text and the privacy surface would be every file the session opened.
+  //
+  // Nothing downstream loses anything. A failure claim quotes the error text;
+  // a "this command works" claim needs only the fact that it worked, which
+  // `success` and `exit` already carry. So the stored text narrows to text
+  // that is already an error message.
+  //
+  // GATED ON `success === true`, not on `!== false`: an outcome that never
+  // said whether it worked is unclassified, not successful, and dropping its
+  // text would lose exactly the failures a client too terse to report status
+  // produces.
+  const captureOutput = outcome.success !== true;
   // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
   // text is INJECTED into model context and EXPORTED to markdown, so the
   // boundary is the only place that can guarantee it: a second caller added
@@ -563,7 +579,7 @@ export function recordToolOutcome(dir, outcome) {
   // rather than `''` when nothing was captured, so JSON.stringify omits the
   // key entirely and an absent capture is distinguishable from an empty one.
   const output =
-    outcome.output === undefined || outcome.output === null
+    !captureOutput || outcome.output === undefined || outcome.output === null
       ? undefined
       : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
   // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric

--- a/integrations/cline/hooks/token-optimizer/lib/metrics.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/metrics.mjs
@@ -663,6 +663,89 @@ export function isFixtureAnchor(anchor) {
  * Fixture anchors are excluded from both.
  */
 /**
+ * Re-reads grouped by anchor -- the one place that decides what "wasteful" means.
+ *
+ * `rereadWaste` needed only the totals, so the grouping lived inside it and the
+ * per-anchor rows were thrown away. `derive.mjs`'s churn detector needs the
+ * rows, and re-deriving them there would put TWO definitions of "a repeat read
+ * of an unchanged file is waste" in the codebase, free to drift apart -- the
+ * exact divergence `npm run sync:hooks` exists to prevent between hooks-core and
+ * its generated copies. So the grouping lives here and both consumers read it.
+ *
+ * A re-read is only a re-read INSIDE ONE SESSION: grouping is keyed on
+ * session + canonical anchor, and rows are then merged per anchor so a file
+ * re-read across three sessions reports as one anchor with the sum of its
+ * repeats rather than three rows the caller has to add up. Merging cannot move
+ * the totals -- a sum of sums -- which is what makes it safe for `rereadWaste`.
+ *
+ * `tokens` is the WASTEFUL token count, not the total: it is the only one of the
+ * three that names something recoverable, and a row whose headline number
+ * included legitimate re-reads would overstate exactly the way the first
+ * version of this measurement did.
+ *
+ * @returns {Array<{anchor: string, repeats: number, wasteful: number,
+ *   tokens: number, legitimate: number, legitimateTokens: number,
+ *   undecidable: number, undecidableTokens: number}>} descending by `wasteful`,
+ *   then by `repeats`.
+ */
+export function rereadsByAnchor(events = [], { includeFixtures = false } = {}) {
+  const groups = new Map();
+  for (const e of events) {
+    if (!e || e.kind !== 'read' || !e.anchor) continue;
+    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
+    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(e);
+  }
+
+  const rows = new Map();
+  for (const list of groups.values()) {
+    if (list.length < 2) continue;
+    list.sort((a, b) => (a.at || 0) - (b.at || 0));
+
+    const anchorKey = canonicalKeyish(list[0].anchor);
+    let row = rows.get(anchorKey);
+    if (!row) {
+      row = {
+        anchor: list[0].anchor,
+        repeats: 0,
+        wasteful: 0,
+        tokens: 0,
+        legitimate: 0,
+        legitimateTokens: 0,
+        undecidable: 0,
+        undecidableTokens: 0,
+      };
+      rows.set(anchorKey, row);
+    }
+
+    for (let i = 1; i < list.length; i++) {
+      const prev = list[i - 1];
+      const cur = list[i];
+      const tokens = cur.tokens || 0;
+      row.repeats += 1;
+      // THE JUDGEMENT, in one place. A repeat read of a file that CHANGED is
+      // correct behaviour, not waste; a read written before fingerprints
+      // existed cannot be judged at all and says so.
+      if (!prev.fp || !cur.fp) {
+        row.undecidable += 1;
+        row.undecidableTokens += tokens;
+      } else if (prev.fp === cur.fp) {
+        row.wasteful += 1;
+        row.tokens += tokens;
+      } else {
+        row.legitimate += 1;
+        row.legitimateTokens += tokens;
+      }
+    }
+  }
+
+  return [...rows.values()].sort(
+    (a, b) => b.wasteful - a.wasteful || b.repeats - a.repeats
+  );
+}
+
+/**
  * Re-read waste, split into what is KNOWN and what is not.
  *
  * The question is narrow on purpose: how often does one session read the same
@@ -677,6 +760,9 @@ export function isFixtureAnchor(anchor) {
  * `undecidable` is reported rather than hidden. Reads written before the
  * fingerprint existed cannot be classified, and a measurement that quietly
  * counted them either way would be inventing its own answer.
+ *
+ * The aggregate fields are UNCHANGED -- `balanceSheet` reads them -- and are now
+ * a fold over `rereadsByAnchor`'s rows. `worst` is purely additive.
  */
 export function rereadWaste(
   dir,
@@ -685,14 +771,7 @@ export function rereadWaste(
   // excludes by design, making the real path untestable.
   { events = readMetrics(dir), includeFixtures = false } = {}
 ) {
-  const groups = new Map();
-  for (const e of events) {
-    if (e.kind !== 'read' || !e.anchor) continue;
-    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
-    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key).push(e);
-  }
+  const rows = rereadsByAnchor(events, { includeFixtures });
 
   const out = {
     repeats: 0,
@@ -704,29 +783,21 @@ export function rereadWaste(
     undecidableTokens: 0,
   };
 
-  for (const list of groups.values()) {
-    if (list.length < 2) continue;
-    list.sort((a, b) => (a.at || 0) - (b.at || 0));
-    for (let i = 1; i < list.length; i++) {
-      const prev = list[i - 1];
-      const cur = list[i];
-      const tokens = cur.tokens || 0;
-      out.repeats += 1;
-      if (!prev.fp || !cur.fp) {
-        out.undecidable += 1;
-        out.undecidableTokens += tokens;
-      } else if (prev.fp === cur.fp) {
-        out.wasteful += 1;
-        out.wastefulTokens += tokens;
-      } else {
-        out.legitimate += 1;
-        out.legitimateTokens += tokens;
-      }
-    }
+  for (const row of rows) {
+    out.repeats += row.repeats;
+    out.wasteful += row.wasteful;
+    out.wastefulTokens += row.tokens;
+    out.legitimate += row.legitimate;
+    out.legitimateTokens += row.legitimateTokens;
+    out.undecidable += row.undecidable;
+    out.undecidableTokens += row.undecidableTokens;
   }
 
   const decided = out.wasteful + out.legitimate;
   out.coverage = out.repeats ? decided / out.repeats : null;
+  // The offenders behind the totals, bounded: a report needs the handful worth
+  // acting on, not one row per file the session touched twice.
+  out.worst = rows.slice(0, 10);
   return out;
 }
 

--- a/integrations/cline/hooks/token-optimizer/lib/recall.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/recall.mjs
@@ -1,0 +1,390 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/recall.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Does retrieval FIND a finding, or does it only find what it was told where
+ * to look?
+ *
+ * `docs/WIKI_GRAPH.md` says embeddings get added "if measurement shows real
+ * recall loss". Nothing measured recall, so the no-embeddings stance was
+ * unfalsifiable -- a claim with no observation that could contradict it. This
+ * module is the observation.
+ *
+ * ---------------------------------------------------------------------------
+ * THE TAUTOLOGY THIS DELIBERATELY DOES NOT SHIP, AND WHY IT IS RECORDED HERE
+ * ---------------------------------------------------------------------------
+ * The obvious probe -- for each finding, take its anchors and ask whether
+ * `findingsFor` returns it from each -- CANNOT FAIL. `findingsFor(graph, A)`
+ * walks `derived_from` edges backwards into A, and the edge F -> A is the very
+ * thing that makes A an anchor of F. So F is in the result by CONSTRUCTION, not
+ * by retrieval quality, for every graph, forever. Its rate is 1.0 always, and a
+ * permanent 1.0 published as a recall rate reads to a human as "retrieval is
+ * perfect, embeddings unnecessary" -- one unfalsifiable claim swapped for
+ * another, leaning the one direction a measurement of this project by this
+ * project must never lean.
+ *
+ * That check is still worth running -- if it ever fails, traversal is broken
+ * rather than merely lossy -- so it is kept, and reported as `integrity` with
+ * its own `what` string saying it is not a recall rate. It is NEVER `rate`.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT IS MEASURED INSTEAD: LEAVE-ONE-EDGE-OUT
+ * ---------------------------------------------------------------------------
+ * For each active finding F and each anchor A of F, delete the edge F -> A and
+ * ask whether touching A would STILL surface F. Two independent arms, both of
+ * which can genuinely miss, which is what makes this a measurement:
+ *
+ *   Arm A -- TRAVERSAL FROM THE NEIGHBOURHOOD. Run the real `findingsFor` over
+ *   the edge-deleted graph from A itself and from A's `contains` parents. This
+ *   hits only when F has some OTHER structural route in: a second anchor on the
+ *   same file, or an anchor on a sibling symbol under the same parent. A's
+ *   `contains` children need no separate call because `findingsFor` expands
+ *   them itself -- calling the parent therefore covers every sibling, which is
+ *   why the neighbour list is `[A, ...parents(A)]` and not a hop-counted
+ *   frontier. The REAL primitive is used rather than an equivalent inlined
+ *   here, because a probe that reimplements the thing it measures drifts from
+ *   it and then measures itself.
+ *
+ *   Arm B -- BM25 FROM THE ANCHOR'S OWN KEY. Rank the whole active corpus with
+ *   `lexical.rank`, querying with A's key -- the file path or symbol name the
+ *   user actually touched -- and hit if F comes back inside `limit`.
+ *
+ * WHY ARM B IS NOT QUERIED WITH THE FINDING'S OWN CLAIM. The plan's literal
+ * form was "the finding's claim terms against the rest of the corpus", and both
+ * readings of it are degenerate. Querying F's claim against a corpus that
+ * INCLUDES F is the tautology again: BM25 scores a document against its own
+ * text, so F wins its own query every time. Querying F's claim against a corpus
+ * that EXCLUDES F cannot return F at all, so a "hit" would mean some DIFFERENT
+ * finding matched -- that is redundancy of storage, not recall of F, and it
+ * would score a graph better for holding duplicates. The anchor's key is the
+ * one query text that is available offline, is not derived from F, and matches
+ * the production question: a session touches a file, and the only lexical
+ * handle on it is its own path. It misses exactly when a finding's claim never
+ * names the code it is about, which is the recall gap embeddings are supposed
+ * to close.
+ *
+ * ---------------------------------------------------------------------------
+ * REFUSALS -- four, and each costs this project its own good news
+ * ---------------------------------------------------------------------------
+ *  1. TOO FEW OBSERVATIONS -> `rate: null` with a reason. See `MIN_PROBED`.
+ *  2. A CORPUS NO LARGER THAN THE RETRIEVAL LIMIT -> `rate: null`. Arm B is
+ *     recall@`limit`, and below the limit NO FINDING IS EVER CUT FOR BUDGET:
+ *     every document scoring above zero is returned, so the arm measures
+ *     whether a token matched, which is a strictly weaker bar than the one
+ *     production applies when `forTouch` fills a token budget from a ranked
+ *     list. A probe more permissive than the system it measures can only
+ *     overstate recall, so the rate is withheld in that band and the counts are
+ *     published instead. It bites between `MIN_PROBED` and `limit` findings --
+ *     on this machine's project graph, whose one finding had both anchor edges
+ *     "recovered" that way, the observation-count refusal fires first.
+ *  3. NO ANCHOR NODE -> the pair is UNPROBEABLE, not a miss. Reported and
+ *     excluded from the denominator; see `probeEdge`.
+ *  4. STRICT AGGREGATION -> a finding counts as retrieved only if EVERY one of
+ *     its probeable anchor edges is recoverable. A finding reachable from one
+ *     anchor and lost from another is a miss, with the losing anchor named.
+ *     This biases the rate DOWN, which is the safe direction here.
+ *
+ * FAILS OPEN. It runs on a report path; a graph it cannot read must cost a
+ * section, not the report.
+ */
+
+import { load, findingsFor } from './wiki.mjs';
+import { rank } from './lexical.mjs';
+
+/**
+ * Distinct findings that must be probeable before a RATE is published at all.
+ *
+ * NOT AN EFFECT-SIZE CONVENTION -- it is a resolution argument. A proportion
+ * over n observations has a resolution of 1/n, so below ten findings the
+ * published figure moves in steps coarser than ten percentage points, and the
+ * two extremes a small graph actually produces (`1.0` and `0.0`) are the two a
+ * reader is most likely to mistake for a finding about retrieval. At n = 10 and
+ * zero misses the exact binomial 95% upper bound on the true miss rate is still
+ * 1 - 0.05^(1/10) = 0.26, so even a clean sweep here bounds recall loss only
+ * below about a quarter -- which is why the refusal reason says what the number
+ * would and would not have supported rather than just naming the floor.
+ *
+ * THE FLOOR IS ON DISTINCT FINDINGS, NOT ANCHOR EDGES. Two anchors of one
+ * finding are two edges of the same claim, not two independent observations;
+ * counting them would let a single multi-anchored finding unlock a rate.
+ */
+export const MIN_PROBED = 10;
+
+/**
+ * The most findings probed in one call.
+ *
+ * Each probed anchor edge costs a graph-sized edge filter plus one or two real
+ * `findingsFor` walks plus one BM25 pass over the corpus, and this runs on the
+ * on-demand report path. The cap is deterministic (findings sorted by key) and
+ * `truncated` says when it bit, so a large graph gets a smaller, honestly
+ * labelled sample rather than a slow report.
+ */
+export const MAX_FINDINGS = 200;
+
+/** Active findings only. A retired claim is withdrawn; recalling it is not a win. */
+function activeFindings(graph) {
+  return [...graph.nodes.values()]
+    .filter((node) => node && node.kind === 'finding' && !node.retired)
+    .sort((a, b) => String(a.key || '').localeCompare(String(b.key || '')));
+}
+
+/** The `contains` parents of every node, indexed once for the whole probe. */
+function parentIndex(graph) {
+  const parents = new Map();
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contains') continue;
+    const list = parents.get(edge.to);
+    if (list) list.push(edge.from);
+    else parents.set(edge.to, [edge.from]);
+  }
+  return parents;
+}
+
+/** The anchors of one finding: the targets of its own `derived_from` edges. */
+function anchorsOf(graph, findingId) {
+  const out = new Set();
+  for (const edge of graph.edges) {
+    if (edge.edge === 'derived_from' && edge.from === findingId) out.add(edge.to);
+  }
+  return [...out];
+}
+
+/**
+ * The graph minus exactly one anchor edge.
+ *
+ * `nodes` is shared rather than copied: nothing here mutates it, and a
+ * 2,600-node Map copied once per anchor edge is the difference between a probe
+ * and a stall.
+ */
+function withoutAnchorEdge(graph, findingId, anchorId) {
+  return {
+    nodes: graph.nodes,
+    edges: graph.edges.filter(
+      (edge) =>
+        !(
+          edge.edge === 'derived_from' &&
+          edge.from === findingId &&
+          edge.to === anchorId
+        )
+    ),
+  };
+}
+
+/**
+ * One anchor edge, hidden, then asked after. Returns `recovered` with the arm
+ * that found it, or a reason -- and `probeable: false` when the question could
+ * not be put at all.
+ */
+function probeEdge(graph, parents, finding, anchorId, corpus, limit) {
+  const hidden = withoutAnchorEdge(graph, finding.id, anchorId);
+
+  // Arm A. `findingsFor` expands `contains` children itself, so the parent call
+  // covers every sibling of the anchor.
+  const neighbours = [anchorId, ...(parents.get(anchorId) || [])];
+  for (const neighbour of neighbours) {
+    const got = findingsFor(hidden, neighbour, { limit });
+    if (got.some((node) => node.id === finding.id)) {
+      return { recovered: true, arm: 'traversal', anchorId };
+    }
+  }
+
+  // Arm B needs a query, and the query is the anchor's own key. A dangling
+  // anchor edge -- an edge whose target node was never indexed, which
+  // `expand.promote` produces -- leaves nothing to query with. That is a
+  // question that could not be asked, NOT an observed miss: scoring it a miss
+  // would manufacture a recall loss out of a graph-integrity defect.
+  const anchor = graph.nodes.get(anchorId);
+  const key = anchor && typeof anchor.key === 'string' ? anchor.key : '';
+  if (!key) {
+    return {
+      recovered: false,
+      probeable: false,
+      anchorId,
+      reason: `anchor ${anchorId} has no node in the graph, so there is no anchor key to query BM25 with`,
+    };
+  }
+
+  const hits = rank(key, corpus, { limit });
+  if (hits.some((hit) => hit.finding && hit.finding.id === finding.id)) {
+    return { recovered: true, arm: 'lexical', anchorId };
+  }
+
+  return {
+    recovered: false,
+    probeable: true,
+    anchorId,
+    reason: `no neighbouring anchor reaches it and BM25 over ${key} does not rank it in the top ${limit}`,
+  };
+}
+
+/**
+ * The probe. An OFFLINE measurement over the graph as it stands -- it reads,
+ * ranks and traverses, and writes nothing.
+ */
+export function recallProbe(
+  dir,
+  {
+    limit = 20,
+    graph = null,
+    minProbed = MIN_PROBED,
+    maxFindings = MAX_FINDINGS,
+  } = {}
+) {
+  const refuse = (reason) => ({
+    basis: 'offline probe over the current graph',
+    probed: 0,
+    retrieved: 0,
+    rate: null,
+    reason,
+    misses: [],
+    unprobeable: [],
+  });
+
+  let g;
+  try {
+    g = graph || load(dir);
+  } catch {
+    return refuse('the graph could not be read, so recall was not measured.');
+  }
+
+  try {
+    const all = activeFindings(g);
+    const truncated = all.length > maxFindings;
+    const findings = truncated ? all.slice(0, maxFindings) : all;
+    const parents = parentIndex(g);
+    // The corpus BM25 ranks over is the ACTIVE graph, uncapped: the sample is
+    // which findings are probed, not what they compete against. Every reported
+    // figure below reads `corpus.length` rather than `all.length`, so the
+    // published size IS the ranking corpus rather than a parallel claim about
+    // it. The distinction is not pedantry: a mutation that shrank the ranking
+    // corpus to the probed sample -- making retrieval easier, in this project's
+    // favour -- SURVIVED the first mutation run precisely because the reported
+    // number came from the other variable and could not move.
+    const corpus = all;
+
+    const misses = [];
+    const unprobeable = [];
+    const integrityFailures = [];
+    let probed = 0;
+    let retrieved = 0;
+    let integrityOk = 0;
+    let probedEdges = 0;
+    let recoveredEdges = 0;
+    const byArm = { traversal: 0, lexical: 0 };
+
+    for (const finding of findings) {
+      const anchors = anchorsOf(g, finding.id);
+
+      // INTEGRITY, run on the UNTOUCHED graph: the by-construction check. Its
+      // only honest use is as a smoke test, and it is reported as one.
+      if (!anchors.length) {
+        integrityFailures.push({
+          key: finding.key,
+          reason:
+            'active finding with no anchor -- writeHarvested refuses to create one',
+        });
+      } else if (
+        anchors.every((anchorId) =>
+          findingsFor(g, anchorId, { limit }).some((node) => node.id === finding.id)
+        )
+      ) {
+        integrityOk += 1;
+      } else {
+        integrityFailures.push({
+          key: finding.key,
+          reason: `not returned by findingsFor from one of its own anchors at limit ${limit}`,
+        });
+      }
+
+      // An unanchored finding is a definite miss, not an unaskable question:
+      // nothing traverses to it and there is no anchor key to query from, so
+      // the anchor-driven path that serves findings on a file touch can never
+      // surface it. Only an explicit wiki_query naming its own terms would.
+      if (!anchors.length) {
+        probed += 1;
+        misses.push({
+          key: finding.key,
+          reason:
+            'no anchor: nothing traverses to it and there is no anchor key to query with, so only an explicit wiki_query of its own terms would surface it',
+        });
+        continue;
+      }
+
+      const results = anchors.map((anchorId) =>
+        probeEdge(g, parents, finding, anchorId, corpus, limit)
+      );
+      const askable = results.filter((result) => result.probeable !== false);
+      probedEdges += askable.length;
+      recoveredEdges += askable.filter((result) => result.recovered).length;
+      for (const result of askable) {
+        if (result.recovered) byArm[result.arm] += 1;
+      }
+
+      if (!askable.length) {
+        unprobeable.push({ key: finding.key, reason: results[0].reason });
+        continue;
+      }
+
+      probed += 1;
+      const lost = askable.filter((result) => !result.recovered);
+      if (!lost.length) retrieved += 1;
+      else misses.push({ key: finding.key, reason: lost[0].reason });
+    }
+
+    const integrity = {
+      what:
+        'BY CONSTRUCTION: a finding is returned by findingsFor from its own anchor because that edge is what makes it an anchor. Expected 1 for every graph. NOT a recall rate.',
+      probed: findings.length,
+      retrieved: integrityOk,
+      rate: findings.length ? integrityOk / findings.length : null,
+      ok: integrityFailures.length === 0,
+      failures: integrityFailures,
+    };
+
+    // Arm B is recall@`limit`. Over a corpus of at most `limit` findings nothing
+    // is ever cut for budget, so the arm asks only whether a token matched --
+    // weaker than the bar production applies under a token budget, and a probe
+    // more permissive than the system it measures can only overstate recall.
+    const discriminating = corpus.length > limit;
+
+    const common = {
+      basis: 'offline probe over the current graph',
+      probed,
+      retrieved,
+      misses,
+      unprobeable,
+      probedEdges,
+      recoveredEdges,
+      byArm,
+      corpus: corpus.length,
+      discriminating,
+      truncated,
+      minProbed,
+      integrity,
+    };
+
+    if (probed < minProbed) {
+      return {
+        ...common,
+        rate: null,
+        reason:
+          probed === 0
+            ? `no probeable finding: ${unprobeable.length} of ${findings.length} active finding(s) have no anchor node to query from, so recall was not measured. No rate is reported, which is not the same as a rate of zero.`
+            : `${probed} probeable finding(s), below the floor of ${minProbed}: a proportion over ${probed} has a resolution of ${Math.round(
+                100 / probed
+              )} percentage points, so no rate is published. ${retrieved} of ${probed} were recovered without their own anchor edge, which is a count and not a rate.`,
+      };
+    }
+
+    if (!discriminating) {
+      return {
+        ...common,
+        rate: null,
+        reason: `the active corpus holds ${corpus.length} finding(s) and the retrieval limit is ${limit}, so nothing is ever cut for budget and the lexical arm asks only whether a token matched -- a weaker bar than production applies. No rate is published off a probe more permissive than the system it measures; ${retrieved} of ${probed} were recovered, which is a count and not a rate.`,
+      };
+    }
+
+    return { ...common, rate: retrieved / probed, reason: null };
+  } catch {
+    return refuse('the probe failed, so recall was not measured.');
+  }
+}

--- a/integrations/cline/hooks/token-optimizer/lib/redact.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/redact.mjs
@@ -1,0 +1,30 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/redact.mjs. Regenerate with `npm run sync:hooks`.
+// hooks-core/redact.mjs
+/**
+ * Redaction for anything derived from captured output.
+ *
+ * WHY THIS IS MANDATORY RATHER THAN PRUDENT. derive.mjs builds claims out of
+ * command stderr. A claim is INJECTED into model context and EXPORTED to
+ * markdown, so a secret that reaches a claim reaches two more places than the
+ * terminal it came from. Pattern matching is imperfect and that is stated in the
+ * spec, but "imperfect" beats "absent" by a wide margin here.
+ */
+
+const PATTERNS = [
+  // Bearer / API-key shaped tokens.
+  [/\b(bearer\s+)[A-Za-z0-9._~+/-]{12,}/gi, '$1[redacted]'],
+  [/\b(sk|pk|ghp|gho|github_pat|xox[baprs])[-_][A-Za-z0-9._-]{10,}/gi, '[redacted]'],
+  // KEY=value where the key name suggests a secret.
+  [/\b([A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|APIKEY|API_KEY|PRIVATE_KEY|CREDENTIAL)[A-Z0-9_]*)\s*[=:]\s*\S+/g, '$1=[redacted]'],
+  // Credentials inside a URL.
+  [/\b([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+):[^\s@]+@/gi, '$1:[redacted]@'],
+  // PEM blocks.
+  [/-----BEGIN[^-]*PRIVATE KEY-----[\s\S]*?-----END[^-]*PRIVATE KEY-----/g, '[redacted key]'],
+];
+
+export function redact(text, { max = 400 } = {}) {
+  let out = String(text ?? '');
+  for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
+}

--- a/integrations/cline/hooks/token-optimizer/lib/redact.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/redact.mjs
@@ -24,7 +24,21 @@ const PATTERNS = [
 ];
 
 export function redact(text, { max = 400 } = {}) {
+  // `?? ''` matters even though String(null)/String(undefined) never throw:
+  // without it a missing value becomes the literal 4-11 character string
+  // "null"/"undefined" -- a garbage claim that silently reaches the graph
+  // and model context instead of surfacing as an error.
   let out = String(text ?? '');
   for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  // Redact BEFORE truncating, never the reverse. Several patterns above rely
+  // on a minimum-length quantifier (e.g. `{10,}`, `{12,}`) plus a prefix.
+  // Truncating first can cut a match down to fewer characters than that
+  // quantifier requires, so the shortened fragment no longer satisfies the
+  // pattern and a live partial secret would pass through in cleartext. By
+  // redacting the full, untruncated string first, every pattern always sees
+  // the complete secret and removes it before any character budget is
+  // spent; the cap below can then only ever cut into already-redacted text
+  // (a label, or the "[redacted]" placeholder itself), never into raw
+  // secret bytes.
   return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
 }

--- a/integrations/cline/hooks/token-optimizer/lib/transcript.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/transcript.mjs
@@ -19,9 +19,11 @@
  */
 
 import {
-  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, unlinkSync,
+  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync,
+  unlinkSync, openSync, readSync, closeSync,
 } from 'node:fs';
 import { join } from 'node:path';
+import { redact } from './redact.mjs';
 
 /** Where a project's transcripts live, under the graph it belongs to. */
 export const transcriptDir = (dir) => join(dir, 'transcripts');
@@ -210,4 +212,204 @@ export function readArchive(dir, sessionId) {
   } catch {
     return [];
   }
+}
+
+/**
+ * How much of a transcript's TAIL is scanned for failed tool results.
+ *
+ * A transcript is the largest file this project reads: the three real ones on
+ * the measuring machine are 5.8 MB, 22 MB and 45 MB. `archive()` above already
+ * reads the whole thing once at Stop, so an unbounded second pass doubles the
+ * most expensive read on the session-end path for evidence that is, by
+ * construction, mostly old. The tail is the right half to keep for the same
+ * reason `buildFeedbackDigest` keeps the end: what a session learned is
+ * concentrated where the work went wrong, which is later rather than sooner.
+ */
+const FAILED_SCAN_BYTES = () =>
+  Number(process.env.TOKEN_OPTIMIZER_TRANSCRIPT_SCAN_BYTES) || 8 * 1024 * 1024;
+
+/** Failed results kept, most recent first. The pairing detector needs a handful. */
+const FAILED_MAX = 50;
+
+/** Same 4 KB cap `recordToolOutcome` applies to `output`, for the same reason. */
+const FAILED_OUTPUT_MAX = 4096;
+
+/**
+ * The same 120-character truncation `recordToolOutcome` applies to `anchor`.
+ *
+ * ONE COMMAND MUST PRODUCE ONE KEY FROM EITHER SOURCE. A `tool-outcome` stores
+ * the command as `String(tool_input.command).slice(0, 120)`, and `attemptKey`
+ * reads up to three non-flag tokens off whatever it is handed. A long first
+ * token -- a quoted grep pattern, an absolute Windows path, a heredoc -- is cut
+ * by that cap INSIDE those three tokens, so the untruncated transcript copy of
+ * the same command lands in a DIFFERENT group. Measured against one real
+ * session's own evidence: 266 commands present in both sources, and truncating
+ * here made 266 of 266 keys agree where the untruncated text agreed on only
+ * 240.
+ *
+ * WHAT THAT ACTUALLY BUYS, stated precisely rather than generously. `derive`
+ * refuses to build a claim out of a command at or over the cap at all (see
+ * `quotable` there), so agreement on a TRUNCATED key never produces a finding
+ * on its own. It buys two things that still matter: a transcript failure lands
+ * in the same run as the event outcomes of the same command, so the
+ * nearest-preceding-failure rule sees the real sequence rather than a sparse
+ * one; and the no-call-id fallback in `derive`'s deduplication compares command
+ * TEXT against an already-truncated anchor, which cannot match unless this side
+ * is truncated identically.
+ */
+const ANCHOR_MAX = 120;
+
+/**
+ * A tool result that reports a command that RAN and exited non-zero.
+ *
+ * A POSITIVE ALLOWLIST, and the measurement is why. Claude Code sets
+ * `is_error: true` on every kind of unhappy tool result, and across three real
+ * transcripts 214 of them fell into four shapes:
+ *
+ *   83  `Exit code N` + stderr    -- a command ran and failed. THIS ONE.
+ *   109 hook and policy denials   -- overwhelmingly THIS optimizer's own
+ *                                    PreToolUse text ("Recursive shell searches
+ *                                    return unbounded output. Call the
+ *                                    token-optimizer MCP tool smart_grep
+ *                                    instead"), plus `Remove-Item on system
+ *                                    path` blocks.
+ *   18  `<tool_use_error>...`     -- protocol errors: `String to replace not
+ *                                    found`, `File has not been read yet`,
+ *                                    `Blocked: ...`.
+ *   4   a person declined the call.
+ *
+ * Only the first shape is a command failing. In every other shape THE COMMAND
+ * NEVER RAN, so "`X` failed with: ..." would be a false claim about X, and a
+ * later success would pair with a failure that never happened. The 109 are the
+ * dangerous ones: ingesting them would have this tool derive findings from its
+ * own advice, at 0.9 confidence, and serve them back as observations about the
+ * project -- a self-referential loop that also inflates its own finding count.
+ * That is the measurement-bias class this plan tracks, and a denylist would
+ * have let every future denial string through by default.
+ */
+const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
+
+/** Reads at most `bytes` from the END of a file, without loading the rest. */
+function readTail(path, bytes) {
+  let fd;
+  try {
+    const size = statSync(path).size;
+    const length = Math.min(size, bytes);
+    if (!length) return '';
+    fd = openSync(path, 'r');
+    const buffer = Buffer.allocUnsafe(length);
+    readSync(fd, buffer, 0, length, size - length);
+    const text = buffer.toString('utf8');
+    // A tail almost never starts on a line boundary, and half a JSON object is
+    // not a parse failure worth reporting -- it is a partial record. Drop it.
+    return length < size ? text.slice(text.indexOf('\n') + 1) : text;
+  } catch {
+    return '';
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+}
+
+/**
+ * The failed COMMAND results a transcript holds, which no hook event carries.
+ *
+ * WHY THIS READER EXISTS. Claude Code never fires PostToolUse for a failed tool
+ * call: a deliberately failing command produced no event at all, and 2,238 of
+ * 2,238 live `tool-outcome` events on the measuring machine carry
+ * `success: true`. So `derive.mjs`'s two strongest detectors -- command
+ * failed-then-succeeded at 0.90 and test/build red-to-green at 0.85 -- have no
+ * input whatsoever on the primary client, while working normally on the ten
+ * adapter clients. The failures exist; they exist only here.
+ *
+ * WHY NOT THE ARCHIVE, which the plan for this reader assumed. `readTurns`
+ * DROPS tool results by design -- that is where whole file contents would enter
+ * the record -- so `readArchive` returns no failure, ever, and an extractor over
+ * archived turns would find nothing however well it was written. Making the
+ * archive carry them would also push command stderr into `buildFeedbackDigest`,
+ * which is the one code path in this project that sends anything to a model
+ * endpoint. So this reads the transcript and STORES NOTHING NEW: read-only, no
+ * capture path, no new event kind, and no widening of what leaves the machine.
+ *
+ * REDACTED HERE, at this boundary, exactly as `recordToolOutcome` redacts
+ * `output`. Transcript text has never passed a redaction boundary -- that one
+ * never saw it -- and everything returned from here is destined for a claim that
+ * is injected into model context and exported to markdown.
+ *
+ * @returns {Array<{command: string, output: string, exit: number|null,
+ *   at: number, toolCallId: string|null}>} in transcript order, so a caller can
+ *   sort it beside `tool-outcome` events without re-ordering.
+ */
+export function failedResultsFromTranscript(transcriptPath, options = {}) {
+  const { max = FAILED_MAX, scanBytes = FAILED_SCAN_BYTES() } = options || {};
+  if (!transcriptPath) return [];
+  const text = readTail(transcriptPath, scanBytes);
+  if (!text) return [];
+
+  // tool_use_id -> the command that was attempted. The join is EXACT and it is
+  // the only one available: the result block carries no command of its own, and
+  // the id is the same string `episodeMeta` reads into `toolCallId`, so the same
+  // key also deduplicates against events on clients that do report failures.
+  const commands = new Map();
+  const failures = [];
+
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const message = entry.message || entry;
+    const role = message.role || entry.type;
+    const content = message.content;
+    if (!Array.isArray(content)) continue;
+
+    if (role === 'assistant') {
+      for (const block of content) {
+        if (!block || block.type !== 'tool_use' || !block.id) continue;
+        const command = block.input?.command;
+        if (typeof command !== 'string' || !command.trim()) continue;
+        commands.set(String(block.id), command.slice(0, ANCHOR_MAX));
+      }
+      continue;
+    }
+
+    if (role !== 'user') continue;
+    for (const block of content) {
+      if (!block || block.type !== 'tool_result' || block.is_error !== true) continue;
+      // Only a STRING result can be an exit-code report; every failed Claude
+      // Code result observed was one, and a structured body is a shape this
+      // classifier has not measured, so it is refused rather than guessed at.
+      if (typeof block.content !== 'string') continue;
+      const match = EXIT_CODE_RESULT.exec(block.content);
+      if (!match) continue;
+      const command = commands.get(String(block.tool_use_id || ''));
+      // No command means no claim. The result says something failed; without
+      // the text of what failed there is nothing to say about it, and nothing
+      // to group it with.
+      if (!command) continue;
+      failures.push({
+        command,
+        // The exit line itself is stripped: `exit` carries it structurally, and
+        // leaving it in makes every failure claim read "failed with: Exit code 1".
+        output: redact(block.content.slice(match[0].length).trim(), {
+          max: FAILED_OUTPUT_MAX,
+        }),
+        exit: Number(match[1]),
+        at: Date.parse(entry.timestamp || '') || 0,
+        toolCallId: block.tool_use_id ? String(block.tool_use_id) : null,
+      });
+    }
+  }
+
+  // The MOST RECENT `max`, keeping chronological order. A session that failed
+  // two hundred times teaches its last lessons, not its first.
+  return failures.slice(-max);
 }

--- a/integrations/cline/hooks/token-optimizer/lib/usage.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/usage.mjs
@@ -42,7 +42,7 @@
  * was referenced" and "nothing could be measured" are different answers and
  * this module gives different answers for them.
  */
-import { readMetrics } from './metrics.mjs';
+import { readMetrics, readTruncation } from './metrics.mjs';
 
 /**
  * The events that name a finding, and it is ONE kind, not the two the plan
@@ -129,17 +129,30 @@ export function classify(dir, { events = null } = {}) {
   try {
     const all = inTimeOrder(events || readMetrics(dir));
 
-    // Every reference, keyed on the finding it names. Only references carrying
-    // a session id are usable -- see `unscopedReferences` in `referenceRate`
-    // for the ones this drops and why they are counted rather than credited.
+    // Every reference, keyed on the finding it names and on nothing else.
+    //
+    // NOT SCOPED BY SESSION, and that is a deliberate reversal. Scoping needs
+    // the query's `sessionId`, which `wiki_query` takes as an OPTIONAL input
+    // the model has to volunteer (`options.sessionId ?? null`) -- so the
+    // numerator depended on the model choosing to identify itself, and an
+    // unverifiable model-supplied id is not evidence. Plan 1 settled that for
+    // the `answers` edge and it settles it here: stop depending on the field
+    // rather than hope for cooperation. The finding key is the specific part
+    // anyway; a key is a graph identity, not a guess.
+    //
+    // THE COST, disclosed here and in `referenceNote` because a reader of the
+    // number has to see it: TWO CONCURRENT SESSIONS ON ONE REPOSITORY CAN
+    // CROSS-ATTRIBUTE. Session A's injection of K plus session B's later query
+    // for K reads as a reference. Nothing in the log can separate them once the
+    // session id is gone, so the exposure is real and is stated rather than
+    // priced.
     const references = new Map();
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       const key = referencedKey(event);
-      const session = sessionOf(event);
-      if (!key || !session) continue;
+      if (!key) continue;
       if (!references.has(key)) references.set(key, []);
-      references.get(key).push({ at: event.at || 0, session });
+      references.get(key).push(event.at || 0);
     }
 
     // Which injections the existing outcome join could attribute. An outcome
@@ -170,9 +183,8 @@ export function classify(dir, { events = null } = {}) {
       const injectionId = event.injectionId ? String(event.injectionId) : null;
       const at = event.at || 0;
       const session = sessionOf(event);
-      // STRICTLY AFTER. A query that PRECEDED the injection is the model
-      // asking on its own initiative; crediting it would let the metric take
-      // the credit for a lookup it had nothing to do with.
+      // STRICTLY AFTER here too: activity that predates the injection is not
+      // an opportunity to have used it.
       const followed = (times) => times.some((t) => t > at);
       const continued =
         (injectionId && attributed.has(injectionId)) ||
@@ -181,9 +193,11 @@ export function classify(dir, { events = null } = {}) {
       for (const raw of keys) {
         const findingKey = String(raw);
         const hits = references.get(findingKey) || [];
-        const referenced = session
-          ? hits.some((hit) => hit.session === session && hit.at > at)
-          : false;
+        // TIME ORDER IS THE ONLY REMAINING GUARD, so it carries the whole
+        // weight of the attribution: a query that PRECEDED the injection is
+        // the model asking on its own initiative, and crediting it would let
+        // the metric take the credit for a lookup it had nothing to do with.
+        const referenced = hits.some((hitAt) => hitAt > at);
         rows.push({
           findingKey,
           injectionId,
@@ -204,9 +218,27 @@ export function classify(dir, { events = null } = {}) {
 /**
  * The rate, with everything needed to tell a real 0 from an absent one.
  *
- * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
- * `unattributable` and `unscopedReferences` are reported beside it, never
- * inside it.
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown` and
+ * `unattributable` are reported beside it, never inside it.
+ *
+ * `windowed` SAYS WHETHER THE DENOMINATOR CAN UNDERSTATE, and it is not
+ * decoration. `readMetrics` reads a 2 MB / 5,000-event TAIL of the firehose,
+ * and injections are rare enough on a real project to age out of it: measured
+ * on this repository, both `inject` events sit at lines 502 and 883 of 6,871
+ * and have scrolled away behind ~6,000 later `read` and `tool-outcome` rows,
+ * so the windowed denominator is 0 where the whole-file truth is 1.
+ *
+ * IT IS REPORTED RATHER THAN FIXED, deliberately. `inject` already gets
+ * unwindowed access through `BALANCE_KINDS` / `EVIDENCE_KINDS`, but `query`
+ * does not -- and reading only the INJECTION arm unwindowed would be worse
+ * than the windowing: every old injection would enter the denominator with no
+ * chance of a matching query in the window and score `not-referenced`,
+ * manufacturing a pessimistic rate out of the asymmetry. Making the query arm
+ * unwindowed means adding `query` to `EVIDENCE_KINDS`, which two other
+ * consumers read, and this project's own standard says a shared-classifier
+ * change needs a per-consumer verdict comparison. So the honest move is to
+ * publish the flag: a caller that needs the unwindowed truth passes its own
+ * `events`, which is exactly what the live measurement in the task report did.
  */
 export function referenceRate(dir, { events = null } = {}) {
   const empty = {
@@ -218,10 +250,15 @@ export function referenceRate(dir, { events = null } = {}) {
     unattributable: 0,
     unattributableWithInjectedToolCall: 0,
     referenceEvents: 0,
-    unscopedReferences: 0,
+    windowed: false,
   };
   try {
     const all = events || readMetrics(dir);
+    // OUT OF BAND, and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` reports on the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
     const rows = classify(dir, { events: all });
     const count = (label) => rows.filter((row) => row.label === label).length;
     const referenced = count('referenced');
@@ -231,17 +268,17 @@ export function referenceRate(dir, { events = null } = {}) {
     // Usable reference events in the window: the numerator's producer. If this
     // is zero the channel never fired, and a 0% rate would be measuring the
     // absence of a producer rather than the uselessness of findings.
+    //
+    // NO SESSION REQUIREMENT, matching the attribution above. The former
+    // `unscopedReferences` counted queries dropped for want of a session id;
+    // nothing is dropped for that reason any more, so the field is GONE rather
+    // than kept at a permanent zero that a later reader would misread as
+    // evidence the loss had been fixed.
     let referenceEvents = 0;
-    let unscopedReferences = 0;
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       if (!referencedKey(event)) continue;
-      if (sessionOf(event)) referenceEvents += 1;
-      // Names a finding but cannot be scoped to one injection. `sessionId` is
-      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
-      // is the expected loss rather than an edge case -- counted here so it is
-      // visible instead of silently deflating the numerator.
-      else unscopedReferences += 1;
+      referenceEvents += 1;
     }
 
     // The tool calls that DID receive findings, keyed the way
@@ -292,7 +329,7 @@ export function referenceRate(dir, { events = null } = {}) {
       unattributable,
       unattributableWithInjectedToolCall,
       referenceEvents,
-      unscopedReferences,
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
     };
   } catch {
     return empty;
@@ -300,11 +337,18 @@ export function referenceRate(dir, { events = null } = {}) {
 }
 
 /**
- * One line for the audit, or nothing at all.
+ * One or two lines for the audit, or nothing at all.
  *
  * Says which of the three things is true -- a measured rate, a live channel
  * with no opportunities yet, or no channel at all -- rather than printing a
  * figure and letting the reader assume the first.
+ *
+ * AND IT CARRIES THE CAVEATS, because this is the only place a human meets the
+ * number. A rate attributed on (finding key, time order) can cross-attribute
+ * between two concurrent sessions on one repository, and a windowed read can
+ * understate the denominator. Both are stated beside the figure they qualify.
+ * Putting them only in a task report would be publishing a clean number and
+ * filing the asterisk somewhere nobody quoting it will look.
  */
 export function referenceNote(dir, { events = null } = {}) {
   const r = referenceRate(dir, { events });
@@ -317,6 +361,11 @@ export function referenceNote(dir, { events = null } = {}) {
   }
   return (
     `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
-    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded. ` +
+    'Matched on finding key and time order, so concurrent sessions on this ' +
+    'repository can cross-attribute' +
+    (r.windowed
+      ? '; and the event log was truncated, so the denominator can understate.'
+      : '.')
   );
 }

--- a/integrations/cline/hooks/token-optimizer/lib/usage.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/usage.mjs
@@ -1,0 +1,322 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/usage.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 1 -- did the model actually go back and use what we injected?
+ *
+ * The cheap behavioural label. One question, answered from the event log alone:
+ * after we put a finding in front of the model, did the model later ASK FOR
+ * THAT FINDING BY NAME?
+ *
+ * WHY EXPLICIT REFERENCE, AND NOT READ-SUPPRESSION. Read-suppression -- "the
+ * file was not re-read, so the finding must have helped" -- is Layer 2's
+ * estimand, measured causally by withholding a finding and comparing. Layer 1
+ * exists to be calibrated AGAINST that. If both layers derived from
+ * suppression, the calibration would compare two spellings of one quantity,
+ * report a strong correlation, and mean nothing. So Layer 1 is deliberately
+ * built on a signal Layer 2 does not touch: an explicit `query` naming the
+ * finding key.
+ *
+ * WHAT THIS DOES NOT DO. It does not invent a join. `recordToolOutcome`
+ * already joins each post-tool result back to the injection that preceded it,
+ * recording `injectionId`, `findingIds` and a `joinMethod` of `tool-call-id`,
+ * `episode-anchor` or `none` -- preferring an exact tool-call id, which is
+ * strictly better evidence than the `(sessionId, findingKey)` approximation an
+ * earlier draft of this plan proposed. This module consumes that join and adds
+ * none of its own. `inject.mjs` needed no change: it has written `findingIds`
+ * at every call site all along.
+ *
+ * WHAT `unknown` IS FOR, and it is the whole reason this file is careful. An
+ * injection whose session simply stopped afterwards is not a miss. Nothing
+ * happened, so nothing can be concluded, and counting it against the finding
+ * would make the metric read worse the more often sessions end -- a number
+ * that moves with session length rather than with usefulness. `unknown` is
+ * therefore EXCLUDED from the denominator rather than scored zero, and
+ * outcomes the join could not attribute at all are reported as
+ * `unattributable` rather than folded into either arm.
+ *
+ * AND WHY THE RATE CAN BE `null`. This project has already shipped two metrics
+ * whose only producer was their own test suite. A rate of 0% that actually
+ * means "no data" is worse than a refusal, because it is a number and numbers
+ * get quoted. So `rate` is null unless there is a denominator AND the
+ * reference channel produced at least one usable event in the window. "Nothing
+ * was referenced" and "nothing could be measured" are different answers and
+ * this module gives different answers for them.
+ */
+import { readMetrics } from './metrics.mjs';
+
+/**
+ * The events that name a finding, and it is ONE kind, not the two the plan
+ * assumed.
+ *
+ * The brief said "a later `query` or `expand` event". Checked against the code
+ * and against every metrics log on this machine, `expand` does not qualify and
+ * cannot be made to:
+ *
+ *   - `recordExpansion` writes `{ ref, tool, shape, asked, sessionId }`. `ref`
+ *     is a TRUNCATION CAPTURE id (a 16-hex digest of captured tool output),
+ *     not a finding key, and `asked` is free text naming a section of that
+ *     output. Neither is a graph key, and no code path ever puts one there.
+ *   - measured: 64 live `expand` events exist on this machine and all 64 carry
+ *     `sessionId: null`, so they could not be scoped to an injection even if
+ *     they did name one.
+ *
+ * Keying the classifier on `expand` would therefore have added a branch that
+ * can never fire -- a metric with no producer, which is the exact defect this
+ * whole effort exists to close. So it is excluded, deliberately and with the
+ * measurement recorded, rather than included for symmetry with the brief.
+ */
+const REFERENCE_KINDS = new Set(['query']);
+
+/**
+ * What counts as the session having CONTINUED past the injection.
+ *
+ * The distinction between `not-referenced` and `unknown` rests entirely on
+ * this, so the set is explicit rather than "any later event". These are the
+ * kinds a tool call produces: if one of them follows the injection in the same
+ * session, the model had the opportunity to ask and did not. If none does, the
+ * session ended and there was no opportunity.
+ *
+ * `inject` is in the set because a later injection means a later tool call
+ * happened. `forecast`, `mcp-client` and `mcp-tool` are NOT: they are written
+ * by session bookkeeping rather than by the model doing something, and
+ * treating them as opportunity would convert `unknown` rows into misses on
+ * bookkeeping alone.
+ */
+const ACTIVITY_KINDS = new Set([
+  'tool-outcome',
+  'read',
+  'query',
+  'expand',
+  'substitute',
+  'inject',
+]);
+
+/** A usable session id: a non-empty string. `null == null` is not a match. */
+const sessionOf = (event) => {
+  const id = event?.sessionId;
+  return typeof id === 'string' && id ? id : null;
+};
+
+/** The finding key a reference event names, or null if it names none. */
+const referencedKey = (event) => {
+  const key = event?.key;
+  return typeof key === 'string' && key ? key : null;
+};
+
+/** Ordering by the caller's timestamp, with log order breaking ties. */
+function inTimeOrder(events) {
+  return events
+    .map((event, index) => ({ event, index }))
+    .sort(
+      (a, b) =>
+        (a.event.at || 0) - (b.event.at || 0) || a.index - b.index
+    )
+    .map((row) => row.event);
+}
+
+/**
+ * One row per (injection, finding) pair, labelled.
+ *
+ * Per injection rather than per finding: the same finding injected twice is two
+ * separate opportunities, and collapsing them would let one reference excuse
+ * every later injection of that key.
+ *
+ * FAILS OPEN. A malformed log yields an empty classification, never a throw:
+ * this runs on report paths that must not break a tool call.
+ */
+export function classify(dir, { events = null } = {}) {
+  let rows = [];
+  try {
+    const all = inTimeOrder(events || readMetrics(dir));
+
+    // Every reference, keyed on the finding it names. Only references carrying
+    // a session id are usable -- see `unscopedReferences` in `referenceRate`
+    // for the ones this drops and why they are counted rather than credited.
+    const references = new Map();
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      const key = referencedKey(event);
+      const session = sessionOf(event);
+      if (!key || !session) continue;
+      if (!references.has(key)) references.set(key, []);
+      references.get(key).push({ at: event.at || 0, session });
+    }
+
+    // Which injections the existing outcome join could attribute. An outcome
+    // carrying our injectionId is proof the tool call completed, which is
+    // opportunity even when the session id is missing from the log.
+    const attributed = new Set();
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) continue;
+      attributed.add(String(event.injectionId));
+    }
+
+    // Activity per session, so "did anything follow?" is one lookup rather
+    // than a scan per injection.
+    const activity = new Map();
+    for (const event of all) {
+      if (!ACTIVITY_KINDS.has(event.kind)) continue;
+      const session = sessionOf(event);
+      if (!session) continue;
+      if (!activity.has(session)) activity.set(session, []);
+      activity.get(session).push(event.at || 0);
+    }
+
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+      if (!keys.length) continue;
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const at = event.at || 0;
+      const session = sessionOf(event);
+      // STRICTLY AFTER. A query that PRECEDED the injection is the model
+      // asking on its own initiative; crediting it would let the metric take
+      // the credit for a lookup it had nothing to do with.
+      const followed = (times) => times.some((t) => t > at);
+      const continued =
+        (injectionId && attributed.has(injectionId)) ||
+        (session ? followed(activity.get(session) || []) : false);
+
+      for (const raw of keys) {
+        const findingKey = String(raw);
+        const hits = references.get(findingKey) || [];
+        const referenced = session
+          ? hits.some((hit) => hit.session === session && hit.at > at)
+          : false;
+        rows.push({
+          findingKey,
+          injectionId,
+          label: referenced
+            ? 'referenced'
+            : continued
+              ? 'not-referenced'
+              : 'unknown',
+        });
+      }
+    }
+  } catch {
+    rows = [];
+  }
+  return rows;
+}
+
+/**
+ * The rate, with everything needed to tell a real 0 from an absent one.
+ *
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
+ * `unattributable` and `unscopedReferences` are reported beside it, never
+ * inside it.
+ */
+export function referenceRate(dir, { events = null } = {}) {
+  const empty = {
+    referenced: 0,
+    notReferenced: 0,
+    unknown: 0,
+    denominator: 0,
+    rate: null,
+    unattributable: 0,
+    unattributableWithInjectedToolCall: 0,
+    referenceEvents: 0,
+    unscopedReferences: 0,
+  };
+  try {
+    const all = events || readMetrics(dir);
+    const rows = classify(dir, { events: all });
+    const count = (label) => rows.filter((row) => row.label === label).length;
+    const referenced = count('referenced');
+    const notReferenced = count('not-referenced');
+    const denominator = referenced + notReferenced;
+
+    // Usable reference events in the window: the numerator's producer. If this
+    // is zero the channel never fired, and a 0% rate would be measuring the
+    // absence of a producer rather than the uselessness of findings.
+    let referenceEvents = 0;
+    let unscopedReferences = 0;
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      if (!referencedKey(event)) continue;
+      if (sessionOf(event)) referenceEvents += 1;
+      // Names a finding but cannot be scoped to one injection. `sessionId` is
+      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
+      // is the expected loss rather than an edge case -- counted here so it is
+      // visible instead of silently deflating the numerator.
+      else unscopedReferences += 1;
+    }
+
+    // The tool calls that DID receive findings, keyed the way
+    // `recordToolOutcome` keys its own primary join: the tool-call id. An
+    // unattributable outcome for one of these is a join that FAILED. An
+    // unattributable outcome for any other tool call had nothing to join to.
+    //
+    // KEYED ON THE TOOL CALL, NOT THE EPISODE, and the first draft of this
+    // got it wrong in a way worth recording because it is the exact
+    // measurement-bias class this plan hunts. `episodeId` equals the SESSION
+    // id, so "unattributable outcomes in an episode that had an injection"
+    // scored all 2,559 tool calls of a session in which ONE injection
+    // happened. It would have published 2,559 join failures where the true
+    // number is zero -- correct code, lying number, and biased pessimistic
+    // rather than flattering, which is no better.
+    const injectedToolCalls = new Set();
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      if (!Array.isArray(event.findingIds) || !event.findingIds.length)
+        continue;
+      if (event.toolCallId) injectedToolCalls.add(String(event.toolCallId));
+    }
+    let unattributable = 0;
+    let unattributableWithInjectedToolCall = 0;
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome' || event.joinMethod !== 'none')
+        continue;
+      unattributable += 1;
+      // BOTH FIGURES, because the raw one alone lies in the pessimistic
+      // direction. Measured on this machine: 2,991 of 2,992 live outcomes
+      // report `joinMethod: 'none'`, and every one of them because NO
+      // INJECTION EXISTED for that tool call -- the graph holds one finding.
+      // Quoting only the raw count would read as a join that fails 99.97% of
+      // the time, which is a different and false claim.
+      if (event.toolCallId && injectedToolCalls.has(String(event.toolCallId)))
+        unattributableWithInjectedToolCall += 1;
+    }
+
+    return {
+      referenced,
+      notReferenced,
+      unknown: count('unknown'),
+      denominator,
+      rate:
+        denominator > 0 && referenceEvents > 0
+          ? referenced / denominator
+          : null,
+      unattributable,
+      unattributableWithInjectedToolCall,
+      referenceEvents,
+      unscopedReferences,
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/**
+ * One line for the audit, or nothing at all.
+ *
+ * Says which of the three things is true -- a measured rate, a live channel
+ * with no opportunities yet, or no channel at all -- rather than printing a
+ * figure and letting the reader assume the first.
+ */
+export function referenceNote(dir, { events = null } = {}) {
+  const r = referenceRate(dir, { events });
+  if (!r.denominator && !r.unknown && !r.referenceEvents) return null;
+  if (r.rate == null) {
+    const why = !r.referenceEvents
+      ? 'no finding was ever queried by key in this window'
+      : `no injection had a chance to be referenced yet (${r.unknown} unknown)`;
+    return `Injected findings referenced later: not measurable -- ${why}.`;
+  }
+  return (
+    `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+  );
+}

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -103,6 +103,44 @@ const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
 
 /**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because FOUR readers depend on it -- mutation accounting,
+ * success classification, output capture and exit-code capture -- and clients
+ * disagree on the envelope name and on nothing else. Letting each reader name
+ * its own subset is exactly how both classifiers came to miss MCP's failure
+ * flag: `toolSucceeded` listed four envelopes and `mutationSucceeded` listed
+ * three, and neither list mentioned `isError` at all.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/**
+ * Did an MCP result declare itself an error?
+ *
+ * `isError` is the ONLY failure signal an MCP result carries -- there is no
+ * `error` field and no `status` -- and `src/server/index.ts` sets it in seven
+ * places. Shared by both classifiers so they cannot disagree about what a
+ * failed call from this project's own tools looks like.
+ *
+ * `=== true` EXACTLY. A client using the key for anything else must not have
+ * its successful calls silently reclassified, and `isError: false` is a
+ * successful MCP call, not a missing verdict.
+ */
+function reportedMcpError(raw) {
+  return [...responseEnvelopes(raw), raw].some(
+    (envelope) => envelope?.isError === true
+  );
+}
+
+/**
  * A post-tool event is not universally proof of success. Some clients split
  * success and failure into distinct events; others expose a result status.
  * Keep mutation accounting conservative so a failed edit cannot arm Stop.
@@ -112,6 +150,19 @@ export function mutationSucceeded(clientName, raw) {
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
     return false;
+  // BEFORE the status read, the explicit-success read AND the client
+  // allowlist, because all three would otherwise pass a failed MCP write. The
+  // allowlist is the one that actually bit: it returns true for claude-code,
+  // codex, qwen, opencode, kilo and windsurf on any post-tool event with no
+  // error and no status, which is precisely the shape of a failed smart_write.
+  //
+  // WHY THIS IS THE SAME BUG AS THE ONE IN `toolSucceeded` AND NOT A COSMETIC
+  // ECHO OF IT: this function gates edit counting and harvest pressure, so
+  // counting a failed write to THE OPTIMIZER'S OWN TOOLS as a mutation
+  // inflates "the optimizer successfully edited a file". Different consumers
+  // from the effectiveness figures, same direction of bias -- toward
+  // flattering the thing being measured.
+  if (reportedMcpError(raw)) return false;
 
   const status =
     raw?.tool_response?.status ??
@@ -145,24 +196,6 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * Spelled out ONCE because three readers depend on it -- success
- * classification, output capture and exit-code capture -- and clients disagree
- * on the envelope name and on nothing else. Letting each reader name its own
- * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
-}
-
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
@@ -181,8 +214,7 @@ export function toolSucceeded(raw) {
   // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
   // optimizer's favour. A measurement that flatters the thing being measured
   // is worse than no measurement.
-  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
-    return false;
+  if (reportedMcpError(raw)) return false;
   const status =
     raw?.tool_response?.status ??
     raw?.toolResponse?.status ??

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -957,10 +957,12 @@ async function runHook(clientName, event, invocation) {
       // accumulates structure and no verdicts at all. These detectors read only
       // what is already on disk and send nothing anywhere.
       //
-      // The COUNT is recorded rather than the candidates: how many findings a
-      // session's own evidence supports is the number that says whether this is
-      // working, and it is measurable before anything is stored. Storage is the
-      // caller's next step, under a budget.
+      // COUNTS are recorded rather than the candidates, and BOTH counts: how
+      // many findings a session's own evidence supports, and how many of them
+      // survived the storage budget and the anchor discipline. The gap between
+      // the two is the number that says whether the bound is doing anything --
+      // one figure alone cannot distinguish "nothing to derive" from "derived
+      // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
       const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
       const dir = wikiDir(projectRoot);
@@ -976,6 +978,7 @@ async function runHook(clientName, event, invocation) {
         sessionId,
         candidates: derived.candidates.length,
         observations: derived.observations.length,
+        written: derived.written.length,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -172,6 +172,136 @@ export function toolSucceeded(raw) {
   return true;
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * The same family `toolSucceeded` reads above, hoisted so the three readers
+ * cannot drift apart. Clients disagree on the envelope name and on nothing
+ * else, so this is the one place that disagreement is spelled out.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/** A non-empty string, or null.  Blank output is the same as none. */
+function nonEmpty(value) {
+  const text = String(value ?? '');
+  return text.trim() ? text : null;
+}
+
+/**
+ * The human-readable result text inside one envelope, or null.
+ *
+ * RETURNS NULL RATHER THAN GUESSING. An envelope shape nobody here has seen
+ * produces no capture at all, which costs one finding. Stringifying it instead
+ * would put `[object Object]` or a wall of JSON metadata into a claim that gets
+ * injected into model context -- a wrong observation, which is strictly worse
+ * than a missing one.
+ */
+function resultText(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'string') return nonEmpty(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return null;
+
+  // MCP content blocks, which is how THIS PROJECT'S OWN tools now arrive:
+  // `normalizeTool` resolves `mcp__<server>__smart_edit`, so smart_edit and
+  // smart_write reach the post-tool path for the first time and their results
+  // are `{ content: [{ type: 'text', text }], isError }` rather than a shell
+  // result. Both the bare array and the wrapping object are accepted because
+  // hosts differ on whether they hand the hook the result or its content.
+  if (Array.isArray(value)) {
+    const blocks = value
+      .map((block) =>
+        typeof block === 'string' ? block : nonEmpty(block?.text)
+      )
+      .filter(Boolean);
+    return blocks.length ? nonEmpty(blocks.join('\n')) : null;
+  }
+  if (typeof value !== 'object') return null;
+
+  // STDERR FIRST, and not because that is the order it was produced in. The
+  // cap can only ever cut the tail, and the diagnostic that explains a failure
+  // is almost always on stderr while the volume is almost always on stdout --
+  // so appending stderr would let a 3 MB build log push the one line worth
+  // capturing out of the window.
+  const streams = [nonEmpty(value.stderr), nonEmpty(value.stdout)].filter(
+    Boolean
+  );
+  if (streams.length) return streams.join('\n');
+
+  if (Array.isArray(value.content)) {
+    const inner = resultText(value.content);
+    if (inner) return inner;
+  }
+
+  const error = value.error;
+  if (error) {
+    const message =
+      typeof error === 'string' ? error : nonEmpty(error.message ?? error.msg);
+    if (message) return message;
+  }
+
+  return (
+    nonEmpty(value.output) ??
+    nonEmpty(value.text) ??
+    nonEmpty(value.message) ??
+    (typeof value.result === 'string' ? nonEmpty(value.result) : null)
+  );
+}
+
+/**
+ * The result text of a completed tool call, or null when the client reports
+ * none.  Redaction and the size cap are NOT applied here -- they belong at the
+ * `recordToolOutcome` boundary, which is the only place every caller passes.
+ */
+export function outputFrom(raw) {
+  for (const envelope of responseEnvelopes(raw)) {
+    const text = resultText(envelope);
+    if (text) return text;
+  }
+  return resultText(raw?.output) ?? resultText(raw?.stdout) ?? null;
+}
+
+/**
+ * Key names that mean "process exit code" and nothing else.
+ *
+ * `code` is deliberately ABSENT. JSON-RPC errors (`code: -32602`), Node errno
+ * objects (`code: 'ENOENT'`) and HTTP wrappers all reuse that name, so reading
+ * it would record a confident exit code for calls that never had one. A null
+ * here is honest; a -32602 claiming to be an exit status is not.
+ */
+const EXIT_KEYS = [
+  'exit_code',
+  'exitCode',
+  'exit',
+  'exit_status',
+  'exitStatus',
+  'return_code',
+  'returncode',
+];
+
+/** The numeric exit code a client reported, or null when it reported none. */
+export function exitFrom(raw) {
+  for (const envelope of [...responseEnvelopes(raw), raw]) {
+    if (!envelope || typeof envelope !== 'object') continue;
+    for (const key of EXIT_KEYS) {
+      const value = envelope[key];
+      if (Number.isInteger(value)) return value;
+      // A client that serializes the code as a digit string still reported it.
+      // Bounded so a hash or an id cannot be mistaken for a status.
+      if (typeof value === 'string' && /^-?\d{1,5}$/.test(value.trim()))
+        return Number(value.trim());
+    }
+  }
+  return null;
+}
+
 function contextOutput(client, eventName, additionalContext) {
   if (client.contextStyle === 'top-level') return { additionalContext };
   if (client.contextStyle === 'cline') {
@@ -890,6 +1020,11 @@ async function runHook(clientName, event, invocation) {
         anchor,
         toolName: payload.tool_name,
         success: toolSucceeded(raw),
+        // The two fields a boolean cannot carry: which KIND of failure this
+        // was. Read through the same normalisers as `success`, never off `raw`
+        // at this call site.
+        output: outputFrom(raw),
+        exit: exitFrom(raw),
         durationMs:
           Number(
             raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -145,11 +145,43 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because three readers depend on it -- success
+ * classification, output capture and exit-code capture -- and clients disagree
+ * on the envelope name and on nothing else. Letting each reader name its own
+ * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
+    return false;
+  // MCP'S OWN FAILURE FLAG, which this function did not read for as long as it
+  // existed. It did not matter while `normalizeTool` dropped MCP names before
+  // any accounting ran; it matters now that `mcp__<server>__smart_edit` and
+  // `smart_write` reach the post-tool path, because an MCP result carries no
+  // `error` field and no `status` -- only `isError` -- so a failed smart_edit
+  // fell through to the optimistic `return true` below.
+  //
+  // WHY THIS IS A MEASUREMENT BUG AND NOT A COSMETIC ONE: this boolean feeds
+  // episode outcomes and effectiveness accounting, so recording every failed
+  // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
+  // optimizer's favour. A measurement that flatters the thing being measured
+  // is worse than no measurement.
+  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
     return false;
   const status =
     raw?.tool_response?.status ??
@@ -170,23 +202,6 @@ export function toolSucceeded(raw) {
   // that its output proved the task.  `success` here is deliberately scoped to
   // the tool call; task correctness comes only from an eval grader.
   return true;
-}
-
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * The same family `toolSucceeded` reads above, hoisted so the three readers
- * cannot drift apart. Clients disagree on the envelope name and on nothing
- * else, so this is the one place that disagreement is spelled out.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
 }
 
 /** A non-empty string, or null.  Blank output is the same as none. */

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -58,6 +58,7 @@ import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { briefing } from './remedy.mjs';
 import { stableText, transcriptFor } from './cache.mjs';
+import { scoreRefreshes } from './keepwarm.mjs';
 import { cachedRoutingBriefing } from './routing.mjs';
 import {
   forCommand,
@@ -1010,6 +1011,26 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE KEEP-WARM FEEDBACK ARM, at the boundary where a turn has just
+      // ended -- which is the only place the arrival question can be answered.
+      // Every refresh whose TTL has since elapsed is scored here as used or
+      // unused; anything the log cannot settle is left unscored rather than
+      // recorded as a miss, because an absent signal is not a miss.
+      //
+      // Nothing in this repository issues a refresh today -- cache_audit only
+      // recommends one -- so this scores nothing, and what it costs while
+      // dormant is one readBalance: median 70 ms on this machine's 3.5 MB log,
+      // against derive's 71-111 ms a few lines below on the same path. The
+      // firehose is read for ARRIVALS only if an unscored refresh exists, so
+      // the dormant case never pays for that. The moment an issuer exists, the
+      // decision starts learning with no second wiring change.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      scoreRefreshes(dir);
+    } catch {
+      // A refresh that cannot be scored costs a measurement, not a session.
     }
     try {
       // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -40,11 +40,13 @@ import {
   touchedFiles,
 } from './decide.mjs';
 import {
+  record,
   recordRead,
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
 } from './metrics.mjs';
+import { derive } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -948,6 +950,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // ZERO-COST DERIVATION, on every client, with no credential. The semantic
+      // harvest below needs an API key, so on a machine without one the graph
+      // accumulates structure and no verdicts at all. These detectors read only
+      // what is already on disk and send nothing anywhere.
+      //
+      // The COUNT is recorded rather than the candidates: how many findings a
+      // session's own evidence supports is the number that says whether this is
+      // working, and it is measurable before anything is stored. Storage is the
+      // caller's next step, under a budget.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      const dir = wikiDir(projectRoot);
+      const derived = derive(dir, {
+        sessionId,
+        projectRoot,
+        transcriptPath: agentScope,
+        // The hook payload's own identity, not a value a model typed.
+        authoritativeSessionId: sessionId,
+      });
+      record(dir, {
+        kind: 'derive',
+        sessionId,
+        candidates: derived.candidates.length,
+        observations: derived.observations.length,
+      });
+    } catch {
+      // A detector failing must never cost a user the end of their session.
     }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -72,7 +72,8 @@ import {
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
-import { isArchived } from './transcript.mjs';
+import { archive, isArchived } from './transcript.mjs';
+import { harvestMode } from './harvest.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
@@ -577,6 +578,65 @@ function emit(object) {
   process.stdout.write(serialized);
 }
 
+/**
+ * What will and will not extract findings after this session, in one sentence.
+ *
+ * THE STATE WAS ONLY EVER LEGIBLE FROM THE DOCTOR, and the doctor is a place
+ * someone visits after they already suspect something is wrong. A user watching
+ * a graph fill with structural nodes and no verdicts has no reason to suspect
+ * anything, which is the failure this project has now measured twice.
+ *
+ * IT IS ADDRESSED TO THE MODEL, NOT ONLY TO THE READER, which is why it earns a
+ * place in the prefix rather than a systemMessage. "Nothing else will write this
+ * down in words" changes what the model does with a conclusion it is holding;
+ * "here is a configuration variable" would not.
+ *
+ * CACHE-SAFE: derived from configuration, so it differs between sessions only
+ * when the configuration does -- the same standard the rest of this block is
+ * held to, and it carries no digits for `stableText` to reject.
+ *
+ * A local endpoint is named FIRST in the off case on purpose. It is the option
+ * that costs nothing and sends nothing, and it was the one buried deepest.
+ */
+function extractionNotice() {
+  switch (harvestMode()) {
+    case 'local':
+      return (
+        '\n\nA local model endpoint is configured, so semantic extraction also runs after this ' +
+        'session -- free and private, with nothing leaving this machine.'
+      );
+    case 'remote':
+      return (
+        '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
+        'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
+    case 'off:mode':
+      // The whole optimizer is off and this text is not emitted anyway. Saying
+      // anything here would be noise stacked on an explicit choice.
+      return '';
+    case 'off:opted-out':
+      // A DELIBERATE CHOICE, SO NO PITCH. The consequence is stated because the
+      // model needs it; the setting that would reverse it is not, because
+      // arguing with a configured decision on every session is how a notice
+      // stops being read. doctor.mjs draws the same line for the same reason.
+      return (
+        '\n\nFallback extraction is off by configuration, so a conclusion you do not record is ' +
+        'not written down in words anywhere. Findings are still derived locally from exit codes, ' +
+        'red-to-green transitions and corrections.'
+      );
+    default:
+      // off:no-key, and any mode a future harvest adds: no extractor is running
+      // and nobody chose that, so the free option is worth naming.
+      return (
+        '\n\nNo separate extractor will run after this session, so a conclusion you do not record ' +
+        'is not written down in words anywhere. Findings are still derived locally from exit ' +
+        'codes, red-to-green transitions and corrections. Pointing ' +
+        'TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model adds semantic extraction, free and ' +
+        'private.'
+      );
+  }
+}
+
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
 export function policyText(
   canDeny,
@@ -635,7 +695,7 @@ export function policyText(
     .filter(Boolean)
     .join(' ');
   const recording = tools.has('wiki_write')
-    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.`
+    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.${extractionNotice()}`
     : '\n\nStructural graph capture remains active through lifecycle hooks. Durable semantic MCP writes are not requested because the writer schema is not proven available.';
 
   return `# Token optimization is active\n\nLive graph capture is active through the lifecycle adapter.\n\n${connection}${routing}${enforcement}${utilities ? `\n\n${utilities}` : ''}${recording}${projectBriefing()}`;
@@ -950,6 +1010,27 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.
+      //
+      // This was lost rather than retired. `plugin/hooks/stop-harvest.mjs` called
+      // `archive()` at Stop, and #300 replaced that entry in `hooks.json` with the
+      // generated `stop.mjs`, which routes here -- so on Claude Code no session has
+      // been archived since. Nothing failed loudly: `readArchive` simply returns an
+      // empty list, so `derive`'s correction detector fell through to the live
+      // transcript (present only for a client that reports one) and `lessons.mjs`
+      // lost the only corpus it can verify a verbatim quote against, which is the
+      // single test that grants a feedback finding human origin.
+      //
+      // BEFORE `derive`, deliberately: the correction detector reads the archive
+      // first and treats the live transcript as the fallback, and the archive is
+      // the copy that survives into later sessions.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      if (agentScope) archive(dir, agentScope, { sessionId });
+    } catch {
+      // The archive is a record, not a result. A session still ends.
     }
     try {
       // ZERO-COST DERIVATION, on every client, with no credential. The semantic

--- a/integrations/codex/hooks/lib/audit.mjs
+++ b/integrations/codex/hooks/lib/audit.mjs
@@ -32,6 +32,7 @@
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
+import { looNote } from './loo.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -401,6 +402,16 @@ export function renderAudit(
   // project with no injections and no queries gains no line at all.
   const reference = referenceNote(dir);
   if (reference) body.push('', reference);
+
+  // WHAT ONE FINDING IS CAUSALLY WORTH (Layer 2).
+  //
+  // The same reasoning as above, and the same refusal: `looNote` returns null
+  // until the leave-one-out experiment has collected an observation, and says
+  // NOT MEASURABLE YET rather than printing a mean until it clears the floor.
+  // A causal number is the most quotable thing this project can produce, so it
+  // is the one that most needs to be absent when it is not earned.
+  const causal = looNote(dir);
+  if (causal) body.push('', causal);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/codex/hooks/lib/audit.mjs
+++ b/integrations/codex/hooks/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
 import { looNote } from './loo.mjs';
+import { calibrationNote } from './crosslayer.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -244,9 +245,15 @@ export function renderAudit(
     lines.push(text);
   }
 
+  // SCOPED TO THE QUEUE, because that is all it ever described. The bare
+  // sentence "Nothing addressable found." was printed directly above a Layer 1
+  // reference note and a published Layer 2 causal verdict -- so a reader was
+  // told nothing had been found immediately before being shown a finding. The
+  // headline is about the remediation queue and nothing else, and saying so
+  // costs four words and removes a false negative shown to a human.
   const head = shown.length
     ? ['What to do next, most expensive first:', ...lines]
-    : ['Nothing addressable found.'];
+    : ['Nothing addressable found in the remediation queue.'];
 
   const body = [...head];
 
@@ -412,6 +419,16 @@ export function renderAudit(
   // is the one that most needs to be absent when it is not earned.
   const causal = looNote(dir);
   if (causal) body.push('', causal);
+
+  // WHETHER LAYER 1'S CHEAP LABEL PREDICTS LAYER 2'S EXPENSIVE EFFECT.
+  //
+  // The reason this is printed rather than kept for a dashboard: the reference
+  // rate is the number a reader is most likely to quote as a saving, and it is
+  // not one until this comparison says so. `calibrationNote` returns null while
+  // both layers are silent, and otherwise prints the refusal -- naming which
+  // input was insufficient -- rather than a gap of zero.
+  const calibrated = calibrationNote(dir);
+  if (calibrated) body.push('', calibrated);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/codex/hooks/lib/audit.mjs
+++ b/integrations/codex/hooks/lib/audit.mjs
@@ -61,6 +61,28 @@ export function declines(dir, { events = readMetrics(dir) } = {}) {
   return counts;
 }
 
+/**
+ * What the local Stop-time derivation path produced in the visible event log.
+ *
+ * The producer records all three counts because any one of them alone is
+ * ambiguous: zero stored can mean no evidence, no candidates, or a binding
+ * storage/anchor filter. This reader keeps those states distinct and prevents
+ * the telemetry itself from becoming an unobserved cost.
+ */
+export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
+  const runs = events.filter((event) => event.kind === 'derive');
+  if (!runs.length) return null;
+
+  const sum = (field) =>
+    runs.reduce((total, event) => total + Math.max(0, Number(event[field]) || 0), 0);
+  const candidates = sum('candidates');
+  const observations = sum('observations');
+  const written = sum('written');
+  return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
+    `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
+    `across ${runs.length.toLocaleString()} Stop run(s).`;
+}
+
 const idOf = (finding) =>
   finding.remedy
     ? `${finding.remedy.type}:${finding.remedy.anchor || finding.remedy.file || (finding.remedy.anchors || []).join(',')}`
@@ -399,6 +421,15 @@ export function renderAudit(
       );
     }
   }
+
+  // WHAT THE DEFAULT, LOCAL DERIVATION PATH ACTUALLY PRODUCED.
+  //
+  // This event used to have a producer and no reader. Keep its three states
+  // together: evidence seen, candidates derived, and findings that survived
+  // selection/storage. A lone stored count would turn every earlier refusal
+  // into an apparent "nothing found" result.
+  const derived = derivationNote(dir);
+  if (derived) body.push('', derived);
 
   // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
   //

--- a/integrations/codex/hooks/lib/audit.mjs
+++ b/integrations/codex/hooks/lib/audit.mjs
@@ -31,6 +31,7 @@
  */
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
+import { referenceNote } from './usage.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -390,6 +391,16 @@ export function renderAudit(
       );
     }
   }
+
+  // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
+  //
+  // Printed here because this is the report that already asks "did the advice
+  // change anything", and because a measurement with no reader is how this
+  // project shipped two metrics whose only consumer was their own test suite.
+  // `referenceNote` returns null when it has nothing honest to say, so a
+  // project with no injections and no queries gains no line at all.
+  const reference = referenceNote(dir);
+  if (reference) body.push('', reference);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/codex/hooks/lib/consolidate.mjs
+++ b/integrations/codex/hooks/lib/consolidate.mjs
@@ -142,7 +142,8 @@ const ALWAYS_KEEP = new Set(['failure', 'decision']);
  * Chooses what to promote into the graph, under a token budget.
  *
  * @param {object} graph      Loaded wiki graph, for reuse probability.
- * @param {Array}  candidates Extracted conclusions, each { type, summary, anchors, evidence, at }.
+ * @param {Array}  candidates Extracted conclusions, each { type, claim (or summary),
+ *                              anchors, evidence, at }.
  * @param {object} options    budget: tokens available for promoted findings.
  */
 export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}) {
@@ -221,4 +222,3 @@ export function aggregateConsolidation(findings) {
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
-

--- a/integrations/codex/hooks/lib/crosslayer.mjs
+++ b/integrations/codex/hooks/lib/crosslayer.mjs
@@ -1,0 +1,351 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/crosslayer.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The calibration loop: does Layer 1's LABEL predict Layer 2's EFFECT?
+ *
+ * Layer 1 (`usage.mjs`) classifies an injected finding by whether the model
+ * later NAMED it. Layer 2 (`loo.mjs`) measures, by leave-one-out, how many
+ * tokens of reading a finding actually SUPPRESSED. Those are two different
+ * quantities, and the whole point of putting them side by side is that the
+ * cheap one (a label, available on every injection) might stand in for the
+ * expensive one (a causal effect, costing three withheld sessions per finding).
+ *
+ * WHY THIS IS A REAL QUESTION AND NOT A TAUTOLOGY. Task 7 established the
+ * independence three ways -- statically (`loo.mjs` contains no `query` or
+ * `reference`; `usage.mjs` contains no `tokens`, `cost` or `bytes`),
+ * behaviourally in both directions, and by naming the one overlap that does
+ * exist (`recordToolOutcome`'s join, which supplies ATTRIBUTABILITY to both and
+ * the measured quantity to neither). This module is built to preserve that:
+ *
+ *   - from Layer 1 it takes ONLY the categorical label per finding key. No
+ *     rate, no count, no magnitude -- Layer 1 has no magnitude to give.
+ *   - from Layer 2 it takes ONLY the effect magnitude per finding key.
+ *   - the join is the finding key, which is a graph identity and not a
+ *     measurement.
+ *
+ * If a magnitude common to both ever entered, this would correlate a quantity
+ * with itself and report a strong result that means nothing. Two tests pin the
+ * separation from opposite sides: flipping the labels while holding the effects
+ * fixed must move the gap, and changing Layer 1's rate WITHOUT changing any
+ * label must leave the gap byte-identical.
+ *
+ * MEASURED UTILITY RANKS A FINDING. IT MUST NEVER RAISE ITS CONFIDENCE.
+ * A confidently WRONG finding suppresses reads better than a hedged true one,
+ * so utility alone optimises directly against "wrong findings are worse than
+ * none". The plan called for a `mayPromote` gate over
+ * `hasOutstandingContradiction` here. There is nothing to gate: every write of
+ * `confidence` in `hooks-core` happens at CREATION (a per-producer constant in
+ * `derive.mjs` / `lessons.mjs` / `harvest.mjs`, or a human's own number in
+ * `curate.mjs`), and no code path updates a stored finding's confidence
+ * afterwards. `assessFindings` in `utility.mjs` READS confidence into an
+ * ephemeral `netUtility` used for ordering and writes nothing back. So a gate
+ * here would be unreachable, and an unreachable gate is the exact defect class
+ * this work exists to close. `hasOutstandingContradiction` already has its
+ * real consumer -- `staleness.mjs` calls it as the dispute gate on serve.
+ * What is enforceable is the invariant itself, and it is: this module never
+ * writes to the graph, and `tests/hooks/calibration-loop.test.mjs` asserts that
+ * neither it nor either layer under it can move a stored confidence.
+ *
+ * NOTHING HERE IS PRICED. A calibration verdict, a holdout estimate and a
+ * consolidation ratio are all estimates; currency belongs only on a measured
+ * counterfactual, and `balanceSheet`'s `measuredCounterfactual` is the one
+ * section in the sheet below that qualifies.
+ */
+
+import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
+import { classify, referenceRate } from './usage.mjs';
+import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Distinct findings needed in EACH arm before a gap is reported at all.
+ *
+ * Two findings per arm is a difference of two numbers; the comparison would be
+ * dominated by whichever finding happened to sit on a big file. Three is still
+ * small, and the refusal says so rather than implying the gap is solid.
+ */
+export const MIN_FINDINGS_PER_ARM = 3;
+
+/**
+ * The smallest gap that may be PUBLISHED, in tokens per touch.
+ *
+ * Not an effect-size convention: it is tied to the unit the verdict prints. The
+ * published sentence rounds the gap to whole tokens, so a gap of 1e-13 -- which
+ * is what two arms of equal means produce once floating point has had its say --
+ * would publish as "referenced findings suppress 0 more tokens/touch". That is a
+ * calibration claim resting on arithmetic noise, and it leans the only direction
+ * a measurement of this project by this project must never lean.
+ */
+export const MIN_GAP_TOKENS = 1;
+
+/**
+ * The per-finding Layer 1 label, folded from per-injection rows.
+ *
+ * ANY reference wins. `classify` emits one row per (injection, finding) because
+ * one reference must not excuse every later injection -- that is the right unit
+ * for a RATE. For a label the question is different: did the model ever name
+ * this finding? A finding referenced once and ignored nine times is a finding
+ * the model reads, and averaging it into `not-referenced` would put it in the
+ * arm whose mean effect it is meant to predict.
+ *
+ * `unknown` rows are dropped rather than defaulted, exactly as Layer 1 drops
+ * them from its own denominator.
+ */
+export function labelsByFinding(rows) {
+  const labels = new Map();
+  for (const row of rows || []) {
+    const key = row?.findingKey;
+    if (typeof key !== 'string' || !key) continue;
+    if (row.label === 'referenced') labels.set(key, 'referenced');
+    else if (row.label === 'not-referenced' && !labels.has(key))
+      labels.set(key, 'not-referenced');
+  }
+  return labels;
+}
+
+const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * Does Layer 1's label predict Layer 2's effect?
+ *
+ * Returns `publishable`, a `verdict` in English, and `gap` ONLY when a gap was
+ * actually computed. There is no `gap: 0` for the unmeasured case, and that is
+ * deliberate: a permanent zero reads as "measured, and the two agree", which is
+ * the opposite of "nothing was measured". Task 7 deleted a field rather than
+ * zero it for the same reason.
+ *
+ * FAILS OPEN. This runs on report paths that must not break a tool call.
+ */
+export function calibration(dir, options = {}) {
+  const refuse = (verdict, extra = {}) => ({
+    publishable: false,
+    verdict,
+    ...extra,
+  });
+
+  try {
+    // ONE READ for both layers, so the two arms of the comparison cannot cover
+    // different spans of the log. `referenceRate` reports `windowed: false`
+    // when the caller supplies events -- correctly, since the bounds are then
+    // the caller's -- so the truncation flag is taken here, from the read that
+    // actually set it, and republished.
+    const supplied = options.events || null;
+    const events = supplied || readMetrics(dir);
+    const truncation = supplied ? null : readTruncation();
+    const truncated = Boolean(
+      truncation && (truncation.byBytes || truncation.byEvents)
+    );
+
+    const layer1 = referenceRate(dir, { events });
+    const labels = labelsByFinding(classify(dir, { events }));
+
+    const obs = observations(dir, { ...options, events });
+    const rows = effects(dir, { ...options, events, obs });
+
+    // ONE POLICY VERSION. Layer 2 refuses to pool arms across serving
+    // policies; a calibration that pooled them would undo that guard one level
+    // up. Rows from any other policy are excluded and counted.
+    const policy = servingPolicyVersion();
+    const inPolicy = rows.filter((row) => row.policy === policy);
+
+    const layer2 = {
+      rows: rows.length,
+      inPolicy: inPolicy.length,
+      published: rows.filter((row) => row.published).length,
+      observations: obs.rows.length,
+      policy,
+    };
+    const l1 = {
+      referenced: layer1.referenced,
+      notReferenced: layer1.notReferenced,
+      unknown: layer1.unknown,
+      denominator: layer1.denominator,
+      rate: layer1.rate,
+      referenceEvents: layer1.referenceEvents,
+    };
+
+    const excluded = { layer1Unknown: layer1.unknown, unlabelled: 0, noEffect: 0 };
+    const arms = { referenced: [], notReferenced: [] };
+    for (const row of inPolicy) {
+      // THE SHRUNK ESTIMATE, not the raw one. Shrinkage pulls every finding
+      // toward the population mean, so it pulls the GAP toward zero -- the
+      // bias runs against publishing, which is the only direction a
+      // measurement of this project by this project may lean.
+      if (row.shrunk === null || !Number.isFinite(row.shrunk)) {
+        excluded.noEffect += 1;
+        continue;
+      }
+      const label = labels.get(row.findingKey);
+      if (label === 'referenced') arms.referenced.push(row.shrunk);
+      else if (label === 'not-referenced') arms.notReferenced.push(row.shrunk);
+      else excluded.unlabelled += 1;
+    }
+
+    const context = { layer1: l1, layer2, arms: { referenced: arms.referenced.length, notReferenced: arms.notReferenced.length }, excluded, windowed: truncated };
+    const caveat = truncated
+      ? ' The event log was truncated, so both sides can understate.'
+      : '';
+
+    // WHICH INPUT WAS INSUFFICIENT, named. "Not enough data" tells a reader
+    // nothing about which half of the loop to go and fix.
+    const l1Silent = layer1.rate === null;
+    const l2Silent = layer2.observations === 0;
+    if (l1Silent || l2Silent) {
+      const why = [];
+      if (l1Silent)
+        why.push(
+          `Layer 1 has ${layer1.denominator} classifiable observation(s) and ` +
+            `${layer1.referenceEvents} reference event(s), so it publishes no rate`
+        );
+      if (l2Silent)
+        why.push(
+          `Layer 2 has ${layer2.observations} observation(s), so it publishes no effect`
+        );
+      return refuse(
+        `not calibrated: ${why.join('; and ')}. No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+    }
+
+    // A POLICY CHANGE RESETS THE CALIBRATION, and says so rather than reporting
+    // an empty arm. Layer 2 refuses to pool arms across serving policies, so
+    // rows generated under an older one cannot answer a question about how the
+    // graph serves findings today -- but "0 findings per arm" would send a
+    // reader hunting for missing observations that are right there in the log.
+    if (rows.length > 0 && inPolicy.length === 0)
+      return refuse(
+        `not calibrated: all ${rows.length} Layer 2 effect row(s) were measured under a different serving ` +
+          `policy than the current ${policy}, and arms are never pooled across policies. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (layer2.published === 0)
+      return refuse(
+        `not calibrated: Layer 2 has ${layer2.observations} observation(s) but no published effect at q=0.1, ` +
+          'so its per-finding numbers are noise and a difference between two means of them would be too. ' +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (
+      arms.referenced.length < MIN_FINDINGS_PER_ARM ||
+      arms.notReferenced.length < MIN_FINDINGS_PER_ARM
+    )
+      return refuse(
+        `not calibrated: ${arms.referenced.length} referenced and ${arms.notReferenced.length} not-referenced ` +
+          `finding(s) carry a Layer 2 effect, below the floor of ${MIN_FINDINGS_PER_ARM} per arm. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    const referencedMean = mean(arms.referenced);
+    const notReferencedMean = mean(arms.notReferenced);
+    const gap = referencedMean - notReferencedMean;
+    const measured = { ...context, gap, referencedMean, notReferencedMean };
+
+    if (!(gap >= MIN_GAP_TOKENS))
+      return refuse(
+        `uncalibrated: Layer 1's "referenced" label does not predict a larger Layer 2 effect ` +
+          `(referenced ${Math.round(referencedMean).toLocaleString()} vs not-referenced ` +
+          `${Math.round(notReferencedMean).toLocaleString()} tokens/touch, gap ${Math.round(gap).toLocaleString()}). ` +
+          `Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
+    return {
+      publishable: true,
+      verdict:
+        `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
+      ...measured,
+    };
+  } catch {
+    return refuse(
+      'not calibrated: the calibration inputs could not be read. No gap is reported, which is not the same as a gap of zero.'
+    );
+  }
+}
+
+/**
+ * What the graph cost to build against what it carries -- AN ESTIMATE, and
+ * never priced.
+ *
+ * `consolidationRatio` is the per-finding form and the aggregate is the fold.
+ * Both need `derivedCost`, which `expand.promote` persists onto the finding
+ * node it creates (`src/server/disclosure.ts` is its caller) and which
+ * `harvest-write.mjs` does not yet carry through -- so a graph built only by
+ * the harvest reports nothing here rather than a ratio of one.
+ */
+export function consolidation(dir, { graph = null } = {}) {
+  try {
+    const g = graph || load(dir);
+    const findings = [...g.nodes.values()].filter(
+      (node) => node.kind === 'finding' && !node.retired
+    );
+    const rated = [];
+    for (const finding of findings) {
+      const ratio = consolidationRatio(finding);
+      if (ratio === null) continue;
+      rated.push({ key: finding.key, ratio, derivedCost: finding.derivedCost });
+    }
+    const aggregate = aggregateConsolidation(findings);
+    return {
+      what: 'cost to derive against cost to carry',
+      // SAID IN THE DATA, not only in the prose above it, because this is the
+      // field a dashboard will read and a dashboard will not read a comment.
+      basis: 'estimate',
+      priced: false,
+      findings: findings.length,
+      withDerivedCost: rated.length,
+      aggregate,
+      best: rated.sort((a, b) => b.ratio - a.ratio).slice(0, 5),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The balance sheet with the graph's own three measurements attached.
+ *
+ * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
+ * imports, so it cannot import them back. This is where the two meet, and it
+ * is the shape `get_optimization_report` serves.
+ */
+export function graphBalanceSheet(dir, options = {}) {
+  const sheet = balanceSheet(dir);
+  const cal = calibration(dir, options);
+  const { layer1 = null, layer2 = null } = cal;
+  return {
+    ...sheet,
+    layer1,
+    layer2,
+    calibration: cal,
+    consolidation: consolidation(dir, options),
+  };
+}
+
+/**
+ * One audit line, or null when there is nothing honest to say.
+ *
+ * Silent when NEITHER layer has produced anything: a reader of a graph that has
+ * never injected a finding is owed no paragraph about a loop that has not
+ * started. The moment either side speaks, the refusal is worth printing --
+ * because at that point a reader could otherwise take Layer 1's rate for a
+ * saving, which is precisely what this loop exists to stop.
+ */
+export function calibrationNote(dir, options = {}) {
+  try {
+    const result = calibration(dir, options);
+    const l1 = result.layer1;
+    const l2 = result.layer2;
+    if (!l1 || !l2) return null;
+    if (l1.denominator === 0 && l2.observations === 0) return null;
+    return `Layer 1 against Layer 2: ${result.verdict}`;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/codex/hooks/lib/crosslayer.mjs
+++ b/integrations/codex/hooks/lib/crosslayer.mjs
@@ -54,7 +54,13 @@
 
 import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
-import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import {
+  effects,
+  observations,
+  servingPolicyVersion,
+  permutationP,
+  FDR_Q,
+} from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
 import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
@@ -106,6 +112,32 @@ export function labelsByFinding(rows) {
 }
 
 const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * A deterministic, label-symmetric permutation test for the headline gap.
+ *
+ * Layer 2 only publishes a per-finding row after a two-sided permutation test.
+ * The calibration headline summarises those rows, so a positive difference of
+ * arm means must clear the same evidential bar rather than being promoted just
+ * because it points in this project's favour.
+ *
+ * Sorting within each arm and then sorting the two arms makes the sampled path
+ * invariant to event order and to swapping the labels. The seed is derived
+ * from that canonical data instead of shared globally, so two different
+ * datasets do not reuse one arbitrary sequence of sampled relabellings.
+ */
+export function calibrationP(referenced, notReferenced) {
+  const arms = [referenced, notReferenced]
+    .map((values) => [...values].sort((a, b) => a - b))
+    .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  const encoded = JSON.stringify(arms);
+  let seed = 2166136261;
+  for (const char of encoded) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return permutationP(arms[0], arms[1], { seed: seed >>> 0 });
+}
 
 /**
  * Does Layer 1's label predict Layer 2's effect?
@@ -244,7 +276,16 @@ export function calibration(dir, options = {}) {
     const referencedMean = mean(arms.referenced);
     const notReferencedMean = mean(arms.notReferenced);
     const gap = referencedMean - notReferencedMean;
-    const measured = { ...context, gap, referencedMean, notReferencedMean };
+    const p = calibrationP(arms.referenced, arms.notReferenced);
+    const measured = {
+      ...context,
+      gap,
+      referencedMean,
+      notReferencedMean,
+      p,
+      alpha: FDR_Q,
+      test: 'two-sided permutation',
+    };
 
     if (!(gap >= MIN_GAP_TOKENS))
       return refuse(
@@ -255,11 +296,20 @@ export function calibration(dir, options = {}) {
         measured
       );
 
+    if (p === null || p > FDR_Q)
+      return refuse(
+        `not calibrated: the positive Layer 1/Layer 2 gap is not statistically resolved by the ` +
+          `two-sided permutation test (p=${p === null ? 'unavailable' : p.toFixed(3)}, ` +
+          `alpha=${FDR_Q.toFixed(3)}). Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
     return {
       publishable: true,
       verdict:
         `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
-        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, ` +
+        `shrunk estimates, two-sided permutation p=${p.toFixed(3)}). ` +
         `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
       ...measured,
     };

--- a/integrations/codex/hooks/lib/crosslayer.mjs
+++ b/integrations/codex/hooks/lib/crosslayer.mjs
@@ -56,6 +56,7 @@ import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
 import { effects, observations, servingPolicyVersion } from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
 
 /**
@@ -309,11 +310,19 @@ export function consolidation(dir, { graph = null } = {}) {
 }
 
 /**
- * The balance sheet with the graph's own three measurements attached.
+ * The balance sheet with the graph's own measurements attached.
  *
  * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
  * imports, so it cannot import them back. This is where the two meet, and it
  * is the shape `get_optimization_report` serves.
+ *
+ * `recall` joins them as an OFFLINE PROBE, and that label travels in the data
+ * (`recall.basis`) as well as in the rendered line. It is not an observation of
+ * anything a session did: it deletes an anchor edge in memory and re-runs the
+ * real retrieval primitives over the graph as it stands right now. `recall.mjs`
+ * imports only `wiki.mjs` and `lexical.mjs`, neither of which imports anything
+ * in this direction, so no cycle -- the same reason `calibration` had to live
+ * here rather than in `metrics.mjs`.
  */
 export function graphBalanceSheet(dir, options = {}) {
   const sheet = balanceSheet(dir);
@@ -325,6 +334,7 @@ export function graphBalanceSheet(dir, options = {}) {
     layer2,
     calibration: cal,
     consolidation: consolidation(dir, options),
+    recall: recallProbe(dir, options),
   };
 }
 

--- a/integrations/codex/hooks/lib/derive.mjs
+++ b/integrations/codex/hooks/lib/derive.mjs
@@ -23,13 +23,21 @@
  * the observation supports no claim at all are refused rather than downgraded
  * (see `attemptKey` and the identical-text guard below).
  *
- * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
- * budget, belongs to the caller.
+ * WHAT IS STORED IS BOUNDED. Candidates go through `selectForConsolidation`
+ * before `writeHarvested`, so a long session cannot spend the whole retrieval
+ * budget of every later session on one afternoon's exit codes. Nothing enters
+ * the graph unbudgeted, and nothing enters it wearing a human origin.
  */
 
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
 import { readArchive, readTurns } from './transcript.mjs';
 import { redact } from './redact.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { load } from './wiki.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -106,6 +114,92 @@ const triggerFor = (command) =>
   attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
 
 /**
+ * Literal root-level files that define how a project is BUILT, RUN and TESTED,
+ * best first. A `command` claim is a claim about this project's commands, and
+ * this is the file those commands are declared in.
+ */
+const PROJECT_MARKERS = [
+  'package.json', 'pyproject.toml', 'Cargo.toml', 'go.mod', 'pom.xml',
+  'build.gradle.kts', 'build.gradle', 'build.sbt', 'mix.exs', 'composer.json',
+  'Gemfile', 'Package.swift', 'CMakeLists.txt', 'Makefile', 'Taskfile.yml',
+  'requirements.txt', 'setup.py', 'deno.json', 'bun.lockb',
+];
+
+/** .NET has no single literal marker; the solution or project file is one. */
+const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
+
+/**
+ * A REAL FILE to anchor a derived claim to, inside the project root.
+ *
+ * WHY NOT THE PROJECT ROOT ITSELF, which is what the extraction step reaches
+ * for and what `promoteToShared` uses in the shared tier. Because
+ * `writeHarvested` resolves every anchor through `indexFile`, `indexFile` reads
+ * the path, and reading a DIRECTORY returns null -- so a candidate anchored to
+ * `projectRoot` resolves to nothing, is refused as unanchorable, and the whole
+ * pipeline stores zero findings while reporting a healthy candidate count.
+ * Verified directly: `indexFile(dir, dir)` returns null. That refusal is
+ * correct and must not be weakened -- an anchor that cannot be indexed is an
+ * anchor that can never be invalidated -- so the anchor has to be a file.
+ *
+ * STALENESS DOES NOT MISFIRE ON THIS. `command`, `failure` and `feedback` are
+ * all outside `CONTENT_DEPENDENT` (staleness.mjs), so the anchor is a RETRIEVAL
+ * AND EXISTENCE hook rather than a contents claim: editing the manifest does
+ * not mark these findings stale. staleness.mjs names this exact case in its own
+ * comment -- "a claim about `npm test` anchored to package.json" -- and calls
+ * missing that invalidation the better error.
+ *
+ * A project with no recognisable marker gets the root back, which will not
+ * resolve, so its candidates are derived and then refused rather than stored
+ * against a fabricated anchor. That is the fail-open direction: no finding
+ * beats a finding anchored to something that is not what the claim is about.
+ */
+export function projectAnchor(projectRoot) {
+  if (!projectRoot) return null;
+  let entries;
+  try {
+    entries = readdirSync(projectRoot);
+  } catch {
+    return projectRoot;
+  }
+  const present = new Set(entries);
+  for (const marker of PROJECT_MARKERS) {
+    if (!present.has(marker)) continue;
+    const path = join(projectRoot, marker);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // A marker that cannot be stat'ed is not a marker.
+    }
+  }
+  // Sorted so two sessions in the same repository pick the SAME solution file:
+  // readdir order is not guaranteed stable across hosts, and an anchor that
+  // varies by host splits one finding into two nodes.
+  for (const entry of [...entries].sort()) {
+    if (!DOTNET_MARKER.test(entry)) continue;
+    const path = join(projectRoot, entry);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // Same.
+    }
+  }
+  return projectRoot;
+}
+
+/**
+ * Tokens of claim text one session may add to the graph.
+ *
+ * SCALED TO THE RETRIEVAL BUDGET IT COMPETES FOR, not picked round. A single
+ * command's injection budget is 500 tokens (`TOKEN_OPTIMIZER_TOUCH_BUDGET`),
+ * and everything stored here is competing for that budget on every later
+ * command, forever. Two touch-budgets per session is the bound: enough for a
+ * few dozen real claims, and short of one session's exit codes crowding out
+ * every finding a human or a model ever wrote.
+ */
+const storageBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_DERIVE_BUDGET) || 1000;
+
+/**
  * Derives finding candidates from one project's local evidence.
  *
  * @param {string} dir wiki directory.
@@ -118,11 +212,18 @@ const triggerFor = (command) =>
  *   and is refused by `writeHarvested` anyway, so emitting one would only spend
  *   the caller's budget on junk.
  * @param {string|null} options.authoritativeSessionId the session id as the HOOK
- *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
- *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
- *   edge -- `taskForAnchors` returns null without one, so an unverified string
- *   would silently produce no edge. Threaded rather than defaulted from
- *   `sessionId`: defaulting would promote any caller's string to trusted.
+ *   PAYLOAD reported it, never a value a model typed. Passed straight to
+ *   `writeHarvested`, which needs it to resolve the `answers` edge --
+ *   `taskForAnchors` returns null without one, so an unverified string would
+ *   silently produce no edge. Threaded rather than defaulted from `sessionId`:
+ *   defaulting would promote any caller's string to trusted. Also returned, so a
+ *   caller can see what it handed over.
+ * @returns {object} `{ candidates, observations, written, selected, dropped,
+ *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
+ *   everything derived; `written` is the subset of keys the graph actually
+ *   holds, which is smaller for three independent reasons -- the budget, the
+ *   anchor discipline, and the duplicate collapse that returns an EXISTING key
+ *   when a later session derives the same claim again.
  */
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
@@ -152,6 +253,11 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // ONE anchor for the whole run, so every candidate from this session points at
+  // the same node and the duplicate collapse in `writeHarvested` can recognise
+  // the same lesson across sessions.
+  const anchorPath = projectAnchor(projectRoot);
 
   const seen = new Set();
   const add = (candidate) => {
@@ -246,7 +352,7 @@ export function derive(dir, options = {}) {
               `observed in one session: \`${failed.command}\` failed` +
                 `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
                 `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
-                'an intervening edit or a flaky run explains the same pair.',
+                'an intervening edit or an unrelated environment change explains the same pair.',
               { max: EVIDENCE_MAX }
             ),
             applicability: 'when about to run this command in this project',
@@ -255,7 +361,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the failing form later succeeds unchanged'],
             trigger: triggerFor(outcome.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: outcome.at || Date.now(),
@@ -280,7 +386,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the same command later succeeds unchanged'],
             trigger: triggerFor(failed.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: failed.at || Date.now(),
@@ -330,7 +436,7 @@ export function derive(dir, options = {}) {
           confidenceLabel: labelFor(CONFIDENCE.correction),
           scope: 'project',
           invalidators: ['the user later asks for the corrected behaviour'],
-          anchors: [projectRoot],
+          anchors: [anchorPath],
           derivedBy: 'correction',
           sessionId,
           at: Date.parse(turn.at || '') || Date.now(),
@@ -379,6 +485,48 @@ export function derive(dir, options = {}) {
     }
   } catch {
     // One detector, never the session.
+  }
+
+  // ---- storage, under a budget -------------------------------------------
+  //
+  // NOTHING ENTERS THE GRAPH UNBUDGETED. `selectForConsolidation` existed for
+  // exactly this and had no caller, which meant that until now nothing bounded
+  // what a session could add. It admits `failure` and `decision` on a FLOOR
+  // before ranking -- a dead end exists nowhere else and is small, and cheap to
+  // find is not cheap to find again -- then fills the remainder by
+  // cost x irrecoverability x reuse-probability.
+  //
+  // ORIGIN_HARVESTED, EXPLICITLY, never ORIGIN_HUMAN. These are machine
+  // derivations; `curate.mjs` states the reason in its own header -- "a
+  // hand-written assertion and a machine guess look identical three months
+  // later, which quietly destroys the reader's ability to calibrate trust".
+  // `writeHarvested` would refuse a batch-wide human origin anyway, and a
+  // candidate here carries neither `origin` nor `quote`, so it cannot earn one
+  // per finding either. That is deliberate: whether a turn was a correction at
+  // all is a lexical guess, and the standing-rules layer selects on human
+  // origin to inject on EVERY turn.
+  try {
+    if (result.candidates.length) {
+      const selected = selectForConsolidation(load(dir), result.candidates, {
+        budget: storageBudget(),
+      });
+      result.selected = selected.kept.length;
+      result.dropped = selected.dropped;
+      result.selectedTokens = selected.tokens;
+      result.written = writeHarvested(dir, selected.kept, {
+        sessionId,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        // The hook payload's own identity, passed through untouched. Without it
+        // `taskForAnchors` returns null and the `answers` edge never fires --
+        // which is the state a default install has been in, because its only
+        // other producer is credential-gated.
+        authoritativeSessionId,
+      });
+    }
+  } catch {
+    // Storage is the last step and the session is already over. A graph write
+    // that fails must not turn a completed session into a hook error.
   }
 
   return result;

--- a/integrations/codex/hooks/lib/derive.mjs
+++ b/integrations/codex/hooks/lib/derive.mjs
@@ -139,17 +139,19 @@ const quotable = (command) => {
  * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
  * found across 163 transcripts on this machine it refuses 2 and keeps 6.
  *
- * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
- * building the key, so the claim is about `npm test` rather than about the `cd`.
- * That changes `attemptKey` for every client and every finding already derived
- * from it, so it belongs in its own change with its own comparison.
+ * `commandBody` below now skips a leading `cd <path> &&`, so those two are
+ * recovered and this guard is left holding only the keys that reached a
+ * separator which is NOT a directory change -- `git fetch && <anything>`, a
+ * pipeline, a `;`-joined pair. Those still name no single attempt.
  */
 const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
 
 /**
  * Did `attemptKey` actually capture a command, or only how one was chained?
  *
- * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart --
+ * which now means AFTER `commandBody` has removed any leading `cd`, so this no
+ * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
 const hasAttemptIdentity = (command) =>
@@ -177,6 +179,81 @@ const CORRECTION_OPENER =
   /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
 
 /**
+ * A leading directory change, stripped before the key is built.
+ *
+ * THE MEASURED CASE, AND ONLY THE MEASURED CASE. `attemptKey` spends up to
+ * three non-flag tokens on identity and the habit on this machine is
+ * `cd <absolute path> && <the real command>`, which spends all three on `cd`,
+ * the path and the separator. This repository's own corpus: 1,400 of 2,243
+ * command outcomes open with a `cd`, and the single key
+ * `cd c:/users/.../token-optimizer-mcp &&` covered 547 distinct command lines.
+ * A `cd` says WHERE a command ran; it says nothing about WHAT ran, so it cannot
+ * be part of the identity of an attempt.
+ *
+ * THE SEPARATOR SET IS THE ONE THAT WAS OBSERVED: `&&` (1,147), a newline (204)
+ * and `;` (38) after a leading `cd`. All three mean "then run this". `||` is
+ * DELIBERATELY EXCLUDED even though it costs one line to add: `cd x || echo
+ * failed` puts an error branch after the separator, not the next step, so
+ * stripping there would key the attempt on a failure handler. It occurred zero
+ * times.
+ *
+ * AND NOTHING WIDER, each refusal for a reason from the same corpus:
+ *
+ *   Environment assignments (`FOO=bar cmd`) DO carry information about what
+ *   ran. The one true instance here is
+ *   `TOKEN_OPTIMIZER_HOLDOUT=1 node ... jest.js ...`, and the holdout arm is a
+ *   genuinely different attempt from the same command without it. The other 20
+ *   are shell variable assignments joined by `;` -- statements, not prefixes --
+ *   whose value is usually a 120-character path that would be stripped down to
+ *   nothing useful.
+ *
+ *   `time`, `env`, `nice`, `sudo`, `bash -c`, `pushd`, `Set-Location`: ZERO
+ *   occurrences in 2,243 commands. Code for an unmeasured prefix is a way to
+ *   over-strip that no evidence asked for, and over-stripping merges commands
+ *   that genuinely differ -- the same bug in the other direction. `bash -c` is
+ *   worse than unmeasured: the command sits inside a quoted string, so stripping
+ *   the wrapper leaves a key beginning with a quote character.
+ *
+ *   `cd /d C:\path &&` and `cd "C:/a b" &&` need no extra rule -- the match runs
+ *   to the separator rather than counting tokens, so flags and quoted paths
+ *   containing spaces are consumed for free. Neither appears here, so neither is
+ *   claimed as tested behaviour beyond its unit test.
+ *
+ * A `cd` with NO separator is left alone: `cd <path>` on its own ran no command,
+ * and its key is as meaningless afterwards as before -- there is nothing to
+ * recover. Stripping is repeated up to `MAX_DIR_PREFIXES` times so
+ * `cd a && cd b && cmd` reaches `cmd`; the bound exists only so a pathological
+ * line cannot loop, since each pass must consume a whole `cd ... <sep>`.
+ *
+ * APPLIED IDENTICALLY TO BOTH SOURCES because it is applied INSIDE `attemptKey`,
+ * which is the single function both the event path and the transcript reader's
+ * output pass through. The 120-character anchor cap that makes the two agree on
+ * 266 of 266 keys is untouched and still applied on both sides before this runs.
+ */
+const DIR_PREFIX = /^\s*cd\s[^\r\n;&|]*?(?:&&|;|\r?\n)\s*/i;
+const MAX_DIR_PREFIXES = 4;
+
+/**
+ * The command text with any leading directory change removed.
+ *
+ * Used for the key AND for the identical-text refusal, which is the half that
+ * keeps this from becoming a licence to pair more loosely: without it,
+ * `cd repo && npm test` failing and `npm test` succeeding would emit
+ * "`npm test` succeeded where `cd repo && npm test` failed" at 0.90 -- two
+ * spellings of one attempt, dressed up as a difference that mattered. The
+ * claim itself still quotes the RAW command, because that is what ran.
+ */
+export function commandBody(command) {
+  let text = String(command || '');
+  for (let i = 0; i < MAX_DIR_PREFIXES; i++) {
+    const stripped = text.replace(DIR_PREFIX, '');
+    if (stripped === text) break;
+    text = stripped;
+  }
+  return text;
+}
+
+/**
  * The prefix that makes two invocations "the same attempt".
  *
  * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
@@ -194,7 +271,7 @@ const CORRECTION_OPENER =
  * ships a false claim into model context.
  */
 export function attemptKey(command) {
-  return String(command || '')
+  return commandBody(command)
     .trim()
     .split(/\s+/)
     .filter((token) => token && !token.startsWith('-'))
@@ -494,7 +571,14 @@ export function derive(dir, options = {}) {
           // is real and supports NEITHER claim, so nothing is emitted. This is
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
-          if (failed.command === outcome.command) continue;
+          // COMPARED WITH THE DIRECTORY CHANGE REMOVED, for the same reason
+          // the key is. `cd repo && npm test` and `npm test` are one attempt
+          // spelled two ways; before `commandBody` they landed in different
+          // groups and never met, and letting them meet without widening this
+          // guard would emit "`npm test` succeeded where `cd repo && npm test`
+          // failed" at 0.90 -- a difference in the claim that is not a
+          // difference in what ran. Same for two `cd`s to different paths.
+          if (commandBody(failed.command) === commandBody(outcome.command)) continue;
 
           // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
           // client both sides of almost every pair are truncated multi-line
@@ -502,10 +586,12 @@ export function derive(dir, options = {}) {
           // spending the retrieval budget of every later session.
           if (!quotable(failed.command) || !quotable(outcome.command)) continue;
 
-          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
-          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
-          // command lines in this repository alone, and any pair drawn from that
-          // group is a false claim about both halves.
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`. The
+          // `cd <path> &&` case that grouped 547 unrelated command lines in this
+          // repository is now handled earlier by `commandBody`; what is left
+          // here is every OTHER separator -- `git fetch && <anything>`, a
+          // pipeline, a `;`-joined pair -- where the key still names no single
+          // attempt and any pair drawn from it is false about both halves.
           if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =

--- a/integrations/codex/hooks/lib/derive.mjs
+++ b/integrations/codex/hooks/lib/derive.mjs
@@ -1,0 +1,385 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/derive.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Findings from data we already hold, with no model call.
+ *
+ * WHY THIS EXISTS. The semantic harvest is on by default but its real gate is a
+ * credential: `harvestMode()` returns `off:no-key` on any machine without one,
+ * which is CI, corporate laptops, and every subscription-only login. This
+ * repository's own graph is the evidence -- 2,965 symbol nodes, 904 file nodes,
+ * 128 task nodes and ONE finding -- because the structural layer accumulates
+ * from ordinary tool traffic while every verdict needed an API key this machine
+ * does not have.
+ *
+ * Everything here is derived from outcomes, transitions and corrections that are
+ * ALREADY RECORDED LOCALLY. Nothing is sent anywhere, nothing is billed, so
+ * there is nothing to consent to and this runs by default. It is the only
+ * finding producer on a machine without a key.
+ *
+ * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
+ * second command fixed the first -- an intervening edit, a dependency install or
+ * a flaky test explains it just as well. So each detector carries a confidence
+ * ceiling, the claim text says only what was OBSERVED, and the two shapes where
+ * the observation supports no claim at all are refused rather than downgraded
+ * (see `attemptKey` and the identical-text guard below).
+ *
+ * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
+ * budget, belongs to the caller.
+ */
+
+import { readMetrics, rereadsByAnchor } from './metrics.mjs';
+import { readArchive, readTurns } from './transcript.mjs';
+import { redact } from './redact.mjs';
+
+/**
+ * Ceilings, ordered by how much the evidence actually supports.
+ *
+ * A command that succeeded where a DIFFERENT command failed is close to a direct
+ * observation. A test or build going red-to-green is weaker, because the usual
+ * cause is the code changing between the two runs rather than anything about the
+ * command. A correction is a lexical guess about what a human meant. Churn
+ * describes our own reading behaviour and says nothing about the code at all.
+ */
+export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+
+/** Claim text cap. A finding is one sentence; a paragraph is evidence. */
+const CLAIM_MAX = 300;
+const EVIDENCE_MAX = 400;
+
+/** Bounded so a pathological log cannot turn session end into real work. */
+const MAX_CANDIDATES = 200;
+
+/**
+ * Commands whose red-to-green transition is usually explained by the CODE
+ * changing rather than by the command. They get the lower ceiling.
+ */
+const CODE_SENSITIVE = /\b(test|tests|jest|vitest|pytest|mocha|build|compile|tsc|lint|typecheck)\b/i;
+
+/**
+ * Openers that mark a user turn as a correction rather than an instruction.
+ *
+ * DELIBERATELY NARROW, and anchored to the START of the turn. The model-based
+ * extractor in `lessons.mjs` can read intent; this cannot, so it only claims the
+ * shapes where the first few words carry the whole signal. Recall is poor by
+ * design: a missed correction costs one finding, a false one puts words in the
+ * user's mouth at 0.6 confidence.
+ */
+const CORRECTION_OPENER =
+  /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
+
+/**
+ * The prefix that makes two invocations "the same attempt".
+ *
+ * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
+ * through what the alternatives do to real command lines:
+ *
+ *   Two tokens conflates `npm run build` with `npm run test`, and the pair then
+ *   produces "`npm run test` works where `npm run build` failed" -- a claim that
+ *   is simply false.
+ *
+ *   Counting flags splits `deploy` from `deploy --retry`, which is the single
+ *   most useful pair this detector can find, into two groups that never meet.
+ *
+ * Conservative in the remaining direction: `npm run build:prod` and
+ * `npm run build` do not pair. A missed pair costs one finding; a wrong pair
+ * ships a false claim into model context.
+ */
+export function attemptKey(command) {
+  return String(command || '')
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'))
+    .slice(0, 3)
+    .join(' ')
+    .toLowerCase();
+}
+
+/** Normalised claim text, so the same lesson derived twice is one candidate. */
+const claimKey = (type, claim) =>
+  `${type}|${String(claim).toLowerCase().replace(/\s+/g, ' ').trim()}`;
+
+/** 0.95 is reserved for verified; everything here is inference. */
+const labelFor = (confidence) => (confidence >= 0.75 ? 'probable' : 'speculative');
+
+/** A literal command prefix, safe to hand to `safeTrigger`. */
+const triggerFor = (command) =>
+  attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
+
+/**
+ * Derives finding candidates from one project's local evidence.
+ *
+ * @param {string} dir wiki directory.
+ * @param {object} options
+ * @param {string|null} options.sessionId session this ran for, for provenance.
+ * @param {string|null} options.transcriptPath live transcript, read only when the
+ *   archive holds nothing for this session yet.
+ * @param {string|null} options.projectRoot the anchor every derived claim gets.
+ *   Without it nothing is derived: an unanchored finding cannot be invalidated
+ *   and is refused by `writeHarvested` anyway, so emitting one would only spend
+ *   the caller's budget on junk.
+ * @param {string|null} options.authoritativeSessionId the session id as the HOOK
+ *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
+ *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
+ *   edge -- `taskForAnchors` returns null without one, so an unverified string
+ *   would silently produce no edge. Threaded rather than defaulted from
+ *   `sessionId`: defaulting would promote any caller's string to trusted.
+ */
+export function derive(dir, options = {}) {
+  // `options || {}` rather than a destructuring default. A default only fires on
+  // `undefined`, so a caller passing an explicitly null options object -- which
+  // is what a hook does when it has nothing to say -- threw a TypeError out of
+  // the parameter list itself, before any of the try/catch below could fail open.
+  const {
+    sessionId = null,
+    transcriptPath = null,
+    projectRoot = null,
+    authoritativeSessionId = null,
+  } = options || {};
+
+  const result = {
+    candidates: [],
+    observations: [],
+    written: [],
+    sessionId,
+    authoritativeSessionId,
+  };
+
+  let events;
+  try {
+    events = readMetrics(dir);
+  } catch {
+    // Session end must cost nothing. No evidence is not an error.
+    return result;
+  }
+  if (!Array.isArray(events)) return result;
+
+  const seen = new Set();
+  const add = (candidate) => {
+    if (result.candidates.length >= MAX_CANDIDATES) return;
+    const key = claimKey(candidate.type, candidate.claim);
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.candidates.push(candidate);
+  };
+
+  // ---- 1 & 2: a failed attempt followed by a succeeding one ---------------
+  //
+  // The event is `tool-outcome` and THE COMMAND TEXT IS IN `anchor`: there is no
+  // separate command field, because the anchor of a command surface IS the
+  // command. It is capped at 120 characters at the boundary, so a very long
+  // command line is compared and quoted truncated.
+  try {
+    if (projectRoot) {
+      const outcomes = events
+        .filter(
+          (e) =>
+            e &&
+            e.kind === 'tool-outcome' &&
+            e.surface === 'command' &&
+            typeof e.anchor === 'string' &&
+            e.anchor.trim()
+        )
+        .map((e) => ({
+          command: e.anchor.trim(),
+          output: typeof e.output === 'string' ? e.output : '',
+          exit: Number.isInteger(e.exit) ? e.exit : null,
+          at: e.at ?? 0,
+          // `success` FIRST, `exit` only as a refinement. MCP tools report no
+          // numeric code at all, so a classifier keyed on `exit !== 0` would be
+          // inert for most clients -- and `exit` is null rather than 0 precisely
+          // so that absence is not read as a clean exit.
+          failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
+        }))
+        .sort((a, b) => a.at - b.at);
+
+      const byAttempt = new Map();
+      for (const outcome of outcomes) {
+        const key = attemptKey(outcome.command);
+        if (!key) continue;
+        if (!byAttempt.has(key)) byAttempt.set(key, []);
+        byAttempt.get(key).push(outcome);
+      }
+
+      for (const run of byAttempt.values()) {
+        // The NEAREST preceding failure, not the first one in the session. With
+        // `find` over the whole run, a command that failed at 09:00 and
+        // succeeded at 17:00 after nine unrelated attempts is reported as one
+        // story.
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          // One pair per failure: a command that succeeds twice afterwards has
+          // not taught two lessons.
+          lastFailure = null;
+
+          // THE GUARD THAT REMOVES THE LARGEST JUNK CLASS. The commonest shape
+          // in a coding session is `npm run build` failing, the code being
+          // fixed, and `npm run build` succeeding -- identical text. From that
+          // pair the two available claims are "`npm run build` works where
+          // `npm run build` failed", which is incoherent, and "`npm run build`
+          // fails", which the same evidence has just disproved. The observation
+          // is real and supports NEITHER claim, so nothing is emitted. This is
+          // not a confidence question; a ceiling cannot rescue a claim whose
+          // content is wrong.
+          if (failed.command === outcome.command) continue;
+
+          const codeSensitive =
+            CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);
+          const confidence = codeSensitive ? CONFIDENCE.test : CONFIDENCE.command;
+          const derivedBy = codeSensitive ? 'test-transition' : 'command-transition';
+
+          // "SUCCEEDED WHERE", NOT "FIXES". What is observed is two outcomes in
+          // order on the same attempt; that the difference in the command line
+          // CAUSED the difference in outcome is not observed and is not claimed.
+          add({
+            type: 'command',
+            claim: redact(
+              `\`${outcome.command}\` succeeded in this project where \`${failed.command}\` failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
+                'an intervening edit or a flaky run explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: 'when about to run this command in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the failing form later succeeds unchanged'],
+            trigger: triggerFor(outcome.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+
+          // The error text, only when there is error text. Without it the claim
+          // degrades to "`X` failed with:" and nothing after the colon, which
+          // carries no information and still costs budget.
+          const firstLine = failed.output.split('\n').find((line) => line.trim()) || '';
+          if (firstLine.trim().length < 8) continue;
+          add({
+            type: 'failure',
+            claim: redact(`\`${failed.command}\` failed with: ${firstLine.trim()}`, {
+              max: CLAIM_MAX,
+            }),
+            evidence: redact(`captured output of the failing run:\n${failed.output}`, {
+              max: EVIDENCE_MAX,
+            }),
+            applicability: 'when this command is about to be run in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the same command later succeeds unchanged'],
+            trigger: triggerFor(failed.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: failed.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 3: user corrections ------------------------------------------------
+  //
+  // A `feedback` finding -- the one type whose source is a person saying the
+  // agent was wrong. The MODEL-BASED extractor for this lives in `lessons.mjs`
+  // and needs the credential this module exists to do without, so here the
+  // signal is lexical: the opening words of the user's own turn.
+  //
+  // ORIGIN IS NOT PROMOTED. `writeHarvested` grants ORIGIN_HUMAN to a finding
+  // carrying a verified verbatim quote, and the standing-rules layer selects on
+  // that origin to inject a claim on EVERY turn. The quote here would be
+  // verbatim -- it is copied out of the archive -- but whether the turn was a
+  // correction at all is a guess, and a guess must not buy always-on injection.
+  // So no `origin` and no `quote` field: this stays harvested provenance.
+  try {
+    if (projectRoot) {
+      let turns = readArchive(dir, sessionId);
+      // The archive is written by the Stop hook too, and the order of the two is
+      // not this module's to assume, so fall back to the live transcript.
+      if (!turns.length && transcriptPath) turns = readTurns(transcriptPath);
+
+      for (const turn of turns) {
+        if (!turn || turn.role !== 'user') continue;
+        const text = String(turn.text || '').trim();
+        // Long turns are new instructions with a complaint somewhere inside
+        // them; truncating one into a claim would misquote the user.
+        if (text.length < 12 || text.length > 300) continue;
+        if (!CORRECTION_OPENER.test(text)) continue;
+        add({
+          type: 'feedback',
+          claim: redact(text, { max: CLAIM_MAX }),
+          evidence: redact(`the user opened a turn with a correction: "${text}"`, {
+            max: EVIDENCE_MAX,
+          }),
+          applicability: 'when working in this project, before repeating what was corrected',
+          confidence: CONFIDENCE.correction,
+          confidenceLabel: labelFor(CONFIDENCE.correction),
+          scope: 'project',
+          invalidators: ['the user later asks for the corrected behaviour'],
+          anchors: [projectRoot],
+          derivedBy: 'correction',
+          sessionId,
+          at: Date.parse(turn.at || '') || Date.now(),
+        });
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 4: re-read churn ---------------------------------------------------
+  //
+  // NOT A FINDING, AND THAT IS THE DECISION RATHER THAN AN OMISSION.
+  //
+  // Churn is a claim about OUR OWN reading behaviour: "this file was read three
+  // times unchanged". Every finding type available is a claim about the work --
+  // `map` describes how an area of the codebase is laid out, and is
+  // content-dependent, so a churn claim filed as `map` would be checked for
+  // staleness against contents it makes no claim about and flip stale on the
+  // first edit to a file it never described. Worse, the anchors it would take
+  // are by construction the HOTTEST files in the project, which are exactly the
+  // files that already carry real findings, so a 0.4-confidence row saying
+  // nothing actionable would sit in the injection budget beside them and render
+  // on the same reads. Nothing a future agent could DO differently follows from
+  // it: it does not say what the file contains, so it cannot substitute for
+  // reading it.
+  //
+  // The signal is still worth having -- as the measurement it already is.
+  // `rereadWaste` reports it on the balance sheet, `rereadsByAnchor` names the
+  // offenders, and this returns those rows as OBSERVATIONS: computed, carried,
+  // and deliberately not competing for context. Three detectors produce
+  // findings; the fourth produces a number.
+  try {
+    for (const row of rereadsByAnchor(events).slice(0, 3)) {
+      if (!row.anchor || row.wasteful < 2) continue;
+      result.observations.push({
+        kind: 'churn',
+        anchor: row.anchor,
+        repeats: row.repeats,
+        wasteful: row.wasteful,
+        tokens: row.tokens,
+        confidence: CONFIDENCE.churn,
+        derivedBy: 'churn',
+        note: `re-read ${row.repeats} times, ${row.wasteful} of them unchanged`,
+      });
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  return result;
+}

--- a/integrations/codex/hooks/lib/derive.mjs
+++ b/integrations/codex/hooks/lib/derive.mjs
@@ -16,6 +16,13 @@
  * there is nothing to consent to and this runs by default. It is the only
  * finding producer on a machine without a key.
  *
+ * THREE SOURCES, NOT TWO. `tool-outcome` events, the transcript archive, and --
+ * since the transition detectors were measured to have no input at all on the
+ * primary client -- the raw transcript's FAILED tool results, which is the only
+ * place a Claude Code failure is recorded (`failedResultsFromTranscript` in
+ * transcript.mjs, and the note above `quotable` for what that measurement
+ * actually yielded).
+ *
  * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
  * second command fixed the first -- an intervening edit, a dependency install or
  * a flaky test explains it just as well. So each detector carries a confidence
@@ -32,7 +39,11 @@
 import { readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
-import { readArchive, readTurns } from './transcript.mjs';
+import {
+  readArchive,
+  readTurns,
+  failedResultsFromTranscript,
+} from './transcript.mjs';
 import { redact } from './redact.mjs';
 import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
@@ -56,6 +67,96 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * The anchor cap a command surface is stored under, restated here as a TEST.
+ *
+ * `recordToolOutcome` truncates `anchor` to 120 characters, so a command at or
+ * over that length reached this module already cut -- and `quotable` below
+ * refuses to build a claim out of the fragment.
+ */
+const COMMAND_ANCHOR_MAX = 120;
+
+/**
+ * Can this command text be QUOTED in a claim a reader could act on?
+ *
+ * THE SECOND REFUSAL OF ITS KIND, and it exists because measurement forced it.
+ * Wiring the transcript reader gave the transition detectors their first real
+ * input on this client and immediately produced four candidates at 0.9
+ * confidence whose claim text read:
+ *
+ *   `cd /c/Users/.../token-optimizer-mcp\ncat >> docs/superpowers/plans/2026-` succeeded
+ *   in this project where `cd /c/Users/.../token-optimizer-mcp\ncat > /tmp/probe3.mjs
+ *   <<'EOF'\nimport { readdirSync, readFileSync, sta` failed
+ *
+ * -- two truncated fragments of throwaway shell scripts, grouped together only
+ * because `attemptKey`'s three tokens were spent on `cd`, the absolute path, and
+ * the verb. Then measured properly across three real transcripts: **0 of 83**
+ * captured command failures are single-line and inside the cap. 65% of this
+ * project's 2,178 successful command outcomes are not either. On this client a
+ * "command" is usually a whole shell script, so the attempt identity the
+ * transition detectors are built on does not fit most of the traffic.
+ *
+ * This is the same judgement as the identical-text guard below rather than a
+ * confidence question: a claim whose subject is a truncated fragment of a
+ * program is not a weaker claim, it is not a claim. A raised cap would not
+ * rescue it -- quoting the whole 500-character heredoc is no more actionable.
+ *
+ * What survives is exactly what the detector was designed for: `npm test`,
+ * `dotnet build X`, `deploy --retry` -- a repeatable command someone could run
+ * again. This machine captured none failing, which is why the honest yield here
+ * is zero and why that is reported rather than dressed up.
+ *
+ * Applied to BOTH sources. Where the evidence arrived from has no bearing on
+ * whether the resulting sentence says anything, and a rule that let events
+ * through would ship the junk on the ten clients that do report failures.
+ */
+const quotable = (command) => {
+  const text = String(command || '');
+  return (
+    text.trim().length > 0 &&
+    !/[\r\n]/.test(text) &&
+    text.length < COMMAND_ANCHOR_MAX
+  );
+};
+
+/**
+ * Tokens that separate one command from the next rather than naming one.
+ *
+ * MEASURED, LIKE EVERY OTHER REFUSAL HERE. `attemptKey` spends up to three
+ * non-flag tokens on identity, and the habit on this machine is
+ * `cd <absolute path> && <the real command>` -- which spends all three on `cd`,
+ * the path and `&&`, so the real command never enters the key. This project's
+ * own evidence: the single key `cd c:/users/.../token-optimizer-mcp &&` covers
+ * **539 distinct command lines**. One quotable failure in that group would pair
+ * with an arbitrary unrelated success and claim "`cd repo && grep -n ...`
+ * succeeded where `cd repo && git merge ...` failed", which is false about both.
+ *
+ * A KEY THAT REACHED A SEPARATOR NEVER REACHED A COMMAND, so there is no attempt
+ * to compare and nothing to claim -- the same judgement as the identical-text
+ * guard rather than a lower ceiling. Narrow on purpose: `2>&1` and `/F` are not
+ * separators and do not trip this, so `cat commitlint.config.mjs 2>&1` and
+ * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
+ * found across 163 transcripts on this machine it refuses 2 and keeps 6.
+ *
+ * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
+ * building the key, so the claim is about `npm test` rather than about the `cd`.
+ * That changes `attemptKey` for every client and every finding already derived
+ * from it, so it belongs in its own change with its own comparison.
+ */
+const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
+
+/**
+ * Did `attemptKey` actually capture a command, or only how one was chained?
+ *
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * One check per pair is enough: both halves share the key by construction.
+ */
+const hasAttemptIdentity = (command) =>
+  attemptKey(command)
+    .split(' ')
+    .filter(Boolean)
+    .every((token) => !COMMAND_SEPARATORS.has(token));
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -274,6 +375,17 @@ export function derive(dir, options = {}) {
   // separate command field, because the anchor of a command surface IS the
   // command. It is capped at 120 characters at the boundary, so a very long
   // command line is compared and quoted truncated.
+  //
+  // TWO SOURCES OF FAILURE, ONE PAIRING LOOP. Claude Code never fires
+  // PostToolUse for a failed tool call -- 2,238 of 2,238 live `tool-outcome`
+  // events on the measuring machine carry `success: true`, and a deliberately
+  // failing command produced no event at all -- so on the primary client these
+  // two detectors had NO INPUT WHATSOEVER while working normally on the ten
+  // adapter clients. `failedResultsFromTranscript` supplies the missing half
+  // from the only place it exists. The successes still come from events only:
+  // a transcript failure that pairs with nothing stays unclaimed, which is also
+  // what keeps a failure from ANOTHER project's directory out of this project's
+  // graph -- a candidate cannot be emitted without a success recorded HERE.
   try {
     if (projectRoot) {
       const outcomes = events
@@ -290,6 +402,9 @@ export function derive(dir, options = {}) {
           output: typeof e.output === 'string' ? e.output : '',
           exit: Number.isInteger(e.exit) ? e.exit : null,
           at: e.at ?? 0,
+          // Carried purely so the transcript merge below can recognise the same
+          // tool call arriving from the other source.
+          toolCallId: e.toolCallId ? String(e.toolCallId) : null,
           // `success` FIRST, `exit` only as a refinement. MCP tools report no
           // numeric code at all, so a classifier keyed on `exit !== 0` would be
           // inert for most clients -- and `exit` is null rather than 0 precisely
@@ -297,6 +412,53 @@ export function derive(dir, options = {}) {
           failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
         }))
         .sort((a, b) => a.at - b.at);
+
+      // DEDUPLICATED ON `toolCallId`, which is the SAME STRING in both sources:
+      // `episodeMeta` reads `raw.tool_use_id` into `toolCallId`, and that is the
+      // transcript's `tool_use_id` verbatim -- verified against live evidence
+      // (`toolu_01L4Nwr...` in metrics.jsonl, the same ids in the transcript).
+      // So on the ten clients that DO report failures, the event copy wins and
+      // the transcript copy is dropped before grouping. Without this the two
+      // copies of one failure would sit in the same run and the second of them
+      // would be paired against the first as a failed-then-succeeded story about
+      // itself.
+      //
+      // The fallback covers a client that reports a failure with no call id:
+      // identical command text within two seconds is one failure recorded twice,
+      // not two failures, because nothing re-runs a command that fast.
+      const eventIds = new Set(
+        outcomes.map((o) => o.toolCallId).filter(Boolean)
+      );
+      const eventFailures = outcomes.filter((o) => o.failed);
+      const alreadyRecorded = (failure) => {
+        if (failure.toolCallId && eventIds.has(failure.toolCallId)) return true;
+        return eventFailures.some(
+          (o) =>
+            o.command === failure.command &&
+            Math.abs((o.at || 0) - (failure.at || 0)) <= 2000
+        );
+      };
+
+      let transcriptFailures = [];
+      try {
+        transcriptFailures = failedResultsFromTranscript(transcriptPath).filter(
+          (failure) => failure.command.trim() && !alreadyRecorded(failure)
+        );
+      } catch {
+        // The reader is an extra source, never a reason the detector stops.
+      }
+      for (const failure of transcriptFailures) {
+        outcomes.push({
+          command: failure.command.trim(),
+          output: failure.output,
+          exit: failure.exit,
+          at: failure.at,
+          toolCallId: failure.toolCallId,
+          // Read from `Exit code N`, which is the only shape the reader admits.
+          failed: true,
+        });
+      }
+      if (transcriptFailures.length) outcomes.sort((a, b) => a.at - b.at);
 
       const byAttempt = new Map();
       for (const outcome of outcomes) {
@@ -333,6 +495,18 @@ export function derive(dir, options = {}) {
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
           if (failed.command === outcome.command) continue;
+
+          // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
+          // client both sides of almost every pair are truncated multi-line
+          // shell scripts, and a claim quoting a fragment of one is noise
+          // spending the retrieval budget of every later session.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
+          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
+          // command lines in this repository alone, and any pair drawn from that
+          // group is a false claim about both halves.
+          if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =
             CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);

--- a/integrations/codex/hooks/lib/doctor.mjs
+++ b/integrations/codex/hooks/lib/doctor.mjs
@@ -197,7 +197,8 @@ function hooksDirFor({ hooksDir, install, root }) {
  * identical from outside: a graph that fills with structural nodes either way.
  *
  * Measured on a real 5.4.0 install: 484 symbol, 286 file and 122 task nodes and
- * ZERO findings, because harvestMode() was 'off:not-opted-in'. Fifteen checks
+ * ZERO findings, because harvestMode() then returned an opt-in refusal (the mode has
+ * since been renamed: it is 'off:no-key' now, and opting in is no longer the gate). Fifteen checks
  * passed and none mentioned harvest. stop-harvest.mjs names this exact gap --
  * "nothing in doctor, audit or waste mentions harvest, so a user sees a graph
  * filling with structural nodes and no findings and has no way to learn why" --
@@ -221,9 +222,15 @@ export function probeHarvest() {
   // optimizer is off" is noise, which is why stop-harvest maps it to no notice.
   if (mode === 'off:mode') return [];
 
+  // SAID PLAINLY, because this is the configuration a user would choose if they
+  // knew it existed and the previous wording buried it in machinery. A local
+  // endpoint is the only setting under which the semantic harvest runs with no
+  // credential, no billing and no digest leaving the machine -- so the two facts
+  // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
     return [ok('finding extraction is available',
-      'active-model wiki_write is primary; local endpoint also enables fallback extraction')];
+      'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
+      'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
@@ -233,10 +240,19 @@ export function probeHarvest() {
 
   // No second-model credential is required for the primary path. The Codex/agent session that
   // already paid to derive the conclusion is the extractor and wiki_write is local.
+  // NAME THE TRADE, not just the missing variable. This is the default state on
+  // every machine without a credential, so it is the text most users will read,
+  // and "unavailable" alone tells them neither what they are missing nor that
+  // the free option exists. Local findings still accumulate: derive.mjs reads
+  // exit codes, red-to-green transitions, corrections and churn out of evidence
+  // already on disk and sends nothing anywhere.
   if (mode === 'off:no-key') {
     return [ok('finding extraction is available',
-      'active model records durable conclusions through local wiki_write; no separate-model ' +
-      'credential is configured, so fallback transcript extraction is unavailable')];
+      'active model records durable conclusions through local wiki_write, and derive runs at ' +
+      'session end with no credential. No separate-model credential is configured, so fallback ' +
+      'transcript extraction is unavailable: point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local ' +
+      'model to run it free and private, or set TOKEN_OPTIMIZER_API_KEY to run it from a bounded ' +
+      'digest of paths, commands, prompts and conclusions -- never file contents')];
   }
 
   // off:opted-out -- a deliberate choice, reported as one. Nagging about a setting somebody chose

--- a/integrations/codex/hooks/lib/inject.mjs
+++ b/integrations/codex/hooks/lib/inject.mjs
@@ -1134,10 +1134,25 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // injected more than the budget allowed and recorded fewer tokens than it
   // spent -- in a block whose entire justification is that it is tightly
   // bounded and measured against the control arm.
+  // THE LAST LINE IS HOW THE NEXT RULE GETS HERE, and it is one line because
+  // this block is charged on every session forever. A rule reaches this list
+  // only by being pinned or by being a person's verified correction, and both
+  // start as a `wiki_write` -- so a model reading a set of standing rules with
+  // no idea how they were produced has no way to add to it. Stated at the point
+  // of the evidence rather than as a separate always-on block: the reader is
+  // already looking at the output of the mechanism being described.
+  //
+  // THE COLD GRAPH IS COVERED ELSEWHERE, deliberately. Nothing here renders
+  // until at least one rule qualifies, which is the property the always-on
+  // budget depends on, so this line cannot be the first-session nudge --
+  // `policyText`'s "Record what you work out" section is, and it is emitted at
+  // SessionStart whether or not the graph holds anything.
   const HEADING =
     '# Standing rules for this project' +
     '\n\nEstablished in previous sessions and expected to hold. ' +
-    'These are not suggestions.\n\n';
+    'These are not suggestions.\n\n' +
+    'Record what you work out with wiki_write and a real file anchor; ' +
+    'that is how a rule reaches this list.\n\n';
   const noticeFor = (n) =>
     n
       ? `\n(${n} further standing rule${n === 1 ? '' : 's'} did not fit this budget; ` +

--- a/integrations/codex/hooks/lib/inject.mjs
+++ b/integrations/codex/hooks/lib/inject.mjs
@@ -35,6 +35,7 @@ import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
 import { cacheOrdered } from './cache.mjs';
+import { withheldFor, exploreOrder, servingPolicyVersion, LOO_ENABLED } from './loo.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -311,8 +312,38 @@ export function forTouch(
     });
     for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
   }
-  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  // LAYER 2 EXPLORATION, BEFORE the budget decides.
+  //
+  // `assessed.eligible` arrives in net-utility order and `fit` keeps that order
+  // until the budget runs out -- so the ranking decides which findings are ever
+  // served, which decides which ever accumulate observations, which decides
+  // their utility. A tenth of touches therefore promote the least-served
+  // candidate first. This is the only place it can go: after `fit` the choice
+  // has already been made.
+  const ordered = exploreOrder(assessed.eligible, dir, { sessionId, anchor: filePath });
+  const { kept, spent } = fit(ordered.map((item) => item.finding), budget);
   if (!kept.length) return null;
+
+  // LAYER 2 WITHHOLDING, AFTER the budget decides, which is the only ordering
+  // that produces a leave-one-out rather than a substitution: withholding first
+  // would let the next-ranked finding take the freed tokens, so the withheld
+  // arm would differ from the served arm by two findings instead of one and the
+  // effect would belong to neither.
+  //
+  // `holdout` is passed so the two experiments cannot compose into "withhold
+  // everything and call it a leave-one-out": that arm already serves nothing.
+  const withheld = withheldFor(kept.map((finding) => finding.key), sessionId, graph, dir, {
+    surface: 'file',
+    anchor: filePath,
+    holdout,
+  });
+  const delivered = withheld ? kept.filter((finding) => finding.key !== withheld) : kept;
+  // RE-PRICED, because `fit` priced what it KEPT and this delivers less. Using
+  // `spent` would bill the injection-cost side of the balance sheet for text
+  // the model never received.
+  const deliveredSpent = withheld
+    ? delivered.reduce((sum, finding) => sum + estimate(render(finding)), 0)
+    : spent;
 
   record(dir, {
     kind: 'inject',
@@ -321,15 +352,20 @@ export function forTouch(
     surface: 'file',
     anchor: filePath,
     holdout,
-    tokens: holdout ? 0 : spent,
-    deliveredTokens: holdout ? 0 : spent,
+    tokens: holdout ? 0 : deliveredSpent,
+    deliveredTokens: holdout ? 0 : deliveredSpent,
     shadowTokens: spent,
-    count: holdout ? 0 : kept.length,
+    count: holdout ? 0 : delivered.length,
     candidateCount: kept.length,
-    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    findingIds: holdout ? [] : delivered.map((finding) => finding.key),
     shadowFindingIds: kept.map((finding) => finding.key),
-    stale: kept.some((f) => f.stale),
+    stale: delivered.some((f) => f.stale),
     sessionId,
+    // ON EVERY RECORD, not only the withheld ones. A served observation needs
+    // the policy version as much as a withheld one does, or `effects` cannot
+    // keep the two arms of one comparison inside one policy.
+    ...(LOO_ENABLED() ? { looPolicy: servingPolicyVersion() } : {}),
+    ...(withheld ? { loo: withheld } : {}),
   });
 
   // MARKED SEEN IN BOTH ARMS, for the same reason as the command path: a file
@@ -339,11 +375,16 @@ export function forTouch(
   // grow faster purely from repetition.
   //
   // This is the identical defect that was fixed in `forCommand` and not here.
+  //
+  // THE WITHHELD KEY IS MARKED TOO, and that is load-bearing rather than tidy:
+  // an unmarked one would be a candidate again on the next touch of this file,
+  // where the one-per-touch tiebreak could serve it -- flipping its arm inside
+  // the very session the arm hash exists to pin it for.
   for (const f of kept) alreadyInjected.add(f.key);
 
-  if (holdout || !kept.length) return null;
+  if (holdout || !delivered.length) return null;
 
-  return `Known about ${filePath} (from previous sessions):\n${kept.map(render).join('\n')}`;
+  return `Known about ${filePath} (from previous sessions):\n${delivered.map(render).join('\n')}`;
 }
 
 /**

--- a/integrations/codex/hooks/lib/keepwarm.mjs
+++ b/integrations/codex/hooks/lib/keepwarm.mjs
@@ -30,6 +30,15 @@ import { record, readMetrics, readBalance } from './metrics.mjs';
 import { WRITE_MULTIPLIER, READ_MULTIPLIER } from './cache.mjs';
 
 /**
+ * The shortest gap that counts as a NEW turn rather than a burst inside one.
+ *
+ * Shared by the gap distribution and by the hit test, because they have to
+ * agree about what a turn is. Two copies of this number would let the decision
+ * be fitted to one definition of a turn and scored against another.
+ */
+export const TURN_GAP_MS = 250;
+
+/**
  * TTL tiers, with what a WRITE costs at each.
  *
  * A five-minute entry is written at 1.25x a plain input token; the one-hour
@@ -85,7 +94,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
     for (let i = 1; i < session.length; i++) {
       const gap = session[i] - session[i - 1];
       // A burst of events inside one turn is not a gap between turns.
-      if (gap > 250) gaps.push(gap);
+      if (gap > TURN_GAP_MS) gaps.push(gap);
     }
   }
   if (gaps.length < 6) return null;
@@ -105,10 +114,91 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
 }
 
 /**
+ * Refreshes to observe at a tier before the observation may bound the decision.
+ *
+ * THE SAME NUMBER THE BACKSTOP DEMANDS, deliberately. The decision and the
+ * tripwire read the same ledger, so letting them disagree about when there is
+ * enough evidence would mean one of them acting on a sample the other calls too
+ * small. Below the floor the decision keeps its expected-value answer, so a
+ * single unlucky miss changes nothing at all.
+ *
+ * NOT A CONFIDENCE INTERVAL, and the reason is arithmetic rather than taste. A
+ * Wilson 95% upper bound at ten refreshes and zero hits is 0.28 -- so a policy
+ * that missed ten times out of ten would still be recommended, which is exactly
+ * the case the loop exists to catch. The point estimate is safe here because of
+ * the bound below: an observation may only ever LOWER the modelled probability,
+ * so sampling noise cannot manufacture a refresh, and the tripwire's realised
+ * ledger is a second guard underneath.
+ */
+export const OBSERVATION_FLOOR = TRIPWIRE_MIN;
+
+/**
+ * The measured hit rate per tier, from recorded outcomes.
+ *
+ * Tiers below the floor are ABSENT rather than present with a small n, because
+ * a rate carrying no weight is the thing most likely to be used as though it
+ * did.
+ */
+export function observedHitRates(outcomes = []) {
+  const byTier = new Map();
+  for (const event of outcomes) {
+    if (event?.kind !== 'keepwarm' || event.action !== 'outcome') continue;
+    const name = TIERS.some((t) => t.name === event.tier) ? event.tier : TIERS[0].name;
+    const row = byTier.get(name) || { refreshes: 0, hits: 0 };
+    row.refreshes += 1;
+    if (event.hit) row.hits += 1;
+    byTier.set(name, row);
+  }
+
+  const qualified = new Map();
+  for (const [name, row] of byTier) {
+    if (row.refreshes < OBSERVATION_FLOOR) continue;
+    qualified.set(name, { ...row, rate: row.hits / row.refreshes });
+  }
+  return qualified;
+}
+
+/**
+ * What the refreshes at this tier actually did, if enough of them have.
+ *
+ * Tolerates being handed anything -- null, a plain object, a Map -- because the
+ * callers are two public functions whose options object is assembled by other
+ * people's code.
+ */
+function observationsFor(observed, tierName) {
+  const row = observed instanceof Map ? observed.get(tierName) : null;
+  return row && Number.isFinite(row.rate) ? row : null;
+}
+
+/**
+ * The modelled probability, BOUNDED BY what was observed and never raised by it.
+ *
+ * The asymmetry is the whole point and runs against this project's interest. A
+ * recorded `hit` says only that a turn arrived before the entry expired; it
+ * cannot say the refresh is what kept the entry alive, because a turn arriving
+ * one minute after a five-minute ping would have found the entry warm anyway.
+ * So the observed rate is an UPPER bound on a refresh's value, and substituting
+ * it for the model would flatter keep-warm badly: on the machine this was
+ * written on, the modelled ping probability is 0.2% and the observable
+ * before-expiry rate is 99.5%, so the substitution would recommend refreshing
+ * forever. A low rate, by contrast, is real evidence against: if turns do not
+ * even arrive inside the TTL, the refresh certainly bought nothing.
+ */
+function bounded(modelled, seen) {
+  return seen ? Math.min(modelled, seen.rate) : modelled;
+}
+
+/**
  * Should we refresh this prefix now?
  *
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
+ *
+ * `observed` is passed IN rather than read from disk here: this function is
+ * pure, its purity is what lets the tests build a distribution by hand, and
+ * `shouldKeepWarm` has already read the outcome log for the tripwire -- so
+ * threading the reader in here would be a second read of the same file and a
+ * second place for the window discipline to be got wrong.
  */
 export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
@@ -125,42 +215,30 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
   const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
-
-  // MEASURED BEATS MODELLED, once there is enough of it.
-  //
-  // The module header already commits to this -- "an expected-value decision is
-  // only as good as the distribution it was fitted to, and distributions
-  // shift" -- and the tripwire underneath was the only thing acting on it, as
-  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
-  // entirely" there was nothing, because the observed hit rate was never
-  // computed: both recording halves had no call site, so ten refreshes that
-  // bought nothing would keep recommending refresh right up to the moment the
-  // tripwire cut the whole feature off.
-  //
-  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
-  // handful of samples would swing the decision harder than the distribution
-  // they replace.
-  const probability = observed ? observed.rate : modelled;
+  const seen = observationsFor(observed, tier.name);
+  const probability = bounded(modelled, seen);
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
-  const basis = observed
-    ? `measured over ${observed.observations} refreshes`
-    : 'modelled from the gap distribution';
+  const note = seen && probability < modelled
+    ? `; bounded by ${seen.refreshes} observed refreshes, ` +
+      `${Math.round(seen.rate * 100)}% used before expiry`
+    : '';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
     modelledProbability: modelled,
-    basis,
+    observedHitRate: seen ? seen.rate : null,
+    observedRefreshes: seen ? seen.refreshes : 0,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
-    reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
+    reason: (ev > 0
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
-        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`) + note,
   };
 }
 
@@ -171,7 +249,12 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
  * long enough that the short tier keeps missing. Returns null when neither tier
  * pays, which is a real answer and the one a default-on product never gives.
  */
-export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS }) {
+export function ttlTier({
+  prefixTokens,
+  gaps,
+  turnsPerSession = DEFAULT_TURNS,
+  observed = null,
+}) {
   if (!prefixTokens || !gaps) return null;
 
   // Expected cost of a turn under each tier, as a multiple of what the prefix
@@ -179,7 +262,16 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   // again; and the FIRST write is amortised over the session, which is what
   // stops the expensive tier from looking free whenever gaps are short.
   const costOf = (tier) => {
-    const hit = gaps.probabilityWithin(tier.ms);
+    // THE SAME QUANTITY THE OUTCOMES RECORD, which is what makes the
+    // observation admissible here at all. `hit` is P(a turn arrives before the
+    // entry expires) and `recordRefreshOutcome`'s `hit` is exactly that event,
+    // measured -- unlike keepWarmDecision, whose probability is the narrower
+    // ping window and for which the same observation is only an upper bound.
+    // Bounded rather than replaced even so: a sample drawn only from moments we
+    // CHOSE to refresh is not a sample of gaps, and its bias runs our way.
+    const modelled = gaps.probabilityWithin(tier.ms);
+    const seen = observationsFor(observed, tier.name);
+    const hit = bounded(modelled, seen);
     const perTurn = hit * READ_MULTIPLIER + (1 - hit) * tier.writeMultiplier;
     // THE SUPPLIED VALUE, not only the computed one. Math.max(1, NaN) is NaN -- Math.max
     // propagates it rather than clamping -- so perTurn became NaN, the `perTurn >= 1` guard below
@@ -192,6 +284,8 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     return {
       tier,
       hit,
+      seen,
+      boundedByObservation: Boolean(seen) && hit < modelled,
       perTurn: (tier.writeMultiplier + (turns - 1) * perTurn) / turns,
     };
   };
@@ -208,99 +302,53 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     action: 'refresh',
     tier: best.tier.name,
     hitProbability: best.hit,
+    observedHitRate: best.seen ? best.seen.rate : null,
+    observedRefreshes: best.seen ? best.seen.refreshes : 0,
     expectedCostPerTurn: Number(best.perTurn.toFixed(3)),
     expectedValue: Math.round((1 - best.perTurn) * prefixTokens),
     reason: `${Math.round(best.hit * 100)}% of gaps land inside ${best.tier.name}; ` +
-      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached`,
+      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached` +
+      (best.boundedByObservation
+        ? `, bounded by ${best.seen.refreshes} observed refreshes ` +
+          `(${Math.round(best.seen.rate * 100)}% used before expiry)`
+        : ''),
   };
 }
 
-/** Observations of a tier before its measured hit rate may override the model. */
-export const OBSERVATION_FLOOR = 5;
-
-/** Records a refresh so its outcome can be scored. */
-export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
-  record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
-}
-
 /**
- * Scores every refresh whose window has since resolved.
+ * Records a refresh so its outcome can be scored.
  *
- * THE MISSING HALF, and it was missing because nobody could see where the
- * signal would come from. `recordRefreshOutcome` needs to know whether a real
- * turn arrived before the entry expired -- and that is not a thing anyone has
- * to instrument, because the event log already records when every turn
- * happened. The answer was in the data the whole time.
+ * `sessionId` IS REQUIRED FOR THE REFRESH TO BE SCOREABLE, and is not defaulted
+ * to anything. The hit test asks whether a turn of THIS conversation arrived
+ * before expiry; pooling arrivals across sessions would let a second concurrent
+ * session's turn pay for this one's ping, which manufactures hits. A refresh
+ * recorded without one is kept in the ledger and reported as unattributable
+ * rather than guessed at.
  *
- * For each unscored refresh at time T on a tier with TTL `ms`:
- *
- *   - a later event within `ms`            -> HIT, observed
- *   - a later event after `ms`             -> MISS, observed
- *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
- *                                             demonstrably closed unused
- *   - no later event, window still open    -> NOTHING RECORDED
- *
- * That last line is the important one and it is Plan 2's own instruction: "if
- * no signal is available for a tier, record nothing rather than guessing
- * `hit: false`". A refresh whose window has not closed yet is not a miss, and
- * scoring it as one would drive the tripwire negative on the newest and least
- * informative records.
- *
- * DRAINED AT READ TIME, which is the pattern this codebase already uses for
- * staleness: the producer cannot know the outcome at the moment it acts, so the
- * next reader resolves what has become knowable since.
+ * Returns the stored record, whose `id` is what `scoreRefreshes` pairs the
+ * outcome to, so an issuer can hold onto it.
  */
-export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
-  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
-  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
-  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
-
-  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
-  // so everything past the number already scored is outstanding. Pairing by
-  // timestamp instead would double-count two refreshes recorded in the same
-  // millisecond, which is reachable: a tool run twice in a loop.
-  const outstanding = refreshes.slice(scored);
-  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
-
-  let recorded = 0;
-  for (const refresh of outstanding) {
-    const at = Number(refresh.at) || 0;
-    if (!at) continue;
-    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
-    const next = timeline.find((t) => t > at);
-
-    let hit;
-    if (next !== undefined) hit = next - at <= tierSpec.ms;
-    else if (now - at > tierSpec.ms) hit = false;
-    else continue; // window still open: not yet knowable
-
-    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
-    recorded += 1;
-  }
-  return { outstanding: outstanding.length, recorded };
-}
-
-/**
- * The measured hit rate for a tier, or null below the observation floor.
- *
- * Null rather than a small-sample number, because the caller substitutes it for
- * a modelled probability and three observations would swing the decision harder
- * than the model they replace.
- */
-export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
-  const relevant = outcomes.filter(
-    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
-  );
-  if (relevant.length < OBSERVATION_FLOOR) return null;
-  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
+export function recordRefresh(dir, { tier, prefixTokens, expectedValue, sessionId, at }) {
+  return record(dir, {
+    kind: 'keepwarm',
+    action: 'refresh',
+    tier,
+    prefixTokens,
+    expectedValue,
+    sessionId,
+    at,
+  });
 }
 
 /**
  * Records whether the refresh was used.
  *
  * `hit` means a real turn arrived before expiry, so the write bought a read.
+ * `refreshId` names the refresh this scores, so the same one cannot be scored
+ * twice -- once per turn for the rest of the session, which is what an
+ * unpaired outcome would become.
  */
-export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
+export function recordRefreshOutcome(dir, { tier, prefixTokens, hit, refreshId = null }) {
   const tierSpec = TIERS.find((t) => t.name === tier) || TIERS[0];
   // THE SAME LEDGER keepWarmDecision BUYS THE REFRESH WITH. That function is explicit that a
   // refresh is a PING, which READS the prefix -- costOfPing = prefixTokens * READ_MULTIPLIER --
@@ -317,7 +365,125 @@ export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
   const realised = hit
     ? prefixTokens * (tierSpec.writeMultiplier - READ_MULTIPLIER) - prefixTokens * READ_MULTIPLIER
     : -prefixTokens * READ_MULTIPLIER;
-  record(dir, { kind: 'keepwarm', action: 'outcome', tier, prefixTokens, hit: Boolean(hit), realised: Math.round(realised) });
+  record(dir, {
+    kind: 'keepwarm',
+    action: 'outcome',
+    tier,
+    prefixTokens,
+    hit: Boolean(hit),
+    refreshId,
+    realised: Math.round(realised),
+  });
+}
+
+/**
+ * Scores every recorded refresh whose window has closed -- and NOTHING ELSE.
+ *
+ * This is the arm that was missing. `recordRefresh` and `recordRefreshOutcome`
+ * were both correct and both called by nothing, so the decision spent money on
+ * refreshes and could never find out whether one bought a read.
+ *
+ * THE SIGNAL IS REAL, not invented. `gapDistribution` already treats this log's
+ * timestamps as turn arrivals -- that is the distribution the whole decision is
+ * fitted to -- so the same log answers the outcome question directly: a refresh
+ * at tier `5m` was used if a turn of the same session arrived within five
+ * minutes of it. Four cases refuse to answer rather than guess, and every one
+ * of them refuses in the direction that costs this project its own good news:
+ *
+ *   - `pending`: the window has not closed yet. A hit could be scored the
+ *     instant it arrives while a miss must wait out the whole TTL, so scoring
+ *     early would mean the recorded hits are always complete and the recorded
+ *     misses always lagging -- right-censoring, biased upward, invisible in any
+ *     test. So a hit waits exactly as long as a miss.
+ *   - `uncovered`: the arrival log no longer reaches back to the refresh, so
+ *     absence of an arrival is absence of evidence. RECORDING `hit: false` HERE
+ *     WOULD BE THE INVENTION THIS IS FORBIDDEN TO MAKE: an absent signal is not
+ *     a miss, and treating it as one biases every rate downward and would
+ *     eventually switch keep-warm off on no evidence at all.
+ *   - `unattributable`: the refresh names no session, so no arrival can be
+ *     shown to belong to it.
+ *   - already scored: an outcome already names this refresh.
+ *
+ * The firehose is READ LAZILY, and only when there is something to score. On a
+ * machine where nothing issues refreshes -- which is every machine today, since
+ * nothing in this repository issues one -- the whole cost is the outcome-log
+ * read: median 70 ms on a 3.5 MB log, of which readBalance is 49 ms, because
+ * that reader also scans the firehose tail for pre-split records.
+ */
+export function scoreRefreshes(dir, {
+  refreshes = readBalance(dir),
+  arrivals = null,
+  now = Date.now(),
+} = {}) {
+  const summary = { scored: 0, hits: 0, pending: 0, uncovered: 0, unattributable: 0 };
+  const keepwarm = refreshes.filter((event) => event?.kind === 'keepwarm');
+  const alreadyScored = new Set(
+    keepwarm
+      .filter((event) => event.action === 'outcome' && event.refreshId)
+      .map((event) => event.refreshId)
+  );
+  const unscored = keepwarm.filter(
+    (event) =>
+      event.action === 'refresh' &&
+      Number.isFinite(event.at) &&
+      event.id &&
+      !alreadyScored.has(event.id)
+  );
+
+  // A refresh with no id cannot be paired, so scoring it would write a fresh
+  // outcome on every turn forever. Reported, not silently dropped.
+  summary.unattributable += keepwarm.filter(
+    (event) => event.action === 'refresh' && (!event.id || !Number.isFinite(event.at))
+  ).length;
+
+  if (!unscored.length) return summary;
+
+  const events = (arrivals ? arrivals() : readMetrics(dir)).filter((event) =>
+    Number.isFinite(event?.at)
+  );
+  // Coverage is judged over EVERY event, including our own bookkeeping: the
+  // refresh's own copy in the firehose is what proves the window is still
+  // inside the read. Arrivals are judged over everything else, because a record
+  // keep-warm wrote about itself is not a turn -- and counting one would
+  // manufacture a hit out of the act of measuring.
+  const earliest = events.reduce((min, event) => Math.min(min, event.at), Infinity);
+  const turns = events.filter((event) => event.kind !== 'keepwarm');
+
+  for (const refresh of unscored) {
+    const tier = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    if (now - refresh.at < tier.ms) {
+      summary.pending += 1;
+      continue;
+    }
+    const session = refresh.sessionId;
+    if (!session) {
+      summary.unattributable += 1;
+      continue;
+    }
+    if (!(earliest <= refresh.at)) {
+      summary.uncovered += 1;
+      continue;
+    }
+
+    const opens = refresh.at + TURN_GAP_MS;
+    const closes = refresh.at + tier.ms;
+    const hit = turns.some(
+      (event) =>
+        (event.sessionId ?? event.episodeId) === session &&
+        event.at > opens &&
+        event.at <= closes
+    );
+    recordRefreshOutcome(dir, {
+      tier: refresh.tier,
+      prefixTokens: refresh.prefixTokens,
+      hit,
+      refreshId: refresh.id,
+    });
+    summary.scored += 1;
+    if (hit) summary.hits += 1;
+  }
+
+  return summary;
 }
 
 /**
@@ -372,23 +538,15 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
-  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
-  // becomes evidence now, so the decision below and the tripwire above both see
-  // the most that is currently knowable -- the same read-time drain the
-  // staleness path uses, and for the same reason: the producer cannot know the
-  // outcome at the moment it acts.
-  try {
-    scoreOutstandingRefreshes(dir, { events, outcomes });
-    outcomes = readBalance(dir);
-  } catch {
-    /* scoring is evidence, never a reason to refuse a decision */
-  }
-
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
+  // THE SAME ARRAY THE TRIPWIRE JUST READ, so closing the loop costs no extra
+  // I/O -- and so the decision and its backstop cannot be looking at different
+  // evidence about the same refreshes.
+  const observed = observedHitRates(outcomes);
   const gaps = gapDistribution(dir, { events });
-  const best = ttlTier({ prefixTokens, gaps });
+  const best = ttlTier({ prefixTokens, gaps, observed });
   if (!best) {
     // THE TWO MODELS ANSWER DIFFERENT QUESTIONS, so they may legitimately disagree. ttlTier asks
     // whether holding a cache beats not caching at all; keepWarmDecision asks whether ONE ping
@@ -397,11 +555,7 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({
-      prefixTokens,
-      gaps,
-      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
-    });
+    const decision = keepWarmDecision({ prefixTokens, gaps, observed });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/integrations/codex/hooks/lib/loo.mjs
+++ b/integrations/codex/hooks/lib/loo.mjs
@@ -1,0 +1,788 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/loo.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 2 -- what one finding is actually worth, measured by withholding it.
+ *
+ * Layer 1 asks whether the model went back and named a finding. This asks the
+ * harder question and answers it causally: WITHHOLD ONE FINDING while serving
+ * every other finding for the same touch, and compare what the session spent
+ * READING that anchor afterwards. Nobody in this space measures per-item value
+ * this way in production; the state of the art is an offline evaluation set.
+ * That is also why this file is more refusal than statistics -- a causal claim
+ * from four observations is worse than no claim, because it is a number and
+ * numbers get quoted.
+ *
+ * THE ESTIMAND IS READ-SUPPRESSION, and it is deliberately DISJOINT from Layer
+ * 1. Layer 1 keys on an explicit `query` naming a finding key. This keys on
+ * `read` events against the injection's anchor. Neither signal appears in the
+ * other's arithmetic: no `query` event is consulted here, and `usage.mjs`
+ * consults no `read` event. Task 8 calibrates one against the other, and if
+ * both derived from the same channel that calibration would report a strong
+ * correlation between two spellings of one quantity and mean nothing.
+ *
+ * IT INVENTS NO JOIN. `recordToolOutcome` already joins each post-tool result
+ * back to the injection that preceded it, recording `injectionId`,
+ * `findingIds` and a `joinMethod` of `tool-call-id` / `episode-anchor` /
+ * `none`. Every observation here is GATED on that join: an injection with no
+ * joined outcome is unattributable and enters neither arm, exactly as Layer 1
+ * treats `joinMethod: 'none'`. An earlier draft of this plan proposed a fresh
+ * `(sessionId, findingKey)` join; it was rejected and is not here.
+ *
+ * WHAT IT COSTS THE USER, because an experiment that degrades a turn owes an
+ * accounting. One withheld finding means the model may re-derive what it was
+ * told last time, and the worst case is one read of that anchor: measured on
+ * this machine, a median read is 3,769 tokens and the 90th percentile is
+ * 14,082. Five guards bound that exposure, and they are the reason the numbers
+ * below are as small as they are:
+ *
+ *   1. only on a FILE touch, because a command injection has no anchor a read
+ *      event can be joined to -- withholding there would cost a user a finding
+ *      and buy no observation at all (see `buildReport`, which excludes command
+ *      injections from the holdout balance for the same reason);
+ *   2. never when fewer than two findings were kept, so "leave one out" always
+ *      leaves something in -- otherwise it degenerates into `inHoldout`, which
+ *      withholds EVERY finding for an anchor and is a different experiment;
+ *   3. never in the same breath as `inHoldout`: if that arm already withheld
+ *      everything, there is nothing to leave out and a Layer 2 arm recorded
+ *      there would be a fabricated observation;
+ *   4. at most ONE finding per touch, or the effect is attributable to neither;
+ *   5. at most ONE withheld finding per SESSION, so the worst case a user can
+ *      experience is a single re-read -- not one per file they open.
+ *
+ * AND IT NEVER OVERRIDES A PERSON. A `pinned` or `origin: 'human'` finding is
+ * an explicit human decision to keep something in front of the model.
+ * Withholding it to run an experiment would overrule that decision for the
+ * convenience of the measurement, so those findings are exempt: they are
+ * always served, they get no causal score, and `looNote` says so rather than
+ * leaving a reader to wonder why they are missing from the table.
+ */
+
+import { createHash } from 'node:crypto';
+import { readEvidence, readMetrics, readTruncation, isFixtureAnchor } from './metrics.mjs';
+import { retrievalPolicy } from './utility.mjs';
+import { ORIGIN_HUMAN } from './curate.mjs';
+import { canonicalPath } from './paths.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Injections of a finding before it may enter the experiment.
+ *
+ * A finding nobody has served yet has no established value to measure the
+ * absence of, and withholding it would be measuring the cold start rather than
+ * the finding. Four is also what makes the ratio below reachable: at a quarter
+ * of (key, session) pairs armed, a key needs roughly a dozen enrolled
+ * injections before it can reach a verdict at all.
+ */
+export const MIN_PRIOR_INJECTIONS = 4;
+
+/** The observation floor. Below this there is no verdict -- and NOT a zero. */
+export const MIN_SERVED = 6;
+export const MIN_WITHHELD = 3;
+
+/** Benjamini-Hochberg false-discovery rate for published verdicts. */
+export const FDR_Q = 0.1;
+
+/**
+ * Exploration rate.
+ *
+ * Without this, utility feeds the ranking, the ranking feeds injection
+ * frequency, injection frequency feeds the observation count, and a low score
+ * becomes self-fulfilling: the finding is never served often enough to earn a
+ * better one. A tenth of touches therefore ignore the utility order and
+ * promote the LEAST-served candidate instead.
+ */
+export const EPSILON = 0.1;
+
+/**
+ * The share of (finding, session) pairs assigned to the withheld arm.
+ *
+ * Chosen against the floors rather than picked: MIN_SERVED / MIN_WITHHELD is
+ * 2:1, so a quarter withheld reaches both floors at about the same time while
+ * leaving three touches in four undamaged.
+ */
+export const WITHHOLD_FRACTION = 0.25;
+
+/**
+ * Withheld findings allowed per session. ONE.
+ *
+ * The per-touch cap alone bounds nothing across a session: a session that
+ * opens twelve files with enrolled findings could have withheld twelve. This
+ * makes the worst case a user can experience one re-read, at the price of a
+ * mild confound that is stated rather than hidden -- when the cap binds, the
+ * other armed findings in that session are served, so the served arm is
+ * slightly enriched by sessions that touch many enrolled findings.
+ */
+export const MAX_WITHHELD_PER_SESSION = 1;
+
+/**
+ * Fallback shrinkage weight when the between-finding variance cannot be
+ * estimated (fewer than two findings with both arms, or no dispersion at all).
+ *
+ * MIN_SERVED + MIN_WITHHELD, deliberately: a finding's own data outweighs the
+ * population prior only once it has reached the publication floor.
+ */
+export const SHRINKAGE_K = MIN_SERVED + MIN_WITHHELD;
+
+/** Bounds on the estimated shrinkage weight, so a degenerate variance ratio cannot run away. */
+const K_MIN = 1;
+const K_MAX = 100;
+
+/**
+ * Bumped BY HAND when the serving code changes in a way that could move a
+ * finding's measured effect. It is the part of the policy version a hash of the
+ * configuration cannot see.
+ */
+export const LOO_POLICY_GENERATION = 1;
+
+/** Permutation budget before the exact null distribution is sampled instead of enumerated. */
+const MAX_EXACT_PERMUTATIONS = 20_000;
+const SAMPLED_PERMUTATIONS = 10_000;
+
+/**
+ * On by default, off by `TOKEN_OPTIMIZER_LOO=off`.
+ *
+ * Read per call rather than at module load, for the reason `holdoutFraction`
+ * gives: a long-lived process started before the setting changed would
+ * otherwise honour the old value forever with no way to tell.
+ */
+export function LOO_ENABLED() {
+  return String(process.env.TOKEN_OPTIMIZER_LOO || '').trim().toLowerCase() !== 'off';
+}
+
+/**
+ * The serving policy an observation was collected under.
+ *
+ * WHY EVERY OBSERVATION CARRIES ONE. An effect is only meaningful against a
+ * fixed policy. Halve the touch budget or move the minimum net utility and the
+ * same finding is served in different company, at a different rank, against a
+ * different counterfactual -- so pooling observations from before and after
+ * that change would average two different experiments and call the result
+ * causal. `effects()` therefore groups by (finding, policy) and never across.
+ *
+ * IT IS DELIBERATELY ABSENT FROM THE ARM HASH. Including it would reassign
+ * arms the moment a setting changed, which is precisely the mid-session flip
+ * the arm hash exists to prevent. Configuration decides which experiment an
+ * observation belongs to; it must never decide which arm.
+ */
+export function servingPolicyVersion() {
+  const policy = retrievalPolicy();
+  const parts = [
+    `g${LOO_POLICY_GENERATION}`,
+    `touch=${Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500}`,
+    `benefit=${policy.baseBenefitTokens}`,
+    `minutility=${policy.minimumNetUtility}`,
+    `cooldown=${policy.cooldownMs}`,
+    `quarantine=${policy.quarantineHarmCount}`,
+    `holdout=${process.env.TOKEN_OPTIMIZER_HOLDOUT ?? 'default'}`,
+    `withhold=${WITHHOLD_FRACTION}`,
+    `prior=${MIN_PRIOR_INJECTIONS}`,
+    `epsilon=${EPSILON}`,
+  ];
+  const digest = createHash('sha256').update(parts.join('|')).digest('hex');
+  return `${LOO_POLICY_GENERATION}-${digest.slice(0, 8)}`;
+}
+
+/**
+ * A stable number in [0, 1) from a string.
+ *
+ * SHA-256 rather than SHA-1 for the same reason `inHoldout` uses it: this is a
+ * bucketing hash and nothing here is secret, but arguing that a CodeQL finding
+ * is benign is a worse habit than paying a cost that rounds to nothing.
+ */
+function bucket(text) {
+  return createHash('sha256').update(String(text)).digest().readUInt32BE(0) / 4_294_967_296;
+}
+
+/**
+ * The arm of one finding in one session.
+ *
+ * Keyed on (findingKey, sessionId) AND NOTHING ELSE, so a finding cannot
+ * change arms partway through a session: not when the candidate set changes,
+ * not when the budget changes, not when the graph grows. The measurement is a
+ * comparison between sessions, and an arm that flips inside one contaminates
+ * both sides of it.
+ */
+function armed(findingKey, sessionId) {
+  return bucket(`loo-arm:${findingKey}:${sessionId}`) < WITHHOLD_FRACTION;
+}
+
+/** Deterministic tiebreak among armed candidates: lowest bucket, then key order. */
+function armRank(findingKey, sessionId) {
+  return bucket(`loo-rank:${findingKey}:${sessionId}`);
+}
+
+/** The graph node for a finding key, or null. Keys are unique per graph. */
+function findingNode(graph, key) {
+  const nodes = graph?.nodes;
+  if (!nodes || typeof nodes.values !== 'function') return null;
+  for (const node of nodes.values()) {
+    if (node?.kind === 'finding' && node.key === key) return node;
+    // A fixture graph may omit `kind`; key identity is what this needs.
+    if (node?.key === key && node.kind === undefined) return node;
+  }
+  return null;
+}
+
+/**
+ * May this finding ever be withheld?
+ *
+ * FAILS CLOSED ON AN UNKNOWN KEY, which is the opposite of how the rest of
+ * this module fails. Everywhere else a missing input costs a measurement; here
+ * it could cost a human their explicit decision, because a key whose node
+ * cannot be read is a key whose `pinned` and `origin` cannot be checked.
+ */
+function withholdable(graph, key) {
+  const node = findingNode(graph, key);
+  if (!node) return false;
+  if (node.pinned) return false;
+  if (node.origin === ORIGIN_HUMAN) return false;
+  if (node.retired) return false;
+  return true;
+}
+
+/** Prior SERVED injections per finding key, and withheld injections per session. */
+function history(dir, { evidence = null } = {}) {
+  const priorServed = new Map();
+  const withheldPerSession = new Map();
+  const events = evidence || readEvidence(dir);
+  for (const event of events) {
+    if (event.kind !== 'inject') continue;
+    if (typeof event.loo === 'string' && event.loo) {
+      const session = typeof event.sessionId === 'string' ? event.sessionId : '';
+      withheldPerSession.set(session, (withheldPerSession.get(session) || 0) + 1);
+    }
+    if (event.holdout) continue;
+    const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+    for (const raw of keys) {
+      const key = String(raw);
+      priorServed.set(key, (priorServed.get(key) || 0) + 1);
+    }
+  }
+  return { priorServed, withheldPerSession };
+}
+
+/**
+ * Which single finding to withhold from this touch, or null.
+ *
+ * Called from `forTouch` AFTER `fit` has decided what would have been served,
+ * which is the only ordering that produces a true leave-one-out. Withholding
+ * BEFORE the budget runs would let a lower-ranked finding take the freed
+ * tokens, so the withheld arm would receive different company as well as one
+ * fewer finding, and the comparison would confound the two.
+ *
+ * @param {string[]} findingKeys keys that would otherwise be delivered
+ * @param {string} sessionId the session, which pins the arm
+ * @param {object} graph the loaded graph, for `pinned` / `origin`
+ * @param {string|null} dir graph directory, for the injection history
+ */
+export function withheldFor(findingKeys, sessionId, graph, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return null;
+
+    // Every guard that needs no I/O runs first: this is the PreToolUse path,
+    // and on a project with one finding per anchor the answer is null before
+    // anything is read.
+    const keys = [...new Set((findingKeys || []).map((k) => String(k)).filter(Boolean))];
+    if (keys.length < 2) return null;
+    if (!sessionId || typeof sessionId !== 'string') return null;
+
+    // FILE SURFACE ONLY. A command injection's anchor is the command text, and
+    // no read event will ever match it -- so both arms would score zero
+    // downstream and the finding would be scored on nothing.
+    const { surface = 'file', anchor = '', holdout = false } = options;
+    if (surface !== 'file' || !anchor) return null;
+    // The all-findings holdout already withheld everything for this anchor.
+    if (holdout) return null;
+
+    const eligible = keys.filter((key) => withholdable(graph, key));
+    if (!eligible.length) return null;
+
+    const { priorServed, withheldPerSession } = history(dir, options);
+    if ((withheldPerSession.get(sessionId) || 0) >= MAX_WITHHELD_PER_SESSION) return null;
+
+    const enrolled = eligible.filter(
+      (key) => (priorServed.get(key) || 0) >= MIN_PRIOR_INJECTIONS
+    );
+    if (!enrolled.length) return null;
+
+    const candidates = enrolled.filter((key) => armed(key, sessionId));
+    if (!candidates.length) return null;
+
+    // AT MOST ONE. Sorted deterministically so the same touch always yields the
+    // same choice; the findings that lose the tiebreak are SERVED, and the
+    // observation records what actually happened rather than what the arm hash
+    // intended.
+    candidates.sort(
+      (a, b) => armRank(a, sessionId) - armRank(b, sessionId) || (a < b ? -1 : a > b ? 1 : 0)
+    );
+    return candidates[0];
+  } catch {
+    // An experiment must never break a tool call. Failing open here means
+    // serving everything, which is the undegraded behaviour.
+    return null;
+  }
+}
+
+/**
+ * Reorders candidates so exploration can break the feedback loop.
+ *
+ * A tenth of touches -- deterministic in (session, anchor), not random, so the
+ * same touch behaves the same way twice -- promote the LEAST-served candidate
+ * ahead of the utility order, giving it a chance to survive `fit` and accrue
+ * the observations it needs to earn a score. The other nine tenths are
+ * untouched.
+ *
+ * @param {Array<{finding:{key:string}}>} items assessed candidates, best first
+ */
+export function exploreOrder(items, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return items;
+    const list = Array.isArray(items) ? items : [];
+    if (list.length < 2) return list;
+    const { sessionId = '', anchor = '' } = options;
+    if (bucket(`loo-explore:${sessionId}:${anchor}`) >= EPSILON) return list;
+
+    const keyOf = (item) => String(item?.finding?.key ?? item?.key ?? '');
+    const { priorServed } = history(dir, options);
+    let promoted = 0;
+    for (let i = 1; i < list.length; i += 1) {
+      const a = priorServed.get(keyOf(list[i])) || 0;
+      const b = priorServed.get(keyOf(list[promoted])) || 0;
+      if (a < b || (a === b && keyOf(list[i]) < keyOf(list[promoted]))) promoted = i;
+    }
+    if (promoted === 0) return list;
+    return [list[promoted], ...list.filter((_, i) => i !== promoted)];
+  } catch {
+    return Array.isArray(items) ? items : [];
+  }
+}
+
+const mean = (values) =>
+  values.length ? values.reduce((sum, v) => sum + v, 0) / values.length : 0;
+
+/** Sample variance (n-1). Zero for a single observation: dispersion is unknown, not large. */
+function variance(values) {
+  if (values.length < 2) return 0;
+  const m = mean(values);
+  return values.reduce((sum, v) => sum + (v - m) * (v - m), 0) / (values.length - 1);
+}
+
+/**
+ * Every attributable Layer 2 observation, one per (injection, finding, arm).
+ *
+ * THREE THINGS ARE REPORTED SEPARATELY RATHER THAN FOLDED IN, because each of
+ * them would otherwise turn an absence into a zero:
+ *
+ *   `unattributable`  the outcome join could not attach a tool call to the
+ *                     injection, so nothing is known about what followed it.
+ *   `excluded`        the injection could never produce a read-join at all
+ *                     (command surface, session-start, fixture anchor) or was
+ *                     already in the all-findings holdout.
+ *   `costObservations` how many observations saw a non-zero read cost. If this
+ *                     is zero, "withholding changed nothing" and "the read
+ *                     channel never fired" are the same picture, and only one
+ *                     of them is a finding about findings.
+ */
+export function observations(dir, { events = null, evidence = null } = {}) {
+  const empty = {
+    rows: [],
+    unattributable: 0,
+    unattributableOutcomes: 0,
+    excluded: { command: 0, holdout: 0, fixture: 0, unanchored: 0 },
+    injections: 0,
+    withheldInjections: 0,
+    costObservations: 0,
+    policies: [],
+    windowed: false,
+  };
+  try {
+    const causal = evidence || readEvidence(dir);
+    const all = events || readMetrics(dir);
+    // OUT OF BAND and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` describes the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
+
+    // THE JOIN THIS MODULE CONSUMES AND DOES NOT REPLACE.
+    const joined = new Set();
+    let unattributableOutcomes = 0;
+    for (const event of causal) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) {
+        unattributableOutcomes += 1;
+        continue;
+      }
+      joined.add(String(event.injectionId));
+    }
+
+    // Read cost, grouped the way `buildReport` groups it: (session, anchor),
+    // canonicalised on both sides so two spellings of one file are one anchor.
+    // A mismatch here would make every read invisible and report a clean zero
+    // effect in both arms -- correct code, absent measurement.
+    const reads = new Map();
+    for (const event of all) {
+      if (event.kind !== 'read' || !event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      if (!reads.has(key)) reads.set(key, []);
+      reads.get(key).push(event);
+    }
+
+    const injects = causal
+      .filter((event) => event.kind === 'inject')
+      .map((event, index) => ({ event, index }))
+      .sort((a, b) => (a.event.at || 0) - (b.event.at || 0) || a.index - b.index)
+      .map((row) => row.event);
+
+    // How many injections share each (session, anchor), so a key's read total
+    // is SPLIT between them rather than charged in full to each -- the same
+    // correction `buildReport` applies, and for the same reason: without it the
+    // arm means scale with injections-per-anchor instead of per-touch cost.
+    const perKey = new Map();
+    for (const event of injects) {
+      if (!event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      perKey.set(key, (perKey.get(key) || 0) + 1);
+    }
+
+    const rows = [];
+    const excluded = { command: 0, holdout: 0, fixture: 0, unanchored: 0 };
+    const priorServed = new Map();
+    const policies = new Set();
+    let unattributable = 0;
+    let considered = 0;
+    let withheldInjections = 0;
+
+    for (const event of injects) {
+      const served = (Array.isArray(event.findingIds) ? event.findingIds : []).map(String);
+      const withheldKey = typeof event.loo === 'string' && event.loo ? event.loo : null;
+      const bump = () => {
+        for (const key of served) priorServed.set(key, (priorServed.get(key) || 0) + 1);
+      };
+
+      const isCommand =
+        event.surface === 'command' ||
+        event.trigger === 'command' ||
+        event.surface === 'session-start';
+      if (isCommand) {
+        excluded.command += 1;
+        bump();
+        continue;
+      }
+      if (!event.anchor) {
+        excluded.unanchored += 1;
+        bump();
+        continue;
+      }
+      if (isFixtureAnchor(event.anchor)) {
+        excluded.fixture += 1;
+        bump();
+        continue;
+      }
+      if (event.holdout) {
+        excluded.holdout += 1;
+        bump();
+        continue;
+      }
+
+      considered += 1;
+      if (withheldKey) withheldInjections += 1;
+      const policy = typeof event.looPolicy === 'string' && event.looPolicy
+        ? event.looPolicy
+        : 'unversioned';
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const attributable = Boolean(injectionId && joined.has(injectionId));
+
+      // DOWNSTREAM MEANS AFTER, STRICTLY. The read that triggered the touch is
+      // not caused by the advice; it happened before the advice existed.
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      const at = event.at || 0;
+      const total = (reads.get(key) || []).reduce(
+        (sum, read) => sum + ((read.at || 0) > at ? read.tokens || 0 : 0),
+        0
+      );
+      const cost = total / Math.max(1, perKey.get(key) || 1);
+
+      const observe = (findingKey, arm) => {
+        // ENROLMENT IS RE-DERIVED FROM THE LOG rather than trusted from the
+        // serving decision. It is the one field an old or hand-written record
+        // could contradict, and a served observation from before a finding was
+        // enrolled would compare an established finding against its own cold
+        // start.
+        //
+        // CHECKED BEFORE ATTRIBUTABILITY, so `unattributable` counts only
+        // observations the experiment actually wanted. Counting the rest there
+        // would report a join failure for every finding that was never in the
+        // experiment to begin with -- the same shape as the 2,559-row
+        // measurement-bias defect Layer 1 found in its own first draft.
+        if ((priorServed.get(findingKey) || 0) < MIN_PRIOR_INJECTIONS) return;
+        if (!attributable) {
+          unattributable += 1;
+          return;
+        }
+        policies.add(policy);
+        rows.push({ findingKey, arm, cost, policy, injectionId, anchor: event.anchor });
+      };
+
+      if (withheldKey) observe(withheldKey, 'withheld');
+      for (const findingKey of served) observe(findingKey, 'served');
+      bump();
+    }
+
+    return {
+      rows,
+      unattributable,
+      unattributableOutcomes,
+      excluded,
+      injections: considered,
+      withheldInjections,
+      costObservations: rows.filter((row) => row.cost > 0).length,
+      policies: [...policies].sort(),
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
+function permutationP(servedCosts, withheldCosts) {
+  const pooled = [...servedCosts, ...withheldCosts];
+  const n = pooled.length;
+  const k = withheldCosts.length;
+  if (!k || k === n) return null;
+  const observed = Math.abs(mean(withheldCosts) - mean(servedCosts));
+  const total = pooled.reduce((sum, v) => sum + v, 0);
+  // Mean difference from the withheld-arm sum alone: the served sum is the
+  // complement, so one number decides the statistic.
+  const diffFrom = (withheldSum) =>
+    Math.abs(withheldSum / k - (total - withheldSum) / (n - k));
+
+  const choose = (a, b) => {
+    let out = 1;
+    for (let i = 1; i <= b; i += 1) out = (out * (a - b + i)) / i;
+    return out;
+  };
+
+  const tolerance = 1e-9;
+  if (choose(n, k) <= MAX_EXACT_PERMUTATIONS) {
+    let extreme = 0;
+    let count = 0;
+    const walk = (start, chosen, sum) => {
+      if (chosen === k) {
+        count += 1;
+        if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+        return;
+      }
+      for (let i = start; i <= n - (k - chosen); i += 1) walk(i + 1, chosen + 1, sum + pooled[i]);
+    };
+    walk(0, 0, 0);
+    return count ? extreme / count : null;
+  }
+
+  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
+  // the same p-value and a verdict cannot flicker between two audit runs.
+  let state = 0x9e3779b9;
+  const random = () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4_294_967_296;
+  };
+  let extreme = 0;
+  const order = [...pooled];
+  for (let round = 0; round < SAMPLED_PERMUTATIONS; round += 1) {
+    for (let i = order.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(random() * (i + 1));
+      [order[i], order[j]] = [order[j], order[i]];
+    }
+    let sum = 0;
+    for (let i = 0; i < k; i += 1) sum += order[i];
+    if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+  }
+  return (extreme + 1) / (SAMPLED_PERMUTATIONS + 1);
+}
+
+/**
+ * The per-finding causal effect, shrunk, and whether it may be published.
+ *
+ * `raw` is `mean(withheld) - mean(served)`: POSITIVE means the session read the
+ * anchor more when the finding was withheld, which is the finding earning its
+ * place. `shrunk` is the number a reader should use.
+ *
+ * EMPIRICAL BAYES, and both halves of it come from the data. The prior mean is
+ * the population effect across findings; the weight `k` is the ratio of
+ * within-finding noise to between-finding spread, so a population where every
+ * finding behaves alike shrinks hard and one where they genuinely differ
+ * shrinks little. `SHRINKAGE_K` is the fallback when that spread cannot be
+ * estimated at all. Two observations therefore cannot post a wild score.
+ *
+ * PUBLICATION IS NOT THE SAME QUESTION as having an estimate. A row is
+ * published only if it clears the observation floor AND its permutation
+ * p-value survives Benjamini-Hochberg at q = 0.10 across every candidate row.
+ * Everything else gets `published: false` -- which is not a zero effect, and
+ * `looNote` says which of the two it is. An all-zero-cost population needs no
+ * separate guard: p is exactly 1 there, so nothing can publish anyway.
+ *
+ * NEVER POOLED ACROSS POLICY VERSIONS: rows are keyed on (findingKey, policy).
+ */
+export function effects(dir, options = {}) {
+  try {
+    // `obs` is accepted so `looNote` can read the logs once for both.
+    const obs = options.obs || observations(dir, options);
+    const groups = new Map();
+    for (const row of obs.rows) {
+      const id = JSON.stringify([row.findingKey, row.policy]);
+      if (!groups.has(id))
+        groups.set(id, { findingKey: row.findingKey, policy: row.policy, served: [], withheld: [] });
+      groups.get(id)[row.arm === 'withheld' ? 'withheld' : 'served'].push(row.cost);
+    }
+
+    const raws = [];
+    const withinVars = [];
+    for (const group of groups.values()) {
+      if (!group.served.length || !group.withheld.length) continue;
+      raws.push(mean(group.withheld) - mean(group.served));
+      withinVars.push(
+        variance(group.withheld) / group.withheld.length +
+          variance(group.served) / group.served.length
+      );
+    }
+    const prior = raws.length ? mean(raws) : 0;
+    const within = withinVars.length ? mean(withinVars) : 0;
+    const between = raws.length > 1 ? Math.max(0, variance(raws) - within) : 0;
+    const weight =
+      between > 0 && within > 0
+        ? Math.min(K_MAX, Math.max(K_MIN, within / between))
+        : SHRINKAGE_K;
+
+    const rows = [...groups.values()]
+      .map((group) => {
+        const served = group.served.length;
+        const withheld = group.withheld.length;
+        const both = served > 0 && withheld > 0;
+        const raw = both ? mean(group.withheld) - mean(group.served) : null;
+        const n = served + withheld;
+        const shrunk = raw === null ? null : (n * raw + weight * prior) / (n + weight);
+        const eligible = served >= MIN_SERVED && withheld >= MIN_WITHHELD;
+        return {
+          findingKey: group.findingKey,
+          policy: group.policy,
+          served,
+          withheld,
+          servedMean: mean(group.served),
+          withheldMean: mean(group.withheld),
+          raw,
+          shrunk,
+          p: eligible ? permutationP(group.served, group.withheld) : null,
+          published: false,
+        };
+      })
+      .sort((a, b) =>
+        a.findingKey < b.findingKey ? -1 : a.findingKey > b.findingKey ? 1 : a.policy < b.policy ? -1 : 1
+      );
+
+    // BENJAMINI-HOCHBERG at q = 0.10 over every row that cleared the floor.
+    // One finding tested in isolation would publish at p < 0.10; a hundred
+    // would publish ten false ones, and this module's whole claim is that its
+    // numbers can be quoted.
+    //
+    // THERE IS NO SEPARATE "WAS ANY READ COST OBSERVED" GATE HERE, and its
+    // absence is deliberate rather than an omission. One was written, and
+    // mutation testing showed it could not change a single verdict: if every
+    // observation has zero cost then both arm means are zero, the permutation
+    // statistic is zero for every relabelling, and p is exactly 1 -- which no
+    // BH threshold can pass. The guard was unfalsifiable, and an unfalsifiable
+    // guard is worse than none because it reads as protection nobody can test.
+    // `costObservations` survives as what it can honestly be: a DISCLOSURE, so
+    // `looNote` can say the read channel never fired instead of letting a
+    // reader take an arithmetic zero for a measured one.
+    const candidates = rows
+      .filter((row) => row.p !== null)
+      .sort((a, b) => a.p - b.p);
+    const m = candidates.length;
+    let cutoff = 0;
+    for (let i = 0; i < m; i += 1) {
+      if (candidates[i].p <= ((i + 1) / m) * FDR_Q) cutoff = i + 1;
+    }
+    for (let i = 0; i < cutoff; i += 1) candidates[i].published = true;
+
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * One or two lines for the audit, or nothing at all.
+ *
+ * THE REFUSAL IS THE PRODUCT HERE. On a machine with two injections in sixteen
+ * thousand events, the only honest output is that nothing is measurable yet,
+ * and this says so with the counts that make it checkable rather than printing
+ * a mean of nothing. It returns `null` when Layer 2 has not collected a single
+ * observation, so an idle experiment costs the reader no line at all -- the
+ * same standard `referenceNote` holds itself to.
+ */
+export function looNote(dir, options = {}) {
+  try {
+    const obs = options.obs || observations(dir, options);
+    const rows = effects(dir, { ...options, obs });
+    if (!obs.rows.length && !obs.withheldInjections) return null;
+
+    let graph = options.graph;
+    if (graph === undefined) {
+      try {
+        graph = load(dir);
+      } catch {
+        graph = null;
+      }
+    }
+    let exempt = 0;
+    if (graph?.nodes?.values) {
+      for (const node of graph.nodes.values()) {
+        if (node?.kind !== 'finding' || node.retired) continue;
+        if (node.pinned || node.origin === ORIGIN_HUMAN) exempt += 1;
+      }
+    }
+
+    const published = rows.filter((row) => row.published);
+    const head = published.length
+      ? `Per-finding causal value (leave-one-out): ${published.length} of ${rows.length} ` +
+        `findings show a verdict at q=${FDR_Q}` +
+        published
+          .slice(0, 3)
+          .map(
+            (row) =>
+              `; ${row.findingKey} saves ~${Math.round(row.shrunk)} tokens/touch ` +
+              `(${row.served} served, ${row.withheld} withheld, p=${row.p.toFixed(3)})`
+          )
+          .join('') +
+        '.'
+      : `Per-finding causal value (leave-one-out): NOT MEASURABLE YET -- ` +
+        `${obs.rows.length} attributable observations across ${rows.length} findings, ` +
+        `${obs.withheldInjections} withheld touches; the floor is ${MIN_SERVED} served ` +
+        `and ${MIN_WITHHELD} withheld per finding` +
+        (obs.costObservations ? '' : ', and no read cost has been observed in either arm') +
+        '. No effect is reported, which is not the same as an effect of zero.';
+
+    const caveats = [];
+    if (obs.unattributable)
+      caveats.push(
+        `${obs.unattributable} observations were unattributable (no joined tool outcome) and are in neither arm`
+      );
+    if (exempt)
+      caveats.push(
+        `${exempt} pinned or human-origin findings are exempt from withholding and get no causal score`
+      );
+    if (obs.policies.length > 1)
+      caveats.push(
+        `observations span ${obs.policies.length} serving-policy versions and are never pooled across them`
+      );
+    if (obs.windowed)
+      caveats.push('the read log was truncated, so downstream cost can understate');
+    return caveats.length ? `${head} ${caveats.join('; ')}.` : head;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/codex/hooks/lib/loo.mjs
+++ b/integrations/codex/hooks/lib/loo.mjs
@@ -545,8 +545,22 @@ export function observations(dir, { events = null, evidence = null } = {}) {
   }
 }
 
-/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
-function permutationP(servedCosts, withheldCosts) {
+/**
+ * Enumerates or samples arm relabellings and returns a two-sided p-value.
+ *
+ * EXPORTED so the cross-layer headline can be held to the same standard as the
+ * per-finding rows it summarises. `crosslayer.mjs` runs this over the two ARMS
+ * of shrunk effect estimates; the statistic, the enumerate-or-sample switch and the
+ * tolerance are therefore shared rather than reimplemented, and there is one
+ * place where "two-sided" is decided.
+ *
+ * `seed` exists for that caller. The default reproduces the fixed seed this
+ * function has always used, so Layer 2's own p-values are byte-identical; the
+ * cross-layer caller passes a seed DERIVED FROM ITS DATA, because a verdict
+ * printed to a human must not depend on `Math.random()` or on which module
+ * happened to call first.
+ */
+export function permutationP(servedCosts, withheldCosts, { seed = 0x9e3779b9 } = {}) {
   const pooled = [...servedCosts, ...withheldCosts];
   const n = pooled.length;
   const k = withheldCosts.length;
@@ -580,9 +594,10 @@ function permutationP(servedCosts, withheldCosts) {
     return count ? extreme / count : null;
   }
 
-  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
-  // the same p-value and a verdict cannot flicker between two audit runs.
-  let state = 0x9e3779b9;
+  // Mulberry32 off the caller's seed: reproducible, so the same data always
+  // yields the same p-value and a verdict cannot flicker between two audit
+  // runs.
+  let state = seed | 0;
   const random = () => {
     state = (state + 0x6d2b79f5) | 0;
     let t = state;

--- a/integrations/codex/hooks/lib/metrics.mjs
+++ b/integrations/codex/hooks/lib/metrics.mjs
@@ -31,6 +31,7 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { createHash, randomBytes } from 'node:crypto';
+import { redact } from './redact.mjs';
 
 /**
  * Read per call, not once at module load.
@@ -517,6 +518,15 @@ export function readEvidence(dir) {
 }
 
 /**
+ * The captured-output budget, in characters.
+ *
+ * Small enough that a 3 MB test log cannot bloat the evidence log or a single
+ * injected claim, large enough to hold the stack trace or compiler diagnostic
+ * that makes a failure finding worth anything.
+ */
+const OUTPUT_MAX_BYTES = 4096;
+
+/**
  * Joins a post-tool result to the most recent matching injection.  The exact
  * tool-call id wins; clients that omit it fall back to episode + surface +
  * anchor, in timestamp order, and the report states the weaker join method.
@@ -545,10 +555,31 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
+  // text is INJECTED into model context and EXPORTED to markdown, so the
+  // boundary is the only place that can guarantee it: a second caller added
+  // later would otherwise have to remember, and the one that forgot would leak
+  // a secret into two more places than the terminal it came from. `undefined`
+  // rather than `''` when nothing was captured, so JSON.stringify omits the
+  // key entirely and an absent capture is distinguishable from an empty one.
+  const output =
+    outcome.output === undefined || outcome.output === null
+      ? undefined
+      : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
+  // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric
+  // code at all, and 0 is the success value -- defaulting to it would claim
+  // every unreported call exited cleanly, which is a fabricated observation
+  // rather than a missing one.
+  const exit = Number.isInteger(outcome.exit) ? outcome.exit : null;
+
   return record(dir, {
     kind: 'tool-outcome',
     ...outcome,
     anchor,
+    // AFTER the spread, so a caller cannot smuggle raw text past the boundary
+    // by setting the field itself.
+    output,
+    exit,
     injectionId: injection?.injectionId || null,
     findingIds: injection?.findingIds || [],
     joinMethod,

--- a/integrations/codex/hooks/lib/metrics.mjs
+++ b/integrations/codex/hooks/lib/metrics.mjs
@@ -555,6 +555,22 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // FAILURES ONLY, and that is a deliberate override of the original plan.
+  // The plan predates MCP tool names reaching this path, so it never
+  // considered that a SUCCESSFUL `smart_read` would deposit 4 KB of file
+  // content into the evidence log on every call -- the log would grow with
+  // file text and the privacy surface would be every file the session opened.
+  //
+  // Nothing downstream loses anything. A failure claim quotes the error text;
+  // a "this command works" claim needs only the fact that it worked, which
+  // `success` and `exit` already carry. So the stored text narrows to text
+  // that is already an error message.
+  //
+  // GATED ON `success === true`, not on `!== false`: an outcome that never
+  // said whether it worked is unclassified, not successful, and dropping its
+  // text would lose exactly the failures a client too terse to report status
+  // produces.
+  const captureOutput = outcome.success !== true;
   // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
   // text is INJECTED into model context and EXPORTED to markdown, so the
   // boundary is the only place that can guarantee it: a second caller added
@@ -563,7 +579,7 @@ export function recordToolOutcome(dir, outcome) {
   // rather than `''` when nothing was captured, so JSON.stringify omits the
   // key entirely and an absent capture is distinguishable from an empty one.
   const output =
-    outcome.output === undefined || outcome.output === null
+    !captureOutput || outcome.output === undefined || outcome.output === null
       ? undefined
       : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
   // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric

--- a/integrations/codex/hooks/lib/metrics.mjs
+++ b/integrations/codex/hooks/lib/metrics.mjs
@@ -663,6 +663,89 @@ export function isFixtureAnchor(anchor) {
  * Fixture anchors are excluded from both.
  */
 /**
+ * Re-reads grouped by anchor -- the one place that decides what "wasteful" means.
+ *
+ * `rereadWaste` needed only the totals, so the grouping lived inside it and the
+ * per-anchor rows were thrown away. `derive.mjs`'s churn detector needs the
+ * rows, and re-deriving them there would put TWO definitions of "a repeat read
+ * of an unchanged file is waste" in the codebase, free to drift apart -- the
+ * exact divergence `npm run sync:hooks` exists to prevent between hooks-core and
+ * its generated copies. So the grouping lives here and both consumers read it.
+ *
+ * A re-read is only a re-read INSIDE ONE SESSION: grouping is keyed on
+ * session + canonical anchor, and rows are then merged per anchor so a file
+ * re-read across three sessions reports as one anchor with the sum of its
+ * repeats rather than three rows the caller has to add up. Merging cannot move
+ * the totals -- a sum of sums -- which is what makes it safe for `rereadWaste`.
+ *
+ * `tokens` is the WASTEFUL token count, not the total: it is the only one of the
+ * three that names something recoverable, and a row whose headline number
+ * included legitimate re-reads would overstate exactly the way the first
+ * version of this measurement did.
+ *
+ * @returns {Array<{anchor: string, repeats: number, wasteful: number,
+ *   tokens: number, legitimate: number, legitimateTokens: number,
+ *   undecidable: number, undecidableTokens: number}>} descending by `wasteful`,
+ *   then by `repeats`.
+ */
+export function rereadsByAnchor(events = [], { includeFixtures = false } = {}) {
+  const groups = new Map();
+  for (const e of events) {
+    if (!e || e.kind !== 'read' || !e.anchor) continue;
+    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
+    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(e);
+  }
+
+  const rows = new Map();
+  for (const list of groups.values()) {
+    if (list.length < 2) continue;
+    list.sort((a, b) => (a.at || 0) - (b.at || 0));
+
+    const anchorKey = canonicalKeyish(list[0].anchor);
+    let row = rows.get(anchorKey);
+    if (!row) {
+      row = {
+        anchor: list[0].anchor,
+        repeats: 0,
+        wasteful: 0,
+        tokens: 0,
+        legitimate: 0,
+        legitimateTokens: 0,
+        undecidable: 0,
+        undecidableTokens: 0,
+      };
+      rows.set(anchorKey, row);
+    }
+
+    for (let i = 1; i < list.length; i++) {
+      const prev = list[i - 1];
+      const cur = list[i];
+      const tokens = cur.tokens || 0;
+      row.repeats += 1;
+      // THE JUDGEMENT, in one place. A repeat read of a file that CHANGED is
+      // correct behaviour, not waste; a read written before fingerprints
+      // existed cannot be judged at all and says so.
+      if (!prev.fp || !cur.fp) {
+        row.undecidable += 1;
+        row.undecidableTokens += tokens;
+      } else if (prev.fp === cur.fp) {
+        row.wasteful += 1;
+        row.tokens += tokens;
+      } else {
+        row.legitimate += 1;
+        row.legitimateTokens += tokens;
+      }
+    }
+  }
+
+  return [...rows.values()].sort(
+    (a, b) => b.wasteful - a.wasteful || b.repeats - a.repeats
+  );
+}
+
+/**
  * Re-read waste, split into what is KNOWN and what is not.
  *
  * The question is narrow on purpose: how often does one session read the same
@@ -677,6 +760,9 @@ export function isFixtureAnchor(anchor) {
  * `undecidable` is reported rather than hidden. Reads written before the
  * fingerprint existed cannot be classified, and a measurement that quietly
  * counted them either way would be inventing its own answer.
+ *
+ * The aggregate fields are UNCHANGED -- `balanceSheet` reads them -- and are now
+ * a fold over `rereadsByAnchor`'s rows. `worst` is purely additive.
  */
 export function rereadWaste(
   dir,
@@ -685,14 +771,7 @@ export function rereadWaste(
   // excludes by design, making the real path untestable.
   { events = readMetrics(dir), includeFixtures = false } = {}
 ) {
-  const groups = new Map();
-  for (const e of events) {
-    if (e.kind !== 'read' || !e.anchor) continue;
-    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
-    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key).push(e);
-  }
+  const rows = rereadsByAnchor(events, { includeFixtures });
 
   const out = {
     repeats: 0,
@@ -704,29 +783,21 @@ export function rereadWaste(
     undecidableTokens: 0,
   };
 
-  for (const list of groups.values()) {
-    if (list.length < 2) continue;
-    list.sort((a, b) => (a.at || 0) - (b.at || 0));
-    for (let i = 1; i < list.length; i++) {
-      const prev = list[i - 1];
-      const cur = list[i];
-      const tokens = cur.tokens || 0;
-      out.repeats += 1;
-      if (!prev.fp || !cur.fp) {
-        out.undecidable += 1;
-        out.undecidableTokens += tokens;
-      } else if (prev.fp === cur.fp) {
-        out.wasteful += 1;
-        out.wastefulTokens += tokens;
-      } else {
-        out.legitimate += 1;
-        out.legitimateTokens += tokens;
-      }
-    }
+  for (const row of rows) {
+    out.repeats += row.repeats;
+    out.wasteful += row.wasteful;
+    out.wastefulTokens += row.tokens;
+    out.legitimate += row.legitimate;
+    out.legitimateTokens += row.legitimateTokens;
+    out.undecidable += row.undecidable;
+    out.undecidableTokens += row.undecidableTokens;
   }
 
   const decided = out.wasteful + out.legitimate;
   out.coverage = out.repeats ? decided / out.repeats : null;
+  // The offenders behind the totals, bounded: a report needs the handful worth
+  // acting on, not one row per file the session touched twice.
+  out.worst = rows.slice(0, 10);
   return out;
 }
 

--- a/integrations/codex/hooks/lib/recall.mjs
+++ b/integrations/codex/hooks/lib/recall.mjs
@@ -1,0 +1,390 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/recall.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Does retrieval FIND a finding, or does it only find what it was told where
+ * to look?
+ *
+ * `docs/WIKI_GRAPH.md` says embeddings get added "if measurement shows real
+ * recall loss". Nothing measured recall, so the no-embeddings stance was
+ * unfalsifiable -- a claim with no observation that could contradict it. This
+ * module is the observation.
+ *
+ * ---------------------------------------------------------------------------
+ * THE TAUTOLOGY THIS DELIBERATELY DOES NOT SHIP, AND WHY IT IS RECORDED HERE
+ * ---------------------------------------------------------------------------
+ * The obvious probe -- for each finding, take its anchors and ask whether
+ * `findingsFor` returns it from each -- CANNOT FAIL. `findingsFor(graph, A)`
+ * walks `derived_from` edges backwards into A, and the edge F -> A is the very
+ * thing that makes A an anchor of F. So F is in the result by CONSTRUCTION, not
+ * by retrieval quality, for every graph, forever. Its rate is 1.0 always, and a
+ * permanent 1.0 published as a recall rate reads to a human as "retrieval is
+ * perfect, embeddings unnecessary" -- one unfalsifiable claim swapped for
+ * another, leaning the one direction a measurement of this project by this
+ * project must never lean.
+ *
+ * That check is still worth running -- if it ever fails, traversal is broken
+ * rather than merely lossy -- so it is kept, and reported as `integrity` with
+ * its own `what` string saying it is not a recall rate. It is NEVER `rate`.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT IS MEASURED INSTEAD: LEAVE-ONE-EDGE-OUT
+ * ---------------------------------------------------------------------------
+ * For each active finding F and each anchor A of F, delete the edge F -> A and
+ * ask whether touching A would STILL surface F. Two independent arms, both of
+ * which can genuinely miss, which is what makes this a measurement:
+ *
+ *   Arm A -- TRAVERSAL FROM THE NEIGHBOURHOOD. Run the real `findingsFor` over
+ *   the edge-deleted graph from A itself and from A's `contains` parents. This
+ *   hits only when F has some OTHER structural route in: a second anchor on the
+ *   same file, or an anchor on a sibling symbol under the same parent. A's
+ *   `contains` children need no separate call because `findingsFor` expands
+ *   them itself -- calling the parent therefore covers every sibling, which is
+ *   why the neighbour list is `[A, ...parents(A)]` and not a hop-counted
+ *   frontier. The REAL primitive is used rather than an equivalent inlined
+ *   here, because a probe that reimplements the thing it measures drifts from
+ *   it and then measures itself.
+ *
+ *   Arm B -- BM25 FROM THE ANCHOR'S OWN KEY. Rank the whole active corpus with
+ *   `lexical.rank`, querying with A's key -- the file path or symbol name the
+ *   user actually touched -- and hit if F comes back inside `limit`.
+ *
+ * WHY ARM B IS NOT QUERIED WITH THE FINDING'S OWN CLAIM. The plan's literal
+ * form was "the finding's claim terms against the rest of the corpus", and both
+ * readings of it are degenerate. Querying F's claim against a corpus that
+ * INCLUDES F is the tautology again: BM25 scores a document against its own
+ * text, so F wins its own query every time. Querying F's claim against a corpus
+ * that EXCLUDES F cannot return F at all, so a "hit" would mean some DIFFERENT
+ * finding matched -- that is redundancy of storage, not recall of F, and it
+ * would score a graph better for holding duplicates. The anchor's key is the
+ * one query text that is available offline, is not derived from F, and matches
+ * the production question: a session touches a file, and the only lexical
+ * handle on it is its own path. It misses exactly when a finding's claim never
+ * names the code it is about, which is the recall gap embeddings are supposed
+ * to close.
+ *
+ * ---------------------------------------------------------------------------
+ * REFUSALS -- four, and each costs this project its own good news
+ * ---------------------------------------------------------------------------
+ *  1. TOO FEW OBSERVATIONS -> `rate: null` with a reason. See `MIN_PROBED`.
+ *  2. A CORPUS NO LARGER THAN THE RETRIEVAL LIMIT -> `rate: null`. Arm B is
+ *     recall@`limit`, and below the limit NO FINDING IS EVER CUT FOR BUDGET:
+ *     every document scoring above zero is returned, so the arm measures
+ *     whether a token matched, which is a strictly weaker bar than the one
+ *     production applies when `forTouch` fills a token budget from a ranked
+ *     list. A probe more permissive than the system it measures can only
+ *     overstate recall, so the rate is withheld in that band and the counts are
+ *     published instead. It bites between `MIN_PROBED` and `limit` findings --
+ *     on this machine's project graph, whose one finding had both anchor edges
+ *     "recovered" that way, the observation-count refusal fires first.
+ *  3. NO ANCHOR NODE -> the pair is UNPROBEABLE, not a miss. Reported and
+ *     excluded from the denominator; see `probeEdge`.
+ *  4. STRICT AGGREGATION -> a finding counts as retrieved only if EVERY one of
+ *     its probeable anchor edges is recoverable. A finding reachable from one
+ *     anchor and lost from another is a miss, with the losing anchor named.
+ *     This biases the rate DOWN, which is the safe direction here.
+ *
+ * FAILS OPEN. It runs on a report path; a graph it cannot read must cost a
+ * section, not the report.
+ */
+
+import { load, findingsFor } from './wiki.mjs';
+import { rank } from './lexical.mjs';
+
+/**
+ * Distinct findings that must be probeable before a RATE is published at all.
+ *
+ * NOT AN EFFECT-SIZE CONVENTION -- it is a resolution argument. A proportion
+ * over n observations has a resolution of 1/n, so below ten findings the
+ * published figure moves in steps coarser than ten percentage points, and the
+ * two extremes a small graph actually produces (`1.0` and `0.0`) are the two a
+ * reader is most likely to mistake for a finding about retrieval. At n = 10 and
+ * zero misses the exact binomial 95% upper bound on the true miss rate is still
+ * 1 - 0.05^(1/10) = 0.26, so even a clean sweep here bounds recall loss only
+ * below about a quarter -- which is why the refusal reason says what the number
+ * would and would not have supported rather than just naming the floor.
+ *
+ * THE FLOOR IS ON DISTINCT FINDINGS, NOT ANCHOR EDGES. Two anchors of one
+ * finding are two edges of the same claim, not two independent observations;
+ * counting them would let a single multi-anchored finding unlock a rate.
+ */
+export const MIN_PROBED = 10;
+
+/**
+ * The most findings probed in one call.
+ *
+ * Each probed anchor edge costs a graph-sized edge filter plus one or two real
+ * `findingsFor` walks plus one BM25 pass over the corpus, and this runs on the
+ * on-demand report path. The cap is deterministic (findings sorted by key) and
+ * `truncated` says when it bit, so a large graph gets a smaller, honestly
+ * labelled sample rather than a slow report.
+ */
+export const MAX_FINDINGS = 200;
+
+/** Active findings only. A retired claim is withdrawn; recalling it is not a win. */
+function activeFindings(graph) {
+  return [...graph.nodes.values()]
+    .filter((node) => node && node.kind === 'finding' && !node.retired)
+    .sort((a, b) => String(a.key || '').localeCompare(String(b.key || '')));
+}
+
+/** The `contains` parents of every node, indexed once for the whole probe. */
+function parentIndex(graph) {
+  const parents = new Map();
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contains') continue;
+    const list = parents.get(edge.to);
+    if (list) list.push(edge.from);
+    else parents.set(edge.to, [edge.from]);
+  }
+  return parents;
+}
+
+/** The anchors of one finding: the targets of its own `derived_from` edges. */
+function anchorsOf(graph, findingId) {
+  const out = new Set();
+  for (const edge of graph.edges) {
+    if (edge.edge === 'derived_from' && edge.from === findingId) out.add(edge.to);
+  }
+  return [...out];
+}
+
+/**
+ * The graph minus exactly one anchor edge.
+ *
+ * `nodes` is shared rather than copied: nothing here mutates it, and a
+ * 2,600-node Map copied once per anchor edge is the difference between a probe
+ * and a stall.
+ */
+function withoutAnchorEdge(graph, findingId, anchorId) {
+  return {
+    nodes: graph.nodes,
+    edges: graph.edges.filter(
+      (edge) =>
+        !(
+          edge.edge === 'derived_from' &&
+          edge.from === findingId &&
+          edge.to === anchorId
+        )
+    ),
+  };
+}
+
+/**
+ * One anchor edge, hidden, then asked after. Returns `recovered` with the arm
+ * that found it, or a reason -- and `probeable: false` when the question could
+ * not be put at all.
+ */
+function probeEdge(graph, parents, finding, anchorId, corpus, limit) {
+  const hidden = withoutAnchorEdge(graph, finding.id, anchorId);
+
+  // Arm A. `findingsFor` expands `contains` children itself, so the parent call
+  // covers every sibling of the anchor.
+  const neighbours = [anchorId, ...(parents.get(anchorId) || [])];
+  for (const neighbour of neighbours) {
+    const got = findingsFor(hidden, neighbour, { limit });
+    if (got.some((node) => node.id === finding.id)) {
+      return { recovered: true, arm: 'traversal', anchorId };
+    }
+  }
+
+  // Arm B needs a query, and the query is the anchor's own key. A dangling
+  // anchor edge -- an edge whose target node was never indexed, which
+  // `expand.promote` produces -- leaves nothing to query with. That is a
+  // question that could not be asked, NOT an observed miss: scoring it a miss
+  // would manufacture a recall loss out of a graph-integrity defect.
+  const anchor = graph.nodes.get(anchorId);
+  const key = anchor && typeof anchor.key === 'string' ? anchor.key : '';
+  if (!key) {
+    return {
+      recovered: false,
+      probeable: false,
+      anchorId,
+      reason: `anchor ${anchorId} has no node in the graph, so there is no anchor key to query BM25 with`,
+    };
+  }
+
+  const hits = rank(key, corpus, { limit });
+  if (hits.some((hit) => hit.finding && hit.finding.id === finding.id)) {
+    return { recovered: true, arm: 'lexical', anchorId };
+  }
+
+  return {
+    recovered: false,
+    probeable: true,
+    anchorId,
+    reason: `no neighbouring anchor reaches it and BM25 over ${key} does not rank it in the top ${limit}`,
+  };
+}
+
+/**
+ * The probe. An OFFLINE measurement over the graph as it stands -- it reads,
+ * ranks and traverses, and writes nothing.
+ */
+export function recallProbe(
+  dir,
+  {
+    limit = 20,
+    graph = null,
+    minProbed = MIN_PROBED,
+    maxFindings = MAX_FINDINGS,
+  } = {}
+) {
+  const refuse = (reason) => ({
+    basis: 'offline probe over the current graph',
+    probed: 0,
+    retrieved: 0,
+    rate: null,
+    reason,
+    misses: [],
+    unprobeable: [],
+  });
+
+  let g;
+  try {
+    g = graph || load(dir);
+  } catch {
+    return refuse('the graph could not be read, so recall was not measured.');
+  }
+
+  try {
+    const all = activeFindings(g);
+    const truncated = all.length > maxFindings;
+    const findings = truncated ? all.slice(0, maxFindings) : all;
+    const parents = parentIndex(g);
+    // The corpus BM25 ranks over is the ACTIVE graph, uncapped: the sample is
+    // which findings are probed, not what they compete against. Every reported
+    // figure below reads `corpus.length` rather than `all.length`, so the
+    // published size IS the ranking corpus rather than a parallel claim about
+    // it. The distinction is not pedantry: a mutation that shrank the ranking
+    // corpus to the probed sample -- making retrieval easier, in this project's
+    // favour -- SURVIVED the first mutation run precisely because the reported
+    // number came from the other variable and could not move.
+    const corpus = all;
+
+    const misses = [];
+    const unprobeable = [];
+    const integrityFailures = [];
+    let probed = 0;
+    let retrieved = 0;
+    let integrityOk = 0;
+    let probedEdges = 0;
+    let recoveredEdges = 0;
+    const byArm = { traversal: 0, lexical: 0 };
+
+    for (const finding of findings) {
+      const anchors = anchorsOf(g, finding.id);
+
+      // INTEGRITY, run on the UNTOUCHED graph: the by-construction check. Its
+      // only honest use is as a smoke test, and it is reported as one.
+      if (!anchors.length) {
+        integrityFailures.push({
+          key: finding.key,
+          reason:
+            'active finding with no anchor -- writeHarvested refuses to create one',
+        });
+      } else if (
+        anchors.every((anchorId) =>
+          findingsFor(g, anchorId, { limit }).some((node) => node.id === finding.id)
+        )
+      ) {
+        integrityOk += 1;
+      } else {
+        integrityFailures.push({
+          key: finding.key,
+          reason: `not returned by findingsFor from one of its own anchors at limit ${limit}`,
+        });
+      }
+
+      // An unanchored finding is a definite miss, not an unaskable question:
+      // nothing traverses to it and there is no anchor key to query from, so
+      // the anchor-driven path that serves findings on a file touch can never
+      // surface it. Only an explicit wiki_query naming its own terms would.
+      if (!anchors.length) {
+        probed += 1;
+        misses.push({
+          key: finding.key,
+          reason:
+            'no anchor: nothing traverses to it and there is no anchor key to query with, so only an explicit wiki_query of its own terms would surface it',
+        });
+        continue;
+      }
+
+      const results = anchors.map((anchorId) =>
+        probeEdge(g, parents, finding, anchorId, corpus, limit)
+      );
+      const askable = results.filter((result) => result.probeable !== false);
+      probedEdges += askable.length;
+      recoveredEdges += askable.filter((result) => result.recovered).length;
+      for (const result of askable) {
+        if (result.recovered) byArm[result.arm] += 1;
+      }
+
+      if (!askable.length) {
+        unprobeable.push({ key: finding.key, reason: results[0].reason });
+        continue;
+      }
+
+      probed += 1;
+      const lost = askable.filter((result) => !result.recovered);
+      if (!lost.length) retrieved += 1;
+      else misses.push({ key: finding.key, reason: lost[0].reason });
+    }
+
+    const integrity = {
+      what:
+        'BY CONSTRUCTION: a finding is returned by findingsFor from its own anchor because that edge is what makes it an anchor. Expected 1 for every graph. NOT a recall rate.',
+      probed: findings.length,
+      retrieved: integrityOk,
+      rate: findings.length ? integrityOk / findings.length : null,
+      ok: integrityFailures.length === 0,
+      failures: integrityFailures,
+    };
+
+    // Arm B is recall@`limit`. Over a corpus of at most `limit` findings nothing
+    // is ever cut for budget, so the arm asks only whether a token matched --
+    // weaker than the bar production applies under a token budget, and a probe
+    // more permissive than the system it measures can only overstate recall.
+    const discriminating = corpus.length > limit;
+
+    const common = {
+      basis: 'offline probe over the current graph',
+      probed,
+      retrieved,
+      misses,
+      unprobeable,
+      probedEdges,
+      recoveredEdges,
+      byArm,
+      corpus: corpus.length,
+      discriminating,
+      truncated,
+      minProbed,
+      integrity,
+    };
+
+    if (probed < minProbed) {
+      return {
+        ...common,
+        rate: null,
+        reason:
+          probed === 0
+            ? `no probeable finding: ${unprobeable.length} of ${findings.length} active finding(s) have no anchor node to query from, so recall was not measured. No rate is reported, which is not the same as a rate of zero.`
+            : `${probed} probeable finding(s), below the floor of ${minProbed}: a proportion over ${probed} has a resolution of ${Math.round(
+                100 / probed
+              )} percentage points, so no rate is published. ${retrieved} of ${probed} were recovered without their own anchor edge, which is a count and not a rate.`,
+      };
+    }
+
+    if (!discriminating) {
+      return {
+        ...common,
+        rate: null,
+        reason: `the active corpus holds ${corpus.length} finding(s) and the retrieval limit is ${limit}, so nothing is ever cut for budget and the lexical arm asks only whether a token matched -- a weaker bar than production applies. No rate is published off a probe more permissive than the system it measures; ${retrieved} of ${probed} were recovered, which is a count and not a rate.`,
+      };
+    }
+
+    return { ...common, rate: retrieved / probed, reason: null };
+  } catch {
+    return refuse('the probe failed, so recall was not measured.');
+  }
+}

--- a/integrations/codex/hooks/lib/redact.mjs
+++ b/integrations/codex/hooks/lib/redact.mjs
@@ -1,0 +1,30 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/redact.mjs. Regenerate with `npm run sync:hooks`.
+// hooks-core/redact.mjs
+/**
+ * Redaction for anything derived from captured output.
+ *
+ * WHY THIS IS MANDATORY RATHER THAN PRUDENT. derive.mjs builds claims out of
+ * command stderr. A claim is INJECTED into model context and EXPORTED to
+ * markdown, so a secret that reaches a claim reaches two more places than the
+ * terminal it came from. Pattern matching is imperfect and that is stated in the
+ * spec, but "imperfect" beats "absent" by a wide margin here.
+ */
+
+const PATTERNS = [
+  // Bearer / API-key shaped tokens.
+  [/\b(bearer\s+)[A-Za-z0-9._~+/-]{12,}/gi, '$1[redacted]'],
+  [/\b(sk|pk|ghp|gho|github_pat|xox[baprs])[-_][A-Za-z0-9._-]{10,}/gi, '[redacted]'],
+  // KEY=value where the key name suggests a secret.
+  [/\b([A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|APIKEY|API_KEY|PRIVATE_KEY|CREDENTIAL)[A-Z0-9_]*)\s*[=:]\s*\S+/g, '$1=[redacted]'],
+  // Credentials inside a URL.
+  [/\b([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+):[^\s@]+@/gi, '$1:[redacted]@'],
+  // PEM blocks.
+  [/-----BEGIN[^-]*PRIVATE KEY-----[\s\S]*?-----END[^-]*PRIVATE KEY-----/g, '[redacted key]'],
+];
+
+export function redact(text, { max = 400 } = {}) {
+  let out = String(text ?? '');
+  for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
+}

--- a/integrations/codex/hooks/lib/redact.mjs
+++ b/integrations/codex/hooks/lib/redact.mjs
@@ -24,7 +24,21 @@ const PATTERNS = [
 ];
 
 export function redact(text, { max = 400 } = {}) {
+  // `?? ''` matters even though String(null)/String(undefined) never throw:
+  // without it a missing value becomes the literal 4-11 character string
+  // "null"/"undefined" -- a garbage claim that silently reaches the graph
+  // and model context instead of surfacing as an error.
   let out = String(text ?? '');
   for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  // Redact BEFORE truncating, never the reverse. Several patterns above rely
+  // on a minimum-length quantifier (e.g. `{10,}`, `{12,}`) plus a prefix.
+  // Truncating first can cut a match down to fewer characters than that
+  // quantifier requires, so the shortened fragment no longer satisfies the
+  // pattern and a live partial secret would pass through in cleartext. By
+  // redacting the full, untruncated string first, every pattern always sees
+  // the complete secret and removes it before any character budget is
+  // spent; the cap below can then only ever cut into already-redacted text
+  // (a label, or the "[redacted]" placeholder itself), never into raw
+  // secret bytes.
   return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
 }

--- a/integrations/codex/hooks/lib/transcript.mjs
+++ b/integrations/codex/hooks/lib/transcript.mjs
@@ -19,9 +19,11 @@
  */
 
 import {
-  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, unlinkSync,
+  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync,
+  unlinkSync, openSync, readSync, closeSync,
 } from 'node:fs';
 import { join } from 'node:path';
+import { redact } from './redact.mjs';
 
 /** Where a project's transcripts live, under the graph it belongs to. */
 export const transcriptDir = (dir) => join(dir, 'transcripts');
@@ -210,4 +212,204 @@ export function readArchive(dir, sessionId) {
   } catch {
     return [];
   }
+}
+
+/**
+ * How much of a transcript's TAIL is scanned for failed tool results.
+ *
+ * A transcript is the largest file this project reads: the three real ones on
+ * the measuring machine are 5.8 MB, 22 MB and 45 MB. `archive()` above already
+ * reads the whole thing once at Stop, so an unbounded second pass doubles the
+ * most expensive read on the session-end path for evidence that is, by
+ * construction, mostly old. The tail is the right half to keep for the same
+ * reason `buildFeedbackDigest` keeps the end: what a session learned is
+ * concentrated where the work went wrong, which is later rather than sooner.
+ */
+const FAILED_SCAN_BYTES = () =>
+  Number(process.env.TOKEN_OPTIMIZER_TRANSCRIPT_SCAN_BYTES) || 8 * 1024 * 1024;
+
+/** Failed results kept, most recent first. The pairing detector needs a handful. */
+const FAILED_MAX = 50;
+
+/** Same 4 KB cap `recordToolOutcome` applies to `output`, for the same reason. */
+const FAILED_OUTPUT_MAX = 4096;
+
+/**
+ * The same 120-character truncation `recordToolOutcome` applies to `anchor`.
+ *
+ * ONE COMMAND MUST PRODUCE ONE KEY FROM EITHER SOURCE. A `tool-outcome` stores
+ * the command as `String(tool_input.command).slice(0, 120)`, and `attemptKey`
+ * reads up to three non-flag tokens off whatever it is handed. A long first
+ * token -- a quoted grep pattern, an absolute Windows path, a heredoc -- is cut
+ * by that cap INSIDE those three tokens, so the untruncated transcript copy of
+ * the same command lands in a DIFFERENT group. Measured against one real
+ * session's own evidence: 266 commands present in both sources, and truncating
+ * here made 266 of 266 keys agree where the untruncated text agreed on only
+ * 240.
+ *
+ * WHAT THAT ACTUALLY BUYS, stated precisely rather than generously. `derive`
+ * refuses to build a claim out of a command at or over the cap at all (see
+ * `quotable` there), so agreement on a TRUNCATED key never produces a finding
+ * on its own. It buys two things that still matter: a transcript failure lands
+ * in the same run as the event outcomes of the same command, so the
+ * nearest-preceding-failure rule sees the real sequence rather than a sparse
+ * one; and the no-call-id fallback in `derive`'s deduplication compares command
+ * TEXT against an already-truncated anchor, which cannot match unless this side
+ * is truncated identically.
+ */
+const ANCHOR_MAX = 120;
+
+/**
+ * A tool result that reports a command that RAN and exited non-zero.
+ *
+ * A POSITIVE ALLOWLIST, and the measurement is why. Claude Code sets
+ * `is_error: true` on every kind of unhappy tool result, and across three real
+ * transcripts 214 of them fell into four shapes:
+ *
+ *   83  `Exit code N` + stderr    -- a command ran and failed. THIS ONE.
+ *   109 hook and policy denials   -- overwhelmingly THIS optimizer's own
+ *                                    PreToolUse text ("Recursive shell searches
+ *                                    return unbounded output. Call the
+ *                                    token-optimizer MCP tool smart_grep
+ *                                    instead"), plus `Remove-Item on system
+ *                                    path` blocks.
+ *   18  `<tool_use_error>...`     -- protocol errors: `String to replace not
+ *                                    found`, `File has not been read yet`,
+ *                                    `Blocked: ...`.
+ *   4   a person declined the call.
+ *
+ * Only the first shape is a command failing. In every other shape THE COMMAND
+ * NEVER RAN, so "`X` failed with: ..." would be a false claim about X, and a
+ * later success would pair with a failure that never happened. The 109 are the
+ * dangerous ones: ingesting them would have this tool derive findings from its
+ * own advice, at 0.9 confidence, and serve them back as observations about the
+ * project -- a self-referential loop that also inflates its own finding count.
+ * That is the measurement-bias class this plan tracks, and a denylist would
+ * have let every future denial string through by default.
+ */
+const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
+
+/** Reads at most `bytes` from the END of a file, without loading the rest. */
+function readTail(path, bytes) {
+  let fd;
+  try {
+    const size = statSync(path).size;
+    const length = Math.min(size, bytes);
+    if (!length) return '';
+    fd = openSync(path, 'r');
+    const buffer = Buffer.allocUnsafe(length);
+    readSync(fd, buffer, 0, length, size - length);
+    const text = buffer.toString('utf8');
+    // A tail almost never starts on a line boundary, and half a JSON object is
+    // not a parse failure worth reporting -- it is a partial record. Drop it.
+    return length < size ? text.slice(text.indexOf('\n') + 1) : text;
+  } catch {
+    return '';
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+}
+
+/**
+ * The failed COMMAND results a transcript holds, which no hook event carries.
+ *
+ * WHY THIS READER EXISTS. Claude Code never fires PostToolUse for a failed tool
+ * call: a deliberately failing command produced no event at all, and 2,238 of
+ * 2,238 live `tool-outcome` events on the measuring machine carry
+ * `success: true`. So `derive.mjs`'s two strongest detectors -- command
+ * failed-then-succeeded at 0.90 and test/build red-to-green at 0.85 -- have no
+ * input whatsoever on the primary client, while working normally on the ten
+ * adapter clients. The failures exist; they exist only here.
+ *
+ * WHY NOT THE ARCHIVE, which the plan for this reader assumed. `readTurns`
+ * DROPS tool results by design -- that is where whole file contents would enter
+ * the record -- so `readArchive` returns no failure, ever, and an extractor over
+ * archived turns would find nothing however well it was written. Making the
+ * archive carry them would also push command stderr into `buildFeedbackDigest`,
+ * which is the one code path in this project that sends anything to a model
+ * endpoint. So this reads the transcript and STORES NOTHING NEW: read-only, no
+ * capture path, no new event kind, and no widening of what leaves the machine.
+ *
+ * REDACTED HERE, at this boundary, exactly as `recordToolOutcome` redacts
+ * `output`. Transcript text has never passed a redaction boundary -- that one
+ * never saw it -- and everything returned from here is destined for a claim that
+ * is injected into model context and exported to markdown.
+ *
+ * @returns {Array<{command: string, output: string, exit: number|null,
+ *   at: number, toolCallId: string|null}>} in transcript order, so a caller can
+ *   sort it beside `tool-outcome` events without re-ordering.
+ */
+export function failedResultsFromTranscript(transcriptPath, options = {}) {
+  const { max = FAILED_MAX, scanBytes = FAILED_SCAN_BYTES() } = options || {};
+  if (!transcriptPath) return [];
+  const text = readTail(transcriptPath, scanBytes);
+  if (!text) return [];
+
+  // tool_use_id -> the command that was attempted. The join is EXACT and it is
+  // the only one available: the result block carries no command of its own, and
+  // the id is the same string `episodeMeta` reads into `toolCallId`, so the same
+  // key also deduplicates against events on clients that do report failures.
+  const commands = new Map();
+  const failures = [];
+
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const message = entry.message || entry;
+    const role = message.role || entry.type;
+    const content = message.content;
+    if (!Array.isArray(content)) continue;
+
+    if (role === 'assistant') {
+      for (const block of content) {
+        if (!block || block.type !== 'tool_use' || !block.id) continue;
+        const command = block.input?.command;
+        if (typeof command !== 'string' || !command.trim()) continue;
+        commands.set(String(block.id), command.slice(0, ANCHOR_MAX));
+      }
+      continue;
+    }
+
+    if (role !== 'user') continue;
+    for (const block of content) {
+      if (!block || block.type !== 'tool_result' || block.is_error !== true) continue;
+      // Only a STRING result can be an exit-code report; every failed Claude
+      // Code result observed was one, and a structured body is a shape this
+      // classifier has not measured, so it is refused rather than guessed at.
+      if (typeof block.content !== 'string') continue;
+      const match = EXIT_CODE_RESULT.exec(block.content);
+      if (!match) continue;
+      const command = commands.get(String(block.tool_use_id || ''));
+      // No command means no claim. The result says something failed; without
+      // the text of what failed there is nothing to say about it, and nothing
+      // to group it with.
+      if (!command) continue;
+      failures.push({
+        command,
+        // The exit line itself is stripped: `exit` carries it structurally, and
+        // leaving it in makes every failure claim read "failed with: Exit code 1".
+        output: redact(block.content.slice(match[0].length).trim(), {
+          max: FAILED_OUTPUT_MAX,
+        }),
+        exit: Number(match[1]),
+        at: Date.parse(entry.timestamp || '') || 0,
+        toolCallId: block.tool_use_id ? String(block.tool_use_id) : null,
+      });
+    }
+  }
+
+  // The MOST RECENT `max`, keeping chronological order. A session that failed
+  // two hundred times teaches its last lessons, not its first.
+  return failures.slice(-max);
 }

--- a/integrations/codex/hooks/lib/usage.mjs
+++ b/integrations/codex/hooks/lib/usage.mjs
@@ -42,7 +42,7 @@
  * was referenced" and "nothing could be measured" are different answers and
  * this module gives different answers for them.
  */
-import { readMetrics } from './metrics.mjs';
+import { readMetrics, readTruncation } from './metrics.mjs';
 
 /**
  * The events that name a finding, and it is ONE kind, not the two the plan
@@ -129,17 +129,30 @@ export function classify(dir, { events = null } = {}) {
   try {
     const all = inTimeOrder(events || readMetrics(dir));
 
-    // Every reference, keyed on the finding it names. Only references carrying
-    // a session id are usable -- see `unscopedReferences` in `referenceRate`
-    // for the ones this drops and why they are counted rather than credited.
+    // Every reference, keyed on the finding it names and on nothing else.
+    //
+    // NOT SCOPED BY SESSION, and that is a deliberate reversal. Scoping needs
+    // the query's `sessionId`, which `wiki_query` takes as an OPTIONAL input
+    // the model has to volunteer (`options.sessionId ?? null`) -- so the
+    // numerator depended on the model choosing to identify itself, and an
+    // unverifiable model-supplied id is not evidence. Plan 1 settled that for
+    // the `answers` edge and it settles it here: stop depending on the field
+    // rather than hope for cooperation. The finding key is the specific part
+    // anyway; a key is a graph identity, not a guess.
+    //
+    // THE COST, disclosed here and in `referenceNote` because a reader of the
+    // number has to see it: TWO CONCURRENT SESSIONS ON ONE REPOSITORY CAN
+    // CROSS-ATTRIBUTE. Session A's injection of K plus session B's later query
+    // for K reads as a reference. Nothing in the log can separate them once the
+    // session id is gone, so the exposure is real and is stated rather than
+    // priced.
     const references = new Map();
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       const key = referencedKey(event);
-      const session = sessionOf(event);
-      if (!key || !session) continue;
+      if (!key) continue;
       if (!references.has(key)) references.set(key, []);
-      references.get(key).push({ at: event.at || 0, session });
+      references.get(key).push(event.at || 0);
     }
 
     // Which injections the existing outcome join could attribute. An outcome
@@ -170,9 +183,8 @@ export function classify(dir, { events = null } = {}) {
       const injectionId = event.injectionId ? String(event.injectionId) : null;
       const at = event.at || 0;
       const session = sessionOf(event);
-      // STRICTLY AFTER. A query that PRECEDED the injection is the model
-      // asking on its own initiative; crediting it would let the metric take
-      // the credit for a lookup it had nothing to do with.
+      // STRICTLY AFTER here too: activity that predates the injection is not
+      // an opportunity to have used it.
       const followed = (times) => times.some((t) => t > at);
       const continued =
         (injectionId && attributed.has(injectionId)) ||
@@ -181,9 +193,11 @@ export function classify(dir, { events = null } = {}) {
       for (const raw of keys) {
         const findingKey = String(raw);
         const hits = references.get(findingKey) || [];
-        const referenced = session
-          ? hits.some((hit) => hit.session === session && hit.at > at)
-          : false;
+        // TIME ORDER IS THE ONLY REMAINING GUARD, so it carries the whole
+        // weight of the attribution: a query that PRECEDED the injection is
+        // the model asking on its own initiative, and crediting it would let
+        // the metric take the credit for a lookup it had nothing to do with.
+        const referenced = hits.some((hitAt) => hitAt > at);
         rows.push({
           findingKey,
           injectionId,
@@ -204,9 +218,27 @@ export function classify(dir, { events = null } = {}) {
 /**
  * The rate, with everything needed to tell a real 0 from an absent one.
  *
- * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
- * `unattributable` and `unscopedReferences` are reported beside it, never
- * inside it.
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown` and
+ * `unattributable` are reported beside it, never inside it.
+ *
+ * `windowed` SAYS WHETHER THE DENOMINATOR CAN UNDERSTATE, and it is not
+ * decoration. `readMetrics` reads a 2 MB / 5,000-event TAIL of the firehose,
+ * and injections are rare enough on a real project to age out of it: measured
+ * on this repository, both `inject` events sit at lines 502 and 883 of 6,871
+ * and have scrolled away behind ~6,000 later `read` and `tool-outcome` rows,
+ * so the windowed denominator is 0 where the whole-file truth is 1.
+ *
+ * IT IS REPORTED RATHER THAN FIXED, deliberately. `inject` already gets
+ * unwindowed access through `BALANCE_KINDS` / `EVIDENCE_KINDS`, but `query`
+ * does not -- and reading only the INJECTION arm unwindowed would be worse
+ * than the windowing: every old injection would enter the denominator with no
+ * chance of a matching query in the window and score `not-referenced`,
+ * manufacturing a pessimistic rate out of the asymmetry. Making the query arm
+ * unwindowed means adding `query` to `EVIDENCE_KINDS`, which two other
+ * consumers read, and this project's own standard says a shared-classifier
+ * change needs a per-consumer verdict comparison. So the honest move is to
+ * publish the flag: a caller that needs the unwindowed truth passes its own
+ * `events`, which is exactly what the live measurement in the task report did.
  */
 export function referenceRate(dir, { events = null } = {}) {
   const empty = {
@@ -218,10 +250,15 @@ export function referenceRate(dir, { events = null } = {}) {
     unattributable: 0,
     unattributableWithInjectedToolCall: 0,
     referenceEvents: 0,
-    unscopedReferences: 0,
+    windowed: false,
   };
   try {
     const all = events || readMetrics(dir);
+    // OUT OF BAND, and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` reports on the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
     const rows = classify(dir, { events: all });
     const count = (label) => rows.filter((row) => row.label === label).length;
     const referenced = count('referenced');
@@ -231,17 +268,17 @@ export function referenceRate(dir, { events = null } = {}) {
     // Usable reference events in the window: the numerator's producer. If this
     // is zero the channel never fired, and a 0% rate would be measuring the
     // absence of a producer rather than the uselessness of findings.
+    //
+    // NO SESSION REQUIREMENT, matching the attribution above. The former
+    // `unscopedReferences` counted queries dropped for want of a session id;
+    // nothing is dropped for that reason any more, so the field is GONE rather
+    // than kept at a permanent zero that a later reader would misread as
+    // evidence the loss had been fixed.
     let referenceEvents = 0;
-    let unscopedReferences = 0;
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       if (!referencedKey(event)) continue;
-      if (sessionOf(event)) referenceEvents += 1;
-      // Names a finding but cannot be scoped to one injection. `sessionId` is
-      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
-      // is the expected loss rather than an edge case -- counted here so it is
-      // visible instead of silently deflating the numerator.
-      else unscopedReferences += 1;
+      referenceEvents += 1;
     }
 
     // The tool calls that DID receive findings, keyed the way
@@ -292,7 +329,7 @@ export function referenceRate(dir, { events = null } = {}) {
       unattributable,
       unattributableWithInjectedToolCall,
       referenceEvents,
-      unscopedReferences,
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
     };
   } catch {
     return empty;
@@ -300,11 +337,18 @@ export function referenceRate(dir, { events = null } = {}) {
 }
 
 /**
- * One line for the audit, or nothing at all.
+ * One or two lines for the audit, or nothing at all.
  *
  * Says which of the three things is true -- a measured rate, a live channel
  * with no opportunities yet, or no channel at all -- rather than printing a
  * figure and letting the reader assume the first.
+ *
+ * AND IT CARRIES THE CAVEATS, because this is the only place a human meets the
+ * number. A rate attributed on (finding key, time order) can cross-attribute
+ * between two concurrent sessions on one repository, and a windowed read can
+ * understate the denominator. Both are stated beside the figure they qualify.
+ * Putting them only in a task report would be publishing a clean number and
+ * filing the asterisk somewhere nobody quoting it will look.
  */
 export function referenceNote(dir, { events = null } = {}) {
   const r = referenceRate(dir, { events });
@@ -317,6 +361,11 @@ export function referenceNote(dir, { events = null } = {}) {
   }
   return (
     `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
-    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded. ` +
+    'Matched on finding key and time order, so concurrent sessions on this ' +
+    'repository can cross-attribute' +
+    (r.windowed
+      ? '; and the event log was truncated, so the denominator can understate.'
+      : '.')
   );
 }

--- a/integrations/codex/hooks/lib/usage.mjs
+++ b/integrations/codex/hooks/lib/usage.mjs
@@ -1,0 +1,322 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/usage.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 1 -- did the model actually go back and use what we injected?
+ *
+ * The cheap behavioural label. One question, answered from the event log alone:
+ * after we put a finding in front of the model, did the model later ASK FOR
+ * THAT FINDING BY NAME?
+ *
+ * WHY EXPLICIT REFERENCE, AND NOT READ-SUPPRESSION. Read-suppression -- "the
+ * file was not re-read, so the finding must have helped" -- is Layer 2's
+ * estimand, measured causally by withholding a finding and comparing. Layer 1
+ * exists to be calibrated AGAINST that. If both layers derived from
+ * suppression, the calibration would compare two spellings of one quantity,
+ * report a strong correlation, and mean nothing. So Layer 1 is deliberately
+ * built on a signal Layer 2 does not touch: an explicit `query` naming the
+ * finding key.
+ *
+ * WHAT THIS DOES NOT DO. It does not invent a join. `recordToolOutcome`
+ * already joins each post-tool result back to the injection that preceded it,
+ * recording `injectionId`, `findingIds` and a `joinMethod` of `tool-call-id`,
+ * `episode-anchor` or `none` -- preferring an exact tool-call id, which is
+ * strictly better evidence than the `(sessionId, findingKey)` approximation an
+ * earlier draft of this plan proposed. This module consumes that join and adds
+ * none of its own. `inject.mjs` needed no change: it has written `findingIds`
+ * at every call site all along.
+ *
+ * WHAT `unknown` IS FOR, and it is the whole reason this file is careful. An
+ * injection whose session simply stopped afterwards is not a miss. Nothing
+ * happened, so nothing can be concluded, and counting it against the finding
+ * would make the metric read worse the more often sessions end -- a number
+ * that moves with session length rather than with usefulness. `unknown` is
+ * therefore EXCLUDED from the denominator rather than scored zero, and
+ * outcomes the join could not attribute at all are reported as
+ * `unattributable` rather than folded into either arm.
+ *
+ * AND WHY THE RATE CAN BE `null`. This project has already shipped two metrics
+ * whose only producer was their own test suite. A rate of 0% that actually
+ * means "no data" is worse than a refusal, because it is a number and numbers
+ * get quoted. So `rate` is null unless there is a denominator AND the
+ * reference channel produced at least one usable event in the window. "Nothing
+ * was referenced" and "nothing could be measured" are different answers and
+ * this module gives different answers for them.
+ */
+import { readMetrics } from './metrics.mjs';
+
+/**
+ * The events that name a finding, and it is ONE kind, not the two the plan
+ * assumed.
+ *
+ * The brief said "a later `query` or `expand` event". Checked against the code
+ * and against every metrics log on this machine, `expand` does not qualify and
+ * cannot be made to:
+ *
+ *   - `recordExpansion` writes `{ ref, tool, shape, asked, sessionId }`. `ref`
+ *     is a TRUNCATION CAPTURE id (a 16-hex digest of captured tool output),
+ *     not a finding key, and `asked` is free text naming a section of that
+ *     output. Neither is a graph key, and no code path ever puts one there.
+ *   - measured: 64 live `expand` events exist on this machine and all 64 carry
+ *     `sessionId: null`, so they could not be scoped to an injection even if
+ *     they did name one.
+ *
+ * Keying the classifier on `expand` would therefore have added a branch that
+ * can never fire -- a metric with no producer, which is the exact defect this
+ * whole effort exists to close. So it is excluded, deliberately and with the
+ * measurement recorded, rather than included for symmetry with the brief.
+ */
+const REFERENCE_KINDS = new Set(['query']);
+
+/**
+ * What counts as the session having CONTINUED past the injection.
+ *
+ * The distinction between `not-referenced` and `unknown` rests entirely on
+ * this, so the set is explicit rather than "any later event". These are the
+ * kinds a tool call produces: if one of them follows the injection in the same
+ * session, the model had the opportunity to ask and did not. If none does, the
+ * session ended and there was no opportunity.
+ *
+ * `inject` is in the set because a later injection means a later tool call
+ * happened. `forecast`, `mcp-client` and `mcp-tool` are NOT: they are written
+ * by session bookkeeping rather than by the model doing something, and
+ * treating them as opportunity would convert `unknown` rows into misses on
+ * bookkeeping alone.
+ */
+const ACTIVITY_KINDS = new Set([
+  'tool-outcome',
+  'read',
+  'query',
+  'expand',
+  'substitute',
+  'inject',
+]);
+
+/** A usable session id: a non-empty string. `null == null` is not a match. */
+const sessionOf = (event) => {
+  const id = event?.sessionId;
+  return typeof id === 'string' && id ? id : null;
+};
+
+/** The finding key a reference event names, or null if it names none. */
+const referencedKey = (event) => {
+  const key = event?.key;
+  return typeof key === 'string' && key ? key : null;
+};
+
+/** Ordering by the caller's timestamp, with log order breaking ties. */
+function inTimeOrder(events) {
+  return events
+    .map((event, index) => ({ event, index }))
+    .sort(
+      (a, b) =>
+        (a.event.at || 0) - (b.event.at || 0) || a.index - b.index
+    )
+    .map((row) => row.event);
+}
+
+/**
+ * One row per (injection, finding) pair, labelled.
+ *
+ * Per injection rather than per finding: the same finding injected twice is two
+ * separate opportunities, and collapsing them would let one reference excuse
+ * every later injection of that key.
+ *
+ * FAILS OPEN. A malformed log yields an empty classification, never a throw:
+ * this runs on report paths that must not break a tool call.
+ */
+export function classify(dir, { events = null } = {}) {
+  let rows = [];
+  try {
+    const all = inTimeOrder(events || readMetrics(dir));
+
+    // Every reference, keyed on the finding it names. Only references carrying
+    // a session id are usable -- see `unscopedReferences` in `referenceRate`
+    // for the ones this drops and why they are counted rather than credited.
+    const references = new Map();
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      const key = referencedKey(event);
+      const session = sessionOf(event);
+      if (!key || !session) continue;
+      if (!references.has(key)) references.set(key, []);
+      references.get(key).push({ at: event.at || 0, session });
+    }
+
+    // Which injections the existing outcome join could attribute. An outcome
+    // carrying our injectionId is proof the tool call completed, which is
+    // opportunity even when the session id is missing from the log.
+    const attributed = new Set();
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) continue;
+      attributed.add(String(event.injectionId));
+    }
+
+    // Activity per session, so "did anything follow?" is one lookup rather
+    // than a scan per injection.
+    const activity = new Map();
+    for (const event of all) {
+      if (!ACTIVITY_KINDS.has(event.kind)) continue;
+      const session = sessionOf(event);
+      if (!session) continue;
+      if (!activity.has(session)) activity.set(session, []);
+      activity.get(session).push(event.at || 0);
+    }
+
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+      if (!keys.length) continue;
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const at = event.at || 0;
+      const session = sessionOf(event);
+      // STRICTLY AFTER. A query that PRECEDED the injection is the model
+      // asking on its own initiative; crediting it would let the metric take
+      // the credit for a lookup it had nothing to do with.
+      const followed = (times) => times.some((t) => t > at);
+      const continued =
+        (injectionId && attributed.has(injectionId)) ||
+        (session ? followed(activity.get(session) || []) : false);
+
+      for (const raw of keys) {
+        const findingKey = String(raw);
+        const hits = references.get(findingKey) || [];
+        const referenced = session
+          ? hits.some((hit) => hit.session === session && hit.at > at)
+          : false;
+        rows.push({
+          findingKey,
+          injectionId,
+          label: referenced
+            ? 'referenced'
+            : continued
+              ? 'not-referenced'
+              : 'unknown',
+        });
+      }
+    }
+  } catch {
+    rows = [];
+  }
+  return rows;
+}
+
+/**
+ * The rate, with everything needed to tell a real 0 from an absent one.
+ *
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
+ * `unattributable` and `unscopedReferences` are reported beside it, never
+ * inside it.
+ */
+export function referenceRate(dir, { events = null } = {}) {
+  const empty = {
+    referenced: 0,
+    notReferenced: 0,
+    unknown: 0,
+    denominator: 0,
+    rate: null,
+    unattributable: 0,
+    unattributableWithInjectedToolCall: 0,
+    referenceEvents: 0,
+    unscopedReferences: 0,
+  };
+  try {
+    const all = events || readMetrics(dir);
+    const rows = classify(dir, { events: all });
+    const count = (label) => rows.filter((row) => row.label === label).length;
+    const referenced = count('referenced');
+    const notReferenced = count('not-referenced');
+    const denominator = referenced + notReferenced;
+
+    // Usable reference events in the window: the numerator's producer. If this
+    // is zero the channel never fired, and a 0% rate would be measuring the
+    // absence of a producer rather than the uselessness of findings.
+    let referenceEvents = 0;
+    let unscopedReferences = 0;
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      if (!referencedKey(event)) continue;
+      if (sessionOf(event)) referenceEvents += 1;
+      // Names a finding but cannot be scoped to one injection. `sessionId` is
+      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
+      // is the expected loss rather than an edge case -- counted here so it is
+      // visible instead of silently deflating the numerator.
+      else unscopedReferences += 1;
+    }
+
+    // The tool calls that DID receive findings, keyed the way
+    // `recordToolOutcome` keys its own primary join: the tool-call id. An
+    // unattributable outcome for one of these is a join that FAILED. An
+    // unattributable outcome for any other tool call had nothing to join to.
+    //
+    // KEYED ON THE TOOL CALL, NOT THE EPISODE, and the first draft of this
+    // got it wrong in a way worth recording because it is the exact
+    // measurement-bias class this plan hunts. `episodeId` equals the SESSION
+    // id, so "unattributable outcomes in an episode that had an injection"
+    // scored all 2,559 tool calls of a session in which ONE injection
+    // happened. It would have published 2,559 join failures where the true
+    // number is zero -- correct code, lying number, and biased pessimistic
+    // rather than flattering, which is no better.
+    const injectedToolCalls = new Set();
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      if (!Array.isArray(event.findingIds) || !event.findingIds.length)
+        continue;
+      if (event.toolCallId) injectedToolCalls.add(String(event.toolCallId));
+    }
+    let unattributable = 0;
+    let unattributableWithInjectedToolCall = 0;
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome' || event.joinMethod !== 'none')
+        continue;
+      unattributable += 1;
+      // BOTH FIGURES, because the raw one alone lies in the pessimistic
+      // direction. Measured on this machine: 2,991 of 2,992 live outcomes
+      // report `joinMethod: 'none'`, and every one of them because NO
+      // INJECTION EXISTED for that tool call -- the graph holds one finding.
+      // Quoting only the raw count would read as a join that fails 99.97% of
+      // the time, which is a different and false claim.
+      if (event.toolCallId && injectedToolCalls.has(String(event.toolCallId)))
+        unattributableWithInjectedToolCall += 1;
+    }
+
+    return {
+      referenced,
+      notReferenced,
+      unknown: count('unknown'),
+      denominator,
+      rate:
+        denominator > 0 && referenceEvents > 0
+          ? referenced / denominator
+          : null,
+      unattributable,
+      unattributableWithInjectedToolCall,
+      referenceEvents,
+      unscopedReferences,
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/**
+ * One line for the audit, or nothing at all.
+ *
+ * Says which of the three things is true -- a measured rate, a live channel
+ * with no opportunities yet, or no channel at all -- rather than printing a
+ * figure and letting the reader assume the first.
+ */
+export function referenceNote(dir, { events = null } = {}) {
+  const r = referenceRate(dir, { events });
+  if (!r.denominator && !r.unknown && !r.referenceEvents) return null;
+  if (r.rate == null) {
+    const why = !r.referenceEvents
+      ? 'no finding was ever queried by key in this window'
+      : `no injection had a chance to be referenced yet (${r.unknown} unknown)`;
+    return `Injected findings referenced later: not measurable -- ${why}.`;
+  }
+  return (
+    `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+  );
+}

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -103,6 +103,44 @@ const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
 
 /**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because FOUR readers depend on it -- mutation accounting,
+ * success classification, output capture and exit-code capture -- and clients
+ * disagree on the envelope name and on nothing else. Letting each reader name
+ * its own subset is exactly how both classifiers came to miss MCP's failure
+ * flag: `toolSucceeded` listed four envelopes and `mutationSucceeded` listed
+ * three, and neither list mentioned `isError` at all.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/**
+ * Did an MCP result declare itself an error?
+ *
+ * `isError` is the ONLY failure signal an MCP result carries -- there is no
+ * `error` field and no `status` -- and `src/server/index.ts` sets it in seven
+ * places. Shared by both classifiers so they cannot disagree about what a
+ * failed call from this project's own tools looks like.
+ *
+ * `=== true` EXACTLY. A client using the key for anything else must not have
+ * its successful calls silently reclassified, and `isError: false` is a
+ * successful MCP call, not a missing verdict.
+ */
+function reportedMcpError(raw) {
+  return [...responseEnvelopes(raw), raw].some(
+    (envelope) => envelope?.isError === true
+  );
+}
+
+/**
  * A post-tool event is not universally proof of success. Some clients split
  * success and failure into distinct events; others expose a result status.
  * Keep mutation accounting conservative so a failed edit cannot arm Stop.
@@ -112,6 +150,19 @@ export function mutationSucceeded(clientName, raw) {
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
     return false;
+  // BEFORE the status read, the explicit-success read AND the client
+  // allowlist, because all three would otherwise pass a failed MCP write. The
+  // allowlist is the one that actually bit: it returns true for claude-code,
+  // codex, qwen, opencode, kilo and windsurf on any post-tool event with no
+  // error and no status, which is precisely the shape of a failed smart_write.
+  //
+  // WHY THIS IS THE SAME BUG AS THE ONE IN `toolSucceeded` AND NOT A COSMETIC
+  // ECHO OF IT: this function gates edit counting and harvest pressure, so
+  // counting a failed write to THE OPTIMIZER'S OWN TOOLS as a mutation
+  // inflates "the optimizer successfully edited a file". Different consumers
+  // from the effectiveness figures, same direction of bias -- toward
+  // flattering the thing being measured.
+  if (reportedMcpError(raw)) return false;
 
   const status =
     raw?.tool_response?.status ??
@@ -145,24 +196,6 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * Spelled out ONCE because three readers depend on it -- success
- * classification, output capture and exit-code capture -- and clients disagree
- * on the envelope name and on nothing else. Letting each reader name its own
- * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
-}
-
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
@@ -181,8 +214,7 @@ export function toolSucceeded(raw) {
   // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
   // optimizer's favour. A measurement that flatters the thing being measured
   // is worse than no measurement.
-  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
-    return false;
+  if (reportedMcpError(raw)) return false;
   const status =
     raw?.tool_response?.status ??
     raw?.toolResponse?.status ??

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -957,10 +957,12 @@ async function runHook(clientName, event, invocation) {
       // accumulates structure and no verdicts at all. These detectors read only
       // what is already on disk and send nothing anywhere.
       //
-      // The COUNT is recorded rather than the candidates: how many findings a
-      // session's own evidence supports is the number that says whether this is
-      // working, and it is measurable before anything is stored. Storage is the
-      // caller's next step, under a budget.
+      // COUNTS are recorded rather than the candidates, and BOTH counts: how
+      // many findings a session's own evidence supports, and how many of them
+      // survived the storage budget and the anchor discipline. The gap between
+      // the two is the number that says whether the bound is doing anything --
+      // one figure alone cannot distinguish "nothing to derive" from "derived
+      // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
       const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
       const dir = wikiDir(projectRoot);
@@ -976,6 +978,7 @@ async function runHook(clientName, event, invocation) {
         sessionId,
         candidates: derived.candidates.length,
         observations: derived.observations.length,
+        written: derived.written.length,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -172,6 +172,136 @@ export function toolSucceeded(raw) {
   return true;
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * The same family `toolSucceeded` reads above, hoisted so the three readers
+ * cannot drift apart. Clients disagree on the envelope name and on nothing
+ * else, so this is the one place that disagreement is spelled out.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/** A non-empty string, or null.  Blank output is the same as none. */
+function nonEmpty(value) {
+  const text = String(value ?? '');
+  return text.trim() ? text : null;
+}
+
+/**
+ * The human-readable result text inside one envelope, or null.
+ *
+ * RETURNS NULL RATHER THAN GUESSING. An envelope shape nobody here has seen
+ * produces no capture at all, which costs one finding. Stringifying it instead
+ * would put `[object Object]` or a wall of JSON metadata into a claim that gets
+ * injected into model context -- a wrong observation, which is strictly worse
+ * than a missing one.
+ */
+function resultText(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'string') return nonEmpty(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return null;
+
+  // MCP content blocks, which is how THIS PROJECT'S OWN tools now arrive:
+  // `normalizeTool` resolves `mcp__<server>__smart_edit`, so smart_edit and
+  // smart_write reach the post-tool path for the first time and their results
+  // are `{ content: [{ type: 'text', text }], isError }` rather than a shell
+  // result. Both the bare array and the wrapping object are accepted because
+  // hosts differ on whether they hand the hook the result or its content.
+  if (Array.isArray(value)) {
+    const blocks = value
+      .map((block) =>
+        typeof block === 'string' ? block : nonEmpty(block?.text)
+      )
+      .filter(Boolean);
+    return blocks.length ? nonEmpty(blocks.join('\n')) : null;
+  }
+  if (typeof value !== 'object') return null;
+
+  // STDERR FIRST, and not because that is the order it was produced in. The
+  // cap can only ever cut the tail, and the diagnostic that explains a failure
+  // is almost always on stderr while the volume is almost always on stdout --
+  // so appending stderr would let a 3 MB build log push the one line worth
+  // capturing out of the window.
+  const streams = [nonEmpty(value.stderr), nonEmpty(value.stdout)].filter(
+    Boolean
+  );
+  if (streams.length) return streams.join('\n');
+
+  if (Array.isArray(value.content)) {
+    const inner = resultText(value.content);
+    if (inner) return inner;
+  }
+
+  const error = value.error;
+  if (error) {
+    const message =
+      typeof error === 'string' ? error : nonEmpty(error.message ?? error.msg);
+    if (message) return message;
+  }
+
+  return (
+    nonEmpty(value.output) ??
+    nonEmpty(value.text) ??
+    nonEmpty(value.message) ??
+    (typeof value.result === 'string' ? nonEmpty(value.result) : null)
+  );
+}
+
+/**
+ * The result text of a completed tool call, or null when the client reports
+ * none.  Redaction and the size cap are NOT applied here -- they belong at the
+ * `recordToolOutcome` boundary, which is the only place every caller passes.
+ */
+export function outputFrom(raw) {
+  for (const envelope of responseEnvelopes(raw)) {
+    const text = resultText(envelope);
+    if (text) return text;
+  }
+  return resultText(raw?.output) ?? resultText(raw?.stdout) ?? null;
+}
+
+/**
+ * Key names that mean "process exit code" and nothing else.
+ *
+ * `code` is deliberately ABSENT. JSON-RPC errors (`code: -32602`), Node errno
+ * objects (`code: 'ENOENT'`) and HTTP wrappers all reuse that name, so reading
+ * it would record a confident exit code for calls that never had one. A null
+ * here is honest; a -32602 claiming to be an exit status is not.
+ */
+const EXIT_KEYS = [
+  'exit_code',
+  'exitCode',
+  'exit',
+  'exit_status',
+  'exitStatus',
+  'return_code',
+  'returncode',
+];
+
+/** The numeric exit code a client reported, or null when it reported none. */
+export function exitFrom(raw) {
+  for (const envelope of [...responseEnvelopes(raw), raw]) {
+    if (!envelope || typeof envelope !== 'object') continue;
+    for (const key of EXIT_KEYS) {
+      const value = envelope[key];
+      if (Number.isInteger(value)) return value;
+      // A client that serializes the code as a digit string still reported it.
+      // Bounded so a hash or an id cannot be mistaken for a status.
+      if (typeof value === 'string' && /^-?\d{1,5}$/.test(value.trim()))
+        return Number(value.trim());
+    }
+  }
+  return null;
+}
+
 function contextOutput(client, eventName, additionalContext) {
   if (client.contextStyle === 'top-level') return { additionalContext };
   if (client.contextStyle === 'cline') {
@@ -890,6 +1020,11 @@ async function runHook(clientName, event, invocation) {
         anchor,
         toolName: payload.tool_name,
         success: toolSucceeded(raw),
+        // The two fields a boolean cannot carry: which KIND of failure this
+        // was. Read through the same normalisers as `success`, never off `raw`
+        // at this call site.
+        output: outputFrom(raw),
+        exit: exitFrom(raw),
         durationMs:
           Number(
             raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -145,11 +145,43 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because three readers depend on it -- success
+ * classification, output capture and exit-code capture -- and clients disagree
+ * on the envelope name and on nothing else. Letting each reader name its own
+ * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
+    return false;
+  // MCP'S OWN FAILURE FLAG, which this function did not read for as long as it
+  // existed. It did not matter while `normalizeTool` dropped MCP names before
+  // any accounting ran; it matters now that `mcp__<server>__smart_edit` and
+  // `smart_write` reach the post-tool path, because an MCP result carries no
+  // `error` field and no `status` -- only `isError` -- so a failed smart_edit
+  // fell through to the optimistic `return true` below.
+  //
+  // WHY THIS IS A MEASUREMENT BUG AND NOT A COSMETIC ONE: this boolean feeds
+  // episode outcomes and effectiveness accounting, so recording every failed
+  // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
+  // optimizer's favour. A measurement that flatters the thing being measured
+  // is worse than no measurement.
+  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
     return false;
   const status =
     raw?.tool_response?.status ??
@@ -170,23 +202,6 @@ export function toolSucceeded(raw) {
   // that its output proved the task.  `success` here is deliberately scoped to
   // the tool call; task correctness comes only from an eval grader.
   return true;
-}
-
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * The same family `toolSucceeded` reads above, hoisted so the three readers
- * cannot drift apart. Clients disagree on the envelope name and on nothing
- * else, so this is the one place that disagreement is spelled out.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
 }
 
 /** A non-empty string, or null.  Blank output is the same as none. */

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -58,6 +58,7 @@ import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { briefing } from './remedy.mjs';
 import { stableText, transcriptFor } from './cache.mjs';
+import { scoreRefreshes } from './keepwarm.mjs';
 import { cachedRoutingBriefing } from './routing.mjs';
 import {
   forCommand,
@@ -1010,6 +1011,26 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE KEEP-WARM FEEDBACK ARM, at the boundary where a turn has just
+      // ended -- which is the only place the arrival question can be answered.
+      // Every refresh whose TTL has since elapsed is scored here as used or
+      // unused; anything the log cannot settle is left unscored rather than
+      // recorded as a miss, because an absent signal is not a miss.
+      //
+      // Nothing in this repository issues a refresh today -- cache_audit only
+      // recommends one -- so this scores nothing, and what it costs while
+      // dormant is one readBalance: median 70 ms on this machine's 3.5 MB log,
+      // against derive's 71-111 ms a few lines below on the same path. The
+      // firehose is read for ARRIVALS only if an unscored refresh exists, so
+      // the dormant case never pays for that. The moment an issuer exists, the
+      // decision starts learning with no second wiring change.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      scoreRefreshes(dir);
+    } catch {
+      // A refresh that cannot be scored costs a measurement, not a session.
     }
     try {
       // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -40,11 +40,13 @@ import {
   touchedFiles,
 } from './decide.mjs';
 import {
+  record,
   recordRead,
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
 } from './metrics.mjs';
+import { derive } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -948,6 +950,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // ZERO-COST DERIVATION, on every client, with no credential. The semantic
+      // harvest below needs an API key, so on a machine without one the graph
+      // accumulates structure and no verdicts at all. These detectors read only
+      // what is already on disk and send nothing anywhere.
+      //
+      // The COUNT is recorded rather than the candidates: how many findings a
+      // session's own evidence supports is the number that says whether this is
+      // working, and it is measurable before anything is stored. Storage is the
+      // caller's next step, under a budget.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      const dir = wikiDir(projectRoot);
+      const derived = derive(dir, {
+        sessionId,
+        projectRoot,
+        transcriptPath: agentScope,
+        // The hook payload's own identity, not a value a model typed.
+        authoritativeSessionId: sessionId,
+      });
+      record(dir, {
+        kind: 'derive',
+        sessionId,
+        candidates: derived.candidates.length,
+        observations: derived.observations.length,
+      });
+    } catch {
+      // A detector failing must never cost a user the end of their session.
     }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -72,7 +72,8 @@ import {
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
-import { isArchived } from './transcript.mjs';
+import { archive, isArchived } from './transcript.mjs';
+import { harvestMode } from './harvest.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
@@ -577,6 +578,65 @@ function emit(object) {
   process.stdout.write(serialized);
 }
 
+/**
+ * What will and will not extract findings after this session, in one sentence.
+ *
+ * THE STATE WAS ONLY EVER LEGIBLE FROM THE DOCTOR, and the doctor is a place
+ * someone visits after they already suspect something is wrong. A user watching
+ * a graph fill with structural nodes and no verdicts has no reason to suspect
+ * anything, which is the failure this project has now measured twice.
+ *
+ * IT IS ADDRESSED TO THE MODEL, NOT ONLY TO THE READER, which is why it earns a
+ * place in the prefix rather than a systemMessage. "Nothing else will write this
+ * down in words" changes what the model does with a conclusion it is holding;
+ * "here is a configuration variable" would not.
+ *
+ * CACHE-SAFE: derived from configuration, so it differs between sessions only
+ * when the configuration does -- the same standard the rest of this block is
+ * held to, and it carries no digits for `stableText` to reject.
+ *
+ * A local endpoint is named FIRST in the off case on purpose. It is the option
+ * that costs nothing and sends nothing, and it was the one buried deepest.
+ */
+function extractionNotice() {
+  switch (harvestMode()) {
+    case 'local':
+      return (
+        '\n\nA local model endpoint is configured, so semantic extraction also runs after this ' +
+        'session -- free and private, with nothing leaving this machine.'
+      );
+    case 'remote':
+      return (
+        '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
+        'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
+    case 'off:mode':
+      // The whole optimizer is off and this text is not emitted anyway. Saying
+      // anything here would be noise stacked on an explicit choice.
+      return '';
+    case 'off:opted-out':
+      // A DELIBERATE CHOICE, SO NO PITCH. The consequence is stated because the
+      // model needs it; the setting that would reverse it is not, because
+      // arguing with a configured decision on every session is how a notice
+      // stops being read. doctor.mjs draws the same line for the same reason.
+      return (
+        '\n\nFallback extraction is off by configuration, so a conclusion you do not record is ' +
+        'not written down in words anywhere. Findings are still derived locally from exit codes, ' +
+        'red-to-green transitions and corrections.'
+      );
+    default:
+      // off:no-key, and any mode a future harvest adds: no extractor is running
+      // and nobody chose that, so the free option is worth naming.
+      return (
+        '\n\nNo separate extractor will run after this session, so a conclusion you do not record ' +
+        'is not written down in words anywhere. Findings are still derived locally from exit ' +
+        'codes, red-to-green transitions and corrections. Pointing ' +
+        'TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model adds semantic extraction, free and ' +
+        'private.'
+      );
+  }
+}
+
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
 export function policyText(
   canDeny,
@@ -635,7 +695,7 @@ export function policyText(
     .filter(Boolean)
     .join(' ');
   const recording = tools.has('wiki_write')
-    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.`
+    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.${extractionNotice()}`
     : '\n\nStructural graph capture remains active through lifecycle hooks. Durable semantic MCP writes are not requested because the writer schema is not proven available.';
 
   return `# Token optimization is active\n\nLive graph capture is active through the lifecycle adapter.\n\n${connection}${routing}${enforcement}${utilities ? `\n\n${utilities}` : ''}${recording}${projectBriefing()}`;
@@ -950,6 +1010,27 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.
+      //
+      // This was lost rather than retired. `plugin/hooks/stop-harvest.mjs` called
+      // `archive()` at Stop, and #300 replaced that entry in `hooks.json` with the
+      // generated `stop.mjs`, which routes here -- so on Claude Code no session has
+      // been archived since. Nothing failed loudly: `readArchive` simply returns an
+      // empty list, so `derive`'s correction detector fell through to the live
+      // transcript (present only for a client that reports one) and `lessons.mjs`
+      // lost the only corpus it can verify a verbatim quote against, which is the
+      // single test that grants a feedback finding human origin.
+      //
+      // BEFORE `derive`, deliberately: the correction detector reads the archive
+      // first and treats the live transcript as the fallback, and the archive is
+      // the copy that survives into later sessions.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      if (agentScope) archive(dir, agentScope, { sessionId });
+    } catch {
+      // The archive is a record, not a result. A session still ends.
     }
     try {
       // ZERO-COST DERIVATION, on every client, with no credential. The semantic

--- a/integrations/codex/plugin/hooks/lib/audit.mjs
+++ b/integrations/codex/plugin/hooks/lib/audit.mjs
@@ -32,6 +32,7 @@
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
+import { looNote } from './loo.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -401,6 +402,16 @@ export function renderAudit(
   // project with no injections and no queries gains no line at all.
   const reference = referenceNote(dir);
   if (reference) body.push('', reference);
+
+  // WHAT ONE FINDING IS CAUSALLY WORTH (Layer 2).
+  //
+  // The same reasoning as above, and the same refusal: `looNote` returns null
+  // until the leave-one-out experiment has collected an observation, and says
+  // NOT MEASURABLE YET rather than printing a mean until it clears the floor.
+  // A causal number is the most quotable thing this project can produce, so it
+  // is the one that most needs to be absent when it is not earned.
+  const causal = looNote(dir);
+  if (causal) body.push('', causal);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/codex/plugin/hooks/lib/audit.mjs
+++ b/integrations/codex/plugin/hooks/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
 import { looNote } from './loo.mjs';
+import { calibrationNote } from './crosslayer.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -244,9 +245,15 @@ export function renderAudit(
     lines.push(text);
   }
 
+  // SCOPED TO THE QUEUE, because that is all it ever described. The bare
+  // sentence "Nothing addressable found." was printed directly above a Layer 1
+  // reference note and a published Layer 2 causal verdict -- so a reader was
+  // told nothing had been found immediately before being shown a finding. The
+  // headline is about the remediation queue and nothing else, and saying so
+  // costs four words and removes a false negative shown to a human.
   const head = shown.length
     ? ['What to do next, most expensive first:', ...lines]
-    : ['Nothing addressable found.'];
+    : ['Nothing addressable found in the remediation queue.'];
 
   const body = [...head];
 
@@ -412,6 +419,16 @@ export function renderAudit(
   // is the one that most needs to be absent when it is not earned.
   const causal = looNote(dir);
   if (causal) body.push('', causal);
+
+  // WHETHER LAYER 1'S CHEAP LABEL PREDICTS LAYER 2'S EXPENSIVE EFFECT.
+  //
+  // The reason this is printed rather than kept for a dashboard: the reference
+  // rate is the number a reader is most likely to quote as a saving, and it is
+  // not one until this comparison says so. `calibrationNote` returns null while
+  // both layers are silent, and otherwise prints the refusal -- naming which
+  // input was insufficient -- rather than a gap of zero.
+  const calibrated = calibrationNote(dir);
+  if (calibrated) body.push('', calibrated);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/codex/plugin/hooks/lib/audit.mjs
+++ b/integrations/codex/plugin/hooks/lib/audit.mjs
@@ -61,6 +61,28 @@ export function declines(dir, { events = readMetrics(dir) } = {}) {
   return counts;
 }
 
+/**
+ * What the local Stop-time derivation path produced in the visible event log.
+ *
+ * The producer records all three counts because any one of them alone is
+ * ambiguous: zero stored can mean no evidence, no candidates, or a binding
+ * storage/anchor filter. This reader keeps those states distinct and prevents
+ * the telemetry itself from becoming an unobserved cost.
+ */
+export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
+  const runs = events.filter((event) => event.kind === 'derive');
+  if (!runs.length) return null;
+
+  const sum = (field) =>
+    runs.reduce((total, event) => total + Math.max(0, Number(event[field]) || 0), 0);
+  const candidates = sum('candidates');
+  const observations = sum('observations');
+  const written = sum('written');
+  return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
+    `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
+    `across ${runs.length.toLocaleString()} Stop run(s).`;
+}
+
 const idOf = (finding) =>
   finding.remedy
     ? `${finding.remedy.type}:${finding.remedy.anchor || finding.remedy.file || (finding.remedy.anchors || []).join(',')}`
@@ -399,6 +421,15 @@ export function renderAudit(
       );
     }
   }
+
+  // WHAT THE DEFAULT, LOCAL DERIVATION PATH ACTUALLY PRODUCED.
+  //
+  // This event used to have a producer and no reader. Keep its three states
+  // together: evidence seen, candidates derived, and findings that survived
+  // selection/storage. A lone stored count would turn every earlier refusal
+  // into an apparent "nothing found" result.
+  const derived = derivationNote(dir);
+  if (derived) body.push('', derived);
 
   // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
   //

--- a/integrations/codex/plugin/hooks/lib/audit.mjs
+++ b/integrations/codex/plugin/hooks/lib/audit.mjs
@@ -31,6 +31,7 @@
  */
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
+import { referenceNote } from './usage.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -390,6 +391,16 @@ export function renderAudit(
       );
     }
   }
+
+  // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
+  //
+  // Printed here because this is the report that already asks "did the advice
+  // change anything", and because a measurement with no reader is how this
+  // project shipped two metrics whose only consumer was their own test suite.
+  // `referenceNote` returns null when it has nothing honest to say, so a
+  // project with no injections and no queries gains no line at all.
+  const reference = referenceNote(dir);
+  if (reference) body.push('', reference);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/codex/plugin/hooks/lib/consolidate.mjs
+++ b/integrations/codex/plugin/hooks/lib/consolidate.mjs
@@ -142,7 +142,8 @@ const ALWAYS_KEEP = new Set(['failure', 'decision']);
  * Chooses what to promote into the graph, under a token budget.
  *
  * @param {object} graph      Loaded wiki graph, for reuse probability.
- * @param {Array}  candidates Extracted conclusions, each { type, summary, anchors, evidence, at }.
+ * @param {Array}  candidates Extracted conclusions, each { type, claim (or summary),
+ *                              anchors, evidence, at }.
  * @param {object} options    budget: tokens available for promoted findings.
  */
 export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}) {
@@ -221,4 +222,3 @@ export function aggregateConsolidation(findings) {
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
-

--- a/integrations/codex/plugin/hooks/lib/crosslayer.mjs
+++ b/integrations/codex/plugin/hooks/lib/crosslayer.mjs
@@ -1,0 +1,351 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/crosslayer.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The calibration loop: does Layer 1's LABEL predict Layer 2's EFFECT?
+ *
+ * Layer 1 (`usage.mjs`) classifies an injected finding by whether the model
+ * later NAMED it. Layer 2 (`loo.mjs`) measures, by leave-one-out, how many
+ * tokens of reading a finding actually SUPPRESSED. Those are two different
+ * quantities, and the whole point of putting them side by side is that the
+ * cheap one (a label, available on every injection) might stand in for the
+ * expensive one (a causal effect, costing three withheld sessions per finding).
+ *
+ * WHY THIS IS A REAL QUESTION AND NOT A TAUTOLOGY. Task 7 established the
+ * independence three ways -- statically (`loo.mjs` contains no `query` or
+ * `reference`; `usage.mjs` contains no `tokens`, `cost` or `bytes`),
+ * behaviourally in both directions, and by naming the one overlap that does
+ * exist (`recordToolOutcome`'s join, which supplies ATTRIBUTABILITY to both and
+ * the measured quantity to neither). This module is built to preserve that:
+ *
+ *   - from Layer 1 it takes ONLY the categorical label per finding key. No
+ *     rate, no count, no magnitude -- Layer 1 has no magnitude to give.
+ *   - from Layer 2 it takes ONLY the effect magnitude per finding key.
+ *   - the join is the finding key, which is a graph identity and not a
+ *     measurement.
+ *
+ * If a magnitude common to both ever entered, this would correlate a quantity
+ * with itself and report a strong result that means nothing. Two tests pin the
+ * separation from opposite sides: flipping the labels while holding the effects
+ * fixed must move the gap, and changing Layer 1's rate WITHOUT changing any
+ * label must leave the gap byte-identical.
+ *
+ * MEASURED UTILITY RANKS A FINDING. IT MUST NEVER RAISE ITS CONFIDENCE.
+ * A confidently WRONG finding suppresses reads better than a hedged true one,
+ * so utility alone optimises directly against "wrong findings are worse than
+ * none". The plan called for a `mayPromote` gate over
+ * `hasOutstandingContradiction` here. There is nothing to gate: every write of
+ * `confidence` in `hooks-core` happens at CREATION (a per-producer constant in
+ * `derive.mjs` / `lessons.mjs` / `harvest.mjs`, or a human's own number in
+ * `curate.mjs`), and no code path updates a stored finding's confidence
+ * afterwards. `assessFindings` in `utility.mjs` READS confidence into an
+ * ephemeral `netUtility` used for ordering and writes nothing back. So a gate
+ * here would be unreachable, and an unreachable gate is the exact defect class
+ * this work exists to close. `hasOutstandingContradiction` already has its
+ * real consumer -- `staleness.mjs` calls it as the dispute gate on serve.
+ * What is enforceable is the invariant itself, and it is: this module never
+ * writes to the graph, and `tests/hooks/calibration-loop.test.mjs` asserts that
+ * neither it nor either layer under it can move a stored confidence.
+ *
+ * NOTHING HERE IS PRICED. A calibration verdict, a holdout estimate and a
+ * consolidation ratio are all estimates; currency belongs only on a measured
+ * counterfactual, and `balanceSheet`'s `measuredCounterfactual` is the one
+ * section in the sheet below that qualifies.
+ */
+
+import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
+import { classify, referenceRate } from './usage.mjs';
+import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Distinct findings needed in EACH arm before a gap is reported at all.
+ *
+ * Two findings per arm is a difference of two numbers; the comparison would be
+ * dominated by whichever finding happened to sit on a big file. Three is still
+ * small, and the refusal says so rather than implying the gap is solid.
+ */
+export const MIN_FINDINGS_PER_ARM = 3;
+
+/**
+ * The smallest gap that may be PUBLISHED, in tokens per touch.
+ *
+ * Not an effect-size convention: it is tied to the unit the verdict prints. The
+ * published sentence rounds the gap to whole tokens, so a gap of 1e-13 -- which
+ * is what two arms of equal means produce once floating point has had its say --
+ * would publish as "referenced findings suppress 0 more tokens/touch". That is a
+ * calibration claim resting on arithmetic noise, and it leans the only direction
+ * a measurement of this project by this project must never lean.
+ */
+export const MIN_GAP_TOKENS = 1;
+
+/**
+ * The per-finding Layer 1 label, folded from per-injection rows.
+ *
+ * ANY reference wins. `classify` emits one row per (injection, finding) because
+ * one reference must not excuse every later injection -- that is the right unit
+ * for a RATE. For a label the question is different: did the model ever name
+ * this finding? A finding referenced once and ignored nine times is a finding
+ * the model reads, and averaging it into `not-referenced` would put it in the
+ * arm whose mean effect it is meant to predict.
+ *
+ * `unknown` rows are dropped rather than defaulted, exactly as Layer 1 drops
+ * them from its own denominator.
+ */
+export function labelsByFinding(rows) {
+  const labels = new Map();
+  for (const row of rows || []) {
+    const key = row?.findingKey;
+    if (typeof key !== 'string' || !key) continue;
+    if (row.label === 'referenced') labels.set(key, 'referenced');
+    else if (row.label === 'not-referenced' && !labels.has(key))
+      labels.set(key, 'not-referenced');
+  }
+  return labels;
+}
+
+const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * Does Layer 1's label predict Layer 2's effect?
+ *
+ * Returns `publishable`, a `verdict` in English, and `gap` ONLY when a gap was
+ * actually computed. There is no `gap: 0` for the unmeasured case, and that is
+ * deliberate: a permanent zero reads as "measured, and the two agree", which is
+ * the opposite of "nothing was measured". Task 7 deleted a field rather than
+ * zero it for the same reason.
+ *
+ * FAILS OPEN. This runs on report paths that must not break a tool call.
+ */
+export function calibration(dir, options = {}) {
+  const refuse = (verdict, extra = {}) => ({
+    publishable: false,
+    verdict,
+    ...extra,
+  });
+
+  try {
+    // ONE READ for both layers, so the two arms of the comparison cannot cover
+    // different spans of the log. `referenceRate` reports `windowed: false`
+    // when the caller supplies events -- correctly, since the bounds are then
+    // the caller's -- so the truncation flag is taken here, from the read that
+    // actually set it, and republished.
+    const supplied = options.events || null;
+    const events = supplied || readMetrics(dir);
+    const truncation = supplied ? null : readTruncation();
+    const truncated = Boolean(
+      truncation && (truncation.byBytes || truncation.byEvents)
+    );
+
+    const layer1 = referenceRate(dir, { events });
+    const labels = labelsByFinding(classify(dir, { events }));
+
+    const obs = observations(dir, { ...options, events });
+    const rows = effects(dir, { ...options, events, obs });
+
+    // ONE POLICY VERSION. Layer 2 refuses to pool arms across serving
+    // policies; a calibration that pooled them would undo that guard one level
+    // up. Rows from any other policy are excluded and counted.
+    const policy = servingPolicyVersion();
+    const inPolicy = rows.filter((row) => row.policy === policy);
+
+    const layer2 = {
+      rows: rows.length,
+      inPolicy: inPolicy.length,
+      published: rows.filter((row) => row.published).length,
+      observations: obs.rows.length,
+      policy,
+    };
+    const l1 = {
+      referenced: layer1.referenced,
+      notReferenced: layer1.notReferenced,
+      unknown: layer1.unknown,
+      denominator: layer1.denominator,
+      rate: layer1.rate,
+      referenceEvents: layer1.referenceEvents,
+    };
+
+    const excluded = { layer1Unknown: layer1.unknown, unlabelled: 0, noEffect: 0 };
+    const arms = { referenced: [], notReferenced: [] };
+    for (const row of inPolicy) {
+      // THE SHRUNK ESTIMATE, not the raw one. Shrinkage pulls every finding
+      // toward the population mean, so it pulls the GAP toward zero -- the
+      // bias runs against publishing, which is the only direction a
+      // measurement of this project by this project may lean.
+      if (row.shrunk === null || !Number.isFinite(row.shrunk)) {
+        excluded.noEffect += 1;
+        continue;
+      }
+      const label = labels.get(row.findingKey);
+      if (label === 'referenced') arms.referenced.push(row.shrunk);
+      else if (label === 'not-referenced') arms.notReferenced.push(row.shrunk);
+      else excluded.unlabelled += 1;
+    }
+
+    const context = { layer1: l1, layer2, arms: { referenced: arms.referenced.length, notReferenced: arms.notReferenced.length }, excluded, windowed: truncated };
+    const caveat = truncated
+      ? ' The event log was truncated, so both sides can understate.'
+      : '';
+
+    // WHICH INPUT WAS INSUFFICIENT, named. "Not enough data" tells a reader
+    // nothing about which half of the loop to go and fix.
+    const l1Silent = layer1.rate === null;
+    const l2Silent = layer2.observations === 0;
+    if (l1Silent || l2Silent) {
+      const why = [];
+      if (l1Silent)
+        why.push(
+          `Layer 1 has ${layer1.denominator} classifiable observation(s) and ` +
+            `${layer1.referenceEvents} reference event(s), so it publishes no rate`
+        );
+      if (l2Silent)
+        why.push(
+          `Layer 2 has ${layer2.observations} observation(s), so it publishes no effect`
+        );
+      return refuse(
+        `not calibrated: ${why.join('; and ')}. No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+    }
+
+    // A POLICY CHANGE RESETS THE CALIBRATION, and says so rather than reporting
+    // an empty arm. Layer 2 refuses to pool arms across serving policies, so
+    // rows generated under an older one cannot answer a question about how the
+    // graph serves findings today -- but "0 findings per arm" would send a
+    // reader hunting for missing observations that are right there in the log.
+    if (rows.length > 0 && inPolicy.length === 0)
+      return refuse(
+        `not calibrated: all ${rows.length} Layer 2 effect row(s) were measured under a different serving ` +
+          `policy than the current ${policy}, and arms are never pooled across policies. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (layer2.published === 0)
+      return refuse(
+        `not calibrated: Layer 2 has ${layer2.observations} observation(s) but no published effect at q=0.1, ` +
+          'so its per-finding numbers are noise and a difference between two means of them would be too. ' +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (
+      arms.referenced.length < MIN_FINDINGS_PER_ARM ||
+      arms.notReferenced.length < MIN_FINDINGS_PER_ARM
+    )
+      return refuse(
+        `not calibrated: ${arms.referenced.length} referenced and ${arms.notReferenced.length} not-referenced ` +
+          `finding(s) carry a Layer 2 effect, below the floor of ${MIN_FINDINGS_PER_ARM} per arm. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    const referencedMean = mean(arms.referenced);
+    const notReferencedMean = mean(arms.notReferenced);
+    const gap = referencedMean - notReferencedMean;
+    const measured = { ...context, gap, referencedMean, notReferencedMean };
+
+    if (!(gap >= MIN_GAP_TOKENS))
+      return refuse(
+        `uncalibrated: Layer 1's "referenced" label does not predict a larger Layer 2 effect ` +
+          `(referenced ${Math.round(referencedMean).toLocaleString()} vs not-referenced ` +
+          `${Math.round(notReferencedMean).toLocaleString()} tokens/touch, gap ${Math.round(gap).toLocaleString()}). ` +
+          `Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
+    return {
+      publishable: true,
+      verdict:
+        `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
+      ...measured,
+    };
+  } catch {
+    return refuse(
+      'not calibrated: the calibration inputs could not be read. No gap is reported, which is not the same as a gap of zero.'
+    );
+  }
+}
+
+/**
+ * What the graph cost to build against what it carries -- AN ESTIMATE, and
+ * never priced.
+ *
+ * `consolidationRatio` is the per-finding form and the aggregate is the fold.
+ * Both need `derivedCost`, which `expand.promote` persists onto the finding
+ * node it creates (`src/server/disclosure.ts` is its caller) and which
+ * `harvest-write.mjs` does not yet carry through -- so a graph built only by
+ * the harvest reports nothing here rather than a ratio of one.
+ */
+export function consolidation(dir, { graph = null } = {}) {
+  try {
+    const g = graph || load(dir);
+    const findings = [...g.nodes.values()].filter(
+      (node) => node.kind === 'finding' && !node.retired
+    );
+    const rated = [];
+    for (const finding of findings) {
+      const ratio = consolidationRatio(finding);
+      if (ratio === null) continue;
+      rated.push({ key: finding.key, ratio, derivedCost: finding.derivedCost });
+    }
+    const aggregate = aggregateConsolidation(findings);
+    return {
+      what: 'cost to derive against cost to carry',
+      // SAID IN THE DATA, not only in the prose above it, because this is the
+      // field a dashboard will read and a dashboard will not read a comment.
+      basis: 'estimate',
+      priced: false,
+      findings: findings.length,
+      withDerivedCost: rated.length,
+      aggregate,
+      best: rated.sort((a, b) => b.ratio - a.ratio).slice(0, 5),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The balance sheet with the graph's own three measurements attached.
+ *
+ * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
+ * imports, so it cannot import them back. This is where the two meet, and it
+ * is the shape `get_optimization_report` serves.
+ */
+export function graphBalanceSheet(dir, options = {}) {
+  const sheet = balanceSheet(dir);
+  const cal = calibration(dir, options);
+  const { layer1 = null, layer2 = null } = cal;
+  return {
+    ...sheet,
+    layer1,
+    layer2,
+    calibration: cal,
+    consolidation: consolidation(dir, options),
+  };
+}
+
+/**
+ * One audit line, or null when there is nothing honest to say.
+ *
+ * Silent when NEITHER layer has produced anything: a reader of a graph that has
+ * never injected a finding is owed no paragraph about a loop that has not
+ * started. The moment either side speaks, the refusal is worth printing --
+ * because at that point a reader could otherwise take Layer 1's rate for a
+ * saving, which is precisely what this loop exists to stop.
+ */
+export function calibrationNote(dir, options = {}) {
+  try {
+    const result = calibration(dir, options);
+    const l1 = result.layer1;
+    const l2 = result.layer2;
+    if (!l1 || !l2) return null;
+    if (l1.denominator === 0 && l2.observations === 0) return null;
+    return `Layer 1 against Layer 2: ${result.verdict}`;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/codex/plugin/hooks/lib/crosslayer.mjs
+++ b/integrations/codex/plugin/hooks/lib/crosslayer.mjs
@@ -54,7 +54,13 @@
 
 import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
-import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import {
+  effects,
+  observations,
+  servingPolicyVersion,
+  permutationP,
+  FDR_Q,
+} from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
 import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
@@ -106,6 +112,32 @@ export function labelsByFinding(rows) {
 }
 
 const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * A deterministic, label-symmetric permutation test for the headline gap.
+ *
+ * Layer 2 only publishes a per-finding row after a two-sided permutation test.
+ * The calibration headline summarises those rows, so a positive difference of
+ * arm means must clear the same evidential bar rather than being promoted just
+ * because it points in this project's favour.
+ *
+ * Sorting within each arm and then sorting the two arms makes the sampled path
+ * invariant to event order and to swapping the labels. The seed is derived
+ * from that canonical data instead of shared globally, so two different
+ * datasets do not reuse one arbitrary sequence of sampled relabellings.
+ */
+export function calibrationP(referenced, notReferenced) {
+  const arms = [referenced, notReferenced]
+    .map((values) => [...values].sort((a, b) => a - b))
+    .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  const encoded = JSON.stringify(arms);
+  let seed = 2166136261;
+  for (const char of encoded) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return permutationP(arms[0], arms[1], { seed: seed >>> 0 });
+}
 
 /**
  * Does Layer 1's label predict Layer 2's effect?
@@ -244,7 +276,16 @@ export function calibration(dir, options = {}) {
     const referencedMean = mean(arms.referenced);
     const notReferencedMean = mean(arms.notReferenced);
     const gap = referencedMean - notReferencedMean;
-    const measured = { ...context, gap, referencedMean, notReferencedMean };
+    const p = calibrationP(arms.referenced, arms.notReferenced);
+    const measured = {
+      ...context,
+      gap,
+      referencedMean,
+      notReferencedMean,
+      p,
+      alpha: FDR_Q,
+      test: 'two-sided permutation',
+    };
 
     if (!(gap >= MIN_GAP_TOKENS))
       return refuse(
@@ -255,11 +296,20 @@ export function calibration(dir, options = {}) {
         measured
       );
 
+    if (p === null || p > FDR_Q)
+      return refuse(
+        `not calibrated: the positive Layer 1/Layer 2 gap is not statistically resolved by the ` +
+          `two-sided permutation test (p=${p === null ? 'unavailable' : p.toFixed(3)}, ` +
+          `alpha=${FDR_Q.toFixed(3)}). Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
     return {
       publishable: true,
       verdict:
         `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
-        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, ` +
+        `shrunk estimates, two-sided permutation p=${p.toFixed(3)}). ` +
         `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
       ...measured,
     };

--- a/integrations/codex/plugin/hooks/lib/crosslayer.mjs
+++ b/integrations/codex/plugin/hooks/lib/crosslayer.mjs
@@ -56,6 +56,7 @@ import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
 import { effects, observations, servingPolicyVersion } from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
 
 /**
@@ -309,11 +310,19 @@ export function consolidation(dir, { graph = null } = {}) {
 }
 
 /**
- * The balance sheet with the graph's own three measurements attached.
+ * The balance sheet with the graph's own measurements attached.
  *
  * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
  * imports, so it cannot import them back. This is where the two meet, and it
  * is the shape `get_optimization_report` serves.
+ *
+ * `recall` joins them as an OFFLINE PROBE, and that label travels in the data
+ * (`recall.basis`) as well as in the rendered line. It is not an observation of
+ * anything a session did: it deletes an anchor edge in memory and re-runs the
+ * real retrieval primitives over the graph as it stands right now. `recall.mjs`
+ * imports only `wiki.mjs` and `lexical.mjs`, neither of which imports anything
+ * in this direction, so no cycle -- the same reason `calibration` had to live
+ * here rather than in `metrics.mjs`.
  */
 export function graphBalanceSheet(dir, options = {}) {
   const sheet = balanceSheet(dir);
@@ -325,6 +334,7 @@ export function graphBalanceSheet(dir, options = {}) {
     layer2,
     calibration: cal,
     consolidation: consolidation(dir, options),
+    recall: recallProbe(dir, options),
   };
 }
 

--- a/integrations/codex/plugin/hooks/lib/derive.mjs
+++ b/integrations/codex/plugin/hooks/lib/derive.mjs
@@ -23,13 +23,21 @@
  * the observation supports no claim at all are refused rather than downgraded
  * (see `attemptKey` and the identical-text guard below).
  *
- * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
- * budget, belongs to the caller.
+ * WHAT IS STORED IS BOUNDED. Candidates go through `selectForConsolidation`
+ * before `writeHarvested`, so a long session cannot spend the whole retrieval
+ * budget of every later session on one afternoon's exit codes. Nothing enters
+ * the graph unbudgeted, and nothing enters it wearing a human origin.
  */
 
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
 import { readArchive, readTurns } from './transcript.mjs';
 import { redact } from './redact.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { load } from './wiki.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -106,6 +114,92 @@ const triggerFor = (command) =>
   attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
 
 /**
+ * Literal root-level files that define how a project is BUILT, RUN and TESTED,
+ * best first. A `command` claim is a claim about this project's commands, and
+ * this is the file those commands are declared in.
+ */
+const PROJECT_MARKERS = [
+  'package.json', 'pyproject.toml', 'Cargo.toml', 'go.mod', 'pom.xml',
+  'build.gradle.kts', 'build.gradle', 'build.sbt', 'mix.exs', 'composer.json',
+  'Gemfile', 'Package.swift', 'CMakeLists.txt', 'Makefile', 'Taskfile.yml',
+  'requirements.txt', 'setup.py', 'deno.json', 'bun.lockb',
+];
+
+/** .NET has no single literal marker; the solution or project file is one. */
+const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
+
+/**
+ * A REAL FILE to anchor a derived claim to, inside the project root.
+ *
+ * WHY NOT THE PROJECT ROOT ITSELF, which is what the extraction step reaches
+ * for and what `promoteToShared` uses in the shared tier. Because
+ * `writeHarvested` resolves every anchor through `indexFile`, `indexFile` reads
+ * the path, and reading a DIRECTORY returns null -- so a candidate anchored to
+ * `projectRoot` resolves to nothing, is refused as unanchorable, and the whole
+ * pipeline stores zero findings while reporting a healthy candidate count.
+ * Verified directly: `indexFile(dir, dir)` returns null. That refusal is
+ * correct and must not be weakened -- an anchor that cannot be indexed is an
+ * anchor that can never be invalidated -- so the anchor has to be a file.
+ *
+ * STALENESS DOES NOT MISFIRE ON THIS. `command`, `failure` and `feedback` are
+ * all outside `CONTENT_DEPENDENT` (staleness.mjs), so the anchor is a RETRIEVAL
+ * AND EXISTENCE hook rather than a contents claim: editing the manifest does
+ * not mark these findings stale. staleness.mjs names this exact case in its own
+ * comment -- "a claim about `npm test` anchored to package.json" -- and calls
+ * missing that invalidation the better error.
+ *
+ * A project with no recognisable marker gets the root back, which will not
+ * resolve, so its candidates are derived and then refused rather than stored
+ * against a fabricated anchor. That is the fail-open direction: no finding
+ * beats a finding anchored to something that is not what the claim is about.
+ */
+export function projectAnchor(projectRoot) {
+  if (!projectRoot) return null;
+  let entries;
+  try {
+    entries = readdirSync(projectRoot);
+  } catch {
+    return projectRoot;
+  }
+  const present = new Set(entries);
+  for (const marker of PROJECT_MARKERS) {
+    if (!present.has(marker)) continue;
+    const path = join(projectRoot, marker);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // A marker that cannot be stat'ed is not a marker.
+    }
+  }
+  // Sorted so two sessions in the same repository pick the SAME solution file:
+  // readdir order is not guaranteed stable across hosts, and an anchor that
+  // varies by host splits one finding into two nodes.
+  for (const entry of [...entries].sort()) {
+    if (!DOTNET_MARKER.test(entry)) continue;
+    const path = join(projectRoot, entry);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // Same.
+    }
+  }
+  return projectRoot;
+}
+
+/**
+ * Tokens of claim text one session may add to the graph.
+ *
+ * SCALED TO THE RETRIEVAL BUDGET IT COMPETES FOR, not picked round. A single
+ * command's injection budget is 500 tokens (`TOKEN_OPTIMIZER_TOUCH_BUDGET`),
+ * and everything stored here is competing for that budget on every later
+ * command, forever. Two touch-budgets per session is the bound: enough for a
+ * few dozen real claims, and short of one session's exit codes crowding out
+ * every finding a human or a model ever wrote.
+ */
+const storageBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_DERIVE_BUDGET) || 1000;
+
+/**
  * Derives finding candidates from one project's local evidence.
  *
  * @param {string} dir wiki directory.
@@ -118,11 +212,18 @@ const triggerFor = (command) =>
  *   and is refused by `writeHarvested` anyway, so emitting one would only spend
  *   the caller's budget on junk.
  * @param {string|null} options.authoritativeSessionId the session id as the HOOK
- *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
- *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
- *   edge -- `taskForAnchors` returns null without one, so an unverified string
- *   would silently produce no edge. Threaded rather than defaulted from
- *   `sessionId`: defaulting would promote any caller's string to trusted.
+ *   PAYLOAD reported it, never a value a model typed. Passed straight to
+ *   `writeHarvested`, which needs it to resolve the `answers` edge --
+ *   `taskForAnchors` returns null without one, so an unverified string would
+ *   silently produce no edge. Threaded rather than defaulted from `sessionId`:
+ *   defaulting would promote any caller's string to trusted. Also returned, so a
+ *   caller can see what it handed over.
+ * @returns {object} `{ candidates, observations, written, selected, dropped,
+ *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
+ *   everything derived; `written` is the subset of keys the graph actually
+ *   holds, which is smaller for three independent reasons -- the budget, the
+ *   anchor discipline, and the duplicate collapse that returns an EXISTING key
+ *   when a later session derives the same claim again.
  */
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
@@ -152,6 +253,11 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // ONE anchor for the whole run, so every candidate from this session points at
+  // the same node and the duplicate collapse in `writeHarvested` can recognise
+  // the same lesson across sessions.
+  const anchorPath = projectAnchor(projectRoot);
 
   const seen = new Set();
   const add = (candidate) => {
@@ -246,7 +352,7 @@ export function derive(dir, options = {}) {
               `observed in one session: \`${failed.command}\` failed` +
                 `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
                 `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
-                'an intervening edit or a flaky run explains the same pair.',
+                'an intervening edit or an unrelated environment change explains the same pair.',
               { max: EVIDENCE_MAX }
             ),
             applicability: 'when about to run this command in this project',
@@ -255,7 +361,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the failing form later succeeds unchanged'],
             trigger: triggerFor(outcome.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: outcome.at || Date.now(),
@@ -280,7 +386,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the same command later succeeds unchanged'],
             trigger: triggerFor(failed.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: failed.at || Date.now(),
@@ -330,7 +436,7 @@ export function derive(dir, options = {}) {
           confidenceLabel: labelFor(CONFIDENCE.correction),
           scope: 'project',
           invalidators: ['the user later asks for the corrected behaviour'],
-          anchors: [projectRoot],
+          anchors: [anchorPath],
           derivedBy: 'correction',
           sessionId,
           at: Date.parse(turn.at || '') || Date.now(),
@@ -379,6 +485,48 @@ export function derive(dir, options = {}) {
     }
   } catch {
     // One detector, never the session.
+  }
+
+  // ---- storage, under a budget -------------------------------------------
+  //
+  // NOTHING ENTERS THE GRAPH UNBUDGETED. `selectForConsolidation` existed for
+  // exactly this and had no caller, which meant that until now nothing bounded
+  // what a session could add. It admits `failure` and `decision` on a FLOOR
+  // before ranking -- a dead end exists nowhere else and is small, and cheap to
+  // find is not cheap to find again -- then fills the remainder by
+  // cost x irrecoverability x reuse-probability.
+  //
+  // ORIGIN_HARVESTED, EXPLICITLY, never ORIGIN_HUMAN. These are machine
+  // derivations; `curate.mjs` states the reason in its own header -- "a
+  // hand-written assertion and a machine guess look identical three months
+  // later, which quietly destroys the reader's ability to calibrate trust".
+  // `writeHarvested` would refuse a batch-wide human origin anyway, and a
+  // candidate here carries neither `origin` nor `quote`, so it cannot earn one
+  // per finding either. That is deliberate: whether a turn was a correction at
+  // all is a lexical guess, and the standing-rules layer selects on human
+  // origin to inject on EVERY turn.
+  try {
+    if (result.candidates.length) {
+      const selected = selectForConsolidation(load(dir), result.candidates, {
+        budget: storageBudget(),
+      });
+      result.selected = selected.kept.length;
+      result.dropped = selected.dropped;
+      result.selectedTokens = selected.tokens;
+      result.written = writeHarvested(dir, selected.kept, {
+        sessionId,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        // The hook payload's own identity, passed through untouched. Without it
+        // `taskForAnchors` returns null and the `answers` edge never fires --
+        // which is the state a default install has been in, because its only
+        // other producer is credential-gated.
+        authoritativeSessionId,
+      });
+    }
+  } catch {
+    // Storage is the last step and the session is already over. A graph write
+    // that fails must not turn a completed session into a hook error.
   }
 
   return result;

--- a/integrations/codex/plugin/hooks/lib/derive.mjs
+++ b/integrations/codex/plugin/hooks/lib/derive.mjs
@@ -139,17 +139,19 @@ const quotable = (command) => {
  * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
  * found across 163 transcripts on this machine it refuses 2 and keeps 6.
  *
- * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
- * building the key, so the claim is about `npm test` rather than about the `cd`.
- * That changes `attemptKey` for every client and every finding already derived
- * from it, so it belongs in its own change with its own comparison.
+ * `commandBody` below now skips a leading `cd <path> &&`, so those two are
+ * recovered and this guard is left holding only the keys that reached a
+ * separator which is NOT a directory change -- `git fetch && <anything>`, a
+ * pipeline, a `;`-joined pair. Those still name no single attempt.
  */
 const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
 
 /**
  * Did `attemptKey` actually capture a command, or only how one was chained?
  *
- * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart --
+ * which now means AFTER `commandBody` has removed any leading `cd`, so this no
+ * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
 const hasAttemptIdentity = (command) =>
@@ -177,6 +179,81 @@ const CORRECTION_OPENER =
   /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
 
 /**
+ * A leading directory change, stripped before the key is built.
+ *
+ * THE MEASURED CASE, AND ONLY THE MEASURED CASE. `attemptKey` spends up to
+ * three non-flag tokens on identity and the habit on this machine is
+ * `cd <absolute path> && <the real command>`, which spends all three on `cd`,
+ * the path and the separator. This repository's own corpus: 1,400 of 2,243
+ * command outcomes open with a `cd`, and the single key
+ * `cd c:/users/.../token-optimizer-mcp &&` covered 547 distinct command lines.
+ * A `cd` says WHERE a command ran; it says nothing about WHAT ran, so it cannot
+ * be part of the identity of an attempt.
+ *
+ * THE SEPARATOR SET IS THE ONE THAT WAS OBSERVED: `&&` (1,147), a newline (204)
+ * and `;` (38) after a leading `cd`. All three mean "then run this". `||` is
+ * DELIBERATELY EXCLUDED even though it costs one line to add: `cd x || echo
+ * failed` puts an error branch after the separator, not the next step, so
+ * stripping there would key the attempt on a failure handler. It occurred zero
+ * times.
+ *
+ * AND NOTHING WIDER, each refusal for a reason from the same corpus:
+ *
+ *   Environment assignments (`FOO=bar cmd`) DO carry information about what
+ *   ran. The one true instance here is
+ *   `TOKEN_OPTIMIZER_HOLDOUT=1 node ... jest.js ...`, and the holdout arm is a
+ *   genuinely different attempt from the same command without it. The other 20
+ *   are shell variable assignments joined by `;` -- statements, not prefixes --
+ *   whose value is usually a 120-character path that would be stripped down to
+ *   nothing useful.
+ *
+ *   `time`, `env`, `nice`, `sudo`, `bash -c`, `pushd`, `Set-Location`: ZERO
+ *   occurrences in 2,243 commands. Code for an unmeasured prefix is a way to
+ *   over-strip that no evidence asked for, and over-stripping merges commands
+ *   that genuinely differ -- the same bug in the other direction. `bash -c` is
+ *   worse than unmeasured: the command sits inside a quoted string, so stripping
+ *   the wrapper leaves a key beginning with a quote character.
+ *
+ *   `cd /d C:\path &&` and `cd "C:/a b" &&` need no extra rule -- the match runs
+ *   to the separator rather than counting tokens, so flags and quoted paths
+ *   containing spaces are consumed for free. Neither appears here, so neither is
+ *   claimed as tested behaviour beyond its unit test.
+ *
+ * A `cd` with NO separator is left alone: `cd <path>` on its own ran no command,
+ * and its key is as meaningless afterwards as before -- there is nothing to
+ * recover. Stripping is repeated up to `MAX_DIR_PREFIXES` times so
+ * `cd a && cd b && cmd` reaches `cmd`; the bound exists only so a pathological
+ * line cannot loop, since each pass must consume a whole `cd ... <sep>`.
+ *
+ * APPLIED IDENTICALLY TO BOTH SOURCES because it is applied INSIDE `attemptKey`,
+ * which is the single function both the event path and the transcript reader's
+ * output pass through. The 120-character anchor cap that makes the two agree on
+ * 266 of 266 keys is untouched and still applied on both sides before this runs.
+ */
+const DIR_PREFIX = /^\s*cd\s[^\r\n;&|]*?(?:&&|;|\r?\n)\s*/i;
+const MAX_DIR_PREFIXES = 4;
+
+/**
+ * The command text with any leading directory change removed.
+ *
+ * Used for the key AND for the identical-text refusal, which is the half that
+ * keeps this from becoming a licence to pair more loosely: without it,
+ * `cd repo && npm test` failing and `npm test` succeeding would emit
+ * "`npm test` succeeded where `cd repo && npm test` failed" at 0.90 -- two
+ * spellings of one attempt, dressed up as a difference that mattered. The
+ * claim itself still quotes the RAW command, because that is what ran.
+ */
+export function commandBody(command) {
+  let text = String(command || '');
+  for (let i = 0; i < MAX_DIR_PREFIXES; i++) {
+    const stripped = text.replace(DIR_PREFIX, '');
+    if (stripped === text) break;
+    text = stripped;
+  }
+  return text;
+}
+
+/**
  * The prefix that makes two invocations "the same attempt".
  *
  * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
@@ -194,7 +271,7 @@ const CORRECTION_OPENER =
  * ships a false claim into model context.
  */
 export function attemptKey(command) {
-  return String(command || '')
+  return commandBody(command)
     .trim()
     .split(/\s+/)
     .filter((token) => token && !token.startsWith('-'))
@@ -494,7 +571,14 @@ export function derive(dir, options = {}) {
           // is real and supports NEITHER claim, so nothing is emitted. This is
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
-          if (failed.command === outcome.command) continue;
+          // COMPARED WITH THE DIRECTORY CHANGE REMOVED, for the same reason
+          // the key is. `cd repo && npm test` and `npm test` are one attempt
+          // spelled two ways; before `commandBody` they landed in different
+          // groups and never met, and letting them meet without widening this
+          // guard would emit "`npm test` succeeded where `cd repo && npm test`
+          // failed" at 0.90 -- a difference in the claim that is not a
+          // difference in what ran. Same for two `cd`s to different paths.
+          if (commandBody(failed.command) === commandBody(outcome.command)) continue;
 
           // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
           // client both sides of almost every pair are truncated multi-line
@@ -502,10 +586,12 @@ export function derive(dir, options = {}) {
           // spending the retrieval budget of every later session.
           if (!quotable(failed.command) || !quotable(outcome.command)) continue;
 
-          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
-          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
-          // command lines in this repository alone, and any pair drawn from that
-          // group is a false claim about both halves.
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`. The
+          // `cd <path> &&` case that grouped 547 unrelated command lines in this
+          // repository is now handled earlier by `commandBody`; what is left
+          // here is every OTHER separator -- `git fetch && <anything>`, a
+          // pipeline, a `;`-joined pair -- where the key still names no single
+          // attempt and any pair drawn from it is false about both halves.
           if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =

--- a/integrations/codex/plugin/hooks/lib/derive.mjs
+++ b/integrations/codex/plugin/hooks/lib/derive.mjs
@@ -1,0 +1,385 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/derive.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Findings from data we already hold, with no model call.
+ *
+ * WHY THIS EXISTS. The semantic harvest is on by default but its real gate is a
+ * credential: `harvestMode()` returns `off:no-key` on any machine without one,
+ * which is CI, corporate laptops, and every subscription-only login. This
+ * repository's own graph is the evidence -- 2,965 symbol nodes, 904 file nodes,
+ * 128 task nodes and ONE finding -- because the structural layer accumulates
+ * from ordinary tool traffic while every verdict needed an API key this machine
+ * does not have.
+ *
+ * Everything here is derived from outcomes, transitions and corrections that are
+ * ALREADY RECORDED LOCALLY. Nothing is sent anywhere, nothing is billed, so
+ * there is nothing to consent to and this runs by default. It is the only
+ * finding producer on a machine without a key.
+ *
+ * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
+ * second command fixed the first -- an intervening edit, a dependency install or
+ * a flaky test explains it just as well. So each detector carries a confidence
+ * ceiling, the claim text says only what was OBSERVED, and the two shapes where
+ * the observation supports no claim at all are refused rather than downgraded
+ * (see `attemptKey` and the identical-text guard below).
+ *
+ * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
+ * budget, belongs to the caller.
+ */
+
+import { readMetrics, rereadsByAnchor } from './metrics.mjs';
+import { readArchive, readTurns } from './transcript.mjs';
+import { redact } from './redact.mjs';
+
+/**
+ * Ceilings, ordered by how much the evidence actually supports.
+ *
+ * A command that succeeded where a DIFFERENT command failed is close to a direct
+ * observation. A test or build going red-to-green is weaker, because the usual
+ * cause is the code changing between the two runs rather than anything about the
+ * command. A correction is a lexical guess about what a human meant. Churn
+ * describes our own reading behaviour and says nothing about the code at all.
+ */
+export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+
+/** Claim text cap. A finding is one sentence; a paragraph is evidence. */
+const CLAIM_MAX = 300;
+const EVIDENCE_MAX = 400;
+
+/** Bounded so a pathological log cannot turn session end into real work. */
+const MAX_CANDIDATES = 200;
+
+/**
+ * Commands whose red-to-green transition is usually explained by the CODE
+ * changing rather than by the command. They get the lower ceiling.
+ */
+const CODE_SENSITIVE = /\b(test|tests|jest|vitest|pytest|mocha|build|compile|tsc|lint|typecheck)\b/i;
+
+/**
+ * Openers that mark a user turn as a correction rather than an instruction.
+ *
+ * DELIBERATELY NARROW, and anchored to the START of the turn. The model-based
+ * extractor in `lessons.mjs` can read intent; this cannot, so it only claims the
+ * shapes where the first few words carry the whole signal. Recall is poor by
+ * design: a missed correction costs one finding, a false one puts words in the
+ * user's mouth at 0.6 confidence.
+ */
+const CORRECTION_OPENER =
+  /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
+
+/**
+ * The prefix that makes two invocations "the same attempt".
+ *
+ * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
+ * through what the alternatives do to real command lines:
+ *
+ *   Two tokens conflates `npm run build` with `npm run test`, and the pair then
+ *   produces "`npm run test` works where `npm run build` failed" -- a claim that
+ *   is simply false.
+ *
+ *   Counting flags splits `deploy` from `deploy --retry`, which is the single
+ *   most useful pair this detector can find, into two groups that never meet.
+ *
+ * Conservative in the remaining direction: `npm run build:prod` and
+ * `npm run build` do not pair. A missed pair costs one finding; a wrong pair
+ * ships a false claim into model context.
+ */
+export function attemptKey(command) {
+  return String(command || '')
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'))
+    .slice(0, 3)
+    .join(' ')
+    .toLowerCase();
+}
+
+/** Normalised claim text, so the same lesson derived twice is one candidate. */
+const claimKey = (type, claim) =>
+  `${type}|${String(claim).toLowerCase().replace(/\s+/g, ' ').trim()}`;
+
+/** 0.95 is reserved for verified; everything here is inference. */
+const labelFor = (confidence) => (confidence >= 0.75 ? 'probable' : 'speculative');
+
+/** A literal command prefix, safe to hand to `safeTrigger`. */
+const triggerFor = (command) =>
+  attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
+
+/**
+ * Derives finding candidates from one project's local evidence.
+ *
+ * @param {string} dir wiki directory.
+ * @param {object} options
+ * @param {string|null} options.sessionId session this ran for, for provenance.
+ * @param {string|null} options.transcriptPath live transcript, read only when the
+ *   archive holds nothing for this session yet.
+ * @param {string|null} options.projectRoot the anchor every derived claim gets.
+ *   Without it nothing is derived: an unanchored finding cannot be invalidated
+ *   and is refused by `writeHarvested` anyway, so emitting one would only spend
+ *   the caller's budget on junk.
+ * @param {string|null} options.authoritativeSessionId the session id as the HOOK
+ *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
+ *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
+ *   edge -- `taskForAnchors` returns null without one, so an unverified string
+ *   would silently produce no edge. Threaded rather than defaulted from
+ *   `sessionId`: defaulting would promote any caller's string to trusted.
+ */
+export function derive(dir, options = {}) {
+  // `options || {}` rather than a destructuring default. A default only fires on
+  // `undefined`, so a caller passing an explicitly null options object -- which
+  // is what a hook does when it has nothing to say -- threw a TypeError out of
+  // the parameter list itself, before any of the try/catch below could fail open.
+  const {
+    sessionId = null,
+    transcriptPath = null,
+    projectRoot = null,
+    authoritativeSessionId = null,
+  } = options || {};
+
+  const result = {
+    candidates: [],
+    observations: [],
+    written: [],
+    sessionId,
+    authoritativeSessionId,
+  };
+
+  let events;
+  try {
+    events = readMetrics(dir);
+  } catch {
+    // Session end must cost nothing. No evidence is not an error.
+    return result;
+  }
+  if (!Array.isArray(events)) return result;
+
+  const seen = new Set();
+  const add = (candidate) => {
+    if (result.candidates.length >= MAX_CANDIDATES) return;
+    const key = claimKey(candidate.type, candidate.claim);
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.candidates.push(candidate);
+  };
+
+  // ---- 1 & 2: a failed attempt followed by a succeeding one ---------------
+  //
+  // The event is `tool-outcome` and THE COMMAND TEXT IS IN `anchor`: there is no
+  // separate command field, because the anchor of a command surface IS the
+  // command. It is capped at 120 characters at the boundary, so a very long
+  // command line is compared and quoted truncated.
+  try {
+    if (projectRoot) {
+      const outcomes = events
+        .filter(
+          (e) =>
+            e &&
+            e.kind === 'tool-outcome' &&
+            e.surface === 'command' &&
+            typeof e.anchor === 'string' &&
+            e.anchor.trim()
+        )
+        .map((e) => ({
+          command: e.anchor.trim(),
+          output: typeof e.output === 'string' ? e.output : '',
+          exit: Number.isInteger(e.exit) ? e.exit : null,
+          at: e.at ?? 0,
+          // `success` FIRST, `exit` only as a refinement. MCP tools report no
+          // numeric code at all, so a classifier keyed on `exit !== 0` would be
+          // inert for most clients -- and `exit` is null rather than 0 precisely
+          // so that absence is not read as a clean exit.
+          failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
+        }))
+        .sort((a, b) => a.at - b.at);
+
+      const byAttempt = new Map();
+      for (const outcome of outcomes) {
+        const key = attemptKey(outcome.command);
+        if (!key) continue;
+        if (!byAttempt.has(key)) byAttempt.set(key, []);
+        byAttempt.get(key).push(outcome);
+      }
+
+      for (const run of byAttempt.values()) {
+        // The NEAREST preceding failure, not the first one in the session. With
+        // `find` over the whole run, a command that failed at 09:00 and
+        // succeeded at 17:00 after nine unrelated attempts is reported as one
+        // story.
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          // One pair per failure: a command that succeeds twice afterwards has
+          // not taught two lessons.
+          lastFailure = null;
+
+          // THE GUARD THAT REMOVES THE LARGEST JUNK CLASS. The commonest shape
+          // in a coding session is `npm run build` failing, the code being
+          // fixed, and `npm run build` succeeding -- identical text. From that
+          // pair the two available claims are "`npm run build` works where
+          // `npm run build` failed", which is incoherent, and "`npm run build`
+          // fails", which the same evidence has just disproved. The observation
+          // is real and supports NEITHER claim, so nothing is emitted. This is
+          // not a confidence question; a ceiling cannot rescue a claim whose
+          // content is wrong.
+          if (failed.command === outcome.command) continue;
+
+          const codeSensitive =
+            CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);
+          const confidence = codeSensitive ? CONFIDENCE.test : CONFIDENCE.command;
+          const derivedBy = codeSensitive ? 'test-transition' : 'command-transition';
+
+          // "SUCCEEDED WHERE", NOT "FIXES". What is observed is two outcomes in
+          // order on the same attempt; that the difference in the command line
+          // CAUSED the difference in outcome is not observed and is not claimed.
+          add({
+            type: 'command',
+            claim: redact(
+              `\`${outcome.command}\` succeeded in this project where \`${failed.command}\` failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
+                'an intervening edit or a flaky run explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: 'when about to run this command in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the failing form later succeeds unchanged'],
+            trigger: triggerFor(outcome.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+
+          // The error text, only when there is error text. Without it the claim
+          // degrades to "`X` failed with:" and nothing after the colon, which
+          // carries no information and still costs budget.
+          const firstLine = failed.output.split('\n').find((line) => line.trim()) || '';
+          if (firstLine.trim().length < 8) continue;
+          add({
+            type: 'failure',
+            claim: redact(`\`${failed.command}\` failed with: ${firstLine.trim()}`, {
+              max: CLAIM_MAX,
+            }),
+            evidence: redact(`captured output of the failing run:\n${failed.output}`, {
+              max: EVIDENCE_MAX,
+            }),
+            applicability: 'when this command is about to be run in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the same command later succeeds unchanged'],
+            trigger: triggerFor(failed.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: failed.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 3: user corrections ------------------------------------------------
+  //
+  // A `feedback` finding -- the one type whose source is a person saying the
+  // agent was wrong. The MODEL-BASED extractor for this lives in `lessons.mjs`
+  // and needs the credential this module exists to do without, so here the
+  // signal is lexical: the opening words of the user's own turn.
+  //
+  // ORIGIN IS NOT PROMOTED. `writeHarvested` grants ORIGIN_HUMAN to a finding
+  // carrying a verified verbatim quote, and the standing-rules layer selects on
+  // that origin to inject a claim on EVERY turn. The quote here would be
+  // verbatim -- it is copied out of the archive -- but whether the turn was a
+  // correction at all is a guess, and a guess must not buy always-on injection.
+  // So no `origin` and no `quote` field: this stays harvested provenance.
+  try {
+    if (projectRoot) {
+      let turns = readArchive(dir, sessionId);
+      // The archive is written by the Stop hook too, and the order of the two is
+      // not this module's to assume, so fall back to the live transcript.
+      if (!turns.length && transcriptPath) turns = readTurns(transcriptPath);
+
+      for (const turn of turns) {
+        if (!turn || turn.role !== 'user') continue;
+        const text = String(turn.text || '').trim();
+        // Long turns are new instructions with a complaint somewhere inside
+        // them; truncating one into a claim would misquote the user.
+        if (text.length < 12 || text.length > 300) continue;
+        if (!CORRECTION_OPENER.test(text)) continue;
+        add({
+          type: 'feedback',
+          claim: redact(text, { max: CLAIM_MAX }),
+          evidence: redact(`the user opened a turn with a correction: "${text}"`, {
+            max: EVIDENCE_MAX,
+          }),
+          applicability: 'when working in this project, before repeating what was corrected',
+          confidence: CONFIDENCE.correction,
+          confidenceLabel: labelFor(CONFIDENCE.correction),
+          scope: 'project',
+          invalidators: ['the user later asks for the corrected behaviour'],
+          anchors: [projectRoot],
+          derivedBy: 'correction',
+          sessionId,
+          at: Date.parse(turn.at || '') || Date.now(),
+        });
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 4: re-read churn ---------------------------------------------------
+  //
+  // NOT A FINDING, AND THAT IS THE DECISION RATHER THAN AN OMISSION.
+  //
+  // Churn is a claim about OUR OWN reading behaviour: "this file was read three
+  // times unchanged". Every finding type available is a claim about the work --
+  // `map` describes how an area of the codebase is laid out, and is
+  // content-dependent, so a churn claim filed as `map` would be checked for
+  // staleness against contents it makes no claim about and flip stale on the
+  // first edit to a file it never described. Worse, the anchors it would take
+  // are by construction the HOTTEST files in the project, which are exactly the
+  // files that already carry real findings, so a 0.4-confidence row saying
+  // nothing actionable would sit in the injection budget beside them and render
+  // on the same reads. Nothing a future agent could DO differently follows from
+  // it: it does not say what the file contains, so it cannot substitute for
+  // reading it.
+  //
+  // The signal is still worth having -- as the measurement it already is.
+  // `rereadWaste` reports it on the balance sheet, `rereadsByAnchor` names the
+  // offenders, and this returns those rows as OBSERVATIONS: computed, carried,
+  // and deliberately not competing for context. Three detectors produce
+  // findings; the fourth produces a number.
+  try {
+    for (const row of rereadsByAnchor(events).slice(0, 3)) {
+      if (!row.anchor || row.wasteful < 2) continue;
+      result.observations.push({
+        kind: 'churn',
+        anchor: row.anchor,
+        repeats: row.repeats,
+        wasteful: row.wasteful,
+        tokens: row.tokens,
+        confidence: CONFIDENCE.churn,
+        derivedBy: 'churn',
+        note: `re-read ${row.repeats} times, ${row.wasteful} of them unchanged`,
+      });
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  return result;
+}

--- a/integrations/codex/plugin/hooks/lib/derive.mjs
+++ b/integrations/codex/plugin/hooks/lib/derive.mjs
@@ -16,6 +16,13 @@
  * there is nothing to consent to and this runs by default. It is the only
  * finding producer on a machine without a key.
  *
+ * THREE SOURCES, NOT TWO. `tool-outcome` events, the transcript archive, and --
+ * since the transition detectors were measured to have no input at all on the
+ * primary client -- the raw transcript's FAILED tool results, which is the only
+ * place a Claude Code failure is recorded (`failedResultsFromTranscript` in
+ * transcript.mjs, and the note above `quotable` for what that measurement
+ * actually yielded).
+ *
  * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
  * second command fixed the first -- an intervening edit, a dependency install or
  * a flaky test explains it just as well. So each detector carries a confidence
@@ -32,7 +39,11 @@
 import { readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
-import { readArchive, readTurns } from './transcript.mjs';
+import {
+  readArchive,
+  readTurns,
+  failedResultsFromTranscript,
+} from './transcript.mjs';
 import { redact } from './redact.mjs';
 import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
@@ -56,6 +67,96 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * The anchor cap a command surface is stored under, restated here as a TEST.
+ *
+ * `recordToolOutcome` truncates `anchor` to 120 characters, so a command at or
+ * over that length reached this module already cut -- and `quotable` below
+ * refuses to build a claim out of the fragment.
+ */
+const COMMAND_ANCHOR_MAX = 120;
+
+/**
+ * Can this command text be QUOTED in a claim a reader could act on?
+ *
+ * THE SECOND REFUSAL OF ITS KIND, and it exists because measurement forced it.
+ * Wiring the transcript reader gave the transition detectors their first real
+ * input on this client and immediately produced four candidates at 0.9
+ * confidence whose claim text read:
+ *
+ *   `cd /c/Users/.../token-optimizer-mcp\ncat >> docs/superpowers/plans/2026-` succeeded
+ *   in this project where `cd /c/Users/.../token-optimizer-mcp\ncat > /tmp/probe3.mjs
+ *   <<'EOF'\nimport { readdirSync, readFileSync, sta` failed
+ *
+ * -- two truncated fragments of throwaway shell scripts, grouped together only
+ * because `attemptKey`'s three tokens were spent on `cd`, the absolute path, and
+ * the verb. Then measured properly across three real transcripts: **0 of 83**
+ * captured command failures are single-line and inside the cap. 65% of this
+ * project's 2,178 successful command outcomes are not either. On this client a
+ * "command" is usually a whole shell script, so the attempt identity the
+ * transition detectors are built on does not fit most of the traffic.
+ *
+ * This is the same judgement as the identical-text guard below rather than a
+ * confidence question: a claim whose subject is a truncated fragment of a
+ * program is not a weaker claim, it is not a claim. A raised cap would not
+ * rescue it -- quoting the whole 500-character heredoc is no more actionable.
+ *
+ * What survives is exactly what the detector was designed for: `npm test`,
+ * `dotnet build X`, `deploy --retry` -- a repeatable command someone could run
+ * again. This machine captured none failing, which is why the honest yield here
+ * is zero and why that is reported rather than dressed up.
+ *
+ * Applied to BOTH sources. Where the evidence arrived from has no bearing on
+ * whether the resulting sentence says anything, and a rule that let events
+ * through would ship the junk on the ten clients that do report failures.
+ */
+const quotable = (command) => {
+  const text = String(command || '');
+  return (
+    text.trim().length > 0 &&
+    !/[\r\n]/.test(text) &&
+    text.length < COMMAND_ANCHOR_MAX
+  );
+};
+
+/**
+ * Tokens that separate one command from the next rather than naming one.
+ *
+ * MEASURED, LIKE EVERY OTHER REFUSAL HERE. `attemptKey` spends up to three
+ * non-flag tokens on identity, and the habit on this machine is
+ * `cd <absolute path> && <the real command>` -- which spends all three on `cd`,
+ * the path and `&&`, so the real command never enters the key. This project's
+ * own evidence: the single key `cd c:/users/.../token-optimizer-mcp &&` covers
+ * **539 distinct command lines**. One quotable failure in that group would pair
+ * with an arbitrary unrelated success and claim "`cd repo && grep -n ...`
+ * succeeded where `cd repo && git merge ...` failed", which is false about both.
+ *
+ * A KEY THAT REACHED A SEPARATOR NEVER REACHED A COMMAND, so there is no attempt
+ * to compare and nothing to claim -- the same judgement as the identical-text
+ * guard rather than a lower ceiling. Narrow on purpose: `2>&1` and `/F` are not
+ * separators and do not trip this, so `cat commitlint.config.mjs 2>&1` and
+ * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
+ * found across 163 transcripts on this machine it refuses 2 and keeps 6.
+ *
+ * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
+ * building the key, so the claim is about `npm test` rather than about the `cd`.
+ * That changes `attemptKey` for every client and every finding already derived
+ * from it, so it belongs in its own change with its own comparison.
+ */
+const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
+
+/**
+ * Did `attemptKey` actually capture a command, or only how one was chained?
+ *
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * One check per pair is enough: both halves share the key by construction.
+ */
+const hasAttemptIdentity = (command) =>
+  attemptKey(command)
+    .split(' ')
+    .filter(Boolean)
+    .every((token) => !COMMAND_SEPARATORS.has(token));
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -274,6 +375,17 @@ export function derive(dir, options = {}) {
   // separate command field, because the anchor of a command surface IS the
   // command. It is capped at 120 characters at the boundary, so a very long
   // command line is compared and quoted truncated.
+  //
+  // TWO SOURCES OF FAILURE, ONE PAIRING LOOP. Claude Code never fires
+  // PostToolUse for a failed tool call -- 2,238 of 2,238 live `tool-outcome`
+  // events on the measuring machine carry `success: true`, and a deliberately
+  // failing command produced no event at all -- so on the primary client these
+  // two detectors had NO INPUT WHATSOEVER while working normally on the ten
+  // adapter clients. `failedResultsFromTranscript` supplies the missing half
+  // from the only place it exists. The successes still come from events only:
+  // a transcript failure that pairs with nothing stays unclaimed, which is also
+  // what keeps a failure from ANOTHER project's directory out of this project's
+  // graph -- a candidate cannot be emitted without a success recorded HERE.
   try {
     if (projectRoot) {
       const outcomes = events
@@ -290,6 +402,9 @@ export function derive(dir, options = {}) {
           output: typeof e.output === 'string' ? e.output : '',
           exit: Number.isInteger(e.exit) ? e.exit : null,
           at: e.at ?? 0,
+          // Carried purely so the transcript merge below can recognise the same
+          // tool call arriving from the other source.
+          toolCallId: e.toolCallId ? String(e.toolCallId) : null,
           // `success` FIRST, `exit` only as a refinement. MCP tools report no
           // numeric code at all, so a classifier keyed on `exit !== 0` would be
           // inert for most clients -- and `exit` is null rather than 0 precisely
@@ -297,6 +412,53 @@ export function derive(dir, options = {}) {
           failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
         }))
         .sort((a, b) => a.at - b.at);
+
+      // DEDUPLICATED ON `toolCallId`, which is the SAME STRING in both sources:
+      // `episodeMeta` reads `raw.tool_use_id` into `toolCallId`, and that is the
+      // transcript's `tool_use_id` verbatim -- verified against live evidence
+      // (`toolu_01L4Nwr...` in metrics.jsonl, the same ids in the transcript).
+      // So on the ten clients that DO report failures, the event copy wins and
+      // the transcript copy is dropped before grouping. Without this the two
+      // copies of one failure would sit in the same run and the second of them
+      // would be paired against the first as a failed-then-succeeded story about
+      // itself.
+      //
+      // The fallback covers a client that reports a failure with no call id:
+      // identical command text within two seconds is one failure recorded twice,
+      // not two failures, because nothing re-runs a command that fast.
+      const eventIds = new Set(
+        outcomes.map((o) => o.toolCallId).filter(Boolean)
+      );
+      const eventFailures = outcomes.filter((o) => o.failed);
+      const alreadyRecorded = (failure) => {
+        if (failure.toolCallId && eventIds.has(failure.toolCallId)) return true;
+        return eventFailures.some(
+          (o) =>
+            o.command === failure.command &&
+            Math.abs((o.at || 0) - (failure.at || 0)) <= 2000
+        );
+      };
+
+      let transcriptFailures = [];
+      try {
+        transcriptFailures = failedResultsFromTranscript(transcriptPath).filter(
+          (failure) => failure.command.trim() && !alreadyRecorded(failure)
+        );
+      } catch {
+        // The reader is an extra source, never a reason the detector stops.
+      }
+      for (const failure of transcriptFailures) {
+        outcomes.push({
+          command: failure.command.trim(),
+          output: failure.output,
+          exit: failure.exit,
+          at: failure.at,
+          toolCallId: failure.toolCallId,
+          // Read from `Exit code N`, which is the only shape the reader admits.
+          failed: true,
+        });
+      }
+      if (transcriptFailures.length) outcomes.sort((a, b) => a.at - b.at);
 
       const byAttempt = new Map();
       for (const outcome of outcomes) {
@@ -333,6 +495,18 @@ export function derive(dir, options = {}) {
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
           if (failed.command === outcome.command) continue;
+
+          // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
+          // client both sides of almost every pair are truncated multi-line
+          // shell scripts, and a claim quoting a fragment of one is noise
+          // spending the retrieval budget of every later session.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
+          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
+          // command lines in this repository alone, and any pair drawn from that
+          // group is a false claim about both halves.
+          if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =
             CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);

--- a/integrations/codex/plugin/hooks/lib/doctor.mjs
+++ b/integrations/codex/plugin/hooks/lib/doctor.mjs
@@ -197,7 +197,8 @@ function hooksDirFor({ hooksDir, install, root }) {
  * identical from outside: a graph that fills with structural nodes either way.
  *
  * Measured on a real 5.4.0 install: 484 symbol, 286 file and 122 task nodes and
- * ZERO findings, because harvestMode() was 'off:not-opted-in'. Fifteen checks
+ * ZERO findings, because harvestMode() then returned an opt-in refusal (the mode has
+ * since been renamed: it is 'off:no-key' now, and opting in is no longer the gate). Fifteen checks
  * passed and none mentioned harvest. stop-harvest.mjs names this exact gap --
  * "nothing in doctor, audit or waste mentions harvest, so a user sees a graph
  * filling with structural nodes and no findings and has no way to learn why" --
@@ -221,9 +222,15 @@ export function probeHarvest() {
   // optimizer is off" is noise, which is why stop-harvest maps it to no notice.
   if (mode === 'off:mode') return [];
 
+  // SAID PLAINLY, because this is the configuration a user would choose if they
+  // knew it existed and the previous wording buried it in machinery. A local
+  // endpoint is the only setting under which the semantic harvest runs with no
+  // credential, no billing and no digest leaving the machine -- so the two facts
+  // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
     return [ok('finding extraction is available',
-      'active-model wiki_write is primary; local endpoint also enables fallback extraction')];
+      'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
+      'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
@@ -233,10 +240,19 @@ export function probeHarvest() {
 
   // No second-model credential is required for the primary path. The Codex/agent session that
   // already paid to derive the conclusion is the extractor and wiki_write is local.
+  // NAME THE TRADE, not just the missing variable. This is the default state on
+  // every machine without a credential, so it is the text most users will read,
+  // and "unavailable" alone tells them neither what they are missing nor that
+  // the free option exists. Local findings still accumulate: derive.mjs reads
+  // exit codes, red-to-green transitions, corrections and churn out of evidence
+  // already on disk and sends nothing anywhere.
   if (mode === 'off:no-key') {
     return [ok('finding extraction is available',
-      'active model records durable conclusions through local wiki_write; no separate-model ' +
-      'credential is configured, so fallback transcript extraction is unavailable')];
+      'active model records durable conclusions through local wiki_write, and derive runs at ' +
+      'session end with no credential. No separate-model credential is configured, so fallback ' +
+      'transcript extraction is unavailable: point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local ' +
+      'model to run it free and private, or set TOKEN_OPTIMIZER_API_KEY to run it from a bounded ' +
+      'digest of paths, commands, prompts and conclusions -- never file contents')];
   }
 
   // off:opted-out -- a deliberate choice, reported as one. Nagging about a setting somebody chose

--- a/integrations/codex/plugin/hooks/lib/inject.mjs
+++ b/integrations/codex/plugin/hooks/lib/inject.mjs
@@ -1134,10 +1134,25 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // injected more than the budget allowed and recorded fewer tokens than it
   // spent -- in a block whose entire justification is that it is tightly
   // bounded and measured against the control arm.
+  // THE LAST LINE IS HOW THE NEXT RULE GETS HERE, and it is one line because
+  // this block is charged on every session forever. A rule reaches this list
+  // only by being pinned or by being a person's verified correction, and both
+  // start as a `wiki_write` -- so a model reading a set of standing rules with
+  // no idea how they were produced has no way to add to it. Stated at the point
+  // of the evidence rather than as a separate always-on block: the reader is
+  // already looking at the output of the mechanism being described.
+  //
+  // THE COLD GRAPH IS COVERED ELSEWHERE, deliberately. Nothing here renders
+  // until at least one rule qualifies, which is the property the always-on
+  // budget depends on, so this line cannot be the first-session nudge --
+  // `policyText`'s "Record what you work out" section is, and it is emitted at
+  // SessionStart whether or not the graph holds anything.
   const HEADING =
     '# Standing rules for this project' +
     '\n\nEstablished in previous sessions and expected to hold. ' +
-    'These are not suggestions.\n\n';
+    'These are not suggestions.\n\n' +
+    'Record what you work out with wiki_write and a real file anchor; ' +
+    'that is how a rule reaches this list.\n\n';
   const noticeFor = (n) =>
     n
       ? `\n(${n} further standing rule${n === 1 ? '' : 's'} did not fit this budget; ` +

--- a/integrations/codex/plugin/hooks/lib/inject.mjs
+++ b/integrations/codex/plugin/hooks/lib/inject.mjs
@@ -35,6 +35,7 @@ import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
 import { cacheOrdered } from './cache.mjs';
+import { withheldFor, exploreOrder, servingPolicyVersion, LOO_ENABLED } from './loo.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -311,8 +312,38 @@ export function forTouch(
     });
     for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
   }
-  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  // LAYER 2 EXPLORATION, BEFORE the budget decides.
+  //
+  // `assessed.eligible` arrives in net-utility order and `fit` keeps that order
+  // until the budget runs out -- so the ranking decides which findings are ever
+  // served, which decides which ever accumulate observations, which decides
+  // their utility. A tenth of touches therefore promote the least-served
+  // candidate first. This is the only place it can go: after `fit` the choice
+  // has already been made.
+  const ordered = exploreOrder(assessed.eligible, dir, { sessionId, anchor: filePath });
+  const { kept, spent } = fit(ordered.map((item) => item.finding), budget);
   if (!kept.length) return null;
+
+  // LAYER 2 WITHHOLDING, AFTER the budget decides, which is the only ordering
+  // that produces a leave-one-out rather than a substitution: withholding first
+  // would let the next-ranked finding take the freed tokens, so the withheld
+  // arm would differ from the served arm by two findings instead of one and the
+  // effect would belong to neither.
+  //
+  // `holdout` is passed so the two experiments cannot compose into "withhold
+  // everything and call it a leave-one-out": that arm already serves nothing.
+  const withheld = withheldFor(kept.map((finding) => finding.key), sessionId, graph, dir, {
+    surface: 'file',
+    anchor: filePath,
+    holdout,
+  });
+  const delivered = withheld ? kept.filter((finding) => finding.key !== withheld) : kept;
+  // RE-PRICED, because `fit` priced what it KEPT and this delivers less. Using
+  // `spent` would bill the injection-cost side of the balance sheet for text
+  // the model never received.
+  const deliveredSpent = withheld
+    ? delivered.reduce((sum, finding) => sum + estimate(render(finding)), 0)
+    : spent;
 
   record(dir, {
     kind: 'inject',
@@ -321,15 +352,20 @@ export function forTouch(
     surface: 'file',
     anchor: filePath,
     holdout,
-    tokens: holdout ? 0 : spent,
-    deliveredTokens: holdout ? 0 : spent,
+    tokens: holdout ? 0 : deliveredSpent,
+    deliveredTokens: holdout ? 0 : deliveredSpent,
     shadowTokens: spent,
-    count: holdout ? 0 : kept.length,
+    count: holdout ? 0 : delivered.length,
     candidateCount: kept.length,
-    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    findingIds: holdout ? [] : delivered.map((finding) => finding.key),
     shadowFindingIds: kept.map((finding) => finding.key),
-    stale: kept.some((f) => f.stale),
+    stale: delivered.some((f) => f.stale),
     sessionId,
+    // ON EVERY RECORD, not only the withheld ones. A served observation needs
+    // the policy version as much as a withheld one does, or `effects` cannot
+    // keep the two arms of one comparison inside one policy.
+    ...(LOO_ENABLED() ? { looPolicy: servingPolicyVersion() } : {}),
+    ...(withheld ? { loo: withheld } : {}),
   });
 
   // MARKED SEEN IN BOTH ARMS, for the same reason as the command path: a file
@@ -339,11 +375,16 @@ export function forTouch(
   // grow faster purely from repetition.
   //
   // This is the identical defect that was fixed in `forCommand` and not here.
+  //
+  // THE WITHHELD KEY IS MARKED TOO, and that is load-bearing rather than tidy:
+  // an unmarked one would be a candidate again on the next touch of this file,
+  // where the one-per-touch tiebreak could serve it -- flipping its arm inside
+  // the very session the arm hash exists to pin it for.
   for (const f of kept) alreadyInjected.add(f.key);
 
-  if (holdout || !kept.length) return null;
+  if (holdout || !delivered.length) return null;
 
-  return `Known about ${filePath} (from previous sessions):\n${kept.map(render).join('\n')}`;
+  return `Known about ${filePath} (from previous sessions):\n${delivered.map(render).join('\n')}`;
 }
 
 /**

--- a/integrations/codex/plugin/hooks/lib/keepwarm.mjs
+++ b/integrations/codex/plugin/hooks/lib/keepwarm.mjs
@@ -30,6 +30,15 @@ import { record, readMetrics, readBalance } from './metrics.mjs';
 import { WRITE_MULTIPLIER, READ_MULTIPLIER } from './cache.mjs';
 
 /**
+ * The shortest gap that counts as a NEW turn rather than a burst inside one.
+ *
+ * Shared by the gap distribution and by the hit test, because they have to
+ * agree about what a turn is. Two copies of this number would let the decision
+ * be fitted to one definition of a turn and scored against another.
+ */
+export const TURN_GAP_MS = 250;
+
+/**
  * TTL tiers, with what a WRITE costs at each.
  *
  * A five-minute entry is written at 1.25x a plain input token; the one-hour
@@ -85,7 +94,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
     for (let i = 1; i < session.length; i++) {
       const gap = session[i] - session[i - 1];
       // A burst of events inside one turn is not a gap between turns.
-      if (gap > 250) gaps.push(gap);
+      if (gap > TURN_GAP_MS) gaps.push(gap);
     }
   }
   if (gaps.length < 6) return null;
@@ -105,10 +114,91 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
 }
 
 /**
+ * Refreshes to observe at a tier before the observation may bound the decision.
+ *
+ * THE SAME NUMBER THE BACKSTOP DEMANDS, deliberately. The decision and the
+ * tripwire read the same ledger, so letting them disagree about when there is
+ * enough evidence would mean one of them acting on a sample the other calls too
+ * small. Below the floor the decision keeps its expected-value answer, so a
+ * single unlucky miss changes nothing at all.
+ *
+ * NOT A CONFIDENCE INTERVAL, and the reason is arithmetic rather than taste. A
+ * Wilson 95% upper bound at ten refreshes and zero hits is 0.28 -- so a policy
+ * that missed ten times out of ten would still be recommended, which is exactly
+ * the case the loop exists to catch. The point estimate is safe here because of
+ * the bound below: an observation may only ever LOWER the modelled probability,
+ * so sampling noise cannot manufacture a refresh, and the tripwire's realised
+ * ledger is a second guard underneath.
+ */
+export const OBSERVATION_FLOOR = TRIPWIRE_MIN;
+
+/**
+ * The measured hit rate per tier, from recorded outcomes.
+ *
+ * Tiers below the floor are ABSENT rather than present with a small n, because
+ * a rate carrying no weight is the thing most likely to be used as though it
+ * did.
+ */
+export function observedHitRates(outcomes = []) {
+  const byTier = new Map();
+  for (const event of outcomes) {
+    if (event?.kind !== 'keepwarm' || event.action !== 'outcome') continue;
+    const name = TIERS.some((t) => t.name === event.tier) ? event.tier : TIERS[0].name;
+    const row = byTier.get(name) || { refreshes: 0, hits: 0 };
+    row.refreshes += 1;
+    if (event.hit) row.hits += 1;
+    byTier.set(name, row);
+  }
+
+  const qualified = new Map();
+  for (const [name, row] of byTier) {
+    if (row.refreshes < OBSERVATION_FLOOR) continue;
+    qualified.set(name, { ...row, rate: row.hits / row.refreshes });
+  }
+  return qualified;
+}
+
+/**
+ * What the refreshes at this tier actually did, if enough of them have.
+ *
+ * Tolerates being handed anything -- null, a plain object, a Map -- because the
+ * callers are two public functions whose options object is assembled by other
+ * people's code.
+ */
+function observationsFor(observed, tierName) {
+  const row = observed instanceof Map ? observed.get(tierName) : null;
+  return row && Number.isFinite(row.rate) ? row : null;
+}
+
+/**
+ * The modelled probability, BOUNDED BY what was observed and never raised by it.
+ *
+ * The asymmetry is the whole point and runs against this project's interest. A
+ * recorded `hit` says only that a turn arrived before the entry expired; it
+ * cannot say the refresh is what kept the entry alive, because a turn arriving
+ * one minute after a five-minute ping would have found the entry warm anyway.
+ * So the observed rate is an UPPER bound on a refresh's value, and substituting
+ * it for the model would flatter keep-warm badly: on the machine this was
+ * written on, the modelled ping probability is 0.2% and the observable
+ * before-expiry rate is 99.5%, so the substitution would recommend refreshing
+ * forever. A low rate, by contrast, is real evidence against: if turns do not
+ * even arrive inside the TTL, the refresh certainly bought nothing.
+ */
+function bounded(modelled, seen) {
+  return seen ? Math.min(modelled, seen.rate) : modelled;
+}
+
+/**
  * Should we refresh this prefix now?
  *
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
+ *
+ * `observed` is passed IN rather than read from disk here: this function is
+ * pure, its purity is what lets the tests build a distribution by hand, and
+ * `shouldKeepWarm` has already read the outcome log for the tripwire -- so
+ * threading the reader in here would be a second read of the same file and a
+ * second place for the window discipline to be got wrong.
  */
 export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
@@ -125,42 +215,30 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
   const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
-
-  // MEASURED BEATS MODELLED, once there is enough of it.
-  //
-  // The module header already commits to this -- "an expected-value decision is
-  // only as good as the distribution it was fitted to, and distributions
-  // shift" -- and the tripwire underneath was the only thing acting on it, as
-  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
-  // entirely" there was nothing, because the observed hit rate was never
-  // computed: both recording halves had no call site, so ten refreshes that
-  // bought nothing would keep recommending refresh right up to the moment the
-  // tripwire cut the whole feature off.
-  //
-  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
-  // handful of samples would swing the decision harder than the distribution
-  // they replace.
-  const probability = observed ? observed.rate : modelled;
+  const seen = observationsFor(observed, tier.name);
+  const probability = bounded(modelled, seen);
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
-  const basis = observed
-    ? `measured over ${observed.observations} refreshes`
-    : 'modelled from the gap distribution';
+  const note = seen && probability < modelled
+    ? `; bounded by ${seen.refreshes} observed refreshes, ` +
+      `${Math.round(seen.rate * 100)}% used before expiry`
+    : '';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
     modelledProbability: modelled,
-    basis,
+    observedHitRate: seen ? seen.rate : null,
+    observedRefreshes: seen ? seen.refreshes : 0,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
-    reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
+    reason: (ev > 0
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
-        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`) + note,
   };
 }
 
@@ -171,7 +249,12 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
  * long enough that the short tier keeps missing. Returns null when neither tier
  * pays, which is a real answer and the one a default-on product never gives.
  */
-export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS }) {
+export function ttlTier({
+  prefixTokens,
+  gaps,
+  turnsPerSession = DEFAULT_TURNS,
+  observed = null,
+}) {
   if (!prefixTokens || !gaps) return null;
 
   // Expected cost of a turn under each tier, as a multiple of what the prefix
@@ -179,7 +262,16 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   // again; and the FIRST write is amortised over the session, which is what
   // stops the expensive tier from looking free whenever gaps are short.
   const costOf = (tier) => {
-    const hit = gaps.probabilityWithin(tier.ms);
+    // THE SAME QUANTITY THE OUTCOMES RECORD, which is what makes the
+    // observation admissible here at all. `hit` is P(a turn arrives before the
+    // entry expires) and `recordRefreshOutcome`'s `hit` is exactly that event,
+    // measured -- unlike keepWarmDecision, whose probability is the narrower
+    // ping window and for which the same observation is only an upper bound.
+    // Bounded rather than replaced even so: a sample drawn only from moments we
+    // CHOSE to refresh is not a sample of gaps, and its bias runs our way.
+    const modelled = gaps.probabilityWithin(tier.ms);
+    const seen = observationsFor(observed, tier.name);
+    const hit = bounded(modelled, seen);
     const perTurn = hit * READ_MULTIPLIER + (1 - hit) * tier.writeMultiplier;
     // THE SUPPLIED VALUE, not only the computed one. Math.max(1, NaN) is NaN -- Math.max
     // propagates it rather than clamping -- so perTurn became NaN, the `perTurn >= 1` guard below
@@ -192,6 +284,8 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     return {
       tier,
       hit,
+      seen,
+      boundedByObservation: Boolean(seen) && hit < modelled,
       perTurn: (tier.writeMultiplier + (turns - 1) * perTurn) / turns,
     };
   };
@@ -208,99 +302,53 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     action: 'refresh',
     tier: best.tier.name,
     hitProbability: best.hit,
+    observedHitRate: best.seen ? best.seen.rate : null,
+    observedRefreshes: best.seen ? best.seen.refreshes : 0,
     expectedCostPerTurn: Number(best.perTurn.toFixed(3)),
     expectedValue: Math.round((1 - best.perTurn) * prefixTokens),
     reason: `${Math.round(best.hit * 100)}% of gaps land inside ${best.tier.name}; ` +
-      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached`,
+      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached` +
+      (best.boundedByObservation
+        ? `, bounded by ${best.seen.refreshes} observed refreshes ` +
+          `(${Math.round(best.seen.rate * 100)}% used before expiry)`
+        : ''),
   };
 }
 
-/** Observations of a tier before its measured hit rate may override the model. */
-export const OBSERVATION_FLOOR = 5;
-
-/** Records a refresh so its outcome can be scored. */
-export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
-  record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
-}
-
 /**
- * Scores every refresh whose window has since resolved.
+ * Records a refresh so its outcome can be scored.
  *
- * THE MISSING HALF, and it was missing because nobody could see where the
- * signal would come from. `recordRefreshOutcome` needs to know whether a real
- * turn arrived before the entry expired -- and that is not a thing anyone has
- * to instrument, because the event log already records when every turn
- * happened. The answer was in the data the whole time.
+ * `sessionId` IS REQUIRED FOR THE REFRESH TO BE SCOREABLE, and is not defaulted
+ * to anything. The hit test asks whether a turn of THIS conversation arrived
+ * before expiry; pooling arrivals across sessions would let a second concurrent
+ * session's turn pay for this one's ping, which manufactures hits. A refresh
+ * recorded without one is kept in the ledger and reported as unattributable
+ * rather than guessed at.
  *
- * For each unscored refresh at time T on a tier with TTL `ms`:
- *
- *   - a later event within `ms`            -> HIT, observed
- *   - a later event after `ms`             -> MISS, observed
- *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
- *                                             demonstrably closed unused
- *   - no later event, window still open    -> NOTHING RECORDED
- *
- * That last line is the important one and it is Plan 2's own instruction: "if
- * no signal is available for a tier, record nothing rather than guessing
- * `hit: false`". A refresh whose window has not closed yet is not a miss, and
- * scoring it as one would drive the tripwire negative on the newest and least
- * informative records.
- *
- * DRAINED AT READ TIME, which is the pattern this codebase already uses for
- * staleness: the producer cannot know the outcome at the moment it acts, so the
- * next reader resolves what has become knowable since.
+ * Returns the stored record, whose `id` is what `scoreRefreshes` pairs the
+ * outcome to, so an issuer can hold onto it.
  */
-export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
-  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
-  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
-  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
-
-  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
-  // so everything past the number already scored is outstanding. Pairing by
-  // timestamp instead would double-count two refreshes recorded in the same
-  // millisecond, which is reachable: a tool run twice in a loop.
-  const outstanding = refreshes.slice(scored);
-  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
-
-  let recorded = 0;
-  for (const refresh of outstanding) {
-    const at = Number(refresh.at) || 0;
-    if (!at) continue;
-    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
-    const next = timeline.find((t) => t > at);
-
-    let hit;
-    if (next !== undefined) hit = next - at <= tierSpec.ms;
-    else if (now - at > tierSpec.ms) hit = false;
-    else continue; // window still open: not yet knowable
-
-    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
-    recorded += 1;
-  }
-  return { outstanding: outstanding.length, recorded };
-}
-
-/**
- * The measured hit rate for a tier, or null below the observation floor.
- *
- * Null rather than a small-sample number, because the caller substitutes it for
- * a modelled probability and three observations would swing the decision harder
- * than the model they replace.
- */
-export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
-  const relevant = outcomes.filter(
-    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
-  );
-  if (relevant.length < OBSERVATION_FLOOR) return null;
-  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
+export function recordRefresh(dir, { tier, prefixTokens, expectedValue, sessionId, at }) {
+  return record(dir, {
+    kind: 'keepwarm',
+    action: 'refresh',
+    tier,
+    prefixTokens,
+    expectedValue,
+    sessionId,
+    at,
+  });
 }
 
 /**
  * Records whether the refresh was used.
  *
  * `hit` means a real turn arrived before expiry, so the write bought a read.
+ * `refreshId` names the refresh this scores, so the same one cannot be scored
+ * twice -- once per turn for the rest of the session, which is what an
+ * unpaired outcome would become.
  */
-export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
+export function recordRefreshOutcome(dir, { tier, prefixTokens, hit, refreshId = null }) {
   const tierSpec = TIERS.find((t) => t.name === tier) || TIERS[0];
   // THE SAME LEDGER keepWarmDecision BUYS THE REFRESH WITH. That function is explicit that a
   // refresh is a PING, which READS the prefix -- costOfPing = prefixTokens * READ_MULTIPLIER --
@@ -317,7 +365,125 @@ export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
   const realised = hit
     ? prefixTokens * (tierSpec.writeMultiplier - READ_MULTIPLIER) - prefixTokens * READ_MULTIPLIER
     : -prefixTokens * READ_MULTIPLIER;
-  record(dir, { kind: 'keepwarm', action: 'outcome', tier, prefixTokens, hit: Boolean(hit), realised: Math.round(realised) });
+  record(dir, {
+    kind: 'keepwarm',
+    action: 'outcome',
+    tier,
+    prefixTokens,
+    hit: Boolean(hit),
+    refreshId,
+    realised: Math.round(realised),
+  });
+}
+
+/**
+ * Scores every recorded refresh whose window has closed -- and NOTHING ELSE.
+ *
+ * This is the arm that was missing. `recordRefresh` and `recordRefreshOutcome`
+ * were both correct and both called by nothing, so the decision spent money on
+ * refreshes and could never find out whether one bought a read.
+ *
+ * THE SIGNAL IS REAL, not invented. `gapDistribution` already treats this log's
+ * timestamps as turn arrivals -- that is the distribution the whole decision is
+ * fitted to -- so the same log answers the outcome question directly: a refresh
+ * at tier `5m` was used if a turn of the same session arrived within five
+ * minutes of it. Four cases refuse to answer rather than guess, and every one
+ * of them refuses in the direction that costs this project its own good news:
+ *
+ *   - `pending`: the window has not closed yet. A hit could be scored the
+ *     instant it arrives while a miss must wait out the whole TTL, so scoring
+ *     early would mean the recorded hits are always complete and the recorded
+ *     misses always lagging -- right-censoring, biased upward, invisible in any
+ *     test. So a hit waits exactly as long as a miss.
+ *   - `uncovered`: the arrival log no longer reaches back to the refresh, so
+ *     absence of an arrival is absence of evidence. RECORDING `hit: false` HERE
+ *     WOULD BE THE INVENTION THIS IS FORBIDDEN TO MAKE: an absent signal is not
+ *     a miss, and treating it as one biases every rate downward and would
+ *     eventually switch keep-warm off on no evidence at all.
+ *   - `unattributable`: the refresh names no session, so no arrival can be
+ *     shown to belong to it.
+ *   - already scored: an outcome already names this refresh.
+ *
+ * The firehose is READ LAZILY, and only when there is something to score. On a
+ * machine where nothing issues refreshes -- which is every machine today, since
+ * nothing in this repository issues one -- the whole cost is the outcome-log
+ * read: median 70 ms on a 3.5 MB log, of which readBalance is 49 ms, because
+ * that reader also scans the firehose tail for pre-split records.
+ */
+export function scoreRefreshes(dir, {
+  refreshes = readBalance(dir),
+  arrivals = null,
+  now = Date.now(),
+} = {}) {
+  const summary = { scored: 0, hits: 0, pending: 0, uncovered: 0, unattributable: 0 };
+  const keepwarm = refreshes.filter((event) => event?.kind === 'keepwarm');
+  const alreadyScored = new Set(
+    keepwarm
+      .filter((event) => event.action === 'outcome' && event.refreshId)
+      .map((event) => event.refreshId)
+  );
+  const unscored = keepwarm.filter(
+    (event) =>
+      event.action === 'refresh' &&
+      Number.isFinite(event.at) &&
+      event.id &&
+      !alreadyScored.has(event.id)
+  );
+
+  // A refresh with no id cannot be paired, so scoring it would write a fresh
+  // outcome on every turn forever. Reported, not silently dropped.
+  summary.unattributable += keepwarm.filter(
+    (event) => event.action === 'refresh' && (!event.id || !Number.isFinite(event.at))
+  ).length;
+
+  if (!unscored.length) return summary;
+
+  const events = (arrivals ? arrivals() : readMetrics(dir)).filter((event) =>
+    Number.isFinite(event?.at)
+  );
+  // Coverage is judged over EVERY event, including our own bookkeeping: the
+  // refresh's own copy in the firehose is what proves the window is still
+  // inside the read. Arrivals are judged over everything else, because a record
+  // keep-warm wrote about itself is not a turn -- and counting one would
+  // manufacture a hit out of the act of measuring.
+  const earliest = events.reduce((min, event) => Math.min(min, event.at), Infinity);
+  const turns = events.filter((event) => event.kind !== 'keepwarm');
+
+  for (const refresh of unscored) {
+    const tier = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    if (now - refresh.at < tier.ms) {
+      summary.pending += 1;
+      continue;
+    }
+    const session = refresh.sessionId;
+    if (!session) {
+      summary.unattributable += 1;
+      continue;
+    }
+    if (!(earliest <= refresh.at)) {
+      summary.uncovered += 1;
+      continue;
+    }
+
+    const opens = refresh.at + TURN_GAP_MS;
+    const closes = refresh.at + tier.ms;
+    const hit = turns.some(
+      (event) =>
+        (event.sessionId ?? event.episodeId) === session &&
+        event.at > opens &&
+        event.at <= closes
+    );
+    recordRefreshOutcome(dir, {
+      tier: refresh.tier,
+      prefixTokens: refresh.prefixTokens,
+      hit,
+      refreshId: refresh.id,
+    });
+    summary.scored += 1;
+    if (hit) summary.hits += 1;
+  }
+
+  return summary;
 }
 
 /**
@@ -372,23 +538,15 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
-  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
-  // becomes evidence now, so the decision below and the tripwire above both see
-  // the most that is currently knowable -- the same read-time drain the
-  // staleness path uses, and for the same reason: the producer cannot know the
-  // outcome at the moment it acts.
-  try {
-    scoreOutstandingRefreshes(dir, { events, outcomes });
-    outcomes = readBalance(dir);
-  } catch {
-    /* scoring is evidence, never a reason to refuse a decision */
-  }
-
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
+  // THE SAME ARRAY THE TRIPWIRE JUST READ, so closing the loop costs no extra
+  // I/O -- and so the decision and its backstop cannot be looking at different
+  // evidence about the same refreshes.
+  const observed = observedHitRates(outcomes);
   const gaps = gapDistribution(dir, { events });
-  const best = ttlTier({ prefixTokens, gaps });
+  const best = ttlTier({ prefixTokens, gaps, observed });
   if (!best) {
     // THE TWO MODELS ANSWER DIFFERENT QUESTIONS, so they may legitimately disagree. ttlTier asks
     // whether holding a cache beats not caching at all; keepWarmDecision asks whether ONE ping
@@ -397,11 +555,7 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({
-      prefixTokens,
-      gaps,
-      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
-    });
+    const decision = keepWarmDecision({ prefixTokens, gaps, observed });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/integrations/codex/plugin/hooks/lib/loo.mjs
+++ b/integrations/codex/plugin/hooks/lib/loo.mjs
@@ -1,0 +1,788 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/loo.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 2 -- what one finding is actually worth, measured by withholding it.
+ *
+ * Layer 1 asks whether the model went back and named a finding. This asks the
+ * harder question and answers it causally: WITHHOLD ONE FINDING while serving
+ * every other finding for the same touch, and compare what the session spent
+ * READING that anchor afterwards. Nobody in this space measures per-item value
+ * this way in production; the state of the art is an offline evaluation set.
+ * That is also why this file is more refusal than statistics -- a causal claim
+ * from four observations is worse than no claim, because it is a number and
+ * numbers get quoted.
+ *
+ * THE ESTIMAND IS READ-SUPPRESSION, and it is deliberately DISJOINT from Layer
+ * 1. Layer 1 keys on an explicit `query` naming a finding key. This keys on
+ * `read` events against the injection's anchor. Neither signal appears in the
+ * other's arithmetic: no `query` event is consulted here, and `usage.mjs`
+ * consults no `read` event. Task 8 calibrates one against the other, and if
+ * both derived from the same channel that calibration would report a strong
+ * correlation between two spellings of one quantity and mean nothing.
+ *
+ * IT INVENTS NO JOIN. `recordToolOutcome` already joins each post-tool result
+ * back to the injection that preceded it, recording `injectionId`,
+ * `findingIds` and a `joinMethod` of `tool-call-id` / `episode-anchor` /
+ * `none`. Every observation here is GATED on that join: an injection with no
+ * joined outcome is unattributable and enters neither arm, exactly as Layer 1
+ * treats `joinMethod: 'none'`. An earlier draft of this plan proposed a fresh
+ * `(sessionId, findingKey)` join; it was rejected and is not here.
+ *
+ * WHAT IT COSTS THE USER, because an experiment that degrades a turn owes an
+ * accounting. One withheld finding means the model may re-derive what it was
+ * told last time, and the worst case is one read of that anchor: measured on
+ * this machine, a median read is 3,769 tokens and the 90th percentile is
+ * 14,082. Five guards bound that exposure, and they are the reason the numbers
+ * below are as small as they are:
+ *
+ *   1. only on a FILE touch, because a command injection has no anchor a read
+ *      event can be joined to -- withholding there would cost a user a finding
+ *      and buy no observation at all (see `buildReport`, which excludes command
+ *      injections from the holdout balance for the same reason);
+ *   2. never when fewer than two findings were kept, so "leave one out" always
+ *      leaves something in -- otherwise it degenerates into `inHoldout`, which
+ *      withholds EVERY finding for an anchor and is a different experiment;
+ *   3. never in the same breath as `inHoldout`: if that arm already withheld
+ *      everything, there is nothing to leave out and a Layer 2 arm recorded
+ *      there would be a fabricated observation;
+ *   4. at most ONE finding per touch, or the effect is attributable to neither;
+ *   5. at most ONE withheld finding per SESSION, so the worst case a user can
+ *      experience is a single re-read -- not one per file they open.
+ *
+ * AND IT NEVER OVERRIDES A PERSON. A `pinned` or `origin: 'human'` finding is
+ * an explicit human decision to keep something in front of the model.
+ * Withholding it to run an experiment would overrule that decision for the
+ * convenience of the measurement, so those findings are exempt: they are
+ * always served, they get no causal score, and `looNote` says so rather than
+ * leaving a reader to wonder why they are missing from the table.
+ */
+
+import { createHash } from 'node:crypto';
+import { readEvidence, readMetrics, readTruncation, isFixtureAnchor } from './metrics.mjs';
+import { retrievalPolicy } from './utility.mjs';
+import { ORIGIN_HUMAN } from './curate.mjs';
+import { canonicalPath } from './paths.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Injections of a finding before it may enter the experiment.
+ *
+ * A finding nobody has served yet has no established value to measure the
+ * absence of, and withholding it would be measuring the cold start rather than
+ * the finding. Four is also what makes the ratio below reachable: at a quarter
+ * of (key, session) pairs armed, a key needs roughly a dozen enrolled
+ * injections before it can reach a verdict at all.
+ */
+export const MIN_PRIOR_INJECTIONS = 4;
+
+/** The observation floor. Below this there is no verdict -- and NOT a zero. */
+export const MIN_SERVED = 6;
+export const MIN_WITHHELD = 3;
+
+/** Benjamini-Hochberg false-discovery rate for published verdicts. */
+export const FDR_Q = 0.1;
+
+/**
+ * Exploration rate.
+ *
+ * Without this, utility feeds the ranking, the ranking feeds injection
+ * frequency, injection frequency feeds the observation count, and a low score
+ * becomes self-fulfilling: the finding is never served often enough to earn a
+ * better one. A tenth of touches therefore ignore the utility order and
+ * promote the LEAST-served candidate instead.
+ */
+export const EPSILON = 0.1;
+
+/**
+ * The share of (finding, session) pairs assigned to the withheld arm.
+ *
+ * Chosen against the floors rather than picked: MIN_SERVED / MIN_WITHHELD is
+ * 2:1, so a quarter withheld reaches both floors at about the same time while
+ * leaving three touches in four undamaged.
+ */
+export const WITHHOLD_FRACTION = 0.25;
+
+/**
+ * Withheld findings allowed per session. ONE.
+ *
+ * The per-touch cap alone bounds nothing across a session: a session that
+ * opens twelve files with enrolled findings could have withheld twelve. This
+ * makes the worst case a user can experience one re-read, at the price of a
+ * mild confound that is stated rather than hidden -- when the cap binds, the
+ * other armed findings in that session are served, so the served arm is
+ * slightly enriched by sessions that touch many enrolled findings.
+ */
+export const MAX_WITHHELD_PER_SESSION = 1;
+
+/**
+ * Fallback shrinkage weight when the between-finding variance cannot be
+ * estimated (fewer than two findings with both arms, or no dispersion at all).
+ *
+ * MIN_SERVED + MIN_WITHHELD, deliberately: a finding's own data outweighs the
+ * population prior only once it has reached the publication floor.
+ */
+export const SHRINKAGE_K = MIN_SERVED + MIN_WITHHELD;
+
+/** Bounds on the estimated shrinkage weight, so a degenerate variance ratio cannot run away. */
+const K_MIN = 1;
+const K_MAX = 100;
+
+/**
+ * Bumped BY HAND when the serving code changes in a way that could move a
+ * finding's measured effect. It is the part of the policy version a hash of the
+ * configuration cannot see.
+ */
+export const LOO_POLICY_GENERATION = 1;
+
+/** Permutation budget before the exact null distribution is sampled instead of enumerated. */
+const MAX_EXACT_PERMUTATIONS = 20_000;
+const SAMPLED_PERMUTATIONS = 10_000;
+
+/**
+ * On by default, off by `TOKEN_OPTIMIZER_LOO=off`.
+ *
+ * Read per call rather than at module load, for the reason `holdoutFraction`
+ * gives: a long-lived process started before the setting changed would
+ * otherwise honour the old value forever with no way to tell.
+ */
+export function LOO_ENABLED() {
+  return String(process.env.TOKEN_OPTIMIZER_LOO || '').trim().toLowerCase() !== 'off';
+}
+
+/**
+ * The serving policy an observation was collected under.
+ *
+ * WHY EVERY OBSERVATION CARRIES ONE. An effect is only meaningful against a
+ * fixed policy. Halve the touch budget or move the minimum net utility and the
+ * same finding is served in different company, at a different rank, against a
+ * different counterfactual -- so pooling observations from before and after
+ * that change would average two different experiments and call the result
+ * causal. `effects()` therefore groups by (finding, policy) and never across.
+ *
+ * IT IS DELIBERATELY ABSENT FROM THE ARM HASH. Including it would reassign
+ * arms the moment a setting changed, which is precisely the mid-session flip
+ * the arm hash exists to prevent. Configuration decides which experiment an
+ * observation belongs to; it must never decide which arm.
+ */
+export function servingPolicyVersion() {
+  const policy = retrievalPolicy();
+  const parts = [
+    `g${LOO_POLICY_GENERATION}`,
+    `touch=${Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500}`,
+    `benefit=${policy.baseBenefitTokens}`,
+    `minutility=${policy.minimumNetUtility}`,
+    `cooldown=${policy.cooldownMs}`,
+    `quarantine=${policy.quarantineHarmCount}`,
+    `holdout=${process.env.TOKEN_OPTIMIZER_HOLDOUT ?? 'default'}`,
+    `withhold=${WITHHOLD_FRACTION}`,
+    `prior=${MIN_PRIOR_INJECTIONS}`,
+    `epsilon=${EPSILON}`,
+  ];
+  const digest = createHash('sha256').update(parts.join('|')).digest('hex');
+  return `${LOO_POLICY_GENERATION}-${digest.slice(0, 8)}`;
+}
+
+/**
+ * A stable number in [0, 1) from a string.
+ *
+ * SHA-256 rather than SHA-1 for the same reason `inHoldout` uses it: this is a
+ * bucketing hash and nothing here is secret, but arguing that a CodeQL finding
+ * is benign is a worse habit than paying a cost that rounds to nothing.
+ */
+function bucket(text) {
+  return createHash('sha256').update(String(text)).digest().readUInt32BE(0) / 4_294_967_296;
+}
+
+/**
+ * The arm of one finding in one session.
+ *
+ * Keyed on (findingKey, sessionId) AND NOTHING ELSE, so a finding cannot
+ * change arms partway through a session: not when the candidate set changes,
+ * not when the budget changes, not when the graph grows. The measurement is a
+ * comparison between sessions, and an arm that flips inside one contaminates
+ * both sides of it.
+ */
+function armed(findingKey, sessionId) {
+  return bucket(`loo-arm:${findingKey}:${sessionId}`) < WITHHOLD_FRACTION;
+}
+
+/** Deterministic tiebreak among armed candidates: lowest bucket, then key order. */
+function armRank(findingKey, sessionId) {
+  return bucket(`loo-rank:${findingKey}:${sessionId}`);
+}
+
+/** The graph node for a finding key, or null. Keys are unique per graph. */
+function findingNode(graph, key) {
+  const nodes = graph?.nodes;
+  if (!nodes || typeof nodes.values !== 'function') return null;
+  for (const node of nodes.values()) {
+    if (node?.kind === 'finding' && node.key === key) return node;
+    // A fixture graph may omit `kind`; key identity is what this needs.
+    if (node?.key === key && node.kind === undefined) return node;
+  }
+  return null;
+}
+
+/**
+ * May this finding ever be withheld?
+ *
+ * FAILS CLOSED ON AN UNKNOWN KEY, which is the opposite of how the rest of
+ * this module fails. Everywhere else a missing input costs a measurement; here
+ * it could cost a human their explicit decision, because a key whose node
+ * cannot be read is a key whose `pinned` and `origin` cannot be checked.
+ */
+function withholdable(graph, key) {
+  const node = findingNode(graph, key);
+  if (!node) return false;
+  if (node.pinned) return false;
+  if (node.origin === ORIGIN_HUMAN) return false;
+  if (node.retired) return false;
+  return true;
+}
+
+/** Prior SERVED injections per finding key, and withheld injections per session. */
+function history(dir, { evidence = null } = {}) {
+  const priorServed = new Map();
+  const withheldPerSession = new Map();
+  const events = evidence || readEvidence(dir);
+  for (const event of events) {
+    if (event.kind !== 'inject') continue;
+    if (typeof event.loo === 'string' && event.loo) {
+      const session = typeof event.sessionId === 'string' ? event.sessionId : '';
+      withheldPerSession.set(session, (withheldPerSession.get(session) || 0) + 1);
+    }
+    if (event.holdout) continue;
+    const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+    for (const raw of keys) {
+      const key = String(raw);
+      priorServed.set(key, (priorServed.get(key) || 0) + 1);
+    }
+  }
+  return { priorServed, withheldPerSession };
+}
+
+/**
+ * Which single finding to withhold from this touch, or null.
+ *
+ * Called from `forTouch` AFTER `fit` has decided what would have been served,
+ * which is the only ordering that produces a true leave-one-out. Withholding
+ * BEFORE the budget runs would let a lower-ranked finding take the freed
+ * tokens, so the withheld arm would receive different company as well as one
+ * fewer finding, and the comparison would confound the two.
+ *
+ * @param {string[]} findingKeys keys that would otherwise be delivered
+ * @param {string} sessionId the session, which pins the arm
+ * @param {object} graph the loaded graph, for `pinned` / `origin`
+ * @param {string|null} dir graph directory, for the injection history
+ */
+export function withheldFor(findingKeys, sessionId, graph, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return null;
+
+    // Every guard that needs no I/O runs first: this is the PreToolUse path,
+    // and on a project with one finding per anchor the answer is null before
+    // anything is read.
+    const keys = [...new Set((findingKeys || []).map((k) => String(k)).filter(Boolean))];
+    if (keys.length < 2) return null;
+    if (!sessionId || typeof sessionId !== 'string') return null;
+
+    // FILE SURFACE ONLY. A command injection's anchor is the command text, and
+    // no read event will ever match it -- so both arms would score zero
+    // downstream and the finding would be scored on nothing.
+    const { surface = 'file', anchor = '', holdout = false } = options;
+    if (surface !== 'file' || !anchor) return null;
+    // The all-findings holdout already withheld everything for this anchor.
+    if (holdout) return null;
+
+    const eligible = keys.filter((key) => withholdable(graph, key));
+    if (!eligible.length) return null;
+
+    const { priorServed, withheldPerSession } = history(dir, options);
+    if ((withheldPerSession.get(sessionId) || 0) >= MAX_WITHHELD_PER_SESSION) return null;
+
+    const enrolled = eligible.filter(
+      (key) => (priorServed.get(key) || 0) >= MIN_PRIOR_INJECTIONS
+    );
+    if (!enrolled.length) return null;
+
+    const candidates = enrolled.filter((key) => armed(key, sessionId));
+    if (!candidates.length) return null;
+
+    // AT MOST ONE. Sorted deterministically so the same touch always yields the
+    // same choice; the findings that lose the tiebreak are SERVED, and the
+    // observation records what actually happened rather than what the arm hash
+    // intended.
+    candidates.sort(
+      (a, b) => armRank(a, sessionId) - armRank(b, sessionId) || (a < b ? -1 : a > b ? 1 : 0)
+    );
+    return candidates[0];
+  } catch {
+    // An experiment must never break a tool call. Failing open here means
+    // serving everything, which is the undegraded behaviour.
+    return null;
+  }
+}
+
+/**
+ * Reorders candidates so exploration can break the feedback loop.
+ *
+ * A tenth of touches -- deterministic in (session, anchor), not random, so the
+ * same touch behaves the same way twice -- promote the LEAST-served candidate
+ * ahead of the utility order, giving it a chance to survive `fit` and accrue
+ * the observations it needs to earn a score. The other nine tenths are
+ * untouched.
+ *
+ * @param {Array<{finding:{key:string}}>} items assessed candidates, best first
+ */
+export function exploreOrder(items, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return items;
+    const list = Array.isArray(items) ? items : [];
+    if (list.length < 2) return list;
+    const { sessionId = '', anchor = '' } = options;
+    if (bucket(`loo-explore:${sessionId}:${anchor}`) >= EPSILON) return list;
+
+    const keyOf = (item) => String(item?.finding?.key ?? item?.key ?? '');
+    const { priorServed } = history(dir, options);
+    let promoted = 0;
+    for (let i = 1; i < list.length; i += 1) {
+      const a = priorServed.get(keyOf(list[i])) || 0;
+      const b = priorServed.get(keyOf(list[promoted])) || 0;
+      if (a < b || (a === b && keyOf(list[i]) < keyOf(list[promoted]))) promoted = i;
+    }
+    if (promoted === 0) return list;
+    return [list[promoted], ...list.filter((_, i) => i !== promoted)];
+  } catch {
+    return Array.isArray(items) ? items : [];
+  }
+}
+
+const mean = (values) =>
+  values.length ? values.reduce((sum, v) => sum + v, 0) / values.length : 0;
+
+/** Sample variance (n-1). Zero for a single observation: dispersion is unknown, not large. */
+function variance(values) {
+  if (values.length < 2) return 0;
+  const m = mean(values);
+  return values.reduce((sum, v) => sum + (v - m) * (v - m), 0) / (values.length - 1);
+}
+
+/**
+ * Every attributable Layer 2 observation, one per (injection, finding, arm).
+ *
+ * THREE THINGS ARE REPORTED SEPARATELY RATHER THAN FOLDED IN, because each of
+ * them would otherwise turn an absence into a zero:
+ *
+ *   `unattributable`  the outcome join could not attach a tool call to the
+ *                     injection, so nothing is known about what followed it.
+ *   `excluded`        the injection could never produce a read-join at all
+ *                     (command surface, session-start, fixture anchor) or was
+ *                     already in the all-findings holdout.
+ *   `costObservations` how many observations saw a non-zero read cost. If this
+ *                     is zero, "withholding changed nothing" and "the read
+ *                     channel never fired" are the same picture, and only one
+ *                     of them is a finding about findings.
+ */
+export function observations(dir, { events = null, evidence = null } = {}) {
+  const empty = {
+    rows: [],
+    unattributable: 0,
+    unattributableOutcomes: 0,
+    excluded: { command: 0, holdout: 0, fixture: 0, unanchored: 0 },
+    injections: 0,
+    withheldInjections: 0,
+    costObservations: 0,
+    policies: [],
+    windowed: false,
+  };
+  try {
+    const causal = evidence || readEvidence(dir);
+    const all = events || readMetrics(dir);
+    // OUT OF BAND and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` describes the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
+
+    // THE JOIN THIS MODULE CONSUMES AND DOES NOT REPLACE.
+    const joined = new Set();
+    let unattributableOutcomes = 0;
+    for (const event of causal) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) {
+        unattributableOutcomes += 1;
+        continue;
+      }
+      joined.add(String(event.injectionId));
+    }
+
+    // Read cost, grouped the way `buildReport` groups it: (session, anchor),
+    // canonicalised on both sides so two spellings of one file are one anchor.
+    // A mismatch here would make every read invisible and report a clean zero
+    // effect in both arms -- correct code, absent measurement.
+    const reads = new Map();
+    for (const event of all) {
+      if (event.kind !== 'read' || !event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      if (!reads.has(key)) reads.set(key, []);
+      reads.get(key).push(event);
+    }
+
+    const injects = causal
+      .filter((event) => event.kind === 'inject')
+      .map((event, index) => ({ event, index }))
+      .sort((a, b) => (a.event.at || 0) - (b.event.at || 0) || a.index - b.index)
+      .map((row) => row.event);
+
+    // How many injections share each (session, anchor), so a key's read total
+    // is SPLIT between them rather than charged in full to each -- the same
+    // correction `buildReport` applies, and for the same reason: without it the
+    // arm means scale with injections-per-anchor instead of per-touch cost.
+    const perKey = new Map();
+    for (const event of injects) {
+      if (!event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      perKey.set(key, (perKey.get(key) || 0) + 1);
+    }
+
+    const rows = [];
+    const excluded = { command: 0, holdout: 0, fixture: 0, unanchored: 0 };
+    const priorServed = new Map();
+    const policies = new Set();
+    let unattributable = 0;
+    let considered = 0;
+    let withheldInjections = 0;
+
+    for (const event of injects) {
+      const served = (Array.isArray(event.findingIds) ? event.findingIds : []).map(String);
+      const withheldKey = typeof event.loo === 'string' && event.loo ? event.loo : null;
+      const bump = () => {
+        for (const key of served) priorServed.set(key, (priorServed.get(key) || 0) + 1);
+      };
+
+      const isCommand =
+        event.surface === 'command' ||
+        event.trigger === 'command' ||
+        event.surface === 'session-start';
+      if (isCommand) {
+        excluded.command += 1;
+        bump();
+        continue;
+      }
+      if (!event.anchor) {
+        excluded.unanchored += 1;
+        bump();
+        continue;
+      }
+      if (isFixtureAnchor(event.anchor)) {
+        excluded.fixture += 1;
+        bump();
+        continue;
+      }
+      if (event.holdout) {
+        excluded.holdout += 1;
+        bump();
+        continue;
+      }
+
+      considered += 1;
+      if (withheldKey) withheldInjections += 1;
+      const policy = typeof event.looPolicy === 'string' && event.looPolicy
+        ? event.looPolicy
+        : 'unversioned';
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const attributable = Boolean(injectionId && joined.has(injectionId));
+
+      // DOWNSTREAM MEANS AFTER, STRICTLY. The read that triggered the touch is
+      // not caused by the advice; it happened before the advice existed.
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      const at = event.at || 0;
+      const total = (reads.get(key) || []).reduce(
+        (sum, read) => sum + ((read.at || 0) > at ? read.tokens || 0 : 0),
+        0
+      );
+      const cost = total / Math.max(1, perKey.get(key) || 1);
+
+      const observe = (findingKey, arm) => {
+        // ENROLMENT IS RE-DERIVED FROM THE LOG rather than trusted from the
+        // serving decision. It is the one field an old or hand-written record
+        // could contradict, and a served observation from before a finding was
+        // enrolled would compare an established finding against its own cold
+        // start.
+        //
+        // CHECKED BEFORE ATTRIBUTABILITY, so `unattributable` counts only
+        // observations the experiment actually wanted. Counting the rest there
+        // would report a join failure for every finding that was never in the
+        // experiment to begin with -- the same shape as the 2,559-row
+        // measurement-bias defect Layer 1 found in its own first draft.
+        if ((priorServed.get(findingKey) || 0) < MIN_PRIOR_INJECTIONS) return;
+        if (!attributable) {
+          unattributable += 1;
+          return;
+        }
+        policies.add(policy);
+        rows.push({ findingKey, arm, cost, policy, injectionId, anchor: event.anchor });
+      };
+
+      if (withheldKey) observe(withheldKey, 'withheld');
+      for (const findingKey of served) observe(findingKey, 'served');
+      bump();
+    }
+
+    return {
+      rows,
+      unattributable,
+      unattributableOutcomes,
+      excluded,
+      injections: considered,
+      withheldInjections,
+      costObservations: rows.filter((row) => row.cost > 0).length,
+      policies: [...policies].sort(),
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
+function permutationP(servedCosts, withheldCosts) {
+  const pooled = [...servedCosts, ...withheldCosts];
+  const n = pooled.length;
+  const k = withheldCosts.length;
+  if (!k || k === n) return null;
+  const observed = Math.abs(mean(withheldCosts) - mean(servedCosts));
+  const total = pooled.reduce((sum, v) => sum + v, 0);
+  // Mean difference from the withheld-arm sum alone: the served sum is the
+  // complement, so one number decides the statistic.
+  const diffFrom = (withheldSum) =>
+    Math.abs(withheldSum / k - (total - withheldSum) / (n - k));
+
+  const choose = (a, b) => {
+    let out = 1;
+    for (let i = 1; i <= b; i += 1) out = (out * (a - b + i)) / i;
+    return out;
+  };
+
+  const tolerance = 1e-9;
+  if (choose(n, k) <= MAX_EXACT_PERMUTATIONS) {
+    let extreme = 0;
+    let count = 0;
+    const walk = (start, chosen, sum) => {
+      if (chosen === k) {
+        count += 1;
+        if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+        return;
+      }
+      for (let i = start; i <= n - (k - chosen); i += 1) walk(i + 1, chosen + 1, sum + pooled[i]);
+    };
+    walk(0, 0, 0);
+    return count ? extreme / count : null;
+  }
+
+  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
+  // the same p-value and a verdict cannot flicker between two audit runs.
+  let state = 0x9e3779b9;
+  const random = () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4_294_967_296;
+  };
+  let extreme = 0;
+  const order = [...pooled];
+  for (let round = 0; round < SAMPLED_PERMUTATIONS; round += 1) {
+    for (let i = order.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(random() * (i + 1));
+      [order[i], order[j]] = [order[j], order[i]];
+    }
+    let sum = 0;
+    for (let i = 0; i < k; i += 1) sum += order[i];
+    if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+  }
+  return (extreme + 1) / (SAMPLED_PERMUTATIONS + 1);
+}
+
+/**
+ * The per-finding causal effect, shrunk, and whether it may be published.
+ *
+ * `raw` is `mean(withheld) - mean(served)`: POSITIVE means the session read the
+ * anchor more when the finding was withheld, which is the finding earning its
+ * place. `shrunk` is the number a reader should use.
+ *
+ * EMPIRICAL BAYES, and both halves of it come from the data. The prior mean is
+ * the population effect across findings; the weight `k` is the ratio of
+ * within-finding noise to between-finding spread, so a population where every
+ * finding behaves alike shrinks hard and one where they genuinely differ
+ * shrinks little. `SHRINKAGE_K` is the fallback when that spread cannot be
+ * estimated at all. Two observations therefore cannot post a wild score.
+ *
+ * PUBLICATION IS NOT THE SAME QUESTION as having an estimate. A row is
+ * published only if it clears the observation floor AND its permutation
+ * p-value survives Benjamini-Hochberg at q = 0.10 across every candidate row.
+ * Everything else gets `published: false` -- which is not a zero effect, and
+ * `looNote` says which of the two it is. An all-zero-cost population needs no
+ * separate guard: p is exactly 1 there, so nothing can publish anyway.
+ *
+ * NEVER POOLED ACROSS POLICY VERSIONS: rows are keyed on (findingKey, policy).
+ */
+export function effects(dir, options = {}) {
+  try {
+    // `obs` is accepted so `looNote` can read the logs once for both.
+    const obs = options.obs || observations(dir, options);
+    const groups = new Map();
+    for (const row of obs.rows) {
+      const id = JSON.stringify([row.findingKey, row.policy]);
+      if (!groups.has(id))
+        groups.set(id, { findingKey: row.findingKey, policy: row.policy, served: [], withheld: [] });
+      groups.get(id)[row.arm === 'withheld' ? 'withheld' : 'served'].push(row.cost);
+    }
+
+    const raws = [];
+    const withinVars = [];
+    for (const group of groups.values()) {
+      if (!group.served.length || !group.withheld.length) continue;
+      raws.push(mean(group.withheld) - mean(group.served));
+      withinVars.push(
+        variance(group.withheld) / group.withheld.length +
+          variance(group.served) / group.served.length
+      );
+    }
+    const prior = raws.length ? mean(raws) : 0;
+    const within = withinVars.length ? mean(withinVars) : 0;
+    const between = raws.length > 1 ? Math.max(0, variance(raws) - within) : 0;
+    const weight =
+      between > 0 && within > 0
+        ? Math.min(K_MAX, Math.max(K_MIN, within / between))
+        : SHRINKAGE_K;
+
+    const rows = [...groups.values()]
+      .map((group) => {
+        const served = group.served.length;
+        const withheld = group.withheld.length;
+        const both = served > 0 && withheld > 0;
+        const raw = both ? mean(group.withheld) - mean(group.served) : null;
+        const n = served + withheld;
+        const shrunk = raw === null ? null : (n * raw + weight * prior) / (n + weight);
+        const eligible = served >= MIN_SERVED && withheld >= MIN_WITHHELD;
+        return {
+          findingKey: group.findingKey,
+          policy: group.policy,
+          served,
+          withheld,
+          servedMean: mean(group.served),
+          withheldMean: mean(group.withheld),
+          raw,
+          shrunk,
+          p: eligible ? permutationP(group.served, group.withheld) : null,
+          published: false,
+        };
+      })
+      .sort((a, b) =>
+        a.findingKey < b.findingKey ? -1 : a.findingKey > b.findingKey ? 1 : a.policy < b.policy ? -1 : 1
+      );
+
+    // BENJAMINI-HOCHBERG at q = 0.10 over every row that cleared the floor.
+    // One finding tested in isolation would publish at p < 0.10; a hundred
+    // would publish ten false ones, and this module's whole claim is that its
+    // numbers can be quoted.
+    //
+    // THERE IS NO SEPARATE "WAS ANY READ COST OBSERVED" GATE HERE, and its
+    // absence is deliberate rather than an omission. One was written, and
+    // mutation testing showed it could not change a single verdict: if every
+    // observation has zero cost then both arm means are zero, the permutation
+    // statistic is zero for every relabelling, and p is exactly 1 -- which no
+    // BH threshold can pass. The guard was unfalsifiable, and an unfalsifiable
+    // guard is worse than none because it reads as protection nobody can test.
+    // `costObservations` survives as what it can honestly be: a DISCLOSURE, so
+    // `looNote` can say the read channel never fired instead of letting a
+    // reader take an arithmetic zero for a measured one.
+    const candidates = rows
+      .filter((row) => row.p !== null)
+      .sort((a, b) => a.p - b.p);
+    const m = candidates.length;
+    let cutoff = 0;
+    for (let i = 0; i < m; i += 1) {
+      if (candidates[i].p <= ((i + 1) / m) * FDR_Q) cutoff = i + 1;
+    }
+    for (let i = 0; i < cutoff; i += 1) candidates[i].published = true;
+
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * One or two lines for the audit, or nothing at all.
+ *
+ * THE REFUSAL IS THE PRODUCT HERE. On a machine with two injections in sixteen
+ * thousand events, the only honest output is that nothing is measurable yet,
+ * and this says so with the counts that make it checkable rather than printing
+ * a mean of nothing. It returns `null` when Layer 2 has not collected a single
+ * observation, so an idle experiment costs the reader no line at all -- the
+ * same standard `referenceNote` holds itself to.
+ */
+export function looNote(dir, options = {}) {
+  try {
+    const obs = options.obs || observations(dir, options);
+    const rows = effects(dir, { ...options, obs });
+    if (!obs.rows.length && !obs.withheldInjections) return null;
+
+    let graph = options.graph;
+    if (graph === undefined) {
+      try {
+        graph = load(dir);
+      } catch {
+        graph = null;
+      }
+    }
+    let exempt = 0;
+    if (graph?.nodes?.values) {
+      for (const node of graph.nodes.values()) {
+        if (node?.kind !== 'finding' || node.retired) continue;
+        if (node.pinned || node.origin === ORIGIN_HUMAN) exempt += 1;
+      }
+    }
+
+    const published = rows.filter((row) => row.published);
+    const head = published.length
+      ? `Per-finding causal value (leave-one-out): ${published.length} of ${rows.length} ` +
+        `findings show a verdict at q=${FDR_Q}` +
+        published
+          .slice(0, 3)
+          .map(
+            (row) =>
+              `; ${row.findingKey} saves ~${Math.round(row.shrunk)} tokens/touch ` +
+              `(${row.served} served, ${row.withheld} withheld, p=${row.p.toFixed(3)})`
+          )
+          .join('') +
+        '.'
+      : `Per-finding causal value (leave-one-out): NOT MEASURABLE YET -- ` +
+        `${obs.rows.length} attributable observations across ${rows.length} findings, ` +
+        `${obs.withheldInjections} withheld touches; the floor is ${MIN_SERVED} served ` +
+        `and ${MIN_WITHHELD} withheld per finding` +
+        (obs.costObservations ? '' : ', and no read cost has been observed in either arm') +
+        '. No effect is reported, which is not the same as an effect of zero.';
+
+    const caveats = [];
+    if (obs.unattributable)
+      caveats.push(
+        `${obs.unattributable} observations were unattributable (no joined tool outcome) and are in neither arm`
+      );
+    if (exempt)
+      caveats.push(
+        `${exempt} pinned or human-origin findings are exempt from withholding and get no causal score`
+      );
+    if (obs.policies.length > 1)
+      caveats.push(
+        `observations span ${obs.policies.length} serving-policy versions and are never pooled across them`
+      );
+    if (obs.windowed)
+      caveats.push('the read log was truncated, so downstream cost can understate');
+    return caveats.length ? `${head} ${caveats.join('; ')}.` : head;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/codex/plugin/hooks/lib/loo.mjs
+++ b/integrations/codex/plugin/hooks/lib/loo.mjs
@@ -545,8 +545,22 @@ export function observations(dir, { events = null, evidence = null } = {}) {
   }
 }
 
-/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
-function permutationP(servedCosts, withheldCosts) {
+/**
+ * Enumerates or samples arm relabellings and returns a two-sided p-value.
+ *
+ * EXPORTED so the cross-layer headline can be held to the same standard as the
+ * per-finding rows it summarises. `crosslayer.mjs` runs this over the two ARMS
+ * of shrunk effect estimates; the statistic, the enumerate-or-sample switch and the
+ * tolerance are therefore shared rather than reimplemented, and there is one
+ * place where "two-sided" is decided.
+ *
+ * `seed` exists for that caller. The default reproduces the fixed seed this
+ * function has always used, so Layer 2's own p-values are byte-identical; the
+ * cross-layer caller passes a seed DERIVED FROM ITS DATA, because a verdict
+ * printed to a human must not depend on `Math.random()` or on which module
+ * happened to call first.
+ */
+export function permutationP(servedCosts, withheldCosts, { seed = 0x9e3779b9 } = {}) {
   const pooled = [...servedCosts, ...withheldCosts];
   const n = pooled.length;
   const k = withheldCosts.length;
@@ -580,9 +594,10 @@ function permutationP(servedCosts, withheldCosts) {
     return count ? extreme / count : null;
   }
 
-  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
-  // the same p-value and a verdict cannot flicker between two audit runs.
-  let state = 0x9e3779b9;
+  // Mulberry32 off the caller's seed: reproducible, so the same data always
+  // yields the same p-value and a verdict cannot flicker between two audit
+  // runs.
+  let state = seed | 0;
   const random = () => {
     state = (state + 0x6d2b79f5) | 0;
     let t = state;

--- a/integrations/codex/plugin/hooks/lib/metrics.mjs
+++ b/integrations/codex/plugin/hooks/lib/metrics.mjs
@@ -31,6 +31,7 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { createHash, randomBytes } from 'node:crypto';
+import { redact } from './redact.mjs';
 
 /**
  * Read per call, not once at module load.
@@ -517,6 +518,15 @@ export function readEvidence(dir) {
 }
 
 /**
+ * The captured-output budget, in characters.
+ *
+ * Small enough that a 3 MB test log cannot bloat the evidence log or a single
+ * injected claim, large enough to hold the stack trace or compiler diagnostic
+ * that makes a failure finding worth anything.
+ */
+const OUTPUT_MAX_BYTES = 4096;
+
+/**
  * Joins a post-tool result to the most recent matching injection.  The exact
  * tool-call id wins; clients that omit it fall back to episode + surface +
  * anchor, in timestamp order, and the report states the weaker join method.
@@ -545,10 +555,31 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
+  // text is INJECTED into model context and EXPORTED to markdown, so the
+  // boundary is the only place that can guarantee it: a second caller added
+  // later would otherwise have to remember, and the one that forgot would leak
+  // a secret into two more places than the terminal it came from. `undefined`
+  // rather than `''` when nothing was captured, so JSON.stringify omits the
+  // key entirely and an absent capture is distinguishable from an empty one.
+  const output =
+    outcome.output === undefined || outcome.output === null
+      ? undefined
+      : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
+  // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric
+  // code at all, and 0 is the success value -- defaulting to it would claim
+  // every unreported call exited cleanly, which is a fabricated observation
+  // rather than a missing one.
+  const exit = Number.isInteger(outcome.exit) ? outcome.exit : null;
+
   return record(dir, {
     kind: 'tool-outcome',
     ...outcome,
     anchor,
+    // AFTER the spread, so a caller cannot smuggle raw text past the boundary
+    // by setting the field itself.
+    output,
+    exit,
     injectionId: injection?.injectionId || null,
     findingIds: injection?.findingIds || [],
     joinMethod,

--- a/integrations/codex/plugin/hooks/lib/metrics.mjs
+++ b/integrations/codex/plugin/hooks/lib/metrics.mjs
@@ -555,6 +555,22 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // FAILURES ONLY, and that is a deliberate override of the original plan.
+  // The plan predates MCP tool names reaching this path, so it never
+  // considered that a SUCCESSFUL `smart_read` would deposit 4 KB of file
+  // content into the evidence log on every call -- the log would grow with
+  // file text and the privacy surface would be every file the session opened.
+  //
+  // Nothing downstream loses anything. A failure claim quotes the error text;
+  // a "this command works" claim needs only the fact that it worked, which
+  // `success` and `exit` already carry. So the stored text narrows to text
+  // that is already an error message.
+  //
+  // GATED ON `success === true`, not on `!== false`: an outcome that never
+  // said whether it worked is unclassified, not successful, and dropping its
+  // text would lose exactly the failures a client too terse to report status
+  // produces.
+  const captureOutput = outcome.success !== true;
   // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
   // text is INJECTED into model context and EXPORTED to markdown, so the
   // boundary is the only place that can guarantee it: a second caller added
@@ -563,7 +579,7 @@ export function recordToolOutcome(dir, outcome) {
   // rather than `''` when nothing was captured, so JSON.stringify omits the
   // key entirely and an absent capture is distinguishable from an empty one.
   const output =
-    outcome.output === undefined || outcome.output === null
+    !captureOutput || outcome.output === undefined || outcome.output === null
       ? undefined
       : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
   // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric

--- a/integrations/codex/plugin/hooks/lib/metrics.mjs
+++ b/integrations/codex/plugin/hooks/lib/metrics.mjs
@@ -663,6 +663,89 @@ export function isFixtureAnchor(anchor) {
  * Fixture anchors are excluded from both.
  */
 /**
+ * Re-reads grouped by anchor -- the one place that decides what "wasteful" means.
+ *
+ * `rereadWaste` needed only the totals, so the grouping lived inside it and the
+ * per-anchor rows were thrown away. `derive.mjs`'s churn detector needs the
+ * rows, and re-deriving them there would put TWO definitions of "a repeat read
+ * of an unchanged file is waste" in the codebase, free to drift apart -- the
+ * exact divergence `npm run sync:hooks` exists to prevent between hooks-core and
+ * its generated copies. So the grouping lives here and both consumers read it.
+ *
+ * A re-read is only a re-read INSIDE ONE SESSION: grouping is keyed on
+ * session + canonical anchor, and rows are then merged per anchor so a file
+ * re-read across three sessions reports as one anchor with the sum of its
+ * repeats rather than three rows the caller has to add up. Merging cannot move
+ * the totals -- a sum of sums -- which is what makes it safe for `rereadWaste`.
+ *
+ * `tokens` is the WASTEFUL token count, not the total: it is the only one of the
+ * three that names something recoverable, and a row whose headline number
+ * included legitimate re-reads would overstate exactly the way the first
+ * version of this measurement did.
+ *
+ * @returns {Array<{anchor: string, repeats: number, wasteful: number,
+ *   tokens: number, legitimate: number, legitimateTokens: number,
+ *   undecidable: number, undecidableTokens: number}>} descending by `wasteful`,
+ *   then by `repeats`.
+ */
+export function rereadsByAnchor(events = [], { includeFixtures = false } = {}) {
+  const groups = new Map();
+  for (const e of events) {
+    if (!e || e.kind !== 'read' || !e.anchor) continue;
+    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
+    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(e);
+  }
+
+  const rows = new Map();
+  for (const list of groups.values()) {
+    if (list.length < 2) continue;
+    list.sort((a, b) => (a.at || 0) - (b.at || 0));
+
+    const anchorKey = canonicalKeyish(list[0].anchor);
+    let row = rows.get(anchorKey);
+    if (!row) {
+      row = {
+        anchor: list[0].anchor,
+        repeats: 0,
+        wasteful: 0,
+        tokens: 0,
+        legitimate: 0,
+        legitimateTokens: 0,
+        undecidable: 0,
+        undecidableTokens: 0,
+      };
+      rows.set(anchorKey, row);
+    }
+
+    for (let i = 1; i < list.length; i++) {
+      const prev = list[i - 1];
+      const cur = list[i];
+      const tokens = cur.tokens || 0;
+      row.repeats += 1;
+      // THE JUDGEMENT, in one place. A repeat read of a file that CHANGED is
+      // correct behaviour, not waste; a read written before fingerprints
+      // existed cannot be judged at all and says so.
+      if (!prev.fp || !cur.fp) {
+        row.undecidable += 1;
+        row.undecidableTokens += tokens;
+      } else if (prev.fp === cur.fp) {
+        row.wasteful += 1;
+        row.tokens += tokens;
+      } else {
+        row.legitimate += 1;
+        row.legitimateTokens += tokens;
+      }
+    }
+  }
+
+  return [...rows.values()].sort(
+    (a, b) => b.wasteful - a.wasteful || b.repeats - a.repeats
+  );
+}
+
+/**
  * Re-read waste, split into what is KNOWN and what is not.
  *
  * The question is narrow on purpose: how often does one session read the same
@@ -677,6 +760,9 @@ export function isFixtureAnchor(anchor) {
  * `undecidable` is reported rather than hidden. Reads written before the
  * fingerprint existed cannot be classified, and a measurement that quietly
  * counted them either way would be inventing its own answer.
+ *
+ * The aggregate fields are UNCHANGED -- `balanceSheet` reads them -- and are now
+ * a fold over `rereadsByAnchor`'s rows. `worst` is purely additive.
  */
 export function rereadWaste(
   dir,
@@ -685,14 +771,7 @@ export function rereadWaste(
   // excludes by design, making the real path untestable.
   { events = readMetrics(dir), includeFixtures = false } = {}
 ) {
-  const groups = new Map();
-  for (const e of events) {
-    if (e.kind !== 'read' || !e.anchor) continue;
-    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
-    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key).push(e);
-  }
+  const rows = rereadsByAnchor(events, { includeFixtures });
 
   const out = {
     repeats: 0,
@@ -704,29 +783,21 @@ export function rereadWaste(
     undecidableTokens: 0,
   };
 
-  for (const list of groups.values()) {
-    if (list.length < 2) continue;
-    list.sort((a, b) => (a.at || 0) - (b.at || 0));
-    for (let i = 1; i < list.length; i++) {
-      const prev = list[i - 1];
-      const cur = list[i];
-      const tokens = cur.tokens || 0;
-      out.repeats += 1;
-      if (!prev.fp || !cur.fp) {
-        out.undecidable += 1;
-        out.undecidableTokens += tokens;
-      } else if (prev.fp === cur.fp) {
-        out.wasteful += 1;
-        out.wastefulTokens += tokens;
-      } else {
-        out.legitimate += 1;
-        out.legitimateTokens += tokens;
-      }
-    }
+  for (const row of rows) {
+    out.repeats += row.repeats;
+    out.wasteful += row.wasteful;
+    out.wastefulTokens += row.tokens;
+    out.legitimate += row.legitimate;
+    out.legitimateTokens += row.legitimateTokens;
+    out.undecidable += row.undecidable;
+    out.undecidableTokens += row.undecidableTokens;
   }
 
   const decided = out.wasteful + out.legitimate;
   out.coverage = out.repeats ? decided / out.repeats : null;
+  // The offenders behind the totals, bounded: a report needs the handful worth
+  // acting on, not one row per file the session touched twice.
+  out.worst = rows.slice(0, 10);
   return out;
 }
 

--- a/integrations/codex/plugin/hooks/lib/recall.mjs
+++ b/integrations/codex/plugin/hooks/lib/recall.mjs
@@ -1,0 +1,390 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/recall.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Does retrieval FIND a finding, or does it only find what it was told where
+ * to look?
+ *
+ * `docs/WIKI_GRAPH.md` says embeddings get added "if measurement shows real
+ * recall loss". Nothing measured recall, so the no-embeddings stance was
+ * unfalsifiable -- a claim with no observation that could contradict it. This
+ * module is the observation.
+ *
+ * ---------------------------------------------------------------------------
+ * THE TAUTOLOGY THIS DELIBERATELY DOES NOT SHIP, AND WHY IT IS RECORDED HERE
+ * ---------------------------------------------------------------------------
+ * The obvious probe -- for each finding, take its anchors and ask whether
+ * `findingsFor` returns it from each -- CANNOT FAIL. `findingsFor(graph, A)`
+ * walks `derived_from` edges backwards into A, and the edge F -> A is the very
+ * thing that makes A an anchor of F. So F is in the result by CONSTRUCTION, not
+ * by retrieval quality, for every graph, forever. Its rate is 1.0 always, and a
+ * permanent 1.0 published as a recall rate reads to a human as "retrieval is
+ * perfect, embeddings unnecessary" -- one unfalsifiable claim swapped for
+ * another, leaning the one direction a measurement of this project by this
+ * project must never lean.
+ *
+ * That check is still worth running -- if it ever fails, traversal is broken
+ * rather than merely lossy -- so it is kept, and reported as `integrity` with
+ * its own `what` string saying it is not a recall rate. It is NEVER `rate`.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT IS MEASURED INSTEAD: LEAVE-ONE-EDGE-OUT
+ * ---------------------------------------------------------------------------
+ * For each active finding F and each anchor A of F, delete the edge F -> A and
+ * ask whether touching A would STILL surface F. Two independent arms, both of
+ * which can genuinely miss, which is what makes this a measurement:
+ *
+ *   Arm A -- TRAVERSAL FROM THE NEIGHBOURHOOD. Run the real `findingsFor` over
+ *   the edge-deleted graph from A itself and from A's `contains` parents. This
+ *   hits only when F has some OTHER structural route in: a second anchor on the
+ *   same file, or an anchor on a sibling symbol under the same parent. A's
+ *   `contains` children need no separate call because `findingsFor` expands
+ *   them itself -- calling the parent therefore covers every sibling, which is
+ *   why the neighbour list is `[A, ...parents(A)]` and not a hop-counted
+ *   frontier. The REAL primitive is used rather than an equivalent inlined
+ *   here, because a probe that reimplements the thing it measures drifts from
+ *   it and then measures itself.
+ *
+ *   Arm B -- BM25 FROM THE ANCHOR'S OWN KEY. Rank the whole active corpus with
+ *   `lexical.rank`, querying with A's key -- the file path or symbol name the
+ *   user actually touched -- and hit if F comes back inside `limit`.
+ *
+ * WHY ARM B IS NOT QUERIED WITH THE FINDING'S OWN CLAIM. The plan's literal
+ * form was "the finding's claim terms against the rest of the corpus", and both
+ * readings of it are degenerate. Querying F's claim against a corpus that
+ * INCLUDES F is the tautology again: BM25 scores a document against its own
+ * text, so F wins its own query every time. Querying F's claim against a corpus
+ * that EXCLUDES F cannot return F at all, so a "hit" would mean some DIFFERENT
+ * finding matched -- that is redundancy of storage, not recall of F, and it
+ * would score a graph better for holding duplicates. The anchor's key is the
+ * one query text that is available offline, is not derived from F, and matches
+ * the production question: a session touches a file, and the only lexical
+ * handle on it is its own path. It misses exactly when a finding's claim never
+ * names the code it is about, which is the recall gap embeddings are supposed
+ * to close.
+ *
+ * ---------------------------------------------------------------------------
+ * REFUSALS -- four, and each costs this project its own good news
+ * ---------------------------------------------------------------------------
+ *  1. TOO FEW OBSERVATIONS -> `rate: null` with a reason. See `MIN_PROBED`.
+ *  2. A CORPUS NO LARGER THAN THE RETRIEVAL LIMIT -> `rate: null`. Arm B is
+ *     recall@`limit`, and below the limit NO FINDING IS EVER CUT FOR BUDGET:
+ *     every document scoring above zero is returned, so the arm measures
+ *     whether a token matched, which is a strictly weaker bar than the one
+ *     production applies when `forTouch` fills a token budget from a ranked
+ *     list. A probe more permissive than the system it measures can only
+ *     overstate recall, so the rate is withheld in that band and the counts are
+ *     published instead. It bites between `MIN_PROBED` and `limit` findings --
+ *     on this machine's project graph, whose one finding had both anchor edges
+ *     "recovered" that way, the observation-count refusal fires first.
+ *  3. NO ANCHOR NODE -> the pair is UNPROBEABLE, not a miss. Reported and
+ *     excluded from the denominator; see `probeEdge`.
+ *  4. STRICT AGGREGATION -> a finding counts as retrieved only if EVERY one of
+ *     its probeable anchor edges is recoverable. A finding reachable from one
+ *     anchor and lost from another is a miss, with the losing anchor named.
+ *     This biases the rate DOWN, which is the safe direction here.
+ *
+ * FAILS OPEN. It runs on a report path; a graph it cannot read must cost a
+ * section, not the report.
+ */
+
+import { load, findingsFor } from './wiki.mjs';
+import { rank } from './lexical.mjs';
+
+/**
+ * Distinct findings that must be probeable before a RATE is published at all.
+ *
+ * NOT AN EFFECT-SIZE CONVENTION -- it is a resolution argument. A proportion
+ * over n observations has a resolution of 1/n, so below ten findings the
+ * published figure moves in steps coarser than ten percentage points, and the
+ * two extremes a small graph actually produces (`1.0` and `0.0`) are the two a
+ * reader is most likely to mistake for a finding about retrieval. At n = 10 and
+ * zero misses the exact binomial 95% upper bound on the true miss rate is still
+ * 1 - 0.05^(1/10) = 0.26, so even a clean sweep here bounds recall loss only
+ * below about a quarter -- which is why the refusal reason says what the number
+ * would and would not have supported rather than just naming the floor.
+ *
+ * THE FLOOR IS ON DISTINCT FINDINGS, NOT ANCHOR EDGES. Two anchors of one
+ * finding are two edges of the same claim, not two independent observations;
+ * counting them would let a single multi-anchored finding unlock a rate.
+ */
+export const MIN_PROBED = 10;
+
+/**
+ * The most findings probed in one call.
+ *
+ * Each probed anchor edge costs a graph-sized edge filter plus one or two real
+ * `findingsFor` walks plus one BM25 pass over the corpus, and this runs on the
+ * on-demand report path. The cap is deterministic (findings sorted by key) and
+ * `truncated` says when it bit, so a large graph gets a smaller, honestly
+ * labelled sample rather than a slow report.
+ */
+export const MAX_FINDINGS = 200;
+
+/** Active findings only. A retired claim is withdrawn; recalling it is not a win. */
+function activeFindings(graph) {
+  return [...graph.nodes.values()]
+    .filter((node) => node && node.kind === 'finding' && !node.retired)
+    .sort((a, b) => String(a.key || '').localeCompare(String(b.key || '')));
+}
+
+/** The `contains` parents of every node, indexed once for the whole probe. */
+function parentIndex(graph) {
+  const parents = new Map();
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contains') continue;
+    const list = parents.get(edge.to);
+    if (list) list.push(edge.from);
+    else parents.set(edge.to, [edge.from]);
+  }
+  return parents;
+}
+
+/** The anchors of one finding: the targets of its own `derived_from` edges. */
+function anchorsOf(graph, findingId) {
+  const out = new Set();
+  for (const edge of graph.edges) {
+    if (edge.edge === 'derived_from' && edge.from === findingId) out.add(edge.to);
+  }
+  return [...out];
+}
+
+/**
+ * The graph minus exactly one anchor edge.
+ *
+ * `nodes` is shared rather than copied: nothing here mutates it, and a
+ * 2,600-node Map copied once per anchor edge is the difference between a probe
+ * and a stall.
+ */
+function withoutAnchorEdge(graph, findingId, anchorId) {
+  return {
+    nodes: graph.nodes,
+    edges: graph.edges.filter(
+      (edge) =>
+        !(
+          edge.edge === 'derived_from' &&
+          edge.from === findingId &&
+          edge.to === anchorId
+        )
+    ),
+  };
+}
+
+/**
+ * One anchor edge, hidden, then asked after. Returns `recovered` with the arm
+ * that found it, or a reason -- and `probeable: false` when the question could
+ * not be put at all.
+ */
+function probeEdge(graph, parents, finding, anchorId, corpus, limit) {
+  const hidden = withoutAnchorEdge(graph, finding.id, anchorId);
+
+  // Arm A. `findingsFor` expands `contains` children itself, so the parent call
+  // covers every sibling of the anchor.
+  const neighbours = [anchorId, ...(parents.get(anchorId) || [])];
+  for (const neighbour of neighbours) {
+    const got = findingsFor(hidden, neighbour, { limit });
+    if (got.some((node) => node.id === finding.id)) {
+      return { recovered: true, arm: 'traversal', anchorId };
+    }
+  }
+
+  // Arm B needs a query, and the query is the anchor's own key. A dangling
+  // anchor edge -- an edge whose target node was never indexed, which
+  // `expand.promote` produces -- leaves nothing to query with. That is a
+  // question that could not be asked, NOT an observed miss: scoring it a miss
+  // would manufacture a recall loss out of a graph-integrity defect.
+  const anchor = graph.nodes.get(anchorId);
+  const key = anchor && typeof anchor.key === 'string' ? anchor.key : '';
+  if (!key) {
+    return {
+      recovered: false,
+      probeable: false,
+      anchorId,
+      reason: `anchor ${anchorId} has no node in the graph, so there is no anchor key to query BM25 with`,
+    };
+  }
+
+  const hits = rank(key, corpus, { limit });
+  if (hits.some((hit) => hit.finding && hit.finding.id === finding.id)) {
+    return { recovered: true, arm: 'lexical', anchorId };
+  }
+
+  return {
+    recovered: false,
+    probeable: true,
+    anchorId,
+    reason: `no neighbouring anchor reaches it and BM25 over ${key} does not rank it in the top ${limit}`,
+  };
+}
+
+/**
+ * The probe. An OFFLINE measurement over the graph as it stands -- it reads,
+ * ranks and traverses, and writes nothing.
+ */
+export function recallProbe(
+  dir,
+  {
+    limit = 20,
+    graph = null,
+    minProbed = MIN_PROBED,
+    maxFindings = MAX_FINDINGS,
+  } = {}
+) {
+  const refuse = (reason) => ({
+    basis: 'offline probe over the current graph',
+    probed: 0,
+    retrieved: 0,
+    rate: null,
+    reason,
+    misses: [],
+    unprobeable: [],
+  });
+
+  let g;
+  try {
+    g = graph || load(dir);
+  } catch {
+    return refuse('the graph could not be read, so recall was not measured.');
+  }
+
+  try {
+    const all = activeFindings(g);
+    const truncated = all.length > maxFindings;
+    const findings = truncated ? all.slice(0, maxFindings) : all;
+    const parents = parentIndex(g);
+    // The corpus BM25 ranks over is the ACTIVE graph, uncapped: the sample is
+    // which findings are probed, not what they compete against. Every reported
+    // figure below reads `corpus.length` rather than `all.length`, so the
+    // published size IS the ranking corpus rather than a parallel claim about
+    // it. The distinction is not pedantry: a mutation that shrank the ranking
+    // corpus to the probed sample -- making retrieval easier, in this project's
+    // favour -- SURVIVED the first mutation run precisely because the reported
+    // number came from the other variable and could not move.
+    const corpus = all;
+
+    const misses = [];
+    const unprobeable = [];
+    const integrityFailures = [];
+    let probed = 0;
+    let retrieved = 0;
+    let integrityOk = 0;
+    let probedEdges = 0;
+    let recoveredEdges = 0;
+    const byArm = { traversal: 0, lexical: 0 };
+
+    for (const finding of findings) {
+      const anchors = anchorsOf(g, finding.id);
+
+      // INTEGRITY, run on the UNTOUCHED graph: the by-construction check. Its
+      // only honest use is as a smoke test, and it is reported as one.
+      if (!anchors.length) {
+        integrityFailures.push({
+          key: finding.key,
+          reason:
+            'active finding with no anchor -- writeHarvested refuses to create one',
+        });
+      } else if (
+        anchors.every((anchorId) =>
+          findingsFor(g, anchorId, { limit }).some((node) => node.id === finding.id)
+        )
+      ) {
+        integrityOk += 1;
+      } else {
+        integrityFailures.push({
+          key: finding.key,
+          reason: `not returned by findingsFor from one of its own anchors at limit ${limit}`,
+        });
+      }
+
+      // An unanchored finding is a definite miss, not an unaskable question:
+      // nothing traverses to it and there is no anchor key to query from, so
+      // the anchor-driven path that serves findings on a file touch can never
+      // surface it. Only an explicit wiki_query naming its own terms would.
+      if (!anchors.length) {
+        probed += 1;
+        misses.push({
+          key: finding.key,
+          reason:
+            'no anchor: nothing traverses to it and there is no anchor key to query with, so only an explicit wiki_query of its own terms would surface it',
+        });
+        continue;
+      }
+
+      const results = anchors.map((anchorId) =>
+        probeEdge(g, parents, finding, anchorId, corpus, limit)
+      );
+      const askable = results.filter((result) => result.probeable !== false);
+      probedEdges += askable.length;
+      recoveredEdges += askable.filter((result) => result.recovered).length;
+      for (const result of askable) {
+        if (result.recovered) byArm[result.arm] += 1;
+      }
+
+      if (!askable.length) {
+        unprobeable.push({ key: finding.key, reason: results[0].reason });
+        continue;
+      }
+
+      probed += 1;
+      const lost = askable.filter((result) => !result.recovered);
+      if (!lost.length) retrieved += 1;
+      else misses.push({ key: finding.key, reason: lost[0].reason });
+    }
+
+    const integrity = {
+      what:
+        'BY CONSTRUCTION: a finding is returned by findingsFor from its own anchor because that edge is what makes it an anchor. Expected 1 for every graph. NOT a recall rate.',
+      probed: findings.length,
+      retrieved: integrityOk,
+      rate: findings.length ? integrityOk / findings.length : null,
+      ok: integrityFailures.length === 0,
+      failures: integrityFailures,
+    };
+
+    // Arm B is recall@`limit`. Over a corpus of at most `limit` findings nothing
+    // is ever cut for budget, so the arm asks only whether a token matched --
+    // weaker than the bar production applies under a token budget, and a probe
+    // more permissive than the system it measures can only overstate recall.
+    const discriminating = corpus.length > limit;
+
+    const common = {
+      basis: 'offline probe over the current graph',
+      probed,
+      retrieved,
+      misses,
+      unprobeable,
+      probedEdges,
+      recoveredEdges,
+      byArm,
+      corpus: corpus.length,
+      discriminating,
+      truncated,
+      minProbed,
+      integrity,
+    };
+
+    if (probed < minProbed) {
+      return {
+        ...common,
+        rate: null,
+        reason:
+          probed === 0
+            ? `no probeable finding: ${unprobeable.length} of ${findings.length} active finding(s) have no anchor node to query from, so recall was not measured. No rate is reported, which is not the same as a rate of zero.`
+            : `${probed} probeable finding(s), below the floor of ${minProbed}: a proportion over ${probed} has a resolution of ${Math.round(
+                100 / probed
+              )} percentage points, so no rate is published. ${retrieved} of ${probed} were recovered without their own anchor edge, which is a count and not a rate.`,
+      };
+    }
+
+    if (!discriminating) {
+      return {
+        ...common,
+        rate: null,
+        reason: `the active corpus holds ${corpus.length} finding(s) and the retrieval limit is ${limit}, so nothing is ever cut for budget and the lexical arm asks only whether a token matched -- a weaker bar than production applies. No rate is published off a probe more permissive than the system it measures; ${retrieved} of ${probed} were recovered, which is a count and not a rate.`,
+      };
+    }
+
+    return { ...common, rate: retrieved / probed, reason: null };
+  } catch {
+    return refuse('the probe failed, so recall was not measured.');
+  }
+}

--- a/integrations/codex/plugin/hooks/lib/redact.mjs
+++ b/integrations/codex/plugin/hooks/lib/redact.mjs
@@ -1,0 +1,30 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/redact.mjs. Regenerate with `npm run sync:hooks`.
+// hooks-core/redact.mjs
+/**
+ * Redaction for anything derived from captured output.
+ *
+ * WHY THIS IS MANDATORY RATHER THAN PRUDENT. derive.mjs builds claims out of
+ * command stderr. A claim is INJECTED into model context and EXPORTED to
+ * markdown, so a secret that reaches a claim reaches two more places than the
+ * terminal it came from. Pattern matching is imperfect and that is stated in the
+ * spec, but "imperfect" beats "absent" by a wide margin here.
+ */
+
+const PATTERNS = [
+  // Bearer / API-key shaped tokens.
+  [/\b(bearer\s+)[A-Za-z0-9._~+/-]{12,}/gi, '$1[redacted]'],
+  [/\b(sk|pk|ghp|gho|github_pat|xox[baprs])[-_][A-Za-z0-9._-]{10,}/gi, '[redacted]'],
+  // KEY=value where the key name suggests a secret.
+  [/\b([A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|APIKEY|API_KEY|PRIVATE_KEY|CREDENTIAL)[A-Z0-9_]*)\s*[=:]\s*\S+/g, '$1=[redacted]'],
+  // Credentials inside a URL.
+  [/\b([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+):[^\s@]+@/gi, '$1:[redacted]@'],
+  // PEM blocks.
+  [/-----BEGIN[^-]*PRIVATE KEY-----[\s\S]*?-----END[^-]*PRIVATE KEY-----/g, '[redacted key]'],
+];
+
+export function redact(text, { max = 400 } = {}) {
+  let out = String(text ?? '');
+  for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
+}

--- a/integrations/codex/plugin/hooks/lib/redact.mjs
+++ b/integrations/codex/plugin/hooks/lib/redact.mjs
@@ -24,7 +24,21 @@ const PATTERNS = [
 ];
 
 export function redact(text, { max = 400 } = {}) {
+  // `?? ''` matters even though String(null)/String(undefined) never throw:
+  // without it a missing value becomes the literal 4-11 character string
+  // "null"/"undefined" -- a garbage claim that silently reaches the graph
+  // and model context instead of surfacing as an error.
   let out = String(text ?? '');
   for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  // Redact BEFORE truncating, never the reverse. Several patterns above rely
+  // on a minimum-length quantifier (e.g. `{10,}`, `{12,}`) plus a prefix.
+  // Truncating first can cut a match down to fewer characters than that
+  // quantifier requires, so the shortened fragment no longer satisfies the
+  // pattern and a live partial secret would pass through in cleartext. By
+  // redacting the full, untruncated string first, every pattern always sees
+  // the complete secret and removes it before any character budget is
+  // spent; the cap below can then only ever cut into already-redacted text
+  // (a label, or the "[redacted]" placeholder itself), never into raw
+  // secret bytes.
   return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
 }

--- a/integrations/codex/plugin/hooks/lib/transcript.mjs
+++ b/integrations/codex/plugin/hooks/lib/transcript.mjs
@@ -19,9 +19,11 @@
  */
 
 import {
-  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, unlinkSync,
+  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync,
+  unlinkSync, openSync, readSync, closeSync,
 } from 'node:fs';
 import { join } from 'node:path';
+import { redact } from './redact.mjs';
 
 /** Where a project's transcripts live, under the graph it belongs to. */
 export const transcriptDir = (dir) => join(dir, 'transcripts');
@@ -210,4 +212,204 @@ export function readArchive(dir, sessionId) {
   } catch {
     return [];
   }
+}
+
+/**
+ * How much of a transcript's TAIL is scanned for failed tool results.
+ *
+ * A transcript is the largest file this project reads: the three real ones on
+ * the measuring machine are 5.8 MB, 22 MB and 45 MB. `archive()` above already
+ * reads the whole thing once at Stop, so an unbounded second pass doubles the
+ * most expensive read on the session-end path for evidence that is, by
+ * construction, mostly old. The tail is the right half to keep for the same
+ * reason `buildFeedbackDigest` keeps the end: what a session learned is
+ * concentrated where the work went wrong, which is later rather than sooner.
+ */
+const FAILED_SCAN_BYTES = () =>
+  Number(process.env.TOKEN_OPTIMIZER_TRANSCRIPT_SCAN_BYTES) || 8 * 1024 * 1024;
+
+/** Failed results kept, most recent first. The pairing detector needs a handful. */
+const FAILED_MAX = 50;
+
+/** Same 4 KB cap `recordToolOutcome` applies to `output`, for the same reason. */
+const FAILED_OUTPUT_MAX = 4096;
+
+/**
+ * The same 120-character truncation `recordToolOutcome` applies to `anchor`.
+ *
+ * ONE COMMAND MUST PRODUCE ONE KEY FROM EITHER SOURCE. A `tool-outcome` stores
+ * the command as `String(tool_input.command).slice(0, 120)`, and `attemptKey`
+ * reads up to three non-flag tokens off whatever it is handed. A long first
+ * token -- a quoted grep pattern, an absolute Windows path, a heredoc -- is cut
+ * by that cap INSIDE those three tokens, so the untruncated transcript copy of
+ * the same command lands in a DIFFERENT group. Measured against one real
+ * session's own evidence: 266 commands present in both sources, and truncating
+ * here made 266 of 266 keys agree where the untruncated text agreed on only
+ * 240.
+ *
+ * WHAT THAT ACTUALLY BUYS, stated precisely rather than generously. `derive`
+ * refuses to build a claim out of a command at or over the cap at all (see
+ * `quotable` there), so agreement on a TRUNCATED key never produces a finding
+ * on its own. It buys two things that still matter: a transcript failure lands
+ * in the same run as the event outcomes of the same command, so the
+ * nearest-preceding-failure rule sees the real sequence rather than a sparse
+ * one; and the no-call-id fallback in `derive`'s deduplication compares command
+ * TEXT against an already-truncated anchor, which cannot match unless this side
+ * is truncated identically.
+ */
+const ANCHOR_MAX = 120;
+
+/**
+ * A tool result that reports a command that RAN and exited non-zero.
+ *
+ * A POSITIVE ALLOWLIST, and the measurement is why. Claude Code sets
+ * `is_error: true` on every kind of unhappy tool result, and across three real
+ * transcripts 214 of them fell into four shapes:
+ *
+ *   83  `Exit code N` + stderr    -- a command ran and failed. THIS ONE.
+ *   109 hook and policy denials   -- overwhelmingly THIS optimizer's own
+ *                                    PreToolUse text ("Recursive shell searches
+ *                                    return unbounded output. Call the
+ *                                    token-optimizer MCP tool smart_grep
+ *                                    instead"), plus `Remove-Item on system
+ *                                    path` blocks.
+ *   18  `<tool_use_error>...`     -- protocol errors: `String to replace not
+ *                                    found`, `File has not been read yet`,
+ *                                    `Blocked: ...`.
+ *   4   a person declined the call.
+ *
+ * Only the first shape is a command failing. In every other shape THE COMMAND
+ * NEVER RAN, so "`X` failed with: ..." would be a false claim about X, and a
+ * later success would pair with a failure that never happened. The 109 are the
+ * dangerous ones: ingesting them would have this tool derive findings from its
+ * own advice, at 0.9 confidence, and serve them back as observations about the
+ * project -- a self-referential loop that also inflates its own finding count.
+ * That is the measurement-bias class this plan tracks, and a denylist would
+ * have let every future denial string through by default.
+ */
+const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
+
+/** Reads at most `bytes` from the END of a file, without loading the rest. */
+function readTail(path, bytes) {
+  let fd;
+  try {
+    const size = statSync(path).size;
+    const length = Math.min(size, bytes);
+    if (!length) return '';
+    fd = openSync(path, 'r');
+    const buffer = Buffer.allocUnsafe(length);
+    readSync(fd, buffer, 0, length, size - length);
+    const text = buffer.toString('utf8');
+    // A tail almost never starts on a line boundary, and half a JSON object is
+    // not a parse failure worth reporting -- it is a partial record. Drop it.
+    return length < size ? text.slice(text.indexOf('\n') + 1) : text;
+  } catch {
+    return '';
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+}
+
+/**
+ * The failed COMMAND results a transcript holds, which no hook event carries.
+ *
+ * WHY THIS READER EXISTS. Claude Code never fires PostToolUse for a failed tool
+ * call: a deliberately failing command produced no event at all, and 2,238 of
+ * 2,238 live `tool-outcome` events on the measuring machine carry
+ * `success: true`. So `derive.mjs`'s two strongest detectors -- command
+ * failed-then-succeeded at 0.90 and test/build red-to-green at 0.85 -- have no
+ * input whatsoever on the primary client, while working normally on the ten
+ * adapter clients. The failures exist; they exist only here.
+ *
+ * WHY NOT THE ARCHIVE, which the plan for this reader assumed. `readTurns`
+ * DROPS tool results by design -- that is where whole file contents would enter
+ * the record -- so `readArchive` returns no failure, ever, and an extractor over
+ * archived turns would find nothing however well it was written. Making the
+ * archive carry them would also push command stderr into `buildFeedbackDigest`,
+ * which is the one code path in this project that sends anything to a model
+ * endpoint. So this reads the transcript and STORES NOTHING NEW: read-only, no
+ * capture path, no new event kind, and no widening of what leaves the machine.
+ *
+ * REDACTED HERE, at this boundary, exactly as `recordToolOutcome` redacts
+ * `output`. Transcript text has never passed a redaction boundary -- that one
+ * never saw it -- and everything returned from here is destined for a claim that
+ * is injected into model context and exported to markdown.
+ *
+ * @returns {Array<{command: string, output: string, exit: number|null,
+ *   at: number, toolCallId: string|null}>} in transcript order, so a caller can
+ *   sort it beside `tool-outcome` events without re-ordering.
+ */
+export function failedResultsFromTranscript(transcriptPath, options = {}) {
+  const { max = FAILED_MAX, scanBytes = FAILED_SCAN_BYTES() } = options || {};
+  if (!transcriptPath) return [];
+  const text = readTail(transcriptPath, scanBytes);
+  if (!text) return [];
+
+  // tool_use_id -> the command that was attempted. The join is EXACT and it is
+  // the only one available: the result block carries no command of its own, and
+  // the id is the same string `episodeMeta` reads into `toolCallId`, so the same
+  // key also deduplicates against events on clients that do report failures.
+  const commands = new Map();
+  const failures = [];
+
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const message = entry.message || entry;
+    const role = message.role || entry.type;
+    const content = message.content;
+    if (!Array.isArray(content)) continue;
+
+    if (role === 'assistant') {
+      for (const block of content) {
+        if (!block || block.type !== 'tool_use' || !block.id) continue;
+        const command = block.input?.command;
+        if (typeof command !== 'string' || !command.trim()) continue;
+        commands.set(String(block.id), command.slice(0, ANCHOR_MAX));
+      }
+      continue;
+    }
+
+    if (role !== 'user') continue;
+    for (const block of content) {
+      if (!block || block.type !== 'tool_result' || block.is_error !== true) continue;
+      // Only a STRING result can be an exit-code report; every failed Claude
+      // Code result observed was one, and a structured body is a shape this
+      // classifier has not measured, so it is refused rather than guessed at.
+      if (typeof block.content !== 'string') continue;
+      const match = EXIT_CODE_RESULT.exec(block.content);
+      if (!match) continue;
+      const command = commands.get(String(block.tool_use_id || ''));
+      // No command means no claim. The result says something failed; without
+      // the text of what failed there is nothing to say about it, and nothing
+      // to group it with.
+      if (!command) continue;
+      failures.push({
+        command,
+        // The exit line itself is stripped: `exit` carries it structurally, and
+        // leaving it in makes every failure claim read "failed with: Exit code 1".
+        output: redact(block.content.slice(match[0].length).trim(), {
+          max: FAILED_OUTPUT_MAX,
+        }),
+        exit: Number(match[1]),
+        at: Date.parse(entry.timestamp || '') || 0,
+        toolCallId: block.tool_use_id ? String(block.tool_use_id) : null,
+      });
+    }
+  }
+
+  // The MOST RECENT `max`, keeping chronological order. A session that failed
+  // two hundred times teaches its last lessons, not its first.
+  return failures.slice(-max);
 }

--- a/integrations/codex/plugin/hooks/lib/usage.mjs
+++ b/integrations/codex/plugin/hooks/lib/usage.mjs
@@ -42,7 +42,7 @@
  * was referenced" and "nothing could be measured" are different answers and
  * this module gives different answers for them.
  */
-import { readMetrics } from './metrics.mjs';
+import { readMetrics, readTruncation } from './metrics.mjs';
 
 /**
  * The events that name a finding, and it is ONE kind, not the two the plan
@@ -129,17 +129,30 @@ export function classify(dir, { events = null } = {}) {
   try {
     const all = inTimeOrder(events || readMetrics(dir));
 
-    // Every reference, keyed on the finding it names. Only references carrying
-    // a session id are usable -- see `unscopedReferences` in `referenceRate`
-    // for the ones this drops and why they are counted rather than credited.
+    // Every reference, keyed on the finding it names and on nothing else.
+    //
+    // NOT SCOPED BY SESSION, and that is a deliberate reversal. Scoping needs
+    // the query's `sessionId`, which `wiki_query` takes as an OPTIONAL input
+    // the model has to volunteer (`options.sessionId ?? null`) -- so the
+    // numerator depended on the model choosing to identify itself, and an
+    // unverifiable model-supplied id is not evidence. Plan 1 settled that for
+    // the `answers` edge and it settles it here: stop depending on the field
+    // rather than hope for cooperation. The finding key is the specific part
+    // anyway; a key is a graph identity, not a guess.
+    //
+    // THE COST, disclosed here and in `referenceNote` because a reader of the
+    // number has to see it: TWO CONCURRENT SESSIONS ON ONE REPOSITORY CAN
+    // CROSS-ATTRIBUTE. Session A's injection of K plus session B's later query
+    // for K reads as a reference. Nothing in the log can separate them once the
+    // session id is gone, so the exposure is real and is stated rather than
+    // priced.
     const references = new Map();
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       const key = referencedKey(event);
-      const session = sessionOf(event);
-      if (!key || !session) continue;
+      if (!key) continue;
       if (!references.has(key)) references.set(key, []);
-      references.get(key).push({ at: event.at || 0, session });
+      references.get(key).push(event.at || 0);
     }
 
     // Which injections the existing outcome join could attribute. An outcome
@@ -170,9 +183,8 @@ export function classify(dir, { events = null } = {}) {
       const injectionId = event.injectionId ? String(event.injectionId) : null;
       const at = event.at || 0;
       const session = sessionOf(event);
-      // STRICTLY AFTER. A query that PRECEDED the injection is the model
-      // asking on its own initiative; crediting it would let the metric take
-      // the credit for a lookup it had nothing to do with.
+      // STRICTLY AFTER here too: activity that predates the injection is not
+      // an opportunity to have used it.
       const followed = (times) => times.some((t) => t > at);
       const continued =
         (injectionId && attributed.has(injectionId)) ||
@@ -181,9 +193,11 @@ export function classify(dir, { events = null } = {}) {
       for (const raw of keys) {
         const findingKey = String(raw);
         const hits = references.get(findingKey) || [];
-        const referenced = session
-          ? hits.some((hit) => hit.session === session && hit.at > at)
-          : false;
+        // TIME ORDER IS THE ONLY REMAINING GUARD, so it carries the whole
+        // weight of the attribution: a query that PRECEDED the injection is
+        // the model asking on its own initiative, and crediting it would let
+        // the metric take the credit for a lookup it had nothing to do with.
+        const referenced = hits.some((hitAt) => hitAt > at);
         rows.push({
           findingKey,
           injectionId,
@@ -204,9 +218,27 @@ export function classify(dir, { events = null } = {}) {
 /**
  * The rate, with everything needed to tell a real 0 from an absent one.
  *
- * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
- * `unattributable` and `unscopedReferences` are reported beside it, never
- * inside it.
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown` and
+ * `unattributable` are reported beside it, never inside it.
+ *
+ * `windowed` SAYS WHETHER THE DENOMINATOR CAN UNDERSTATE, and it is not
+ * decoration. `readMetrics` reads a 2 MB / 5,000-event TAIL of the firehose,
+ * and injections are rare enough on a real project to age out of it: measured
+ * on this repository, both `inject` events sit at lines 502 and 883 of 6,871
+ * and have scrolled away behind ~6,000 later `read` and `tool-outcome` rows,
+ * so the windowed denominator is 0 where the whole-file truth is 1.
+ *
+ * IT IS REPORTED RATHER THAN FIXED, deliberately. `inject` already gets
+ * unwindowed access through `BALANCE_KINDS` / `EVIDENCE_KINDS`, but `query`
+ * does not -- and reading only the INJECTION arm unwindowed would be worse
+ * than the windowing: every old injection would enter the denominator with no
+ * chance of a matching query in the window and score `not-referenced`,
+ * manufacturing a pessimistic rate out of the asymmetry. Making the query arm
+ * unwindowed means adding `query` to `EVIDENCE_KINDS`, which two other
+ * consumers read, and this project's own standard says a shared-classifier
+ * change needs a per-consumer verdict comparison. So the honest move is to
+ * publish the flag: a caller that needs the unwindowed truth passes its own
+ * `events`, which is exactly what the live measurement in the task report did.
  */
 export function referenceRate(dir, { events = null } = {}) {
   const empty = {
@@ -218,10 +250,15 @@ export function referenceRate(dir, { events = null } = {}) {
     unattributable: 0,
     unattributableWithInjectedToolCall: 0,
     referenceEvents: 0,
-    unscopedReferences: 0,
+    windowed: false,
   };
   try {
     const all = events || readMetrics(dir);
+    // OUT OF BAND, and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` reports on the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
     const rows = classify(dir, { events: all });
     const count = (label) => rows.filter((row) => row.label === label).length;
     const referenced = count('referenced');
@@ -231,17 +268,17 @@ export function referenceRate(dir, { events = null } = {}) {
     // Usable reference events in the window: the numerator's producer. If this
     // is zero the channel never fired, and a 0% rate would be measuring the
     // absence of a producer rather than the uselessness of findings.
+    //
+    // NO SESSION REQUIREMENT, matching the attribution above. The former
+    // `unscopedReferences` counted queries dropped for want of a session id;
+    // nothing is dropped for that reason any more, so the field is GONE rather
+    // than kept at a permanent zero that a later reader would misread as
+    // evidence the loss had been fixed.
     let referenceEvents = 0;
-    let unscopedReferences = 0;
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       if (!referencedKey(event)) continue;
-      if (sessionOf(event)) referenceEvents += 1;
-      // Names a finding but cannot be scoped to one injection. `sessionId` is
-      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
-      // is the expected loss rather than an edge case -- counted here so it is
-      // visible instead of silently deflating the numerator.
-      else unscopedReferences += 1;
+      referenceEvents += 1;
     }
 
     // The tool calls that DID receive findings, keyed the way
@@ -292,7 +329,7 @@ export function referenceRate(dir, { events = null } = {}) {
       unattributable,
       unattributableWithInjectedToolCall,
       referenceEvents,
-      unscopedReferences,
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
     };
   } catch {
     return empty;
@@ -300,11 +337,18 @@ export function referenceRate(dir, { events = null } = {}) {
 }
 
 /**
- * One line for the audit, or nothing at all.
+ * One or two lines for the audit, or nothing at all.
  *
  * Says which of the three things is true -- a measured rate, a live channel
  * with no opportunities yet, or no channel at all -- rather than printing a
  * figure and letting the reader assume the first.
+ *
+ * AND IT CARRIES THE CAVEATS, because this is the only place a human meets the
+ * number. A rate attributed on (finding key, time order) can cross-attribute
+ * between two concurrent sessions on one repository, and a windowed read can
+ * understate the denominator. Both are stated beside the figure they qualify.
+ * Putting them only in a task report would be publishing a clean number and
+ * filing the asterisk somewhere nobody quoting it will look.
  */
 export function referenceNote(dir, { events = null } = {}) {
   const r = referenceRate(dir, { events });
@@ -317,6 +361,11 @@ export function referenceNote(dir, { events = null } = {}) {
   }
   return (
     `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
-    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded. ` +
+    'Matched on finding key and time order, so concurrent sessions on this ' +
+    'repository can cross-attribute' +
+    (r.windowed
+      ? '; and the event log was truncated, so the denominator can understate.'
+      : '.')
   );
 }

--- a/integrations/codex/plugin/hooks/lib/usage.mjs
+++ b/integrations/codex/plugin/hooks/lib/usage.mjs
@@ -1,0 +1,322 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/usage.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 1 -- did the model actually go back and use what we injected?
+ *
+ * The cheap behavioural label. One question, answered from the event log alone:
+ * after we put a finding in front of the model, did the model later ASK FOR
+ * THAT FINDING BY NAME?
+ *
+ * WHY EXPLICIT REFERENCE, AND NOT READ-SUPPRESSION. Read-suppression -- "the
+ * file was not re-read, so the finding must have helped" -- is Layer 2's
+ * estimand, measured causally by withholding a finding and comparing. Layer 1
+ * exists to be calibrated AGAINST that. If both layers derived from
+ * suppression, the calibration would compare two spellings of one quantity,
+ * report a strong correlation, and mean nothing. So Layer 1 is deliberately
+ * built on a signal Layer 2 does not touch: an explicit `query` naming the
+ * finding key.
+ *
+ * WHAT THIS DOES NOT DO. It does not invent a join. `recordToolOutcome`
+ * already joins each post-tool result back to the injection that preceded it,
+ * recording `injectionId`, `findingIds` and a `joinMethod` of `tool-call-id`,
+ * `episode-anchor` or `none` -- preferring an exact tool-call id, which is
+ * strictly better evidence than the `(sessionId, findingKey)` approximation an
+ * earlier draft of this plan proposed. This module consumes that join and adds
+ * none of its own. `inject.mjs` needed no change: it has written `findingIds`
+ * at every call site all along.
+ *
+ * WHAT `unknown` IS FOR, and it is the whole reason this file is careful. An
+ * injection whose session simply stopped afterwards is not a miss. Nothing
+ * happened, so nothing can be concluded, and counting it against the finding
+ * would make the metric read worse the more often sessions end -- a number
+ * that moves with session length rather than with usefulness. `unknown` is
+ * therefore EXCLUDED from the denominator rather than scored zero, and
+ * outcomes the join could not attribute at all are reported as
+ * `unattributable` rather than folded into either arm.
+ *
+ * AND WHY THE RATE CAN BE `null`. This project has already shipped two metrics
+ * whose only producer was their own test suite. A rate of 0% that actually
+ * means "no data" is worse than a refusal, because it is a number and numbers
+ * get quoted. So `rate` is null unless there is a denominator AND the
+ * reference channel produced at least one usable event in the window. "Nothing
+ * was referenced" and "nothing could be measured" are different answers and
+ * this module gives different answers for them.
+ */
+import { readMetrics } from './metrics.mjs';
+
+/**
+ * The events that name a finding, and it is ONE kind, not the two the plan
+ * assumed.
+ *
+ * The brief said "a later `query` or `expand` event". Checked against the code
+ * and against every metrics log on this machine, `expand` does not qualify and
+ * cannot be made to:
+ *
+ *   - `recordExpansion` writes `{ ref, tool, shape, asked, sessionId }`. `ref`
+ *     is a TRUNCATION CAPTURE id (a 16-hex digest of captured tool output),
+ *     not a finding key, and `asked` is free text naming a section of that
+ *     output. Neither is a graph key, and no code path ever puts one there.
+ *   - measured: 64 live `expand` events exist on this machine and all 64 carry
+ *     `sessionId: null`, so they could not be scoped to an injection even if
+ *     they did name one.
+ *
+ * Keying the classifier on `expand` would therefore have added a branch that
+ * can never fire -- a metric with no producer, which is the exact defect this
+ * whole effort exists to close. So it is excluded, deliberately and with the
+ * measurement recorded, rather than included for symmetry with the brief.
+ */
+const REFERENCE_KINDS = new Set(['query']);
+
+/**
+ * What counts as the session having CONTINUED past the injection.
+ *
+ * The distinction between `not-referenced` and `unknown` rests entirely on
+ * this, so the set is explicit rather than "any later event". These are the
+ * kinds a tool call produces: if one of them follows the injection in the same
+ * session, the model had the opportunity to ask and did not. If none does, the
+ * session ended and there was no opportunity.
+ *
+ * `inject` is in the set because a later injection means a later tool call
+ * happened. `forecast`, `mcp-client` and `mcp-tool` are NOT: they are written
+ * by session bookkeeping rather than by the model doing something, and
+ * treating them as opportunity would convert `unknown` rows into misses on
+ * bookkeeping alone.
+ */
+const ACTIVITY_KINDS = new Set([
+  'tool-outcome',
+  'read',
+  'query',
+  'expand',
+  'substitute',
+  'inject',
+]);
+
+/** A usable session id: a non-empty string. `null == null` is not a match. */
+const sessionOf = (event) => {
+  const id = event?.sessionId;
+  return typeof id === 'string' && id ? id : null;
+};
+
+/** The finding key a reference event names, or null if it names none. */
+const referencedKey = (event) => {
+  const key = event?.key;
+  return typeof key === 'string' && key ? key : null;
+};
+
+/** Ordering by the caller's timestamp, with log order breaking ties. */
+function inTimeOrder(events) {
+  return events
+    .map((event, index) => ({ event, index }))
+    .sort(
+      (a, b) =>
+        (a.event.at || 0) - (b.event.at || 0) || a.index - b.index
+    )
+    .map((row) => row.event);
+}
+
+/**
+ * One row per (injection, finding) pair, labelled.
+ *
+ * Per injection rather than per finding: the same finding injected twice is two
+ * separate opportunities, and collapsing them would let one reference excuse
+ * every later injection of that key.
+ *
+ * FAILS OPEN. A malformed log yields an empty classification, never a throw:
+ * this runs on report paths that must not break a tool call.
+ */
+export function classify(dir, { events = null } = {}) {
+  let rows = [];
+  try {
+    const all = inTimeOrder(events || readMetrics(dir));
+
+    // Every reference, keyed on the finding it names. Only references carrying
+    // a session id are usable -- see `unscopedReferences` in `referenceRate`
+    // for the ones this drops and why they are counted rather than credited.
+    const references = new Map();
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      const key = referencedKey(event);
+      const session = sessionOf(event);
+      if (!key || !session) continue;
+      if (!references.has(key)) references.set(key, []);
+      references.get(key).push({ at: event.at || 0, session });
+    }
+
+    // Which injections the existing outcome join could attribute. An outcome
+    // carrying our injectionId is proof the tool call completed, which is
+    // opportunity even when the session id is missing from the log.
+    const attributed = new Set();
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) continue;
+      attributed.add(String(event.injectionId));
+    }
+
+    // Activity per session, so "did anything follow?" is one lookup rather
+    // than a scan per injection.
+    const activity = new Map();
+    for (const event of all) {
+      if (!ACTIVITY_KINDS.has(event.kind)) continue;
+      const session = sessionOf(event);
+      if (!session) continue;
+      if (!activity.has(session)) activity.set(session, []);
+      activity.get(session).push(event.at || 0);
+    }
+
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+      if (!keys.length) continue;
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const at = event.at || 0;
+      const session = sessionOf(event);
+      // STRICTLY AFTER. A query that PRECEDED the injection is the model
+      // asking on its own initiative; crediting it would let the metric take
+      // the credit for a lookup it had nothing to do with.
+      const followed = (times) => times.some((t) => t > at);
+      const continued =
+        (injectionId && attributed.has(injectionId)) ||
+        (session ? followed(activity.get(session) || []) : false);
+
+      for (const raw of keys) {
+        const findingKey = String(raw);
+        const hits = references.get(findingKey) || [];
+        const referenced = session
+          ? hits.some((hit) => hit.session === session && hit.at > at)
+          : false;
+        rows.push({
+          findingKey,
+          injectionId,
+          label: referenced
+            ? 'referenced'
+            : continued
+              ? 'not-referenced'
+              : 'unknown',
+        });
+      }
+    }
+  } catch {
+    rows = [];
+  }
+  return rows;
+}
+
+/**
+ * The rate, with everything needed to tell a real 0 from an absent one.
+ *
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
+ * `unattributable` and `unscopedReferences` are reported beside it, never
+ * inside it.
+ */
+export function referenceRate(dir, { events = null } = {}) {
+  const empty = {
+    referenced: 0,
+    notReferenced: 0,
+    unknown: 0,
+    denominator: 0,
+    rate: null,
+    unattributable: 0,
+    unattributableWithInjectedToolCall: 0,
+    referenceEvents: 0,
+    unscopedReferences: 0,
+  };
+  try {
+    const all = events || readMetrics(dir);
+    const rows = classify(dir, { events: all });
+    const count = (label) => rows.filter((row) => row.label === label).length;
+    const referenced = count('referenced');
+    const notReferenced = count('not-referenced');
+    const denominator = referenced + notReferenced;
+
+    // Usable reference events in the window: the numerator's producer. If this
+    // is zero the channel never fired, and a 0% rate would be measuring the
+    // absence of a producer rather than the uselessness of findings.
+    let referenceEvents = 0;
+    let unscopedReferences = 0;
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      if (!referencedKey(event)) continue;
+      if (sessionOf(event)) referenceEvents += 1;
+      // Names a finding but cannot be scoped to one injection. `sessionId` is
+      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
+      // is the expected loss rather than an edge case -- counted here so it is
+      // visible instead of silently deflating the numerator.
+      else unscopedReferences += 1;
+    }
+
+    // The tool calls that DID receive findings, keyed the way
+    // `recordToolOutcome` keys its own primary join: the tool-call id. An
+    // unattributable outcome for one of these is a join that FAILED. An
+    // unattributable outcome for any other tool call had nothing to join to.
+    //
+    // KEYED ON THE TOOL CALL, NOT THE EPISODE, and the first draft of this
+    // got it wrong in a way worth recording because it is the exact
+    // measurement-bias class this plan hunts. `episodeId` equals the SESSION
+    // id, so "unattributable outcomes in an episode that had an injection"
+    // scored all 2,559 tool calls of a session in which ONE injection
+    // happened. It would have published 2,559 join failures where the true
+    // number is zero -- correct code, lying number, and biased pessimistic
+    // rather than flattering, which is no better.
+    const injectedToolCalls = new Set();
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      if (!Array.isArray(event.findingIds) || !event.findingIds.length)
+        continue;
+      if (event.toolCallId) injectedToolCalls.add(String(event.toolCallId));
+    }
+    let unattributable = 0;
+    let unattributableWithInjectedToolCall = 0;
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome' || event.joinMethod !== 'none')
+        continue;
+      unattributable += 1;
+      // BOTH FIGURES, because the raw one alone lies in the pessimistic
+      // direction. Measured on this machine: 2,991 of 2,992 live outcomes
+      // report `joinMethod: 'none'`, and every one of them because NO
+      // INJECTION EXISTED for that tool call -- the graph holds one finding.
+      // Quoting only the raw count would read as a join that fails 99.97% of
+      // the time, which is a different and false claim.
+      if (event.toolCallId && injectedToolCalls.has(String(event.toolCallId)))
+        unattributableWithInjectedToolCall += 1;
+    }
+
+    return {
+      referenced,
+      notReferenced,
+      unknown: count('unknown'),
+      denominator,
+      rate:
+        denominator > 0 && referenceEvents > 0
+          ? referenced / denominator
+          : null,
+      unattributable,
+      unattributableWithInjectedToolCall,
+      referenceEvents,
+      unscopedReferences,
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/**
+ * One line for the audit, or nothing at all.
+ *
+ * Says which of the three things is true -- a measured rate, a live channel
+ * with no opportunities yet, or no channel at all -- rather than printing a
+ * figure and letting the reader assume the first.
+ */
+export function referenceNote(dir, { events = null } = {}) {
+  const r = referenceRate(dir, { events });
+  if (!r.denominator && !r.unknown && !r.referenceEvents) return null;
+  if (r.rate == null) {
+    const why = !r.referenceEvents
+      ? 'no finding was ever queried by key in this window'
+      : `no injection had a chance to be referenced yet (${r.unknown} unknown)`;
+    return `Injected findings referenced later: not measurable -- ${why}.`;
+  }
+  return (
+    `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+  );
+}

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -103,6 +103,44 @@ const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
 
 /**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because FOUR readers depend on it -- mutation accounting,
+ * success classification, output capture and exit-code capture -- and clients
+ * disagree on the envelope name and on nothing else. Letting each reader name
+ * its own subset is exactly how both classifiers came to miss MCP's failure
+ * flag: `toolSucceeded` listed four envelopes and `mutationSucceeded` listed
+ * three, and neither list mentioned `isError` at all.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/**
+ * Did an MCP result declare itself an error?
+ *
+ * `isError` is the ONLY failure signal an MCP result carries -- there is no
+ * `error` field and no `status` -- and `src/server/index.ts` sets it in seven
+ * places. Shared by both classifiers so they cannot disagree about what a
+ * failed call from this project's own tools looks like.
+ *
+ * `=== true` EXACTLY. A client using the key for anything else must not have
+ * its successful calls silently reclassified, and `isError: false` is a
+ * successful MCP call, not a missing verdict.
+ */
+function reportedMcpError(raw) {
+  return [...responseEnvelopes(raw), raw].some(
+    (envelope) => envelope?.isError === true
+  );
+}
+
+/**
  * A post-tool event is not universally proof of success. Some clients split
  * success and failure into distinct events; others expose a result status.
  * Keep mutation accounting conservative so a failed edit cannot arm Stop.
@@ -112,6 +150,19 @@ export function mutationSucceeded(clientName, raw) {
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
     return false;
+  // BEFORE the status read, the explicit-success read AND the client
+  // allowlist, because all three would otherwise pass a failed MCP write. The
+  // allowlist is the one that actually bit: it returns true for claude-code,
+  // codex, qwen, opencode, kilo and windsurf on any post-tool event with no
+  // error and no status, which is precisely the shape of a failed smart_write.
+  //
+  // WHY THIS IS THE SAME BUG AS THE ONE IN `toolSucceeded` AND NOT A COSMETIC
+  // ECHO OF IT: this function gates edit counting and harvest pressure, so
+  // counting a failed write to THE OPTIMIZER'S OWN TOOLS as a mutation
+  // inflates "the optimizer successfully edited a file". Different consumers
+  // from the effectiveness figures, same direction of bias -- toward
+  // flattering the thing being measured.
+  if (reportedMcpError(raw)) return false;
 
   const status =
     raw?.tool_response?.status ??
@@ -145,24 +196,6 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * Spelled out ONCE because three readers depend on it -- success
- * classification, output capture and exit-code capture -- and clients disagree
- * on the envelope name and on nothing else. Letting each reader name its own
- * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
-}
-
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
@@ -181,8 +214,7 @@ export function toolSucceeded(raw) {
   // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
   // optimizer's favour. A measurement that flatters the thing being measured
   // is worse than no measurement.
-  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
-    return false;
+  if (reportedMcpError(raw)) return false;
   const status =
     raw?.tool_response?.status ??
     raw?.toolResponse?.status ??

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -957,10 +957,12 @@ async function runHook(clientName, event, invocation) {
       // accumulates structure and no verdicts at all. These detectors read only
       // what is already on disk and send nothing anywhere.
       //
-      // The COUNT is recorded rather than the candidates: how many findings a
-      // session's own evidence supports is the number that says whether this is
-      // working, and it is measurable before anything is stored. Storage is the
-      // caller's next step, under a budget.
+      // COUNTS are recorded rather than the candidates, and BOTH counts: how
+      // many findings a session's own evidence supports, and how many of them
+      // survived the storage budget and the anchor discipline. The gap between
+      // the two is the number that says whether the bound is doing anything --
+      // one figure alone cannot distinguish "nothing to derive" from "derived
+      // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
       const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
       const dir = wikiDir(projectRoot);
@@ -976,6 +978,7 @@ async function runHook(clientName, event, invocation) {
         sessionId,
         candidates: derived.candidates.length,
         observations: derived.observations.length,
+        written: derived.written.length,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -172,6 +172,136 @@ export function toolSucceeded(raw) {
   return true;
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * The same family `toolSucceeded` reads above, hoisted so the three readers
+ * cannot drift apart. Clients disagree on the envelope name and on nothing
+ * else, so this is the one place that disagreement is spelled out.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/** A non-empty string, or null.  Blank output is the same as none. */
+function nonEmpty(value) {
+  const text = String(value ?? '');
+  return text.trim() ? text : null;
+}
+
+/**
+ * The human-readable result text inside one envelope, or null.
+ *
+ * RETURNS NULL RATHER THAN GUESSING. An envelope shape nobody here has seen
+ * produces no capture at all, which costs one finding. Stringifying it instead
+ * would put `[object Object]` or a wall of JSON metadata into a claim that gets
+ * injected into model context -- a wrong observation, which is strictly worse
+ * than a missing one.
+ */
+function resultText(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'string') return nonEmpty(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return null;
+
+  // MCP content blocks, which is how THIS PROJECT'S OWN tools now arrive:
+  // `normalizeTool` resolves `mcp__<server>__smart_edit`, so smart_edit and
+  // smart_write reach the post-tool path for the first time and their results
+  // are `{ content: [{ type: 'text', text }], isError }` rather than a shell
+  // result. Both the bare array and the wrapping object are accepted because
+  // hosts differ on whether they hand the hook the result or its content.
+  if (Array.isArray(value)) {
+    const blocks = value
+      .map((block) =>
+        typeof block === 'string' ? block : nonEmpty(block?.text)
+      )
+      .filter(Boolean);
+    return blocks.length ? nonEmpty(blocks.join('\n')) : null;
+  }
+  if (typeof value !== 'object') return null;
+
+  // STDERR FIRST, and not because that is the order it was produced in. The
+  // cap can only ever cut the tail, and the diagnostic that explains a failure
+  // is almost always on stderr while the volume is almost always on stdout --
+  // so appending stderr would let a 3 MB build log push the one line worth
+  // capturing out of the window.
+  const streams = [nonEmpty(value.stderr), nonEmpty(value.stdout)].filter(
+    Boolean
+  );
+  if (streams.length) return streams.join('\n');
+
+  if (Array.isArray(value.content)) {
+    const inner = resultText(value.content);
+    if (inner) return inner;
+  }
+
+  const error = value.error;
+  if (error) {
+    const message =
+      typeof error === 'string' ? error : nonEmpty(error.message ?? error.msg);
+    if (message) return message;
+  }
+
+  return (
+    nonEmpty(value.output) ??
+    nonEmpty(value.text) ??
+    nonEmpty(value.message) ??
+    (typeof value.result === 'string' ? nonEmpty(value.result) : null)
+  );
+}
+
+/**
+ * The result text of a completed tool call, or null when the client reports
+ * none.  Redaction and the size cap are NOT applied here -- they belong at the
+ * `recordToolOutcome` boundary, which is the only place every caller passes.
+ */
+export function outputFrom(raw) {
+  for (const envelope of responseEnvelopes(raw)) {
+    const text = resultText(envelope);
+    if (text) return text;
+  }
+  return resultText(raw?.output) ?? resultText(raw?.stdout) ?? null;
+}
+
+/**
+ * Key names that mean "process exit code" and nothing else.
+ *
+ * `code` is deliberately ABSENT. JSON-RPC errors (`code: -32602`), Node errno
+ * objects (`code: 'ENOENT'`) and HTTP wrappers all reuse that name, so reading
+ * it would record a confident exit code for calls that never had one. A null
+ * here is honest; a -32602 claiming to be an exit status is not.
+ */
+const EXIT_KEYS = [
+  'exit_code',
+  'exitCode',
+  'exit',
+  'exit_status',
+  'exitStatus',
+  'return_code',
+  'returncode',
+];
+
+/** The numeric exit code a client reported, or null when it reported none. */
+export function exitFrom(raw) {
+  for (const envelope of [...responseEnvelopes(raw), raw]) {
+    if (!envelope || typeof envelope !== 'object') continue;
+    for (const key of EXIT_KEYS) {
+      const value = envelope[key];
+      if (Number.isInteger(value)) return value;
+      // A client that serializes the code as a digit string still reported it.
+      // Bounded so a hash or an id cannot be mistaken for a status.
+      if (typeof value === 'string' && /^-?\d{1,5}$/.test(value.trim()))
+        return Number(value.trim());
+    }
+  }
+  return null;
+}
+
 function contextOutput(client, eventName, additionalContext) {
   if (client.contextStyle === 'top-level') return { additionalContext };
   if (client.contextStyle === 'cline') {
@@ -890,6 +1020,11 @@ async function runHook(clientName, event, invocation) {
         anchor,
         toolName: payload.tool_name,
         success: toolSucceeded(raw),
+        // The two fields a boolean cannot carry: which KIND of failure this
+        // was. Read through the same normalisers as `success`, never off `raw`
+        // at this call site.
+        output: outputFrom(raw),
+        exit: exitFrom(raw),
         durationMs:
           Number(
             raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -145,11 +145,43 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because three readers depend on it -- success
+ * classification, output capture and exit-code capture -- and clients disagree
+ * on the envelope name and on nothing else. Letting each reader name its own
+ * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
+    return false;
+  // MCP'S OWN FAILURE FLAG, which this function did not read for as long as it
+  // existed. It did not matter while `normalizeTool` dropped MCP names before
+  // any accounting ran; it matters now that `mcp__<server>__smart_edit` and
+  // `smart_write` reach the post-tool path, because an MCP result carries no
+  // `error` field and no `status` -- only `isError` -- so a failed smart_edit
+  // fell through to the optimistic `return true` below.
+  //
+  // WHY THIS IS A MEASUREMENT BUG AND NOT A COSMETIC ONE: this boolean feeds
+  // episode outcomes and effectiveness accounting, so recording every failed
+  // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
+  // optimizer's favour. A measurement that flatters the thing being measured
+  // is worse than no measurement.
+  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
     return false;
   const status =
     raw?.tool_response?.status ??
@@ -170,23 +202,6 @@ export function toolSucceeded(raw) {
   // that its output proved the task.  `success` here is deliberately scoped to
   // the tool call; task correctness comes only from an eval grader.
   return true;
-}
-
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * The same family `toolSucceeded` reads above, hoisted so the three readers
- * cannot drift apart. Clients disagree on the envelope name and on nothing
- * else, so this is the one place that disagreement is spelled out.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
 }
 
 /** A non-empty string, or null.  Blank output is the same as none. */

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -58,6 +58,7 @@ import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { briefing } from './remedy.mjs';
 import { stableText, transcriptFor } from './cache.mjs';
+import { scoreRefreshes } from './keepwarm.mjs';
 import { cachedRoutingBriefing } from './routing.mjs';
 import {
   forCommand,
@@ -1010,6 +1011,26 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE KEEP-WARM FEEDBACK ARM, at the boundary where a turn has just
+      // ended -- which is the only place the arrival question can be answered.
+      // Every refresh whose TTL has since elapsed is scored here as used or
+      // unused; anything the log cannot settle is left unscored rather than
+      // recorded as a miss, because an absent signal is not a miss.
+      //
+      // Nothing in this repository issues a refresh today -- cache_audit only
+      // recommends one -- so this scores nothing, and what it costs while
+      // dormant is one readBalance: median 70 ms on this machine's 3.5 MB log,
+      // against derive's 71-111 ms a few lines below on the same path. The
+      // firehose is read for ARRIVALS only if an unscored refresh exists, so
+      // the dormant case never pays for that. The moment an issuer exists, the
+      // decision starts learning with no second wiring change.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      scoreRefreshes(dir);
+    } catch {
+      // A refresh that cannot be scored costs a measurement, not a session.
     }
     try {
       // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -40,11 +40,13 @@ import {
   touchedFiles,
 } from './decide.mjs';
 import {
+  record,
   recordRead,
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
 } from './metrics.mjs';
+import { derive } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -948,6 +950,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // ZERO-COST DERIVATION, on every client, with no credential. The semantic
+      // harvest below needs an API key, so on a machine without one the graph
+      // accumulates structure and no verdicts at all. These detectors read only
+      // what is already on disk and send nothing anywhere.
+      //
+      // The COUNT is recorded rather than the candidates: how many findings a
+      // session's own evidence supports is the number that says whether this is
+      // working, and it is measurable before anything is stored. Storage is the
+      // caller's next step, under a budget.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      const dir = wikiDir(projectRoot);
+      const derived = derive(dir, {
+        sessionId,
+        projectRoot,
+        transcriptPath: agentScope,
+        // The hook payload's own identity, not a value a model typed.
+        authoritativeSessionId: sessionId,
+      });
+      record(dir, {
+        kind: 'derive',
+        sessionId,
+        candidates: derived.candidates.length,
+        observations: derived.observations.length,
+      });
+    } catch {
+      // A detector failing must never cost a user the end of their session.
     }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -72,7 +72,8 @@ import {
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
-import { isArchived } from './transcript.mjs';
+import { archive, isArchived } from './transcript.mjs';
+import { harvestMode } from './harvest.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
@@ -577,6 +578,65 @@ function emit(object) {
   process.stdout.write(serialized);
 }
 
+/**
+ * What will and will not extract findings after this session, in one sentence.
+ *
+ * THE STATE WAS ONLY EVER LEGIBLE FROM THE DOCTOR, and the doctor is a place
+ * someone visits after they already suspect something is wrong. A user watching
+ * a graph fill with structural nodes and no verdicts has no reason to suspect
+ * anything, which is the failure this project has now measured twice.
+ *
+ * IT IS ADDRESSED TO THE MODEL, NOT ONLY TO THE READER, which is why it earns a
+ * place in the prefix rather than a systemMessage. "Nothing else will write this
+ * down in words" changes what the model does with a conclusion it is holding;
+ * "here is a configuration variable" would not.
+ *
+ * CACHE-SAFE: derived from configuration, so it differs between sessions only
+ * when the configuration does -- the same standard the rest of this block is
+ * held to, and it carries no digits for `stableText` to reject.
+ *
+ * A local endpoint is named FIRST in the off case on purpose. It is the option
+ * that costs nothing and sends nothing, and it was the one buried deepest.
+ */
+function extractionNotice() {
+  switch (harvestMode()) {
+    case 'local':
+      return (
+        '\n\nA local model endpoint is configured, so semantic extraction also runs after this ' +
+        'session -- free and private, with nothing leaving this machine.'
+      );
+    case 'remote':
+      return (
+        '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
+        'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
+    case 'off:mode':
+      // The whole optimizer is off and this text is not emitted anyway. Saying
+      // anything here would be noise stacked on an explicit choice.
+      return '';
+    case 'off:opted-out':
+      // A DELIBERATE CHOICE, SO NO PITCH. The consequence is stated because the
+      // model needs it; the setting that would reverse it is not, because
+      // arguing with a configured decision on every session is how a notice
+      // stops being read. doctor.mjs draws the same line for the same reason.
+      return (
+        '\n\nFallback extraction is off by configuration, so a conclusion you do not record is ' +
+        'not written down in words anywhere. Findings are still derived locally from exit codes, ' +
+        'red-to-green transitions and corrections.'
+      );
+    default:
+      // off:no-key, and any mode a future harvest adds: no extractor is running
+      // and nobody chose that, so the free option is worth naming.
+      return (
+        '\n\nNo separate extractor will run after this session, so a conclusion you do not record ' +
+        'is not written down in words anywhere. Findings are still derived locally from exit ' +
+        'codes, red-to-green transitions and corrections. Pointing ' +
+        'TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model adds semantic extraction, free and ' +
+        'private.'
+      );
+  }
+}
+
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
 export function policyText(
   canDeny,
@@ -635,7 +695,7 @@ export function policyText(
     .filter(Boolean)
     .join(' ');
   const recording = tools.has('wiki_write')
-    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.`
+    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.${extractionNotice()}`
     : '\n\nStructural graph capture remains active through lifecycle hooks. Durable semantic MCP writes are not requested because the writer schema is not proven available.';
 
   return `# Token optimization is active\n\nLive graph capture is active through the lifecycle adapter.\n\n${connection}${routing}${enforcement}${utilities ? `\n\n${utilities}` : ''}${recording}${projectBriefing()}`;
@@ -950,6 +1010,27 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.
+      //
+      // This was lost rather than retired. `plugin/hooks/stop-harvest.mjs` called
+      // `archive()` at Stop, and #300 replaced that entry in `hooks.json` with the
+      // generated `stop.mjs`, which routes here -- so on Claude Code no session has
+      // been archived since. Nothing failed loudly: `readArchive` simply returns an
+      // empty list, so `derive`'s correction detector fell through to the live
+      // transcript (present only for a client that reports one) and `lessons.mjs`
+      // lost the only corpus it can verify a verbatim quote against, which is the
+      // single test that grants a feedback finding human origin.
+      //
+      // BEFORE `derive`, deliberately: the correction detector reads the archive
+      // first and treats the live transcript as the fallback, and the archive is
+      // the copy that survives into later sessions.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      if (agentScope) archive(dir, agentScope, { sessionId });
+    } catch {
+      // The archive is a record, not a result. A session still ends.
     }
     try {
       // ZERO-COST DERIVATION, on every client, with no credential. The semantic

--- a/integrations/copilot/.github/hooks/lib/audit.mjs
+++ b/integrations/copilot/.github/hooks/lib/audit.mjs
@@ -32,6 +32,7 @@
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
+import { looNote } from './loo.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -401,6 +402,16 @@ export function renderAudit(
   // project with no injections and no queries gains no line at all.
   const reference = referenceNote(dir);
   if (reference) body.push('', reference);
+
+  // WHAT ONE FINDING IS CAUSALLY WORTH (Layer 2).
+  //
+  // The same reasoning as above, and the same refusal: `looNote` returns null
+  // until the leave-one-out experiment has collected an observation, and says
+  // NOT MEASURABLE YET rather than printing a mean until it clears the floor.
+  // A causal number is the most quotable thing this project can produce, so it
+  // is the one that most needs to be absent when it is not earned.
+  const causal = looNote(dir);
+  if (causal) body.push('', causal);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/copilot/.github/hooks/lib/audit.mjs
+++ b/integrations/copilot/.github/hooks/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
 import { looNote } from './loo.mjs';
+import { calibrationNote } from './crosslayer.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -244,9 +245,15 @@ export function renderAudit(
     lines.push(text);
   }
 
+  // SCOPED TO THE QUEUE, because that is all it ever described. The bare
+  // sentence "Nothing addressable found." was printed directly above a Layer 1
+  // reference note and a published Layer 2 causal verdict -- so a reader was
+  // told nothing had been found immediately before being shown a finding. The
+  // headline is about the remediation queue and nothing else, and saying so
+  // costs four words and removes a false negative shown to a human.
   const head = shown.length
     ? ['What to do next, most expensive first:', ...lines]
-    : ['Nothing addressable found.'];
+    : ['Nothing addressable found in the remediation queue.'];
 
   const body = [...head];
 
@@ -412,6 +419,16 @@ export function renderAudit(
   // is the one that most needs to be absent when it is not earned.
   const causal = looNote(dir);
   if (causal) body.push('', causal);
+
+  // WHETHER LAYER 1'S CHEAP LABEL PREDICTS LAYER 2'S EXPENSIVE EFFECT.
+  //
+  // The reason this is printed rather than kept for a dashboard: the reference
+  // rate is the number a reader is most likely to quote as a saving, and it is
+  // not one until this comparison says so. `calibrationNote` returns null while
+  // both layers are silent, and otherwise prints the refusal -- naming which
+  // input was insufficient -- rather than a gap of zero.
+  const calibrated = calibrationNote(dir);
+  if (calibrated) body.push('', calibrated);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/copilot/.github/hooks/lib/audit.mjs
+++ b/integrations/copilot/.github/hooks/lib/audit.mjs
@@ -61,6 +61,28 @@ export function declines(dir, { events = readMetrics(dir) } = {}) {
   return counts;
 }
 
+/**
+ * What the local Stop-time derivation path produced in the visible event log.
+ *
+ * The producer records all three counts because any one of them alone is
+ * ambiguous: zero stored can mean no evidence, no candidates, or a binding
+ * storage/anchor filter. This reader keeps those states distinct and prevents
+ * the telemetry itself from becoming an unobserved cost.
+ */
+export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
+  const runs = events.filter((event) => event.kind === 'derive');
+  if (!runs.length) return null;
+
+  const sum = (field) =>
+    runs.reduce((total, event) => total + Math.max(0, Number(event[field]) || 0), 0);
+  const candidates = sum('candidates');
+  const observations = sum('observations');
+  const written = sum('written');
+  return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
+    `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
+    `across ${runs.length.toLocaleString()} Stop run(s).`;
+}
+
 const idOf = (finding) =>
   finding.remedy
     ? `${finding.remedy.type}:${finding.remedy.anchor || finding.remedy.file || (finding.remedy.anchors || []).join(',')}`
@@ -399,6 +421,15 @@ export function renderAudit(
       );
     }
   }
+
+  // WHAT THE DEFAULT, LOCAL DERIVATION PATH ACTUALLY PRODUCED.
+  //
+  // This event used to have a producer and no reader. Keep its three states
+  // together: evidence seen, candidates derived, and findings that survived
+  // selection/storage. A lone stored count would turn every earlier refusal
+  // into an apparent "nothing found" result.
+  const derived = derivationNote(dir);
+  if (derived) body.push('', derived);
 
   // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
   //

--- a/integrations/copilot/.github/hooks/lib/audit.mjs
+++ b/integrations/copilot/.github/hooks/lib/audit.mjs
@@ -31,6 +31,7 @@
  */
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
+import { referenceNote } from './usage.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -390,6 +391,16 @@ export function renderAudit(
       );
     }
   }
+
+  // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
+  //
+  // Printed here because this is the report that already asks "did the advice
+  // change anything", and because a measurement with no reader is how this
+  // project shipped two metrics whose only consumer was their own test suite.
+  // `referenceNote` returns null when it has nothing honest to say, so a
+  // project with no injections and no queries gains no line at all.
+  const reference = referenceNote(dir);
+  if (reference) body.push('', reference);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/copilot/.github/hooks/lib/consolidate.mjs
+++ b/integrations/copilot/.github/hooks/lib/consolidate.mjs
@@ -142,7 +142,8 @@ const ALWAYS_KEEP = new Set(['failure', 'decision']);
  * Chooses what to promote into the graph, under a token budget.
  *
  * @param {object} graph      Loaded wiki graph, for reuse probability.
- * @param {Array}  candidates Extracted conclusions, each { type, summary, anchors, evidence, at }.
+ * @param {Array}  candidates Extracted conclusions, each { type, claim (or summary),
+ *                              anchors, evidence, at }.
  * @param {object} options    budget: tokens available for promoted findings.
  */
 export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}) {
@@ -221,4 +222,3 @@ export function aggregateConsolidation(findings) {
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
-

--- a/integrations/copilot/.github/hooks/lib/crosslayer.mjs
+++ b/integrations/copilot/.github/hooks/lib/crosslayer.mjs
@@ -1,0 +1,351 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/crosslayer.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The calibration loop: does Layer 1's LABEL predict Layer 2's EFFECT?
+ *
+ * Layer 1 (`usage.mjs`) classifies an injected finding by whether the model
+ * later NAMED it. Layer 2 (`loo.mjs`) measures, by leave-one-out, how many
+ * tokens of reading a finding actually SUPPRESSED. Those are two different
+ * quantities, and the whole point of putting them side by side is that the
+ * cheap one (a label, available on every injection) might stand in for the
+ * expensive one (a causal effect, costing three withheld sessions per finding).
+ *
+ * WHY THIS IS A REAL QUESTION AND NOT A TAUTOLOGY. Task 7 established the
+ * independence three ways -- statically (`loo.mjs` contains no `query` or
+ * `reference`; `usage.mjs` contains no `tokens`, `cost` or `bytes`),
+ * behaviourally in both directions, and by naming the one overlap that does
+ * exist (`recordToolOutcome`'s join, which supplies ATTRIBUTABILITY to both and
+ * the measured quantity to neither). This module is built to preserve that:
+ *
+ *   - from Layer 1 it takes ONLY the categorical label per finding key. No
+ *     rate, no count, no magnitude -- Layer 1 has no magnitude to give.
+ *   - from Layer 2 it takes ONLY the effect magnitude per finding key.
+ *   - the join is the finding key, which is a graph identity and not a
+ *     measurement.
+ *
+ * If a magnitude common to both ever entered, this would correlate a quantity
+ * with itself and report a strong result that means nothing. Two tests pin the
+ * separation from opposite sides: flipping the labels while holding the effects
+ * fixed must move the gap, and changing Layer 1's rate WITHOUT changing any
+ * label must leave the gap byte-identical.
+ *
+ * MEASURED UTILITY RANKS A FINDING. IT MUST NEVER RAISE ITS CONFIDENCE.
+ * A confidently WRONG finding suppresses reads better than a hedged true one,
+ * so utility alone optimises directly against "wrong findings are worse than
+ * none". The plan called for a `mayPromote` gate over
+ * `hasOutstandingContradiction` here. There is nothing to gate: every write of
+ * `confidence` in `hooks-core` happens at CREATION (a per-producer constant in
+ * `derive.mjs` / `lessons.mjs` / `harvest.mjs`, or a human's own number in
+ * `curate.mjs`), and no code path updates a stored finding's confidence
+ * afterwards. `assessFindings` in `utility.mjs` READS confidence into an
+ * ephemeral `netUtility` used for ordering and writes nothing back. So a gate
+ * here would be unreachable, and an unreachable gate is the exact defect class
+ * this work exists to close. `hasOutstandingContradiction` already has its
+ * real consumer -- `staleness.mjs` calls it as the dispute gate on serve.
+ * What is enforceable is the invariant itself, and it is: this module never
+ * writes to the graph, and `tests/hooks/calibration-loop.test.mjs` asserts that
+ * neither it nor either layer under it can move a stored confidence.
+ *
+ * NOTHING HERE IS PRICED. A calibration verdict, a holdout estimate and a
+ * consolidation ratio are all estimates; currency belongs only on a measured
+ * counterfactual, and `balanceSheet`'s `measuredCounterfactual` is the one
+ * section in the sheet below that qualifies.
+ */
+
+import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
+import { classify, referenceRate } from './usage.mjs';
+import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Distinct findings needed in EACH arm before a gap is reported at all.
+ *
+ * Two findings per arm is a difference of two numbers; the comparison would be
+ * dominated by whichever finding happened to sit on a big file. Three is still
+ * small, and the refusal says so rather than implying the gap is solid.
+ */
+export const MIN_FINDINGS_PER_ARM = 3;
+
+/**
+ * The smallest gap that may be PUBLISHED, in tokens per touch.
+ *
+ * Not an effect-size convention: it is tied to the unit the verdict prints. The
+ * published sentence rounds the gap to whole tokens, so a gap of 1e-13 -- which
+ * is what two arms of equal means produce once floating point has had its say --
+ * would publish as "referenced findings suppress 0 more tokens/touch". That is a
+ * calibration claim resting on arithmetic noise, and it leans the only direction
+ * a measurement of this project by this project must never lean.
+ */
+export const MIN_GAP_TOKENS = 1;
+
+/**
+ * The per-finding Layer 1 label, folded from per-injection rows.
+ *
+ * ANY reference wins. `classify` emits one row per (injection, finding) because
+ * one reference must not excuse every later injection -- that is the right unit
+ * for a RATE. For a label the question is different: did the model ever name
+ * this finding? A finding referenced once and ignored nine times is a finding
+ * the model reads, and averaging it into `not-referenced` would put it in the
+ * arm whose mean effect it is meant to predict.
+ *
+ * `unknown` rows are dropped rather than defaulted, exactly as Layer 1 drops
+ * them from its own denominator.
+ */
+export function labelsByFinding(rows) {
+  const labels = new Map();
+  for (const row of rows || []) {
+    const key = row?.findingKey;
+    if (typeof key !== 'string' || !key) continue;
+    if (row.label === 'referenced') labels.set(key, 'referenced');
+    else if (row.label === 'not-referenced' && !labels.has(key))
+      labels.set(key, 'not-referenced');
+  }
+  return labels;
+}
+
+const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * Does Layer 1's label predict Layer 2's effect?
+ *
+ * Returns `publishable`, a `verdict` in English, and `gap` ONLY when a gap was
+ * actually computed. There is no `gap: 0` for the unmeasured case, and that is
+ * deliberate: a permanent zero reads as "measured, and the two agree", which is
+ * the opposite of "nothing was measured". Task 7 deleted a field rather than
+ * zero it for the same reason.
+ *
+ * FAILS OPEN. This runs on report paths that must not break a tool call.
+ */
+export function calibration(dir, options = {}) {
+  const refuse = (verdict, extra = {}) => ({
+    publishable: false,
+    verdict,
+    ...extra,
+  });
+
+  try {
+    // ONE READ for both layers, so the two arms of the comparison cannot cover
+    // different spans of the log. `referenceRate` reports `windowed: false`
+    // when the caller supplies events -- correctly, since the bounds are then
+    // the caller's -- so the truncation flag is taken here, from the read that
+    // actually set it, and republished.
+    const supplied = options.events || null;
+    const events = supplied || readMetrics(dir);
+    const truncation = supplied ? null : readTruncation();
+    const truncated = Boolean(
+      truncation && (truncation.byBytes || truncation.byEvents)
+    );
+
+    const layer1 = referenceRate(dir, { events });
+    const labels = labelsByFinding(classify(dir, { events }));
+
+    const obs = observations(dir, { ...options, events });
+    const rows = effects(dir, { ...options, events, obs });
+
+    // ONE POLICY VERSION. Layer 2 refuses to pool arms across serving
+    // policies; a calibration that pooled them would undo that guard one level
+    // up. Rows from any other policy are excluded and counted.
+    const policy = servingPolicyVersion();
+    const inPolicy = rows.filter((row) => row.policy === policy);
+
+    const layer2 = {
+      rows: rows.length,
+      inPolicy: inPolicy.length,
+      published: rows.filter((row) => row.published).length,
+      observations: obs.rows.length,
+      policy,
+    };
+    const l1 = {
+      referenced: layer1.referenced,
+      notReferenced: layer1.notReferenced,
+      unknown: layer1.unknown,
+      denominator: layer1.denominator,
+      rate: layer1.rate,
+      referenceEvents: layer1.referenceEvents,
+    };
+
+    const excluded = { layer1Unknown: layer1.unknown, unlabelled: 0, noEffect: 0 };
+    const arms = { referenced: [], notReferenced: [] };
+    for (const row of inPolicy) {
+      // THE SHRUNK ESTIMATE, not the raw one. Shrinkage pulls every finding
+      // toward the population mean, so it pulls the GAP toward zero -- the
+      // bias runs against publishing, which is the only direction a
+      // measurement of this project by this project may lean.
+      if (row.shrunk === null || !Number.isFinite(row.shrunk)) {
+        excluded.noEffect += 1;
+        continue;
+      }
+      const label = labels.get(row.findingKey);
+      if (label === 'referenced') arms.referenced.push(row.shrunk);
+      else if (label === 'not-referenced') arms.notReferenced.push(row.shrunk);
+      else excluded.unlabelled += 1;
+    }
+
+    const context = { layer1: l1, layer2, arms: { referenced: arms.referenced.length, notReferenced: arms.notReferenced.length }, excluded, windowed: truncated };
+    const caveat = truncated
+      ? ' The event log was truncated, so both sides can understate.'
+      : '';
+
+    // WHICH INPUT WAS INSUFFICIENT, named. "Not enough data" tells a reader
+    // nothing about which half of the loop to go and fix.
+    const l1Silent = layer1.rate === null;
+    const l2Silent = layer2.observations === 0;
+    if (l1Silent || l2Silent) {
+      const why = [];
+      if (l1Silent)
+        why.push(
+          `Layer 1 has ${layer1.denominator} classifiable observation(s) and ` +
+            `${layer1.referenceEvents} reference event(s), so it publishes no rate`
+        );
+      if (l2Silent)
+        why.push(
+          `Layer 2 has ${layer2.observations} observation(s), so it publishes no effect`
+        );
+      return refuse(
+        `not calibrated: ${why.join('; and ')}. No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+    }
+
+    // A POLICY CHANGE RESETS THE CALIBRATION, and says so rather than reporting
+    // an empty arm. Layer 2 refuses to pool arms across serving policies, so
+    // rows generated under an older one cannot answer a question about how the
+    // graph serves findings today -- but "0 findings per arm" would send a
+    // reader hunting for missing observations that are right there in the log.
+    if (rows.length > 0 && inPolicy.length === 0)
+      return refuse(
+        `not calibrated: all ${rows.length} Layer 2 effect row(s) were measured under a different serving ` +
+          `policy than the current ${policy}, and arms are never pooled across policies. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (layer2.published === 0)
+      return refuse(
+        `not calibrated: Layer 2 has ${layer2.observations} observation(s) but no published effect at q=0.1, ` +
+          'so its per-finding numbers are noise and a difference between two means of them would be too. ' +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (
+      arms.referenced.length < MIN_FINDINGS_PER_ARM ||
+      arms.notReferenced.length < MIN_FINDINGS_PER_ARM
+    )
+      return refuse(
+        `not calibrated: ${arms.referenced.length} referenced and ${arms.notReferenced.length} not-referenced ` +
+          `finding(s) carry a Layer 2 effect, below the floor of ${MIN_FINDINGS_PER_ARM} per arm. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    const referencedMean = mean(arms.referenced);
+    const notReferencedMean = mean(arms.notReferenced);
+    const gap = referencedMean - notReferencedMean;
+    const measured = { ...context, gap, referencedMean, notReferencedMean };
+
+    if (!(gap >= MIN_GAP_TOKENS))
+      return refuse(
+        `uncalibrated: Layer 1's "referenced" label does not predict a larger Layer 2 effect ` +
+          `(referenced ${Math.round(referencedMean).toLocaleString()} vs not-referenced ` +
+          `${Math.round(notReferencedMean).toLocaleString()} tokens/touch, gap ${Math.round(gap).toLocaleString()}). ` +
+          `Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
+    return {
+      publishable: true,
+      verdict:
+        `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
+      ...measured,
+    };
+  } catch {
+    return refuse(
+      'not calibrated: the calibration inputs could not be read. No gap is reported, which is not the same as a gap of zero.'
+    );
+  }
+}
+
+/**
+ * What the graph cost to build against what it carries -- AN ESTIMATE, and
+ * never priced.
+ *
+ * `consolidationRatio` is the per-finding form and the aggregate is the fold.
+ * Both need `derivedCost`, which `expand.promote` persists onto the finding
+ * node it creates (`src/server/disclosure.ts` is its caller) and which
+ * `harvest-write.mjs` does not yet carry through -- so a graph built only by
+ * the harvest reports nothing here rather than a ratio of one.
+ */
+export function consolidation(dir, { graph = null } = {}) {
+  try {
+    const g = graph || load(dir);
+    const findings = [...g.nodes.values()].filter(
+      (node) => node.kind === 'finding' && !node.retired
+    );
+    const rated = [];
+    for (const finding of findings) {
+      const ratio = consolidationRatio(finding);
+      if (ratio === null) continue;
+      rated.push({ key: finding.key, ratio, derivedCost: finding.derivedCost });
+    }
+    const aggregate = aggregateConsolidation(findings);
+    return {
+      what: 'cost to derive against cost to carry',
+      // SAID IN THE DATA, not only in the prose above it, because this is the
+      // field a dashboard will read and a dashboard will not read a comment.
+      basis: 'estimate',
+      priced: false,
+      findings: findings.length,
+      withDerivedCost: rated.length,
+      aggregate,
+      best: rated.sort((a, b) => b.ratio - a.ratio).slice(0, 5),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The balance sheet with the graph's own three measurements attached.
+ *
+ * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
+ * imports, so it cannot import them back. This is where the two meet, and it
+ * is the shape `get_optimization_report` serves.
+ */
+export function graphBalanceSheet(dir, options = {}) {
+  const sheet = balanceSheet(dir);
+  const cal = calibration(dir, options);
+  const { layer1 = null, layer2 = null } = cal;
+  return {
+    ...sheet,
+    layer1,
+    layer2,
+    calibration: cal,
+    consolidation: consolidation(dir, options),
+  };
+}
+
+/**
+ * One audit line, or null when there is nothing honest to say.
+ *
+ * Silent when NEITHER layer has produced anything: a reader of a graph that has
+ * never injected a finding is owed no paragraph about a loop that has not
+ * started. The moment either side speaks, the refusal is worth printing --
+ * because at that point a reader could otherwise take Layer 1's rate for a
+ * saving, which is precisely what this loop exists to stop.
+ */
+export function calibrationNote(dir, options = {}) {
+  try {
+    const result = calibration(dir, options);
+    const l1 = result.layer1;
+    const l2 = result.layer2;
+    if (!l1 || !l2) return null;
+    if (l1.denominator === 0 && l2.observations === 0) return null;
+    return `Layer 1 against Layer 2: ${result.verdict}`;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/copilot/.github/hooks/lib/crosslayer.mjs
+++ b/integrations/copilot/.github/hooks/lib/crosslayer.mjs
@@ -54,7 +54,13 @@
 
 import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
-import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import {
+  effects,
+  observations,
+  servingPolicyVersion,
+  permutationP,
+  FDR_Q,
+} from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
 import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
@@ -106,6 +112,32 @@ export function labelsByFinding(rows) {
 }
 
 const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * A deterministic, label-symmetric permutation test for the headline gap.
+ *
+ * Layer 2 only publishes a per-finding row after a two-sided permutation test.
+ * The calibration headline summarises those rows, so a positive difference of
+ * arm means must clear the same evidential bar rather than being promoted just
+ * because it points in this project's favour.
+ *
+ * Sorting within each arm and then sorting the two arms makes the sampled path
+ * invariant to event order and to swapping the labels. The seed is derived
+ * from that canonical data instead of shared globally, so two different
+ * datasets do not reuse one arbitrary sequence of sampled relabellings.
+ */
+export function calibrationP(referenced, notReferenced) {
+  const arms = [referenced, notReferenced]
+    .map((values) => [...values].sort((a, b) => a - b))
+    .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  const encoded = JSON.stringify(arms);
+  let seed = 2166136261;
+  for (const char of encoded) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return permutationP(arms[0], arms[1], { seed: seed >>> 0 });
+}
 
 /**
  * Does Layer 1's label predict Layer 2's effect?
@@ -244,7 +276,16 @@ export function calibration(dir, options = {}) {
     const referencedMean = mean(arms.referenced);
     const notReferencedMean = mean(arms.notReferenced);
     const gap = referencedMean - notReferencedMean;
-    const measured = { ...context, gap, referencedMean, notReferencedMean };
+    const p = calibrationP(arms.referenced, arms.notReferenced);
+    const measured = {
+      ...context,
+      gap,
+      referencedMean,
+      notReferencedMean,
+      p,
+      alpha: FDR_Q,
+      test: 'two-sided permutation',
+    };
 
     if (!(gap >= MIN_GAP_TOKENS))
       return refuse(
@@ -255,11 +296,20 @@ export function calibration(dir, options = {}) {
         measured
       );
 
+    if (p === null || p > FDR_Q)
+      return refuse(
+        `not calibrated: the positive Layer 1/Layer 2 gap is not statistically resolved by the ` +
+          `two-sided permutation test (p=${p === null ? 'unavailable' : p.toFixed(3)}, ` +
+          `alpha=${FDR_Q.toFixed(3)}). Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
     return {
       publishable: true,
       verdict:
         `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
-        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, ` +
+        `shrunk estimates, two-sided permutation p=${p.toFixed(3)}). ` +
         `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
       ...measured,
     };

--- a/integrations/copilot/.github/hooks/lib/crosslayer.mjs
+++ b/integrations/copilot/.github/hooks/lib/crosslayer.mjs
@@ -56,6 +56,7 @@ import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
 import { effects, observations, servingPolicyVersion } from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
 
 /**
@@ -309,11 +310,19 @@ export function consolidation(dir, { graph = null } = {}) {
 }
 
 /**
- * The balance sheet with the graph's own three measurements attached.
+ * The balance sheet with the graph's own measurements attached.
  *
  * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
  * imports, so it cannot import them back. This is where the two meet, and it
  * is the shape `get_optimization_report` serves.
+ *
+ * `recall` joins them as an OFFLINE PROBE, and that label travels in the data
+ * (`recall.basis`) as well as in the rendered line. It is not an observation of
+ * anything a session did: it deletes an anchor edge in memory and re-runs the
+ * real retrieval primitives over the graph as it stands right now. `recall.mjs`
+ * imports only `wiki.mjs` and `lexical.mjs`, neither of which imports anything
+ * in this direction, so no cycle -- the same reason `calibration` had to live
+ * here rather than in `metrics.mjs`.
  */
 export function graphBalanceSheet(dir, options = {}) {
   const sheet = balanceSheet(dir);
@@ -325,6 +334,7 @@ export function graphBalanceSheet(dir, options = {}) {
     layer2,
     calibration: cal,
     consolidation: consolidation(dir, options),
+    recall: recallProbe(dir, options),
   };
 }
 

--- a/integrations/copilot/.github/hooks/lib/derive.mjs
+++ b/integrations/copilot/.github/hooks/lib/derive.mjs
@@ -23,13 +23,21 @@
  * the observation supports no claim at all are refused rather than downgraded
  * (see `attemptKey` and the identical-text guard below).
  *
- * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
- * budget, belongs to the caller.
+ * WHAT IS STORED IS BOUNDED. Candidates go through `selectForConsolidation`
+ * before `writeHarvested`, so a long session cannot spend the whole retrieval
+ * budget of every later session on one afternoon's exit codes. Nothing enters
+ * the graph unbudgeted, and nothing enters it wearing a human origin.
  */
 
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
 import { readArchive, readTurns } from './transcript.mjs';
 import { redact } from './redact.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { load } from './wiki.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -106,6 +114,92 @@ const triggerFor = (command) =>
   attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
 
 /**
+ * Literal root-level files that define how a project is BUILT, RUN and TESTED,
+ * best first. A `command` claim is a claim about this project's commands, and
+ * this is the file those commands are declared in.
+ */
+const PROJECT_MARKERS = [
+  'package.json', 'pyproject.toml', 'Cargo.toml', 'go.mod', 'pom.xml',
+  'build.gradle.kts', 'build.gradle', 'build.sbt', 'mix.exs', 'composer.json',
+  'Gemfile', 'Package.swift', 'CMakeLists.txt', 'Makefile', 'Taskfile.yml',
+  'requirements.txt', 'setup.py', 'deno.json', 'bun.lockb',
+];
+
+/** .NET has no single literal marker; the solution or project file is one. */
+const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
+
+/**
+ * A REAL FILE to anchor a derived claim to, inside the project root.
+ *
+ * WHY NOT THE PROJECT ROOT ITSELF, which is what the extraction step reaches
+ * for and what `promoteToShared` uses in the shared tier. Because
+ * `writeHarvested` resolves every anchor through `indexFile`, `indexFile` reads
+ * the path, and reading a DIRECTORY returns null -- so a candidate anchored to
+ * `projectRoot` resolves to nothing, is refused as unanchorable, and the whole
+ * pipeline stores zero findings while reporting a healthy candidate count.
+ * Verified directly: `indexFile(dir, dir)` returns null. That refusal is
+ * correct and must not be weakened -- an anchor that cannot be indexed is an
+ * anchor that can never be invalidated -- so the anchor has to be a file.
+ *
+ * STALENESS DOES NOT MISFIRE ON THIS. `command`, `failure` and `feedback` are
+ * all outside `CONTENT_DEPENDENT` (staleness.mjs), so the anchor is a RETRIEVAL
+ * AND EXISTENCE hook rather than a contents claim: editing the manifest does
+ * not mark these findings stale. staleness.mjs names this exact case in its own
+ * comment -- "a claim about `npm test` anchored to package.json" -- and calls
+ * missing that invalidation the better error.
+ *
+ * A project with no recognisable marker gets the root back, which will not
+ * resolve, so its candidates are derived and then refused rather than stored
+ * against a fabricated anchor. That is the fail-open direction: no finding
+ * beats a finding anchored to something that is not what the claim is about.
+ */
+export function projectAnchor(projectRoot) {
+  if (!projectRoot) return null;
+  let entries;
+  try {
+    entries = readdirSync(projectRoot);
+  } catch {
+    return projectRoot;
+  }
+  const present = new Set(entries);
+  for (const marker of PROJECT_MARKERS) {
+    if (!present.has(marker)) continue;
+    const path = join(projectRoot, marker);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // A marker that cannot be stat'ed is not a marker.
+    }
+  }
+  // Sorted so two sessions in the same repository pick the SAME solution file:
+  // readdir order is not guaranteed stable across hosts, and an anchor that
+  // varies by host splits one finding into two nodes.
+  for (const entry of [...entries].sort()) {
+    if (!DOTNET_MARKER.test(entry)) continue;
+    const path = join(projectRoot, entry);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // Same.
+    }
+  }
+  return projectRoot;
+}
+
+/**
+ * Tokens of claim text one session may add to the graph.
+ *
+ * SCALED TO THE RETRIEVAL BUDGET IT COMPETES FOR, not picked round. A single
+ * command's injection budget is 500 tokens (`TOKEN_OPTIMIZER_TOUCH_BUDGET`),
+ * and everything stored here is competing for that budget on every later
+ * command, forever. Two touch-budgets per session is the bound: enough for a
+ * few dozen real claims, and short of one session's exit codes crowding out
+ * every finding a human or a model ever wrote.
+ */
+const storageBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_DERIVE_BUDGET) || 1000;
+
+/**
  * Derives finding candidates from one project's local evidence.
  *
  * @param {string} dir wiki directory.
@@ -118,11 +212,18 @@ const triggerFor = (command) =>
  *   and is refused by `writeHarvested` anyway, so emitting one would only spend
  *   the caller's budget on junk.
  * @param {string|null} options.authoritativeSessionId the session id as the HOOK
- *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
- *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
- *   edge -- `taskForAnchors` returns null without one, so an unverified string
- *   would silently produce no edge. Threaded rather than defaulted from
- *   `sessionId`: defaulting would promote any caller's string to trusted.
+ *   PAYLOAD reported it, never a value a model typed. Passed straight to
+ *   `writeHarvested`, which needs it to resolve the `answers` edge --
+ *   `taskForAnchors` returns null without one, so an unverified string would
+ *   silently produce no edge. Threaded rather than defaulted from `sessionId`:
+ *   defaulting would promote any caller's string to trusted. Also returned, so a
+ *   caller can see what it handed over.
+ * @returns {object} `{ candidates, observations, written, selected, dropped,
+ *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
+ *   everything derived; `written` is the subset of keys the graph actually
+ *   holds, which is smaller for three independent reasons -- the budget, the
+ *   anchor discipline, and the duplicate collapse that returns an EXISTING key
+ *   when a later session derives the same claim again.
  */
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
@@ -152,6 +253,11 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // ONE anchor for the whole run, so every candidate from this session points at
+  // the same node and the duplicate collapse in `writeHarvested` can recognise
+  // the same lesson across sessions.
+  const anchorPath = projectAnchor(projectRoot);
 
   const seen = new Set();
   const add = (candidate) => {
@@ -246,7 +352,7 @@ export function derive(dir, options = {}) {
               `observed in one session: \`${failed.command}\` failed` +
                 `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
                 `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
-                'an intervening edit or a flaky run explains the same pair.',
+                'an intervening edit or an unrelated environment change explains the same pair.',
               { max: EVIDENCE_MAX }
             ),
             applicability: 'when about to run this command in this project',
@@ -255,7 +361,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the failing form later succeeds unchanged'],
             trigger: triggerFor(outcome.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: outcome.at || Date.now(),
@@ -280,7 +386,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the same command later succeeds unchanged'],
             trigger: triggerFor(failed.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: failed.at || Date.now(),
@@ -330,7 +436,7 @@ export function derive(dir, options = {}) {
           confidenceLabel: labelFor(CONFIDENCE.correction),
           scope: 'project',
           invalidators: ['the user later asks for the corrected behaviour'],
-          anchors: [projectRoot],
+          anchors: [anchorPath],
           derivedBy: 'correction',
           sessionId,
           at: Date.parse(turn.at || '') || Date.now(),
@@ -379,6 +485,48 @@ export function derive(dir, options = {}) {
     }
   } catch {
     // One detector, never the session.
+  }
+
+  // ---- storage, under a budget -------------------------------------------
+  //
+  // NOTHING ENTERS THE GRAPH UNBUDGETED. `selectForConsolidation` existed for
+  // exactly this and had no caller, which meant that until now nothing bounded
+  // what a session could add. It admits `failure` and `decision` on a FLOOR
+  // before ranking -- a dead end exists nowhere else and is small, and cheap to
+  // find is not cheap to find again -- then fills the remainder by
+  // cost x irrecoverability x reuse-probability.
+  //
+  // ORIGIN_HARVESTED, EXPLICITLY, never ORIGIN_HUMAN. These are machine
+  // derivations; `curate.mjs` states the reason in its own header -- "a
+  // hand-written assertion and a machine guess look identical three months
+  // later, which quietly destroys the reader's ability to calibrate trust".
+  // `writeHarvested` would refuse a batch-wide human origin anyway, and a
+  // candidate here carries neither `origin` nor `quote`, so it cannot earn one
+  // per finding either. That is deliberate: whether a turn was a correction at
+  // all is a lexical guess, and the standing-rules layer selects on human
+  // origin to inject on EVERY turn.
+  try {
+    if (result.candidates.length) {
+      const selected = selectForConsolidation(load(dir), result.candidates, {
+        budget: storageBudget(),
+      });
+      result.selected = selected.kept.length;
+      result.dropped = selected.dropped;
+      result.selectedTokens = selected.tokens;
+      result.written = writeHarvested(dir, selected.kept, {
+        sessionId,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        // The hook payload's own identity, passed through untouched. Without it
+        // `taskForAnchors` returns null and the `answers` edge never fires --
+        // which is the state a default install has been in, because its only
+        // other producer is credential-gated.
+        authoritativeSessionId,
+      });
+    }
+  } catch {
+    // Storage is the last step and the session is already over. A graph write
+    // that fails must not turn a completed session into a hook error.
   }
 
   return result;

--- a/integrations/copilot/.github/hooks/lib/derive.mjs
+++ b/integrations/copilot/.github/hooks/lib/derive.mjs
@@ -139,17 +139,19 @@ const quotable = (command) => {
  * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
  * found across 163 transcripts on this machine it refuses 2 and keeps 6.
  *
- * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
- * building the key, so the claim is about `npm test` rather than about the `cd`.
- * That changes `attemptKey` for every client and every finding already derived
- * from it, so it belongs in its own change with its own comparison.
+ * `commandBody` below now skips a leading `cd <path> &&`, so those two are
+ * recovered and this guard is left holding only the keys that reached a
+ * separator which is NOT a directory change -- `git fetch && <anything>`, a
+ * pipeline, a `;`-joined pair. Those still name no single attempt.
  */
 const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
 
 /**
  * Did `attemptKey` actually capture a command, or only how one was chained?
  *
- * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart --
+ * which now means AFTER `commandBody` has removed any leading `cd`, so this no
+ * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
 const hasAttemptIdentity = (command) =>
@@ -177,6 +179,81 @@ const CORRECTION_OPENER =
   /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
 
 /**
+ * A leading directory change, stripped before the key is built.
+ *
+ * THE MEASURED CASE, AND ONLY THE MEASURED CASE. `attemptKey` spends up to
+ * three non-flag tokens on identity and the habit on this machine is
+ * `cd <absolute path> && <the real command>`, which spends all three on `cd`,
+ * the path and the separator. This repository's own corpus: 1,400 of 2,243
+ * command outcomes open with a `cd`, and the single key
+ * `cd c:/users/.../token-optimizer-mcp &&` covered 547 distinct command lines.
+ * A `cd` says WHERE a command ran; it says nothing about WHAT ran, so it cannot
+ * be part of the identity of an attempt.
+ *
+ * THE SEPARATOR SET IS THE ONE THAT WAS OBSERVED: `&&` (1,147), a newline (204)
+ * and `;` (38) after a leading `cd`. All three mean "then run this". `||` is
+ * DELIBERATELY EXCLUDED even though it costs one line to add: `cd x || echo
+ * failed` puts an error branch after the separator, not the next step, so
+ * stripping there would key the attempt on a failure handler. It occurred zero
+ * times.
+ *
+ * AND NOTHING WIDER, each refusal for a reason from the same corpus:
+ *
+ *   Environment assignments (`FOO=bar cmd`) DO carry information about what
+ *   ran. The one true instance here is
+ *   `TOKEN_OPTIMIZER_HOLDOUT=1 node ... jest.js ...`, and the holdout arm is a
+ *   genuinely different attempt from the same command without it. The other 20
+ *   are shell variable assignments joined by `;` -- statements, not prefixes --
+ *   whose value is usually a 120-character path that would be stripped down to
+ *   nothing useful.
+ *
+ *   `time`, `env`, `nice`, `sudo`, `bash -c`, `pushd`, `Set-Location`: ZERO
+ *   occurrences in 2,243 commands. Code for an unmeasured prefix is a way to
+ *   over-strip that no evidence asked for, and over-stripping merges commands
+ *   that genuinely differ -- the same bug in the other direction. `bash -c` is
+ *   worse than unmeasured: the command sits inside a quoted string, so stripping
+ *   the wrapper leaves a key beginning with a quote character.
+ *
+ *   `cd /d C:\path &&` and `cd "C:/a b" &&` need no extra rule -- the match runs
+ *   to the separator rather than counting tokens, so flags and quoted paths
+ *   containing spaces are consumed for free. Neither appears here, so neither is
+ *   claimed as tested behaviour beyond its unit test.
+ *
+ * A `cd` with NO separator is left alone: `cd <path>` on its own ran no command,
+ * and its key is as meaningless afterwards as before -- there is nothing to
+ * recover. Stripping is repeated up to `MAX_DIR_PREFIXES` times so
+ * `cd a && cd b && cmd` reaches `cmd`; the bound exists only so a pathological
+ * line cannot loop, since each pass must consume a whole `cd ... <sep>`.
+ *
+ * APPLIED IDENTICALLY TO BOTH SOURCES because it is applied INSIDE `attemptKey`,
+ * which is the single function both the event path and the transcript reader's
+ * output pass through. The 120-character anchor cap that makes the two agree on
+ * 266 of 266 keys is untouched and still applied on both sides before this runs.
+ */
+const DIR_PREFIX = /^\s*cd\s[^\r\n;&|]*?(?:&&|;|\r?\n)\s*/i;
+const MAX_DIR_PREFIXES = 4;
+
+/**
+ * The command text with any leading directory change removed.
+ *
+ * Used for the key AND for the identical-text refusal, which is the half that
+ * keeps this from becoming a licence to pair more loosely: without it,
+ * `cd repo && npm test` failing and `npm test` succeeding would emit
+ * "`npm test` succeeded where `cd repo && npm test` failed" at 0.90 -- two
+ * spellings of one attempt, dressed up as a difference that mattered. The
+ * claim itself still quotes the RAW command, because that is what ran.
+ */
+export function commandBody(command) {
+  let text = String(command || '');
+  for (let i = 0; i < MAX_DIR_PREFIXES; i++) {
+    const stripped = text.replace(DIR_PREFIX, '');
+    if (stripped === text) break;
+    text = stripped;
+  }
+  return text;
+}
+
+/**
  * The prefix that makes two invocations "the same attempt".
  *
  * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
@@ -194,7 +271,7 @@ const CORRECTION_OPENER =
  * ships a false claim into model context.
  */
 export function attemptKey(command) {
-  return String(command || '')
+  return commandBody(command)
     .trim()
     .split(/\s+/)
     .filter((token) => token && !token.startsWith('-'))
@@ -494,7 +571,14 @@ export function derive(dir, options = {}) {
           // is real and supports NEITHER claim, so nothing is emitted. This is
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
-          if (failed.command === outcome.command) continue;
+          // COMPARED WITH THE DIRECTORY CHANGE REMOVED, for the same reason
+          // the key is. `cd repo && npm test` and `npm test` are one attempt
+          // spelled two ways; before `commandBody` they landed in different
+          // groups and never met, and letting them meet without widening this
+          // guard would emit "`npm test` succeeded where `cd repo && npm test`
+          // failed" at 0.90 -- a difference in the claim that is not a
+          // difference in what ran. Same for two `cd`s to different paths.
+          if (commandBody(failed.command) === commandBody(outcome.command)) continue;
 
           // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
           // client both sides of almost every pair are truncated multi-line
@@ -502,10 +586,12 @@ export function derive(dir, options = {}) {
           // spending the retrieval budget of every later session.
           if (!quotable(failed.command) || !quotable(outcome.command)) continue;
 
-          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
-          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
-          // command lines in this repository alone, and any pair drawn from that
-          // group is a false claim about both halves.
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`. The
+          // `cd <path> &&` case that grouped 547 unrelated command lines in this
+          // repository is now handled earlier by `commandBody`; what is left
+          // here is every OTHER separator -- `git fetch && <anything>`, a
+          // pipeline, a `;`-joined pair -- where the key still names no single
+          // attempt and any pair drawn from it is false about both halves.
           if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =

--- a/integrations/copilot/.github/hooks/lib/derive.mjs
+++ b/integrations/copilot/.github/hooks/lib/derive.mjs
@@ -1,0 +1,385 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/derive.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Findings from data we already hold, with no model call.
+ *
+ * WHY THIS EXISTS. The semantic harvest is on by default but its real gate is a
+ * credential: `harvestMode()` returns `off:no-key` on any machine without one,
+ * which is CI, corporate laptops, and every subscription-only login. This
+ * repository's own graph is the evidence -- 2,965 symbol nodes, 904 file nodes,
+ * 128 task nodes and ONE finding -- because the structural layer accumulates
+ * from ordinary tool traffic while every verdict needed an API key this machine
+ * does not have.
+ *
+ * Everything here is derived from outcomes, transitions and corrections that are
+ * ALREADY RECORDED LOCALLY. Nothing is sent anywhere, nothing is billed, so
+ * there is nothing to consent to and this runs by default. It is the only
+ * finding producer on a machine without a key.
+ *
+ * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
+ * second command fixed the first -- an intervening edit, a dependency install or
+ * a flaky test explains it just as well. So each detector carries a confidence
+ * ceiling, the claim text says only what was OBSERVED, and the two shapes where
+ * the observation supports no claim at all are refused rather than downgraded
+ * (see `attemptKey` and the identical-text guard below).
+ *
+ * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
+ * budget, belongs to the caller.
+ */
+
+import { readMetrics, rereadsByAnchor } from './metrics.mjs';
+import { readArchive, readTurns } from './transcript.mjs';
+import { redact } from './redact.mjs';
+
+/**
+ * Ceilings, ordered by how much the evidence actually supports.
+ *
+ * A command that succeeded where a DIFFERENT command failed is close to a direct
+ * observation. A test or build going red-to-green is weaker, because the usual
+ * cause is the code changing between the two runs rather than anything about the
+ * command. A correction is a lexical guess about what a human meant. Churn
+ * describes our own reading behaviour and says nothing about the code at all.
+ */
+export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+
+/** Claim text cap. A finding is one sentence; a paragraph is evidence. */
+const CLAIM_MAX = 300;
+const EVIDENCE_MAX = 400;
+
+/** Bounded so a pathological log cannot turn session end into real work. */
+const MAX_CANDIDATES = 200;
+
+/**
+ * Commands whose red-to-green transition is usually explained by the CODE
+ * changing rather than by the command. They get the lower ceiling.
+ */
+const CODE_SENSITIVE = /\b(test|tests|jest|vitest|pytest|mocha|build|compile|tsc|lint|typecheck)\b/i;
+
+/**
+ * Openers that mark a user turn as a correction rather than an instruction.
+ *
+ * DELIBERATELY NARROW, and anchored to the START of the turn. The model-based
+ * extractor in `lessons.mjs` can read intent; this cannot, so it only claims the
+ * shapes where the first few words carry the whole signal. Recall is poor by
+ * design: a missed correction costs one finding, a false one puts words in the
+ * user's mouth at 0.6 confidence.
+ */
+const CORRECTION_OPENER =
+  /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
+
+/**
+ * The prefix that makes two invocations "the same attempt".
+ *
+ * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
+ * through what the alternatives do to real command lines:
+ *
+ *   Two tokens conflates `npm run build` with `npm run test`, and the pair then
+ *   produces "`npm run test` works where `npm run build` failed" -- a claim that
+ *   is simply false.
+ *
+ *   Counting flags splits `deploy` from `deploy --retry`, which is the single
+ *   most useful pair this detector can find, into two groups that never meet.
+ *
+ * Conservative in the remaining direction: `npm run build:prod` and
+ * `npm run build` do not pair. A missed pair costs one finding; a wrong pair
+ * ships a false claim into model context.
+ */
+export function attemptKey(command) {
+  return String(command || '')
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'))
+    .slice(0, 3)
+    .join(' ')
+    .toLowerCase();
+}
+
+/** Normalised claim text, so the same lesson derived twice is one candidate. */
+const claimKey = (type, claim) =>
+  `${type}|${String(claim).toLowerCase().replace(/\s+/g, ' ').trim()}`;
+
+/** 0.95 is reserved for verified; everything here is inference. */
+const labelFor = (confidence) => (confidence >= 0.75 ? 'probable' : 'speculative');
+
+/** A literal command prefix, safe to hand to `safeTrigger`. */
+const triggerFor = (command) =>
+  attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
+
+/**
+ * Derives finding candidates from one project's local evidence.
+ *
+ * @param {string} dir wiki directory.
+ * @param {object} options
+ * @param {string|null} options.sessionId session this ran for, for provenance.
+ * @param {string|null} options.transcriptPath live transcript, read only when the
+ *   archive holds nothing for this session yet.
+ * @param {string|null} options.projectRoot the anchor every derived claim gets.
+ *   Without it nothing is derived: an unanchored finding cannot be invalidated
+ *   and is refused by `writeHarvested` anyway, so emitting one would only spend
+ *   the caller's budget on junk.
+ * @param {string|null} options.authoritativeSessionId the session id as the HOOK
+ *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
+ *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
+ *   edge -- `taskForAnchors` returns null without one, so an unverified string
+ *   would silently produce no edge. Threaded rather than defaulted from
+ *   `sessionId`: defaulting would promote any caller's string to trusted.
+ */
+export function derive(dir, options = {}) {
+  // `options || {}` rather than a destructuring default. A default only fires on
+  // `undefined`, so a caller passing an explicitly null options object -- which
+  // is what a hook does when it has nothing to say -- threw a TypeError out of
+  // the parameter list itself, before any of the try/catch below could fail open.
+  const {
+    sessionId = null,
+    transcriptPath = null,
+    projectRoot = null,
+    authoritativeSessionId = null,
+  } = options || {};
+
+  const result = {
+    candidates: [],
+    observations: [],
+    written: [],
+    sessionId,
+    authoritativeSessionId,
+  };
+
+  let events;
+  try {
+    events = readMetrics(dir);
+  } catch {
+    // Session end must cost nothing. No evidence is not an error.
+    return result;
+  }
+  if (!Array.isArray(events)) return result;
+
+  const seen = new Set();
+  const add = (candidate) => {
+    if (result.candidates.length >= MAX_CANDIDATES) return;
+    const key = claimKey(candidate.type, candidate.claim);
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.candidates.push(candidate);
+  };
+
+  // ---- 1 & 2: a failed attempt followed by a succeeding one ---------------
+  //
+  // The event is `tool-outcome` and THE COMMAND TEXT IS IN `anchor`: there is no
+  // separate command field, because the anchor of a command surface IS the
+  // command. It is capped at 120 characters at the boundary, so a very long
+  // command line is compared and quoted truncated.
+  try {
+    if (projectRoot) {
+      const outcomes = events
+        .filter(
+          (e) =>
+            e &&
+            e.kind === 'tool-outcome' &&
+            e.surface === 'command' &&
+            typeof e.anchor === 'string' &&
+            e.anchor.trim()
+        )
+        .map((e) => ({
+          command: e.anchor.trim(),
+          output: typeof e.output === 'string' ? e.output : '',
+          exit: Number.isInteger(e.exit) ? e.exit : null,
+          at: e.at ?? 0,
+          // `success` FIRST, `exit` only as a refinement. MCP tools report no
+          // numeric code at all, so a classifier keyed on `exit !== 0` would be
+          // inert for most clients -- and `exit` is null rather than 0 precisely
+          // so that absence is not read as a clean exit.
+          failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
+        }))
+        .sort((a, b) => a.at - b.at);
+
+      const byAttempt = new Map();
+      for (const outcome of outcomes) {
+        const key = attemptKey(outcome.command);
+        if (!key) continue;
+        if (!byAttempt.has(key)) byAttempt.set(key, []);
+        byAttempt.get(key).push(outcome);
+      }
+
+      for (const run of byAttempt.values()) {
+        // The NEAREST preceding failure, not the first one in the session. With
+        // `find` over the whole run, a command that failed at 09:00 and
+        // succeeded at 17:00 after nine unrelated attempts is reported as one
+        // story.
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          // One pair per failure: a command that succeeds twice afterwards has
+          // not taught two lessons.
+          lastFailure = null;
+
+          // THE GUARD THAT REMOVES THE LARGEST JUNK CLASS. The commonest shape
+          // in a coding session is `npm run build` failing, the code being
+          // fixed, and `npm run build` succeeding -- identical text. From that
+          // pair the two available claims are "`npm run build` works where
+          // `npm run build` failed", which is incoherent, and "`npm run build`
+          // fails", which the same evidence has just disproved. The observation
+          // is real and supports NEITHER claim, so nothing is emitted. This is
+          // not a confidence question; a ceiling cannot rescue a claim whose
+          // content is wrong.
+          if (failed.command === outcome.command) continue;
+
+          const codeSensitive =
+            CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);
+          const confidence = codeSensitive ? CONFIDENCE.test : CONFIDENCE.command;
+          const derivedBy = codeSensitive ? 'test-transition' : 'command-transition';
+
+          // "SUCCEEDED WHERE", NOT "FIXES". What is observed is two outcomes in
+          // order on the same attempt; that the difference in the command line
+          // CAUSED the difference in outcome is not observed and is not claimed.
+          add({
+            type: 'command',
+            claim: redact(
+              `\`${outcome.command}\` succeeded in this project where \`${failed.command}\` failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
+                'an intervening edit or a flaky run explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: 'when about to run this command in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the failing form later succeeds unchanged'],
+            trigger: triggerFor(outcome.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+
+          // The error text, only when there is error text. Without it the claim
+          // degrades to "`X` failed with:" and nothing after the colon, which
+          // carries no information and still costs budget.
+          const firstLine = failed.output.split('\n').find((line) => line.trim()) || '';
+          if (firstLine.trim().length < 8) continue;
+          add({
+            type: 'failure',
+            claim: redact(`\`${failed.command}\` failed with: ${firstLine.trim()}`, {
+              max: CLAIM_MAX,
+            }),
+            evidence: redact(`captured output of the failing run:\n${failed.output}`, {
+              max: EVIDENCE_MAX,
+            }),
+            applicability: 'when this command is about to be run in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the same command later succeeds unchanged'],
+            trigger: triggerFor(failed.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: failed.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 3: user corrections ------------------------------------------------
+  //
+  // A `feedback` finding -- the one type whose source is a person saying the
+  // agent was wrong. The MODEL-BASED extractor for this lives in `lessons.mjs`
+  // and needs the credential this module exists to do without, so here the
+  // signal is lexical: the opening words of the user's own turn.
+  //
+  // ORIGIN IS NOT PROMOTED. `writeHarvested` grants ORIGIN_HUMAN to a finding
+  // carrying a verified verbatim quote, and the standing-rules layer selects on
+  // that origin to inject a claim on EVERY turn. The quote here would be
+  // verbatim -- it is copied out of the archive -- but whether the turn was a
+  // correction at all is a guess, and a guess must not buy always-on injection.
+  // So no `origin` and no `quote` field: this stays harvested provenance.
+  try {
+    if (projectRoot) {
+      let turns = readArchive(dir, sessionId);
+      // The archive is written by the Stop hook too, and the order of the two is
+      // not this module's to assume, so fall back to the live transcript.
+      if (!turns.length && transcriptPath) turns = readTurns(transcriptPath);
+
+      for (const turn of turns) {
+        if (!turn || turn.role !== 'user') continue;
+        const text = String(turn.text || '').trim();
+        // Long turns are new instructions with a complaint somewhere inside
+        // them; truncating one into a claim would misquote the user.
+        if (text.length < 12 || text.length > 300) continue;
+        if (!CORRECTION_OPENER.test(text)) continue;
+        add({
+          type: 'feedback',
+          claim: redact(text, { max: CLAIM_MAX }),
+          evidence: redact(`the user opened a turn with a correction: "${text}"`, {
+            max: EVIDENCE_MAX,
+          }),
+          applicability: 'when working in this project, before repeating what was corrected',
+          confidence: CONFIDENCE.correction,
+          confidenceLabel: labelFor(CONFIDENCE.correction),
+          scope: 'project',
+          invalidators: ['the user later asks for the corrected behaviour'],
+          anchors: [projectRoot],
+          derivedBy: 'correction',
+          sessionId,
+          at: Date.parse(turn.at || '') || Date.now(),
+        });
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 4: re-read churn ---------------------------------------------------
+  //
+  // NOT A FINDING, AND THAT IS THE DECISION RATHER THAN AN OMISSION.
+  //
+  // Churn is a claim about OUR OWN reading behaviour: "this file was read three
+  // times unchanged". Every finding type available is a claim about the work --
+  // `map` describes how an area of the codebase is laid out, and is
+  // content-dependent, so a churn claim filed as `map` would be checked for
+  // staleness against contents it makes no claim about and flip stale on the
+  // first edit to a file it never described. Worse, the anchors it would take
+  // are by construction the HOTTEST files in the project, which are exactly the
+  // files that already carry real findings, so a 0.4-confidence row saying
+  // nothing actionable would sit in the injection budget beside them and render
+  // on the same reads. Nothing a future agent could DO differently follows from
+  // it: it does not say what the file contains, so it cannot substitute for
+  // reading it.
+  //
+  // The signal is still worth having -- as the measurement it already is.
+  // `rereadWaste` reports it on the balance sheet, `rereadsByAnchor` names the
+  // offenders, and this returns those rows as OBSERVATIONS: computed, carried,
+  // and deliberately not competing for context. Three detectors produce
+  // findings; the fourth produces a number.
+  try {
+    for (const row of rereadsByAnchor(events).slice(0, 3)) {
+      if (!row.anchor || row.wasteful < 2) continue;
+      result.observations.push({
+        kind: 'churn',
+        anchor: row.anchor,
+        repeats: row.repeats,
+        wasteful: row.wasteful,
+        tokens: row.tokens,
+        confidence: CONFIDENCE.churn,
+        derivedBy: 'churn',
+        note: `re-read ${row.repeats} times, ${row.wasteful} of them unchanged`,
+      });
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  return result;
+}

--- a/integrations/copilot/.github/hooks/lib/derive.mjs
+++ b/integrations/copilot/.github/hooks/lib/derive.mjs
@@ -16,6 +16,13 @@
  * there is nothing to consent to and this runs by default. It is the only
  * finding producer on a machine without a key.
  *
+ * THREE SOURCES, NOT TWO. `tool-outcome` events, the transcript archive, and --
+ * since the transition detectors were measured to have no input at all on the
+ * primary client -- the raw transcript's FAILED tool results, which is the only
+ * place a Claude Code failure is recorded (`failedResultsFromTranscript` in
+ * transcript.mjs, and the note above `quotable` for what that measurement
+ * actually yielded).
+ *
  * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
  * second command fixed the first -- an intervening edit, a dependency install or
  * a flaky test explains it just as well. So each detector carries a confidence
@@ -32,7 +39,11 @@
 import { readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
-import { readArchive, readTurns } from './transcript.mjs';
+import {
+  readArchive,
+  readTurns,
+  failedResultsFromTranscript,
+} from './transcript.mjs';
 import { redact } from './redact.mjs';
 import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
@@ -56,6 +67,96 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * The anchor cap a command surface is stored under, restated here as a TEST.
+ *
+ * `recordToolOutcome` truncates `anchor` to 120 characters, so a command at or
+ * over that length reached this module already cut -- and `quotable` below
+ * refuses to build a claim out of the fragment.
+ */
+const COMMAND_ANCHOR_MAX = 120;
+
+/**
+ * Can this command text be QUOTED in a claim a reader could act on?
+ *
+ * THE SECOND REFUSAL OF ITS KIND, and it exists because measurement forced it.
+ * Wiring the transcript reader gave the transition detectors their first real
+ * input on this client and immediately produced four candidates at 0.9
+ * confidence whose claim text read:
+ *
+ *   `cd /c/Users/.../token-optimizer-mcp\ncat >> docs/superpowers/plans/2026-` succeeded
+ *   in this project where `cd /c/Users/.../token-optimizer-mcp\ncat > /tmp/probe3.mjs
+ *   <<'EOF'\nimport { readdirSync, readFileSync, sta` failed
+ *
+ * -- two truncated fragments of throwaway shell scripts, grouped together only
+ * because `attemptKey`'s three tokens were spent on `cd`, the absolute path, and
+ * the verb. Then measured properly across three real transcripts: **0 of 83**
+ * captured command failures are single-line and inside the cap. 65% of this
+ * project's 2,178 successful command outcomes are not either. On this client a
+ * "command" is usually a whole shell script, so the attempt identity the
+ * transition detectors are built on does not fit most of the traffic.
+ *
+ * This is the same judgement as the identical-text guard below rather than a
+ * confidence question: a claim whose subject is a truncated fragment of a
+ * program is not a weaker claim, it is not a claim. A raised cap would not
+ * rescue it -- quoting the whole 500-character heredoc is no more actionable.
+ *
+ * What survives is exactly what the detector was designed for: `npm test`,
+ * `dotnet build X`, `deploy --retry` -- a repeatable command someone could run
+ * again. This machine captured none failing, which is why the honest yield here
+ * is zero and why that is reported rather than dressed up.
+ *
+ * Applied to BOTH sources. Where the evidence arrived from has no bearing on
+ * whether the resulting sentence says anything, and a rule that let events
+ * through would ship the junk on the ten clients that do report failures.
+ */
+const quotable = (command) => {
+  const text = String(command || '');
+  return (
+    text.trim().length > 0 &&
+    !/[\r\n]/.test(text) &&
+    text.length < COMMAND_ANCHOR_MAX
+  );
+};
+
+/**
+ * Tokens that separate one command from the next rather than naming one.
+ *
+ * MEASURED, LIKE EVERY OTHER REFUSAL HERE. `attemptKey` spends up to three
+ * non-flag tokens on identity, and the habit on this machine is
+ * `cd <absolute path> && <the real command>` -- which spends all three on `cd`,
+ * the path and `&&`, so the real command never enters the key. This project's
+ * own evidence: the single key `cd c:/users/.../token-optimizer-mcp &&` covers
+ * **539 distinct command lines**. One quotable failure in that group would pair
+ * with an arbitrary unrelated success and claim "`cd repo && grep -n ...`
+ * succeeded where `cd repo && git merge ...` failed", which is false about both.
+ *
+ * A KEY THAT REACHED A SEPARATOR NEVER REACHED A COMMAND, so there is no attempt
+ * to compare and nothing to claim -- the same judgement as the identical-text
+ * guard rather than a lower ceiling. Narrow on purpose: `2>&1` and `/F` are not
+ * separators and do not trip this, so `cat commitlint.config.mjs 2>&1` and
+ * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
+ * found across 163 transcripts on this machine it refuses 2 and keeps 6.
+ *
+ * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
+ * building the key, so the claim is about `npm test` rather than about the `cd`.
+ * That changes `attemptKey` for every client and every finding already derived
+ * from it, so it belongs in its own change with its own comparison.
+ */
+const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
+
+/**
+ * Did `attemptKey` actually capture a command, or only how one was chained?
+ *
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * One check per pair is enough: both halves share the key by construction.
+ */
+const hasAttemptIdentity = (command) =>
+  attemptKey(command)
+    .split(' ')
+    .filter(Boolean)
+    .every((token) => !COMMAND_SEPARATORS.has(token));
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -274,6 +375,17 @@ export function derive(dir, options = {}) {
   // separate command field, because the anchor of a command surface IS the
   // command. It is capped at 120 characters at the boundary, so a very long
   // command line is compared and quoted truncated.
+  //
+  // TWO SOURCES OF FAILURE, ONE PAIRING LOOP. Claude Code never fires
+  // PostToolUse for a failed tool call -- 2,238 of 2,238 live `tool-outcome`
+  // events on the measuring machine carry `success: true`, and a deliberately
+  // failing command produced no event at all -- so on the primary client these
+  // two detectors had NO INPUT WHATSOEVER while working normally on the ten
+  // adapter clients. `failedResultsFromTranscript` supplies the missing half
+  // from the only place it exists. The successes still come from events only:
+  // a transcript failure that pairs with nothing stays unclaimed, which is also
+  // what keeps a failure from ANOTHER project's directory out of this project's
+  // graph -- a candidate cannot be emitted without a success recorded HERE.
   try {
     if (projectRoot) {
       const outcomes = events
@@ -290,6 +402,9 @@ export function derive(dir, options = {}) {
           output: typeof e.output === 'string' ? e.output : '',
           exit: Number.isInteger(e.exit) ? e.exit : null,
           at: e.at ?? 0,
+          // Carried purely so the transcript merge below can recognise the same
+          // tool call arriving from the other source.
+          toolCallId: e.toolCallId ? String(e.toolCallId) : null,
           // `success` FIRST, `exit` only as a refinement. MCP tools report no
           // numeric code at all, so a classifier keyed on `exit !== 0` would be
           // inert for most clients -- and `exit` is null rather than 0 precisely
@@ -297,6 +412,53 @@ export function derive(dir, options = {}) {
           failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
         }))
         .sort((a, b) => a.at - b.at);
+
+      // DEDUPLICATED ON `toolCallId`, which is the SAME STRING in both sources:
+      // `episodeMeta` reads `raw.tool_use_id` into `toolCallId`, and that is the
+      // transcript's `tool_use_id` verbatim -- verified against live evidence
+      // (`toolu_01L4Nwr...` in metrics.jsonl, the same ids in the transcript).
+      // So on the ten clients that DO report failures, the event copy wins and
+      // the transcript copy is dropped before grouping. Without this the two
+      // copies of one failure would sit in the same run and the second of them
+      // would be paired against the first as a failed-then-succeeded story about
+      // itself.
+      //
+      // The fallback covers a client that reports a failure with no call id:
+      // identical command text within two seconds is one failure recorded twice,
+      // not two failures, because nothing re-runs a command that fast.
+      const eventIds = new Set(
+        outcomes.map((o) => o.toolCallId).filter(Boolean)
+      );
+      const eventFailures = outcomes.filter((o) => o.failed);
+      const alreadyRecorded = (failure) => {
+        if (failure.toolCallId && eventIds.has(failure.toolCallId)) return true;
+        return eventFailures.some(
+          (o) =>
+            o.command === failure.command &&
+            Math.abs((o.at || 0) - (failure.at || 0)) <= 2000
+        );
+      };
+
+      let transcriptFailures = [];
+      try {
+        transcriptFailures = failedResultsFromTranscript(transcriptPath).filter(
+          (failure) => failure.command.trim() && !alreadyRecorded(failure)
+        );
+      } catch {
+        // The reader is an extra source, never a reason the detector stops.
+      }
+      for (const failure of transcriptFailures) {
+        outcomes.push({
+          command: failure.command.trim(),
+          output: failure.output,
+          exit: failure.exit,
+          at: failure.at,
+          toolCallId: failure.toolCallId,
+          // Read from `Exit code N`, which is the only shape the reader admits.
+          failed: true,
+        });
+      }
+      if (transcriptFailures.length) outcomes.sort((a, b) => a.at - b.at);
 
       const byAttempt = new Map();
       for (const outcome of outcomes) {
@@ -333,6 +495,18 @@ export function derive(dir, options = {}) {
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
           if (failed.command === outcome.command) continue;
+
+          // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
+          // client both sides of almost every pair are truncated multi-line
+          // shell scripts, and a claim quoting a fragment of one is noise
+          // spending the retrieval budget of every later session.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
+          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
+          // command lines in this repository alone, and any pair drawn from that
+          // group is a false claim about both halves.
+          if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =
             CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);

--- a/integrations/copilot/.github/hooks/lib/doctor.mjs
+++ b/integrations/copilot/.github/hooks/lib/doctor.mjs
@@ -197,7 +197,8 @@ function hooksDirFor({ hooksDir, install, root }) {
  * identical from outside: a graph that fills with structural nodes either way.
  *
  * Measured on a real 5.4.0 install: 484 symbol, 286 file and 122 task nodes and
- * ZERO findings, because harvestMode() was 'off:not-opted-in'. Fifteen checks
+ * ZERO findings, because harvestMode() then returned an opt-in refusal (the mode has
+ * since been renamed: it is 'off:no-key' now, and opting in is no longer the gate). Fifteen checks
  * passed and none mentioned harvest. stop-harvest.mjs names this exact gap --
  * "nothing in doctor, audit or waste mentions harvest, so a user sees a graph
  * filling with structural nodes and no findings and has no way to learn why" --
@@ -221,9 +222,15 @@ export function probeHarvest() {
   // optimizer is off" is noise, which is why stop-harvest maps it to no notice.
   if (mode === 'off:mode') return [];
 
+  // SAID PLAINLY, because this is the configuration a user would choose if they
+  // knew it existed and the previous wording buried it in machinery. A local
+  // endpoint is the only setting under which the semantic harvest runs with no
+  // credential, no billing and no digest leaving the machine -- so the two facts
+  // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
     return [ok('finding extraction is available',
-      'active-model wiki_write is primary; local endpoint also enables fallback extraction')];
+      'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
+      'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
@@ -233,10 +240,19 @@ export function probeHarvest() {
 
   // No second-model credential is required for the primary path. The Codex/agent session that
   // already paid to derive the conclusion is the extractor and wiki_write is local.
+  // NAME THE TRADE, not just the missing variable. This is the default state on
+  // every machine without a credential, so it is the text most users will read,
+  // and "unavailable" alone tells them neither what they are missing nor that
+  // the free option exists. Local findings still accumulate: derive.mjs reads
+  // exit codes, red-to-green transitions, corrections and churn out of evidence
+  // already on disk and sends nothing anywhere.
   if (mode === 'off:no-key') {
     return [ok('finding extraction is available',
-      'active model records durable conclusions through local wiki_write; no separate-model ' +
-      'credential is configured, so fallback transcript extraction is unavailable')];
+      'active model records durable conclusions through local wiki_write, and derive runs at ' +
+      'session end with no credential. No separate-model credential is configured, so fallback ' +
+      'transcript extraction is unavailable: point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local ' +
+      'model to run it free and private, or set TOKEN_OPTIMIZER_API_KEY to run it from a bounded ' +
+      'digest of paths, commands, prompts and conclusions -- never file contents')];
   }
 
   // off:opted-out -- a deliberate choice, reported as one. Nagging about a setting somebody chose

--- a/integrations/copilot/.github/hooks/lib/inject.mjs
+++ b/integrations/copilot/.github/hooks/lib/inject.mjs
@@ -1134,10 +1134,25 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // injected more than the budget allowed and recorded fewer tokens than it
   // spent -- in a block whose entire justification is that it is tightly
   // bounded and measured against the control arm.
+  // THE LAST LINE IS HOW THE NEXT RULE GETS HERE, and it is one line because
+  // this block is charged on every session forever. A rule reaches this list
+  // only by being pinned or by being a person's verified correction, and both
+  // start as a `wiki_write` -- so a model reading a set of standing rules with
+  // no idea how they were produced has no way to add to it. Stated at the point
+  // of the evidence rather than as a separate always-on block: the reader is
+  // already looking at the output of the mechanism being described.
+  //
+  // THE COLD GRAPH IS COVERED ELSEWHERE, deliberately. Nothing here renders
+  // until at least one rule qualifies, which is the property the always-on
+  // budget depends on, so this line cannot be the first-session nudge --
+  // `policyText`'s "Record what you work out" section is, and it is emitted at
+  // SessionStart whether or not the graph holds anything.
   const HEADING =
     '# Standing rules for this project' +
     '\n\nEstablished in previous sessions and expected to hold. ' +
-    'These are not suggestions.\n\n';
+    'These are not suggestions.\n\n' +
+    'Record what you work out with wiki_write and a real file anchor; ' +
+    'that is how a rule reaches this list.\n\n';
   const noticeFor = (n) =>
     n
       ? `\n(${n} further standing rule${n === 1 ? '' : 's'} did not fit this budget; ` +

--- a/integrations/copilot/.github/hooks/lib/inject.mjs
+++ b/integrations/copilot/.github/hooks/lib/inject.mjs
@@ -35,6 +35,7 @@ import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
 import { cacheOrdered } from './cache.mjs';
+import { withheldFor, exploreOrder, servingPolicyVersion, LOO_ENABLED } from './loo.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -311,8 +312,38 @@ export function forTouch(
     });
     for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
   }
-  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  // LAYER 2 EXPLORATION, BEFORE the budget decides.
+  //
+  // `assessed.eligible` arrives in net-utility order and `fit` keeps that order
+  // until the budget runs out -- so the ranking decides which findings are ever
+  // served, which decides which ever accumulate observations, which decides
+  // their utility. A tenth of touches therefore promote the least-served
+  // candidate first. This is the only place it can go: after `fit` the choice
+  // has already been made.
+  const ordered = exploreOrder(assessed.eligible, dir, { sessionId, anchor: filePath });
+  const { kept, spent } = fit(ordered.map((item) => item.finding), budget);
   if (!kept.length) return null;
+
+  // LAYER 2 WITHHOLDING, AFTER the budget decides, which is the only ordering
+  // that produces a leave-one-out rather than a substitution: withholding first
+  // would let the next-ranked finding take the freed tokens, so the withheld
+  // arm would differ from the served arm by two findings instead of one and the
+  // effect would belong to neither.
+  //
+  // `holdout` is passed so the two experiments cannot compose into "withhold
+  // everything and call it a leave-one-out": that arm already serves nothing.
+  const withheld = withheldFor(kept.map((finding) => finding.key), sessionId, graph, dir, {
+    surface: 'file',
+    anchor: filePath,
+    holdout,
+  });
+  const delivered = withheld ? kept.filter((finding) => finding.key !== withheld) : kept;
+  // RE-PRICED, because `fit` priced what it KEPT and this delivers less. Using
+  // `spent` would bill the injection-cost side of the balance sheet for text
+  // the model never received.
+  const deliveredSpent = withheld
+    ? delivered.reduce((sum, finding) => sum + estimate(render(finding)), 0)
+    : spent;
 
   record(dir, {
     kind: 'inject',
@@ -321,15 +352,20 @@ export function forTouch(
     surface: 'file',
     anchor: filePath,
     holdout,
-    tokens: holdout ? 0 : spent,
-    deliveredTokens: holdout ? 0 : spent,
+    tokens: holdout ? 0 : deliveredSpent,
+    deliveredTokens: holdout ? 0 : deliveredSpent,
     shadowTokens: spent,
-    count: holdout ? 0 : kept.length,
+    count: holdout ? 0 : delivered.length,
     candidateCount: kept.length,
-    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    findingIds: holdout ? [] : delivered.map((finding) => finding.key),
     shadowFindingIds: kept.map((finding) => finding.key),
-    stale: kept.some((f) => f.stale),
+    stale: delivered.some((f) => f.stale),
     sessionId,
+    // ON EVERY RECORD, not only the withheld ones. A served observation needs
+    // the policy version as much as a withheld one does, or `effects` cannot
+    // keep the two arms of one comparison inside one policy.
+    ...(LOO_ENABLED() ? { looPolicy: servingPolicyVersion() } : {}),
+    ...(withheld ? { loo: withheld } : {}),
   });
 
   // MARKED SEEN IN BOTH ARMS, for the same reason as the command path: a file
@@ -339,11 +375,16 @@ export function forTouch(
   // grow faster purely from repetition.
   //
   // This is the identical defect that was fixed in `forCommand` and not here.
+  //
+  // THE WITHHELD KEY IS MARKED TOO, and that is load-bearing rather than tidy:
+  // an unmarked one would be a candidate again on the next touch of this file,
+  // where the one-per-touch tiebreak could serve it -- flipping its arm inside
+  // the very session the arm hash exists to pin it for.
   for (const f of kept) alreadyInjected.add(f.key);
 
-  if (holdout || !kept.length) return null;
+  if (holdout || !delivered.length) return null;
 
-  return `Known about ${filePath} (from previous sessions):\n${kept.map(render).join('\n')}`;
+  return `Known about ${filePath} (from previous sessions):\n${delivered.map(render).join('\n')}`;
 }
 
 /**

--- a/integrations/copilot/.github/hooks/lib/keepwarm.mjs
+++ b/integrations/copilot/.github/hooks/lib/keepwarm.mjs
@@ -30,6 +30,15 @@ import { record, readMetrics, readBalance } from './metrics.mjs';
 import { WRITE_MULTIPLIER, READ_MULTIPLIER } from './cache.mjs';
 
 /**
+ * The shortest gap that counts as a NEW turn rather than a burst inside one.
+ *
+ * Shared by the gap distribution and by the hit test, because they have to
+ * agree about what a turn is. Two copies of this number would let the decision
+ * be fitted to one definition of a turn and scored against another.
+ */
+export const TURN_GAP_MS = 250;
+
+/**
  * TTL tiers, with what a WRITE costs at each.
  *
  * A five-minute entry is written at 1.25x a plain input token; the one-hour
@@ -85,7 +94,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
     for (let i = 1; i < session.length; i++) {
       const gap = session[i] - session[i - 1];
       // A burst of events inside one turn is not a gap between turns.
-      if (gap > 250) gaps.push(gap);
+      if (gap > TURN_GAP_MS) gaps.push(gap);
     }
   }
   if (gaps.length < 6) return null;
@@ -105,10 +114,91 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
 }
 
 /**
+ * Refreshes to observe at a tier before the observation may bound the decision.
+ *
+ * THE SAME NUMBER THE BACKSTOP DEMANDS, deliberately. The decision and the
+ * tripwire read the same ledger, so letting them disagree about when there is
+ * enough evidence would mean one of them acting on a sample the other calls too
+ * small. Below the floor the decision keeps its expected-value answer, so a
+ * single unlucky miss changes nothing at all.
+ *
+ * NOT A CONFIDENCE INTERVAL, and the reason is arithmetic rather than taste. A
+ * Wilson 95% upper bound at ten refreshes and zero hits is 0.28 -- so a policy
+ * that missed ten times out of ten would still be recommended, which is exactly
+ * the case the loop exists to catch. The point estimate is safe here because of
+ * the bound below: an observation may only ever LOWER the modelled probability,
+ * so sampling noise cannot manufacture a refresh, and the tripwire's realised
+ * ledger is a second guard underneath.
+ */
+export const OBSERVATION_FLOOR = TRIPWIRE_MIN;
+
+/**
+ * The measured hit rate per tier, from recorded outcomes.
+ *
+ * Tiers below the floor are ABSENT rather than present with a small n, because
+ * a rate carrying no weight is the thing most likely to be used as though it
+ * did.
+ */
+export function observedHitRates(outcomes = []) {
+  const byTier = new Map();
+  for (const event of outcomes) {
+    if (event?.kind !== 'keepwarm' || event.action !== 'outcome') continue;
+    const name = TIERS.some((t) => t.name === event.tier) ? event.tier : TIERS[0].name;
+    const row = byTier.get(name) || { refreshes: 0, hits: 0 };
+    row.refreshes += 1;
+    if (event.hit) row.hits += 1;
+    byTier.set(name, row);
+  }
+
+  const qualified = new Map();
+  for (const [name, row] of byTier) {
+    if (row.refreshes < OBSERVATION_FLOOR) continue;
+    qualified.set(name, { ...row, rate: row.hits / row.refreshes });
+  }
+  return qualified;
+}
+
+/**
+ * What the refreshes at this tier actually did, if enough of them have.
+ *
+ * Tolerates being handed anything -- null, a plain object, a Map -- because the
+ * callers are two public functions whose options object is assembled by other
+ * people's code.
+ */
+function observationsFor(observed, tierName) {
+  const row = observed instanceof Map ? observed.get(tierName) : null;
+  return row && Number.isFinite(row.rate) ? row : null;
+}
+
+/**
+ * The modelled probability, BOUNDED BY what was observed and never raised by it.
+ *
+ * The asymmetry is the whole point and runs against this project's interest. A
+ * recorded `hit` says only that a turn arrived before the entry expired; it
+ * cannot say the refresh is what kept the entry alive, because a turn arriving
+ * one minute after a five-minute ping would have found the entry warm anyway.
+ * So the observed rate is an UPPER bound on a refresh's value, and substituting
+ * it for the model would flatter keep-warm badly: on the machine this was
+ * written on, the modelled ping probability is 0.2% and the observable
+ * before-expiry rate is 99.5%, so the substitution would recommend refreshing
+ * forever. A low rate, by contrast, is real evidence against: if turns do not
+ * even arrive inside the TTL, the refresh certainly bought nothing.
+ */
+function bounded(modelled, seen) {
+  return seen ? Math.min(modelled, seen.rate) : modelled;
+}
+
+/**
  * Should we refresh this prefix now?
  *
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
+ *
+ * `observed` is passed IN rather than read from disk here: this function is
+ * pure, its purity is what lets the tests build a distribution by hand, and
+ * `shouldKeepWarm` has already read the outcome log for the tripwire -- so
+ * threading the reader in here would be a second read of the same file and a
+ * second place for the window discipline to be got wrong.
  */
 export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
@@ -125,42 +215,30 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
   const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
-
-  // MEASURED BEATS MODELLED, once there is enough of it.
-  //
-  // The module header already commits to this -- "an expected-value decision is
-  // only as good as the distribution it was fitted to, and distributions
-  // shift" -- and the tripwire underneath was the only thing acting on it, as
-  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
-  // entirely" there was nothing, because the observed hit rate was never
-  // computed: both recording halves had no call site, so ten refreshes that
-  // bought nothing would keep recommending refresh right up to the moment the
-  // tripwire cut the whole feature off.
-  //
-  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
-  // handful of samples would swing the decision harder than the distribution
-  // they replace.
-  const probability = observed ? observed.rate : modelled;
+  const seen = observationsFor(observed, tier.name);
+  const probability = bounded(modelled, seen);
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
-  const basis = observed
-    ? `measured over ${observed.observations} refreshes`
-    : 'modelled from the gap distribution';
+  const note = seen && probability < modelled
+    ? `; bounded by ${seen.refreshes} observed refreshes, ` +
+      `${Math.round(seen.rate * 100)}% used before expiry`
+    : '';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
     modelledProbability: modelled,
-    basis,
+    observedHitRate: seen ? seen.rate : null,
+    observedRefreshes: seen ? seen.refreshes : 0,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
-    reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
+    reason: (ev > 0
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
-        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`) + note,
   };
 }
 
@@ -171,7 +249,12 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
  * long enough that the short tier keeps missing. Returns null when neither tier
  * pays, which is a real answer and the one a default-on product never gives.
  */
-export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS }) {
+export function ttlTier({
+  prefixTokens,
+  gaps,
+  turnsPerSession = DEFAULT_TURNS,
+  observed = null,
+}) {
   if (!prefixTokens || !gaps) return null;
 
   // Expected cost of a turn under each tier, as a multiple of what the prefix
@@ -179,7 +262,16 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   // again; and the FIRST write is amortised over the session, which is what
   // stops the expensive tier from looking free whenever gaps are short.
   const costOf = (tier) => {
-    const hit = gaps.probabilityWithin(tier.ms);
+    // THE SAME QUANTITY THE OUTCOMES RECORD, which is what makes the
+    // observation admissible here at all. `hit` is P(a turn arrives before the
+    // entry expires) and `recordRefreshOutcome`'s `hit` is exactly that event,
+    // measured -- unlike keepWarmDecision, whose probability is the narrower
+    // ping window and for which the same observation is only an upper bound.
+    // Bounded rather than replaced even so: a sample drawn only from moments we
+    // CHOSE to refresh is not a sample of gaps, and its bias runs our way.
+    const modelled = gaps.probabilityWithin(tier.ms);
+    const seen = observationsFor(observed, tier.name);
+    const hit = bounded(modelled, seen);
     const perTurn = hit * READ_MULTIPLIER + (1 - hit) * tier.writeMultiplier;
     // THE SUPPLIED VALUE, not only the computed one. Math.max(1, NaN) is NaN -- Math.max
     // propagates it rather than clamping -- so perTurn became NaN, the `perTurn >= 1` guard below
@@ -192,6 +284,8 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     return {
       tier,
       hit,
+      seen,
+      boundedByObservation: Boolean(seen) && hit < modelled,
       perTurn: (tier.writeMultiplier + (turns - 1) * perTurn) / turns,
     };
   };
@@ -208,99 +302,53 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     action: 'refresh',
     tier: best.tier.name,
     hitProbability: best.hit,
+    observedHitRate: best.seen ? best.seen.rate : null,
+    observedRefreshes: best.seen ? best.seen.refreshes : 0,
     expectedCostPerTurn: Number(best.perTurn.toFixed(3)),
     expectedValue: Math.round((1 - best.perTurn) * prefixTokens),
     reason: `${Math.round(best.hit * 100)}% of gaps land inside ${best.tier.name}; ` +
-      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached`,
+      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached` +
+      (best.boundedByObservation
+        ? `, bounded by ${best.seen.refreshes} observed refreshes ` +
+          `(${Math.round(best.seen.rate * 100)}% used before expiry)`
+        : ''),
   };
 }
 
-/** Observations of a tier before its measured hit rate may override the model. */
-export const OBSERVATION_FLOOR = 5;
-
-/** Records a refresh so its outcome can be scored. */
-export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
-  record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
-}
-
 /**
- * Scores every refresh whose window has since resolved.
+ * Records a refresh so its outcome can be scored.
  *
- * THE MISSING HALF, and it was missing because nobody could see where the
- * signal would come from. `recordRefreshOutcome` needs to know whether a real
- * turn arrived before the entry expired -- and that is not a thing anyone has
- * to instrument, because the event log already records when every turn
- * happened. The answer was in the data the whole time.
+ * `sessionId` IS REQUIRED FOR THE REFRESH TO BE SCOREABLE, and is not defaulted
+ * to anything. The hit test asks whether a turn of THIS conversation arrived
+ * before expiry; pooling arrivals across sessions would let a second concurrent
+ * session's turn pay for this one's ping, which manufactures hits. A refresh
+ * recorded without one is kept in the ledger and reported as unattributable
+ * rather than guessed at.
  *
- * For each unscored refresh at time T on a tier with TTL `ms`:
- *
- *   - a later event within `ms`            -> HIT, observed
- *   - a later event after `ms`             -> MISS, observed
- *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
- *                                             demonstrably closed unused
- *   - no later event, window still open    -> NOTHING RECORDED
- *
- * That last line is the important one and it is Plan 2's own instruction: "if
- * no signal is available for a tier, record nothing rather than guessing
- * `hit: false`". A refresh whose window has not closed yet is not a miss, and
- * scoring it as one would drive the tripwire negative on the newest and least
- * informative records.
- *
- * DRAINED AT READ TIME, which is the pattern this codebase already uses for
- * staleness: the producer cannot know the outcome at the moment it acts, so the
- * next reader resolves what has become knowable since.
+ * Returns the stored record, whose `id` is what `scoreRefreshes` pairs the
+ * outcome to, so an issuer can hold onto it.
  */
-export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
-  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
-  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
-  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
-
-  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
-  // so everything past the number already scored is outstanding. Pairing by
-  // timestamp instead would double-count two refreshes recorded in the same
-  // millisecond, which is reachable: a tool run twice in a loop.
-  const outstanding = refreshes.slice(scored);
-  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
-
-  let recorded = 0;
-  for (const refresh of outstanding) {
-    const at = Number(refresh.at) || 0;
-    if (!at) continue;
-    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
-    const next = timeline.find((t) => t > at);
-
-    let hit;
-    if (next !== undefined) hit = next - at <= tierSpec.ms;
-    else if (now - at > tierSpec.ms) hit = false;
-    else continue; // window still open: not yet knowable
-
-    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
-    recorded += 1;
-  }
-  return { outstanding: outstanding.length, recorded };
-}
-
-/**
- * The measured hit rate for a tier, or null below the observation floor.
- *
- * Null rather than a small-sample number, because the caller substitutes it for
- * a modelled probability and three observations would swing the decision harder
- * than the model they replace.
- */
-export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
-  const relevant = outcomes.filter(
-    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
-  );
-  if (relevant.length < OBSERVATION_FLOOR) return null;
-  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
+export function recordRefresh(dir, { tier, prefixTokens, expectedValue, sessionId, at }) {
+  return record(dir, {
+    kind: 'keepwarm',
+    action: 'refresh',
+    tier,
+    prefixTokens,
+    expectedValue,
+    sessionId,
+    at,
+  });
 }
 
 /**
  * Records whether the refresh was used.
  *
  * `hit` means a real turn arrived before expiry, so the write bought a read.
+ * `refreshId` names the refresh this scores, so the same one cannot be scored
+ * twice -- once per turn for the rest of the session, which is what an
+ * unpaired outcome would become.
  */
-export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
+export function recordRefreshOutcome(dir, { tier, prefixTokens, hit, refreshId = null }) {
   const tierSpec = TIERS.find((t) => t.name === tier) || TIERS[0];
   // THE SAME LEDGER keepWarmDecision BUYS THE REFRESH WITH. That function is explicit that a
   // refresh is a PING, which READS the prefix -- costOfPing = prefixTokens * READ_MULTIPLIER --
@@ -317,7 +365,125 @@ export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
   const realised = hit
     ? prefixTokens * (tierSpec.writeMultiplier - READ_MULTIPLIER) - prefixTokens * READ_MULTIPLIER
     : -prefixTokens * READ_MULTIPLIER;
-  record(dir, { kind: 'keepwarm', action: 'outcome', tier, prefixTokens, hit: Boolean(hit), realised: Math.round(realised) });
+  record(dir, {
+    kind: 'keepwarm',
+    action: 'outcome',
+    tier,
+    prefixTokens,
+    hit: Boolean(hit),
+    refreshId,
+    realised: Math.round(realised),
+  });
+}
+
+/**
+ * Scores every recorded refresh whose window has closed -- and NOTHING ELSE.
+ *
+ * This is the arm that was missing. `recordRefresh` and `recordRefreshOutcome`
+ * were both correct and both called by nothing, so the decision spent money on
+ * refreshes and could never find out whether one bought a read.
+ *
+ * THE SIGNAL IS REAL, not invented. `gapDistribution` already treats this log's
+ * timestamps as turn arrivals -- that is the distribution the whole decision is
+ * fitted to -- so the same log answers the outcome question directly: a refresh
+ * at tier `5m` was used if a turn of the same session arrived within five
+ * minutes of it. Four cases refuse to answer rather than guess, and every one
+ * of them refuses in the direction that costs this project its own good news:
+ *
+ *   - `pending`: the window has not closed yet. A hit could be scored the
+ *     instant it arrives while a miss must wait out the whole TTL, so scoring
+ *     early would mean the recorded hits are always complete and the recorded
+ *     misses always lagging -- right-censoring, biased upward, invisible in any
+ *     test. So a hit waits exactly as long as a miss.
+ *   - `uncovered`: the arrival log no longer reaches back to the refresh, so
+ *     absence of an arrival is absence of evidence. RECORDING `hit: false` HERE
+ *     WOULD BE THE INVENTION THIS IS FORBIDDEN TO MAKE: an absent signal is not
+ *     a miss, and treating it as one biases every rate downward and would
+ *     eventually switch keep-warm off on no evidence at all.
+ *   - `unattributable`: the refresh names no session, so no arrival can be
+ *     shown to belong to it.
+ *   - already scored: an outcome already names this refresh.
+ *
+ * The firehose is READ LAZILY, and only when there is something to score. On a
+ * machine where nothing issues refreshes -- which is every machine today, since
+ * nothing in this repository issues one -- the whole cost is the outcome-log
+ * read: median 70 ms on a 3.5 MB log, of which readBalance is 49 ms, because
+ * that reader also scans the firehose tail for pre-split records.
+ */
+export function scoreRefreshes(dir, {
+  refreshes = readBalance(dir),
+  arrivals = null,
+  now = Date.now(),
+} = {}) {
+  const summary = { scored: 0, hits: 0, pending: 0, uncovered: 0, unattributable: 0 };
+  const keepwarm = refreshes.filter((event) => event?.kind === 'keepwarm');
+  const alreadyScored = new Set(
+    keepwarm
+      .filter((event) => event.action === 'outcome' && event.refreshId)
+      .map((event) => event.refreshId)
+  );
+  const unscored = keepwarm.filter(
+    (event) =>
+      event.action === 'refresh' &&
+      Number.isFinite(event.at) &&
+      event.id &&
+      !alreadyScored.has(event.id)
+  );
+
+  // A refresh with no id cannot be paired, so scoring it would write a fresh
+  // outcome on every turn forever. Reported, not silently dropped.
+  summary.unattributable += keepwarm.filter(
+    (event) => event.action === 'refresh' && (!event.id || !Number.isFinite(event.at))
+  ).length;
+
+  if (!unscored.length) return summary;
+
+  const events = (arrivals ? arrivals() : readMetrics(dir)).filter((event) =>
+    Number.isFinite(event?.at)
+  );
+  // Coverage is judged over EVERY event, including our own bookkeeping: the
+  // refresh's own copy in the firehose is what proves the window is still
+  // inside the read. Arrivals are judged over everything else, because a record
+  // keep-warm wrote about itself is not a turn -- and counting one would
+  // manufacture a hit out of the act of measuring.
+  const earliest = events.reduce((min, event) => Math.min(min, event.at), Infinity);
+  const turns = events.filter((event) => event.kind !== 'keepwarm');
+
+  for (const refresh of unscored) {
+    const tier = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    if (now - refresh.at < tier.ms) {
+      summary.pending += 1;
+      continue;
+    }
+    const session = refresh.sessionId;
+    if (!session) {
+      summary.unattributable += 1;
+      continue;
+    }
+    if (!(earliest <= refresh.at)) {
+      summary.uncovered += 1;
+      continue;
+    }
+
+    const opens = refresh.at + TURN_GAP_MS;
+    const closes = refresh.at + tier.ms;
+    const hit = turns.some(
+      (event) =>
+        (event.sessionId ?? event.episodeId) === session &&
+        event.at > opens &&
+        event.at <= closes
+    );
+    recordRefreshOutcome(dir, {
+      tier: refresh.tier,
+      prefixTokens: refresh.prefixTokens,
+      hit,
+      refreshId: refresh.id,
+    });
+    summary.scored += 1;
+    if (hit) summary.hits += 1;
+  }
+
+  return summary;
 }
 
 /**
@@ -372,23 +538,15 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
-  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
-  // becomes evidence now, so the decision below and the tripwire above both see
-  // the most that is currently knowable -- the same read-time drain the
-  // staleness path uses, and for the same reason: the producer cannot know the
-  // outcome at the moment it acts.
-  try {
-    scoreOutstandingRefreshes(dir, { events, outcomes });
-    outcomes = readBalance(dir);
-  } catch {
-    /* scoring is evidence, never a reason to refuse a decision */
-  }
-
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
+  // THE SAME ARRAY THE TRIPWIRE JUST READ, so closing the loop costs no extra
+  // I/O -- and so the decision and its backstop cannot be looking at different
+  // evidence about the same refreshes.
+  const observed = observedHitRates(outcomes);
   const gaps = gapDistribution(dir, { events });
-  const best = ttlTier({ prefixTokens, gaps });
+  const best = ttlTier({ prefixTokens, gaps, observed });
   if (!best) {
     // THE TWO MODELS ANSWER DIFFERENT QUESTIONS, so they may legitimately disagree. ttlTier asks
     // whether holding a cache beats not caching at all; keepWarmDecision asks whether ONE ping
@@ -397,11 +555,7 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({
-      prefixTokens,
-      gaps,
-      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
-    });
+    const decision = keepWarmDecision({ prefixTokens, gaps, observed });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/integrations/copilot/.github/hooks/lib/loo.mjs
+++ b/integrations/copilot/.github/hooks/lib/loo.mjs
@@ -1,0 +1,788 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/loo.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 2 -- what one finding is actually worth, measured by withholding it.
+ *
+ * Layer 1 asks whether the model went back and named a finding. This asks the
+ * harder question and answers it causally: WITHHOLD ONE FINDING while serving
+ * every other finding for the same touch, and compare what the session spent
+ * READING that anchor afterwards. Nobody in this space measures per-item value
+ * this way in production; the state of the art is an offline evaluation set.
+ * That is also why this file is more refusal than statistics -- a causal claim
+ * from four observations is worse than no claim, because it is a number and
+ * numbers get quoted.
+ *
+ * THE ESTIMAND IS READ-SUPPRESSION, and it is deliberately DISJOINT from Layer
+ * 1. Layer 1 keys on an explicit `query` naming a finding key. This keys on
+ * `read` events against the injection's anchor. Neither signal appears in the
+ * other's arithmetic: no `query` event is consulted here, and `usage.mjs`
+ * consults no `read` event. Task 8 calibrates one against the other, and if
+ * both derived from the same channel that calibration would report a strong
+ * correlation between two spellings of one quantity and mean nothing.
+ *
+ * IT INVENTS NO JOIN. `recordToolOutcome` already joins each post-tool result
+ * back to the injection that preceded it, recording `injectionId`,
+ * `findingIds` and a `joinMethod` of `tool-call-id` / `episode-anchor` /
+ * `none`. Every observation here is GATED on that join: an injection with no
+ * joined outcome is unattributable and enters neither arm, exactly as Layer 1
+ * treats `joinMethod: 'none'`. An earlier draft of this plan proposed a fresh
+ * `(sessionId, findingKey)` join; it was rejected and is not here.
+ *
+ * WHAT IT COSTS THE USER, because an experiment that degrades a turn owes an
+ * accounting. One withheld finding means the model may re-derive what it was
+ * told last time, and the worst case is one read of that anchor: measured on
+ * this machine, a median read is 3,769 tokens and the 90th percentile is
+ * 14,082. Five guards bound that exposure, and they are the reason the numbers
+ * below are as small as they are:
+ *
+ *   1. only on a FILE touch, because a command injection has no anchor a read
+ *      event can be joined to -- withholding there would cost a user a finding
+ *      and buy no observation at all (see `buildReport`, which excludes command
+ *      injections from the holdout balance for the same reason);
+ *   2. never when fewer than two findings were kept, so "leave one out" always
+ *      leaves something in -- otherwise it degenerates into `inHoldout`, which
+ *      withholds EVERY finding for an anchor and is a different experiment;
+ *   3. never in the same breath as `inHoldout`: if that arm already withheld
+ *      everything, there is nothing to leave out and a Layer 2 arm recorded
+ *      there would be a fabricated observation;
+ *   4. at most ONE finding per touch, or the effect is attributable to neither;
+ *   5. at most ONE withheld finding per SESSION, so the worst case a user can
+ *      experience is a single re-read -- not one per file they open.
+ *
+ * AND IT NEVER OVERRIDES A PERSON. A `pinned` or `origin: 'human'` finding is
+ * an explicit human decision to keep something in front of the model.
+ * Withholding it to run an experiment would overrule that decision for the
+ * convenience of the measurement, so those findings are exempt: they are
+ * always served, they get no causal score, and `looNote` says so rather than
+ * leaving a reader to wonder why they are missing from the table.
+ */
+
+import { createHash } from 'node:crypto';
+import { readEvidence, readMetrics, readTruncation, isFixtureAnchor } from './metrics.mjs';
+import { retrievalPolicy } from './utility.mjs';
+import { ORIGIN_HUMAN } from './curate.mjs';
+import { canonicalPath } from './paths.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Injections of a finding before it may enter the experiment.
+ *
+ * A finding nobody has served yet has no established value to measure the
+ * absence of, and withholding it would be measuring the cold start rather than
+ * the finding. Four is also what makes the ratio below reachable: at a quarter
+ * of (key, session) pairs armed, a key needs roughly a dozen enrolled
+ * injections before it can reach a verdict at all.
+ */
+export const MIN_PRIOR_INJECTIONS = 4;
+
+/** The observation floor. Below this there is no verdict -- and NOT a zero. */
+export const MIN_SERVED = 6;
+export const MIN_WITHHELD = 3;
+
+/** Benjamini-Hochberg false-discovery rate for published verdicts. */
+export const FDR_Q = 0.1;
+
+/**
+ * Exploration rate.
+ *
+ * Without this, utility feeds the ranking, the ranking feeds injection
+ * frequency, injection frequency feeds the observation count, and a low score
+ * becomes self-fulfilling: the finding is never served often enough to earn a
+ * better one. A tenth of touches therefore ignore the utility order and
+ * promote the LEAST-served candidate instead.
+ */
+export const EPSILON = 0.1;
+
+/**
+ * The share of (finding, session) pairs assigned to the withheld arm.
+ *
+ * Chosen against the floors rather than picked: MIN_SERVED / MIN_WITHHELD is
+ * 2:1, so a quarter withheld reaches both floors at about the same time while
+ * leaving three touches in four undamaged.
+ */
+export const WITHHOLD_FRACTION = 0.25;
+
+/**
+ * Withheld findings allowed per session. ONE.
+ *
+ * The per-touch cap alone bounds nothing across a session: a session that
+ * opens twelve files with enrolled findings could have withheld twelve. This
+ * makes the worst case a user can experience one re-read, at the price of a
+ * mild confound that is stated rather than hidden -- when the cap binds, the
+ * other armed findings in that session are served, so the served arm is
+ * slightly enriched by sessions that touch many enrolled findings.
+ */
+export const MAX_WITHHELD_PER_SESSION = 1;
+
+/**
+ * Fallback shrinkage weight when the between-finding variance cannot be
+ * estimated (fewer than two findings with both arms, or no dispersion at all).
+ *
+ * MIN_SERVED + MIN_WITHHELD, deliberately: a finding's own data outweighs the
+ * population prior only once it has reached the publication floor.
+ */
+export const SHRINKAGE_K = MIN_SERVED + MIN_WITHHELD;
+
+/** Bounds on the estimated shrinkage weight, so a degenerate variance ratio cannot run away. */
+const K_MIN = 1;
+const K_MAX = 100;
+
+/**
+ * Bumped BY HAND when the serving code changes in a way that could move a
+ * finding's measured effect. It is the part of the policy version a hash of the
+ * configuration cannot see.
+ */
+export const LOO_POLICY_GENERATION = 1;
+
+/** Permutation budget before the exact null distribution is sampled instead of enumerated. */
+const MAX_EXACT_PERMUTATIONS = 20_000;
+const SAMPLED_PERMUTATIONS = 10_000;
+
+/**
+ * On by default, off by `TOKEN_OPTIMIZER_LOO=off`.
+ *
+ * Read per call rather than at module load, for the reason `holdoutFraction`
+ * gives: a long-lived process started before the setting changed would
+ * otherwise honour the old value forever with no way to tell.
+ */
+export function LOO_ENABLED() {
+  return String(process.env.TOKEN_OPTIMIZER_LOO || '').trim().toLowerCase() !== 'off';
+}
+
+/**
+ * The serving policy an observation was collected under.
+ *
+ * WHY EVERY OBSERVATION CARRIES ONE. An effect is only meaningful against a
+ * fixed policy. Halve the touch budget or move the minimum net utility and the
+ * same finding is served in different company, at a different rank, against a
+ * different counterfactual -- so pooling observations from before and after
+ * that change would average two different experiments and call the result
+ * causal. `effects()` therefore groups by (finding, policy) and never across.
+ *
+ * IT IS DELIBERATELY ABSENT FROM THE ARM HASH. Including it would reassign
+ * arms the moment a setting changed, which is precisely the mid-session flip
+ * the arm hash exists to prevent. Configuration decides which experiment an
+ * observation belongs to; it must never decide which arm.
+ */
+export function servingPolicyVersion() {
+  const policy = retrievalPolicy();
+  const parts = [
+    `g${LOO_POLICY_GENERATION}`,
+    `touch=${Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500}`,
+    `benefit=${policy.baseBenefitTokens}`,
+    `minutility=${policy.minimumNetUtility}`,
+    `cooldown=${policy.cooldownMs}`,
+    `quarantine=${policy.quarantineHarmCount}`,
+    `holdout=${process.env.TOKEN_OPTIMIZER_HOLDOUT ?? 'default'}`,
+    `withhold=${WITHHOLD_FRACTION}`,
+    `prior=${MIN_PRIOR_INJECTIONS}`,
+    `epsilon=${EPSILON}`,
+  ];
+  const digest = createHash('sha256').update(parts.join('|')).digest('hex');
+  return `${LOO_POLICY_GENERATION}-${digest.slice(0, 8)}`;
+}
+
+/**
+ * A stable number in [0, 1) from a string.
+ *
+ * SHA-256 rather than SHA-1 for the same reason `inHoldout` uses it: this is a
+ * bucketing hash and nothing here is secret, but arguing that a CodeQL finding
+ * is benign is a worse habit than paying a cost that rounds to nothing.
+ */
+function bucket(text) {
+  return createHash('sha256').update(String(text)).digest().readUInt32BE(0) / 4_294_967_296;
+}
+
+/**
+ * The arm of one finding in one session.
+ *
+ * Keyed on (findingKey, sessionId) AND NOTHING ELSE, so a finding cannot
+ * change arms partway through a session: not when the candidate set changes,
+ * not when the budget changes, not when the graph grows. The measurement is a
+ * comparison between sessions, and an arm that flips inside one contaminates
+ * both sides of it.
+ */
+function armed(findingKey, sessionId) {
+  return bucket(`loo-arm:${findingKey}:${sessionId}`) < WITHHOLD_FRACTION;
+}
+
+/** Deterministic tiebreak among armed candidates: lowest bucket, then key order. */
+function armRank(findingKey, sessionId) {
+  return bucket(`loo-rank:${findingKey}:${sessionId}`);
+}
+
+/** The graph node for a finding key, or null. Keys are unique per graph. */
+function findingNode(graph, key) {
+  const nodes = graph?.nodes;
+  if (!nodes || typeof nodes.values !== 'function') return null;
+  for (const node of nodes.values()) {
+    if (node?.kind === 'finding' && node.key === key) return node;
+    // A fixture graph may omit `kind`; key identity is what this needs.
+    if (node?.key === key && node.kind === undefined) return node;
+  }
+  return null;
+}
+
+/**
+ * May this finding ever be withheld?
+ *
+ * FAILS CLOSED ON AN UNKNOWN KEY, which is the opposite of how the rest of
+ * this module fails. Everywhere else a missing input costs a measurement; here
+ * it could cost a human their explicit decision, because a key whose node
+ * cannot be read is a key whose `pinned` and `origin` cannot be checked.
+ */
+function withholdable(graph, key) {
+  const node = findingNode(graph, key);
+  if (!node) return false;
+  if (node.pinned) return false;
+  if (node.origin === ORIGIN_HUMAN) return false;
+  if (node.retired) return false;
+  return true;
+}
+
+/** Prior SERVED injections per finding key, and withheld injections per session. */
+function history(dir, { evidence = null } = {}) {
+  const priorServed = new Map();
+  const withheldPerSession = new Map();
+  const events = evidence || readEvidence(dir);
+  for (const event of events) {
+    if (event.kind !== 'inject') continue;
+    if (typeof event.loo === 'string' && event.loo) {
+      const session = typeof event.sessionId === 'string' ? event.sessionId : '';
+      withheldPerSession.set(session, (withheldPerSession.get(session) || 0) + 1);
+    }
+    if (event.holdout) continue;
+    const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+    for (const raw of keys) {
+      const key = String(raw);
+      priorServed.set(key, (priorServed.get(key) || 0) + 1);
+    }
+  }
+  return { priorServed, withheldPerSession };
+}
+
+/**
+ * Which single finding to withhold from this touch, or null.
+ *
+ * Called from `forTouch` AFTER `fit` has decided what would have been served,
+ * which is the only ordering that produces a true leave-one-out. Withholding
+ * BEFORE the budget runs would let a lower-ranked finding take the freed
+ * tokens, so the withheld arm would receive different company as well as one
+ * fewer finding, and the comparison would confound the two.
+ *
+ * @param {string[]} findingKeys keys that would otherwise be delivered
+ * @param {string} sessionId the session, which pins the arm
+ * @param {object} graph the loaded graph, for `pinned` / `origin`
+ * @param {string|null} dir graph directory, for the injection history
+ */
+export function withheldFor(findingKeys, sessionId, graph, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return null;
+
+    // Every guard that needs no I/O runs first: this is the PreToolUse path,
+    // and on a project with one finding per anchor the answer is null before
+    // anything is read.
+    const keys = [...new Set((findingKeys || []).map((k) => String(k)).filter(Boolean))];
+    if (keys.length < 2) return null;
+    if (!sessionId || typeof sessionId !== 'string') return null;
+
+    // FILE SURFACE ONLY. A command injection's anchor is the command text, and
+    // no read event will ever match it -- so both arms would score zero
+    // downstream and the finding would be scored on nothing.
+    const { surface = 'file', anchor = '', holdout = false } = options;
+    if (surface !== 'file' || !anchor) return null;
+    // The all-findings holdout already withheld everything for this anchor.
+    if (holdout) return null;
+
+    const eligible = keys.filter((key) => withholdable(graph, key));
+    if (!eligible.length) return null;
+
+    const { priorServed, withheldPerSession } = history(dir, options);
+    if ((withheldPerSession.get(sessionId) || 0) >= MAX_WITHHELD_PER_SESSION) return null;
+
+    const enrolled = eligible.filter(
+      (key) => (priorServed.get(key) || 0) >= MIN_PRIOR_INJECTIONS
+    );
+    if (!enrolled.length) return null;
+
+    const candidates = enrolled.filter((key) => armed(key, sessionId));
+    if (!candidates.length) return null;
+
+    // AT MOST ONE. Sorted deterministically so the same touch always yields the
+    // same choice; the findings that lose the tiebreak are SERVED, and the
+    // observation records what actually happened rather than what the arm hash
+    // intended.
+    candidates.sort(
+      (a, b) => armRank(a, sessionId) - armRank(b, sessionId) || (a < b ? -1 : a > b ? 1 : 0)
+    );
+    return candidates[0];
+  } catch {
+    // An experiment must never break a tool call. Failing open here means
+    // serving everything, which is the undegraded behaviour.
+    return null;
+  }
+}
+
+/**
+ * Reorders candidates so exploration can break the feedback loop.
+ *
+ * A tenth of touches -- deterministic in (session, anchor), not random, so the
+ * same touch behaves the same way twice -- promote the LEAST-served candidate
+ * ahead of the utility order, giving it a chance to survive `fit` and accrue
+ * the observations it needs to earn a score. The other nine tenths are
+ * untouched.
+ *
+ * @param {Array<{finding:{key:string}}>} items assessed candidates, best first
+ */
+export function exploreOrder(items, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return items;
+    const list = Array.isArray(items) ? items : [];
+    if (list.length < 2) return list;
+    const { sessionId = '', anchor = '' } = options;
+    if (bucket(`loo-explore:${sessionId}:${anchor}`) >= EPSILON) return list;
+
+    const keyOf = (item) => String(item?.finding?.key ?? item?.key ?? '');
+    const { priorServed } = history(dir, options);
+    let promoted = 0;
+    for (let i = 1; i < list.length; i += 1) {
+      const a = priorServed.get(keyOf(list[i])) || 0;
+      const b = priorServed.get(keyOf(list[promoted])) || 0;
+      if (a < b || (a === b && keyOf(list[i]) < keyOf(list[promoted]))) promoted = i;
+    }
+    if (promoted === 0) return list;
+    return [list[promoted], ...list.filter((_, i) => i !== promoted)];
+  } catch {
+    return Array.isArray(items) ? items : [];
+  }
+}
+
+const mean = (values) =>
+  values.length ? values.reduce((sum, v) => sum + v, 0) / values.length : 0;
+
+/** Sample variance (n-1). Zero for a single observation: dispersion is unknown, not large. */
+function variance(values) {
+  if (values.length < 2) return 0;
+  const m = mean(values);
+  return values.reduce((sum, v) => sum + (v - m) * (v - m), 0) / (values.length - 1);
+}
+
+/**
+ * Every attributable Layer 2 observation, one per (injection, finding, arm).
+ *
+ * THREE THINGS ARE REPORTED SEPARATELY RATHER THAN FOLDED IN, because each of
+ * them would otherwise turn an absence into a zero:
+ *
+ *   `unattributable`  the outcome join could not attach a tool call to the
+ *                     injection, so nothing is known about what followed it.
+ *   `excluded`        the injection could never produce a read-join at all
+ *                     (command surface, session-start, fixture anchor) or was
+ *                     already in the all-findings holdout.
+ *   `costObservations` how many observations saw a non-zero read cost. If this
+ *                     is zero, "withholding changed nothing" and "the read
+ *                     channel never fired" are the same picture, and only one
+ *                     of them is a finding about findings.
+ */
+export function observations(dir, { events = null, evidence = null } = {}) {
+  const empty = {
+    rows: [],
+    unattributable: 0,
+    unattributableOutcomes: 0,
+    excluded: { command: 0, holdout: 0, fixture: 0, unanchored: 0 },
+    injections: 0,
+    withheldInjections: 0,
+    costObservations: 0,
+    policies: [],
+    windowed: false,
+  };
+  try {
+    const causal = evidence || readEvidence(dir);
+    const all = events || readMetrics(dir);
+    // OUT OF BAND and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` describes the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
+
+    // THE JOIN THIS MODULE CONSUMES AND DOES NOT REPLACE.
+    const joined = new Set();
+    let unattributableOutcomes = 0;
+    for (const event of causal) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) {
+        unattributableOutcomes += 1;
+        continue;
+      }
+      joined.add(String(event.injectionId));
+    }
+
+    // Read cost, grouped the way `buildReport` groups it: (session, anchor),
+    // canonicalised on both sides so two spellings of one file are one anchor.
+    // A mismatch here would make every read invisible and report a clean zero
+    // effect in both arms -- correct code, absent measurement.
+    const reads = new Map();
+    for (const event of all) {
+      if (event.kind !== 'read' || !event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      if (!reads.has(key)) reads.set(key, []);
+      reads.get(key).push(event);
+    }
+
+    const injects = causal
+      .filter((event) => event.kind === 'inject')
+      .map((event, index) => ({ event, index }))
+      .sort((a, b) => (a.event.at || 0) - (b.event.at || 0) || a.index - b.index)
+      .map((row) => row.event);
+
+    // How many injections share each (session, anchor), so a key's read total
+    // is SPLIT between them rather than charged in full to each -- the same
+    // correction `buildReport` applies, and for the same reason: without it the
+    // arm means scale with injections-per-anchor instead of per-touch cost.
+    const perKey = new Map();
+    for (const event of injects) {
+      if (!event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      perKey.set(key, (perKey.get(key) || 0) + 1);
+    }
+
+    const rows = [];
+    const excluded = { command: 0, holdout: 0, fixture: 0, unanchored: 0 };
+    const priorServed = new Map();
+    const policies = new Set();
+    let unattributable = 0;
+    let considered = 0;
+    let withheldInjections = 0;
+
+    for (const event of injects) {
+      const served = (Array.isArray(event.findingIds) ? event.findingIds : []).map(String);
+      const withheldKey = typeof event.loo === 'string' && event.loo ? event.loo : null;
+      const bump = () => {
+        for (const key of served) priorServed.set(key, (priorServed.get(key) || 0) + 1);
+      };
+
+      const isCommand =
+        event.surface === 'command' ||
+        event.trigger === 'command' ||
+        event.surface === 'session-start';
+      if (isCommand) {
+        excluded.command += 1;
+        bump();
+        continue;
+      }
+      if (!event.anchor) {
+        excluded.unanchored += 1;
+        bump();
+        continue;
+      }
+      if (isFixtureAnchor(event.anchor)) {
+        excluded.fixture += 1;
+        bump();
+        continue;
+      }
+      if (event.holdout) {
+        excluded.holdout += 1;
+        bump();
+        continue;
+      }
+
+      considered += 1;
+      if (withheldKey) withheldInjections += 1;
+      const policy = typeof event.looPolicy === 'string' && event.looPolicy
+        ? event.looPolicy
+        : 'unversioned';
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const attributable = Boolean(injectionId && joined.has(injectionId));
+
+      // DOWNSTREAM MEANS AFTER, STRICTLY. The read that triggered the touch is
+      // not caused by the advice; it happened before the advice existed.
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      const at = event.at || 0;
+      const total = (reads.get(key) || []).reduce(
+        (sum, read) => sum + ((read.at || 0) > at ? read.tokens || 0 : 0),
+        0
+      );
+      const cost = total / Math.max(1, perKey.get(key) || 1);
+
+      const observe = (findingKey, arm) => {
+        // ENROLMENT IS RE-DERIVED FROM THE LOG rather than trusted from the
+        // serving decision. It is the one field an old or hand-written record
+        // could contradict, and a served observation from before a finding was
+        // enrolled would compare an established finding against its own cold
+        // start.
+        //
+        // CHECKED BEFORE ATTRIBUTABILITY, so `unattributable` counts only
+        // observations the experiment actually wanted. Counting the rest there
+        // would report a join failure for every finding that was never in the
+        // experiment to begin with -- the same shape as the 2,559-row
+        // measurement-bias defect Layer 1 found in its own first draft.
+        if ((priorServed.get(findingKey) || 0) < MIN_PRIOR_INJECTIONS) return;
+        if (!attributable) {
+          unattributable += 1;
+          return;
+        }
+        policies.add(policy);
+        rows.push({ findingKey, arm, cost, policy, injectionId, anchor: event.anchor });
+      };
+
+      if (withheldKey) observe(withheldKey, 'withheld');
+      for (const findingKey of served) observe(findingKey, 'served');
+      bump();
+    }
+
+    return {
+      rows,
+      unattributable,
+      unattributableOutcomes,
+      excluded,
+      injections: considered,
+      withheldInjections,
+      costObservations: rows.filter((row) => row.cost > 0).length,
+      policies: [...policies].sort(),
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
+function permutationP(servedCosts, withheldCosts) {
+  const pooled = [...servedCosts, ...withheldCosts];
+  const n = pooled.length;
+  const k = withheldCosts.length;
+  if (!k || k === n) return null;
+  const observed = Math.abs(mean(withheldCosts) - mean(servedCosts));
+  const total = pooled.reduce((sum, v) => sum + v, 0);
+  // Mean difference from the withheld-arm sum alone: the served sum is the
+  // complement, so one number decides the statistic.
+  const diffFrom = (withheldSum) =>
+    Math.abs(withheldSum / k - (total - withheldSum) / (n - k));
+
+  const choose = (a, b) => {
+    let out = 1;
+    for (let i = 1; i <= b; i += 1) out = (out * (a - b + i)) / i;
+    return out;
+  };
+
+  const tolerance = 1e-9;
+  if (choose(n, k) <= MAX_EXACT_PERMUTATIONS) {
+    let extreme = 0;
+    let count = 0;
+    const walk = (start, chosen, sum) => {
+      if (chosen === k) {
+        count += 1;
+        if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+        return;
+      }
+      for (let i = start; i <= n - (k - chosen); i += 1) walk(i + 1, chosen + 1, sum + pooled[i]);
+    };
+    walk(0, 0, 0);
+    return count ? extreme / count : null;
+  }
+
+  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
+  // the same p-value and a verdict cannot flicker between two audit runs.
+  let state = 0x9e3779b9;
+  const random = () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4_294_967_296;
+  };
+  let extreme = 0;
+  const order = [...pooled];
+  for (let round = 0; round < SAMPLED_PERMUTATIONS; round += 1) {
+    for (let i = order.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(random() * (i + 1));
+      [order[i], order[j]] = [order[j], order[i]];
+    }
+    let sum = 0;
+    for (let i = 0; i < k; i += 1) sum += order[i];
+    if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+  }
+  return (extreme + 1) / (SAMPLED_PERMUTATIONS + 1);
+}
+
+/**
+ * The per-finding causal effect, shrunk, and whether it may be published.
+ *
+ * `raw` is `mean(withheld) - mean(served)`: POSITIVE means the session read the
+ * anchor more when the finding was withheld, which is the finding earning its
+ * place. `shrunk` is the number a reader should use.
+ *
+ * EMPIRICAL BAYES, and both halves of it come from the data. The prior mean is
+ * the population effect across findings; the weight `k` is the ratio of
+ * within-finding noise to between-finding spread, so a population where every
+ * finding behaves alike shrinks hard and one where they genuinely differ
+ * shrinks little. `SHRINKAGE_K` is the fallback when that spread cannot be
+ * estimated at all. Two observations therefore cannot post a wild score.
+ *
+ * PUBLICATION IS NOT THE SAME QUESTION as having an estimate. A row is
+ * published only if it clears the observation floor AND its permutation
+ * p-value survives Benjamini-Hochberg at q = 0.10 across every candidate row.
+ * Everything else gets `published: false` -- which is not a zero effect, and
+ * `looNote` says which of the two it is. An all-zero-cost population needs no
+ * separate guard: p is exactly 1 there, so nothing can publish anyway.
+ *
+ * NEVER POOLED ACROSS POLICY VERSIONS: rows are keyed on (findingKey, policy).
+ */
+export function effects(dir, options = {}) {
+  try {
+    // `obs` is accepted so `looNote` can read the logs once for both.
+    const obs = options.obs || observations(dir, options);
+    const groups = new Map();
+    for (const row of obs.rows) {
+      const id = JSON.stringify([row.findingKey, row.policy]);
+      if (!groups.has(id))
+        groups.set(id, { findingKey: row.findingKey, policy: row.policy, served: [], withheld: [] });
+      groups.get(id)[row.arm === 'withheld' ? 'withheld' : 'served'].push(row.cost);
+    }
+
+    const raws = [];
+    const withinVars = [];
+    for (const group of groups.values()) {
+      if (!group.served.length || !group.withheld.length) continue;
+      raws.push(mean(group.withheld) - mean(group.served));
+      withinVars.push(
+        variance(group.withheld) / group.withheld.length +
+          variance(group.served) / group.served.length
+      );
+    }
+    const prior = raws.length ? mean(raws) : 0;
+    const within = withinVars.length ? mean(withinVars) : 0;
+    const between = raws.length > 1 ? Math.max(0, variance(raws) - within) : 0;
+    const weight =
+      between > 0 && within > 0
+        ? Math.min(K_MAX, Math.max(K_MIN, within / between))
+        : SHRINKAGE_K;
+
+    const rows = [...groups.values()]
+      .map((group) => {
+        const served = group.served.length;
+        const withheld = group.withheld.length;
+        const both = served > 0 && withheld > 0;
+        const raw = both ? mean(group.withheld) - mean(group.served) : null;
+        const n = served + withheld;
+        const shrunk = raw === null ? null : (n * raw + weight * prior) / (n + weight);
+        const eligible = served >= MIN_SERVED && withheld >= MIN_WITHHELD;
+        return {
+          findingKey: group.findingKey,
+          policy: group.policy,
+          served,
+          withheld,
+          servedMean: mean(group.served),
+          withheldMean: mean(group.withheld),
+          raw,
+          shrunk,
+          p: eligible ? permutationP(group.served, group.withheld) : null,
+          published: false,
+        };
+      })
+      .sort((a, b) =>
+        a.findingKey < b.findingKey ? -1 : a.findingKey > b.findingKey ? 1 : a.policy < b.policy ? -1 : 1
+      );
+
+    // BENJAMINI-HOCHBERG at q = 0.10 over every row that cleared the floor.
+    // One finding tested in isolation would publish at p < 0.10; a hundred
+    // would publish ten false ones, and this module's whole claim is that its
+    // numbers can be quoted.
+    //
+    // THERE IS NO SEPARATE "WAS ANY READ COST OBSERVED" GATE HERE, and its
+    // absence is deliberate rather than an omission. One was written, and
+    // mutation testing showed it could not change a single verdict: if every
+    // observation has zero cost then both arm means are zero, the permutation
+    // statistic is zero for every relabelling, and p is exactly 1 -- which no
+    // BH threshold can pass. The guard was unfalsifiable, and an unfalsifiable
+    // guard is worse than none because it reads as protection nobody can test.
+    // `costObservations` survives as what it can honestly be: a DISCLOSURE, so
+    // `looNote` can say the read channel never fired instead of letting a
+    // reader take an arithmetic zero for a measured one.
+    const candidates = rows
+      .filter((row) => row.p !== null)
+      .sort((a, b) => a.p - b.p);
+    const m = candidates.length;
+    let cutoff = 0;
+    for (let i = 0; i < m; i += 1) {
+      if (candidates[i].p <= ((i + 1) / m) * FDR_Q) cutoff = i + 1;
+    }
+    for (let i = 0; i < cutoff; i += 1) candidates[i].published = true;
+
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * One or two lines for the audit, or nothing at all.
+ *
+ * THE REFUSAL IS THE PRODUCT HERE. On a machine with two injections in sixteen
+ * thousand events, the only honest output is that nothing is measurable yet,
+ * and this says so with the counts that make it checkable rather than printing
+ * a mean of nothing. It returns `null` when Layer 2 has not collected a single
+ * observation, so an idle experiment costs the reader no line at all -- the
+ * same standard `referenceNote` holds itself to.
+ */
+export function looNote(dir, options = {}) {
+  try {
+    const obs = options.obs || observations(dir, options);
+    const rows = effects(dir, { ...options, obs });
+    if (!obs.rows.length && !obs.withheldInjections) return null;
+
+    let graph = options.graph;
+    if (graph === undefined) {
+      try {
+        graph = load(dir);
+      } catch {
+        graph = null;
+      }
+    }
+    let exempt = 0;
+    if (graph?.nodes?.values) {
+      for (const node of graph.nodes.values()) {
+        if (node?.kind !== 'finding' || node.retired) continue;
+        if (node.pinned || node.origin === ORIGIN_HUMAN) exempt += 1;
+      }
+    }
+
+    const published = rows.filter((row) => row.published);
+    const head = published.length
+      ? `Per-finding causal value (leave-one-out): ${published.length} of ${rows.length} ` +
+        `findings show a verdict at q=${FDR_Q}` +
+        published
+          .slice(0, 3)
+          .map(
+            (row) =>
+              `; ${row.findingKey} saves ~${Math.round(row.shrunk)} tokens/touch ` +
+              `(${row.served} served, ${row.withheld} withheld, p=${row.p.toFixed(3)})`
+          )
+          .join('') +
+        '.'
+      : `Per-finding causal value (leave-one-out): NOT MEASURABLE YET -- ` +
+        `${obs.rows.length} attributable observations across ${rows.length} findings, ` +
+        `${obs.withheldInjections} withheld touches; the floor is ${MIN_SERVED} served ` +
+        `and ${MIN_WITHHELD} withheld per finding` +
+        (obs.costObservations ? '' : ', and no read cost has been observed in either arm') +
+        '. No effect is reported, which is not the same as an effect of zero.';
+
+    const caveats = [];
+    if (obs.unattributable)
+      caveats.push(
+        `${obs.unattributable} observations were unattributable (no joined tool outcome) and are in neither arm`
+      );
+    if (exempt)
+      caveats.push(
+        `${exempt} pinned or human-origin findings are exempt from withholding and get no causal score`
+      );
+    if (obs.policies.length > 1)
+      caveats.push(
+        `observations span ${obs.policies.length} serving-policy versions and are never pooled across them`
+      );
+    if (obs.windowed)
+      caveats.push('the read log was truncated, so downstream cost can understate');
+    return caveats.length ? `${head} ${caveats.join('; ')}.` : head;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/copilot/.github/hooks/lib/loo.mjs
+++ b/integrations/copilot/.github/hooks/lib/loo.mjs
@@ -545,8 +545,22 @@ export function observations(dir, { events = null, evidence = null } = {}) {
   }
 }
 
-/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
-function permutationP(servedCosts, withheldCosts) {
+/**
+ * Enumerates or samples arm relabellings and returns a two-sided p-value.
+ *
+ * EXPORTED so the cross-layer headline can be held to the same standard as the
+ * per-finding rows it summarises. `crosslayer.mjs` runs this over the two ARMS
+ * of shrunk effect estimates; the statistic, the enumerate-or-sample switch and the
+ * tolerance are therefore shared rather than reimplemented, and there is one
+ * place where "two-sided" is decided.
+ *
+ * `seed` exists for that caller. The default reproduces the fixed seed this
+ * function has always used, so Layer 2's own p-values are byte-identical; the
+ * cross-layer caller passes a seed DERIVED FROM ITS DATA, because a verdict
+ * printed to a human must not depend on `Math.random()` or on which module
+ * happened to call first.
+ */
+export function permutationP(servedCosts, withheldCosts, { seed = 0x9e3779b9 } = {}) {
   const pooled = [...servedCosts, ...withheldCosts];
   const n = pooled.length;
   const k = withheldCosts.length;
@@ -580,9 +594,10 @@ function permutationP(servedCosts, withheldCosts) {
     return count ? extreme / count : null;
   }
 
-  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
-  // the same p-value and a verdict cannot flicker between two audit runs.
-  let state = 0x9e3779b9;
+  // Mulberry32 off the caller's seed: reproducible, so the same data always
+  // yields the same p-value and a verdict cannot flicker between two audit
+  // runs.
+  let state = seed | 0;
   const random = () => {
     state = (state + 0x6d2b79f5) | 0;
     let t = state;

--- a/integrations/copilot/.github/hooks/lib/metrics.mjs
+++ b/integrations/copilot/.github/hooks/lib/metrics.mjs
@@ -31,6 +31,7 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { createHash, randomBytes } from 'node:crypto';
+import { redact } from './redact.mjs';
 
 /**
  * Read per call, not once at module load.
@@ -517,6 +518,15 @@ export function readEvidence(dir) {
 }
 
 /**
+ * The captured-output budget, in characters.
+ *
+ * Small enough that a 3 MB test log cannot bloat the evidence log or a single
+ * injected claim, large enough to hold the stack trace or compiler diagnostic
+ * that makes a failure finding worth anything.
+ */
+const OUTPUT_MAX_BYTES = 4096;
+
+/**
  * Joins a post-tool result to the most recent matching injection.  The exact
  * tool-call id wins; clients that omit it fall back to episode + surface +
  * anchor, in timestamp order, and the report states the weaker join method.
@@ -545,10 +555,31 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
+  // text is INJECTED into model context and EXPORTED to markdown, so the
+  // boundary is the only place that can guarantee it: a second caller added
+  // later would otherwise have to remember, and the one that forgot would leak
+  // a secret into two more places than the terminal it came from. `undefined`
+  // rather than `''` when nothing was captured, so JSON.stringify omits the
+  // key entirely and an absent capture is distinguishable from an empty one.
+  const output =
+    outcome.output === undefined || outcome.output === null
+      ? undefined
+      : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
+  // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric
+  // code at all, and 0 is the success value -- defaulting to it would claim
+  // every unreported call exited cleanly, which is a fabricated observation
+  // rather than a missing one.
+  const exit = Number.isInteger(outcome.exit) ? outcome.exit : null;
+
   return record(dir, {
     kind: 'tool-outcome',
     ...outcome,
     anchor,
+    // AFTER the spread, so a caller cannot smuggle raw text past the boundary
+    // by setting the field itself.
+    output,
+    exit,
     injectionId: injection?.injectionId || null,
     findingIds: injection?.findingIds || [],
     joinMethod,

--- a/integrations/copilot/.github/hooks/lib/metrics.mjs
+++ b/integrations/copilot/.github/hooks/lib/metrics.mjs
@@ -555,6 +555,22 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // FAILURES ONLY, and that is a deliberate override of the original plan.
+  // The plan predates MCP tool names reaching this path, so it never
+  // considered that a SUCCESSFUL `smart_read` would deposit 4 KB of file
+  // content into the evidence log on every call -- the log would grow with
+  // file text and the privacy surface would be every file the session opened.
+  //
+  // Nothing downstream loses anything. A failure claim quotes the error text;
+  // a "this command works" claim needs only the fact that it worked, which
+  // `success` and `exit` already carry. So the stored text narrows to text
+  // that is already an error message.
+  //
+  // GATED ON `success === true`, not on `!== false`: an outcome that never
+  // said whether it worked is unclassified, not successful, and dropping its
+  // text would lose exactly the failures a client too terse to report status
+  // produces.
+  const captureOutput = outcome.success !== true;
   // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
   // text is INJECTED into model context and EXPORTED to markdown, so the
   // boundary is the only place that can guarantee it: a second caller added
@@ -563,7 +579,7 @@ export function recordToolOutcome(dir, outcome) {
   // rather than `''` when nothing was captured, so JSON.stringify omits the
   // key entirely and an absent capture is distinguishable from an empty one.
   const output =
-    outcome.output === undefined || outcome.output === null
+    !captureOutput || outcome.output === undefined || outcome.output === null
       ? undefined
       : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
   // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric

--- a/integrations/copilot/.github/hooks/lib/metrics.mjs
+++ b/integrations/copilot/.github/hooks/lib/metrics.mjs
@@ -663,6 +663,89 @@ export function isFixtureAnchor(anchor) {
  * Fixture anchors are excluded from both.
  */
 /**
+ * Re-reads grouped by anchor -- the one place that decides what "wasteful" means.
+ *
+ * `rereadWaste` needed only the totals, so the grouping lived inside it and the
+ * per-anchor rows were thrown away. `derive.mjs`'s churn detector needs the
+ * rows, and re-deriving them there would put TWO definitions of "a repeat read
+ * of an unchanged file is waste" in the codebase, free to drift apart -- the
+ * exact divergence `npm run sync:hooks` exists to prevent between hooks-core and
+ * its generated copies. So the grouping lives here and both consumers read it.
+ *
+ * A re-read is only a re-read INSIDE ONE SESSION: grouping is keyed on
+ * session + canonical anchor, and rows are then merged per anchor so a file
+ * re-read across three sessions reports as one anchor with the sum of its
+ * repeats rather than three rows the caller has to add up. Merging cannot move
+ * the totals -- a sum of sums -- which is what makes it safe for `rereadWaste`.
+ *
+ * `tokens` is the WASTEFUL token count, not the total: it is the only one of the
+ * three that names something recoverable, and a row whose headline number
+ * included legitimate re-reads would overstate exactly the way the first
+ * version of this measurement did.
+ *
+ * @returns {Array<{anchor: string, repeats: number, wasteful: number,
+ *   tokens: number, legitimate: number, legitimateTokens: number,
+ *   undecidable: number, undecidableTokens: number}>} descending by `wasteful`,
+ *   then by `repeats`.
+ */
+export function rereadsByAnchor(events = [], { includeFixtures = false } = {}) {
+  const groups = new Map();
+  for (const e of events) {
+    if (!e || e.kind !== 'read' || !e.anchor) continue;
+    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
+    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(e);
+  }
+
+  const rows = new Map();
+  for (const list of groups.values()) {
+    if (list.length < 2) continue;
+    list.sort((a, b) => (a.at || 0) - (b.at || 0));
+
+    const anchorKey = canonicalKeyish(list[0].anchor);
+    let row = rows.get(anchorKey);
+    if (!row) {
+      row = {
+        anchor: list[0].anchor,
+        repeats: 0,
+        wasteful: 0,
+        tokens: 0,
+        legitimate: 0,
+        legitimateTokens: 0,
+        undecidable: 0,
+        undecidableTokens: 0,
+      };
+      rows.set(anchorKey, row);
+    }
+
+    for (let i = 1; i < list.length; i++) {
+      const prev = list[i - 1];
+      const cur = list[i];
+      const tokens = cur.tokens || 0;
+      row.repeats += 1;
+      // THE JUDGEMENT, in one place. A repeat read of a file that CHANGED is
+      // correct behaviour, not waste; a read written before fingerprints
+      // existed cannot be judged at all and says so.
+      if (!prev.fp || !cur.fp) {
+        row.undecidable += 1;
+        row.undecidableTokens += tokens;
+      } else if (prev.fp === cur.fp) {
+        row.wasteful += 1;
+        row.tokens += tokens;
+      } else {
+        row.legitimate += 1;
+        row.legitimateTokens += tokens;
+      }
+    }
+  }
+
+  return [...rows.values()].sort(
+    (a, b) => b.wasteful - a.wasteful || b.repeats - a.repeats
+  );
+}
+
+/**
  * Re-read waste, split into what is KNOWN and what is not.
  *
  * The question is narrow on purpose: how often does one session read the same
@@ -677,6 +760,9 @@ export function isFixtureAnchor(anchor) {
  * `undecidable` is reported rather than hidden. Reads written before the
  * fingerprint existed cannot be classified, and a measurement that quietly
  * counted them either way would be inventing its own answer.
+ *
+ * The aggregate fields are UNCHANGED -- `balanceSheet` reads them -- and are now
+ * a fold over `rereadsByAnchor`'s rows. `worst` is purely additive.
  */
 export function rereadWaste(
   dir,
@@ -685,14 +771,7 @@ export function rereadWaste(
   // excludes by design, making the real path untestable.
   { events = readMetrics(dir), includeFixtures = false } = {}
 ) {
-  const groups = new Map();
-  for (const e of events) {
-    if (e.kind !== 'read' || !e.anchor) continue;
-    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
-    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key).push(e);
-  }
+  const rows = rereadsByAnchor(events, { includeFixtures });
 
   const out = {
     repeats: 0,
@@ -704,29 +783,21 @@ export function rereadWaste(
     undecidableTokens: 0,
   };
 
-  for (const list of groups.values()) {
-    if (list.length < 2) continue;
-    list.sort((a, b) => (a.at || 0) - (b.at || 0));
-    for (let i = 1; i < list.length; i++) {
-      const prev = list[i - 1];
-      const cur = list[i];
-      const tokens = cur.tokens || 0;
-      out.repeats += 1;
-      if (!prev.fp || !cur.fp) {
-        out.undecidable += 1;
-        out.undecidableTokens += tokens;
-      } else if (prev.fp === cur.fp) {
-        out.wasteful += 1;
-        out.wastefulTokens += tokens;
-      } else {
-        out.legitimate += 1;
-        out.legitimateTokens += tokens;
-      }
-    }
+  for (const row of rows) {
+    out.repeats += row.repeats;
+    out.wasteful += row.wasteful;
+    out.wastefulTokens += row.tokens;
+    out.legitimate += row.legitimate;
+    out.legitimateTokens += row.legitimateTokens;
+    out.undecidable += row.undecidable;
+    out.undecidableTokens += row.undecidableTokens;
   }
 
   const decided = out.wasteful + out.legitimate;
   out.coverage = out.repeats ? decided / out.repeats : null;
+  // The offenders behind the totals, bounded: a report needs the handful worth
+  // acting on, not one row per file the session touched twice.
+  out.worst = rows.slice(0, 10);
   return out;
 }
 

--- a/integrations/copilot/.github/hooks/lib/recall.mjs
+++ b/integrations/copilot/.github/hooks/lib/recall.mjs
@@ -1,0 +1,390 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/recall.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Does retrieval FIND a finding, or does it only find what it was told where
+ * to look?
+ *
+ * `docs/WIKI_GRAPH.md` says embeddings get added "if measurement shows real
+ * recall loss". Nothing measured recall, so the no-embeddings stance was
+ * unfalsifiable -- a claim with no observation that could contradict it. This
+ * module is the observation.
+ *
+ * ---------------------------------------------------------------------------
+ * THE TAUTOLOGY THIS DELIBERATELY DOES NOT SHIP, AND WHY IT IS RECORDED HERE
+ * ---------------------------------------------------------------------------
+ * The obvious probe -- for each finding, take its anchors and ask whether
+ * `findingsFor` returns it from each -- CANNOT FAIL. `findingsFor(graph, A)`
+ * walks `derived_from` edges backwards into A, and the edge F -> A is the very
+ * thing that makes A an anchor of F. So F is in the result by CONSTRUCTION, not
+ * by retrieval quality, for every graph, forever. Its rate is 1.0 always, and a
+ * permanent 1.0 published as a recall rate reads to a human as "retrieval is
+ * perfect, embeddings unnecessary" -- one unfalsifiable claim swapped for
+ * another, leaning the one direction a measurement of this project by this
+ * project must never lean.
+ *
+ * That check is still worth running -- if it ever fails, traversal is broken
+ * rather than merely lossy -- so it is kept, and reported as `integrity` with
+ * its own `what` string saying it is not a recall rate. It is NEVER `rate`.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT IS MEASURED INSTEAD: LEAVE-ONE-EDGE-OUT
+ * ---------------------------------------------------------------------------
+ * For each active finding F and each anchor A of F, delete the edge F -> A and
+ * ask whether touching A would STILL surface F. Two independent arms, both of
+ * which can genuinely miss, which is what makes this a measurement:
+ *
+ *   Arm A -- TRAVERSAL FROM THE NEIGHBOURHOOD. Run the real `findingsFor` over
+ *   the edge-deleted graph from A itself and from A's `contains` parents. This
+ *   hits only when F has some OTHER structural route in: a second anchor on the
+ *   same file, or an anchor on a sibling symbol under the same parent. A's
+ *   `contains` children need no separate call because `findingsFor` expands
+ *   them itself -- calling the parent therefore covers every sibling, which is
+ *   why the neighbour list is `[A, ...parents(A)]` and not a hop-counted
+ *   frontier. The REAL primitive is used rather than an equivalent inlined
+ *   here, because a probe that reimplements the thing it measures drifts from
+ *   it and then measures itself.
+ *
+ *   Arm B -- BM25 FROM THE ANCHOR'S OWN KEY. Rank the whole active corpus with
+ *   `lexical.rank`, querying with A's key -- the file path or symbol name the
+ *   user actually touched -- and hit if F comes back inside `limit`.
+ *
+ * WHY ARM B IS NOT QUERIED WITH THE FINDING'S OWN CLAIM. The plan's literal
+ * form was "the finding's claim terms against the rest of the corpus", and both
+ * readings of it are degenerate. Querying F's claim against a corpus that
+ * INCLUDES F is the tautology again: BM25 scores a document against its own
+ * text, so F wins its own query every time. Querying F's claim against a corpus
+ * that EXCLUDES F cannot return F at all, so a "hit" would mean some DIFFERENT
+ * finding matched -- that is redundancy of storage, not recall of F, and it
+ * would score a graph better for holding duplicates. The anchor's key is the
+ * one query text that is available offline, is not derived from F, and matches
+ * the production question: a session touches a file, and the only lexical
+ * handle on it is its own path. It misses exactly when a finding's claim never
+ * names the code it is about, which is the recall gap embeddings are supposed
+ * to close.
+ *
+ * ---------------------------------------------------------------------------
+ * REFUSALS -- four, and each costs this project its own good news
+ * ---------------------------------------------------------------------------
+ *  1. TOO FEW OBSERVATIONS -> `rate: null` with a reason. See `MIN_PROBED`.
+ *  2. A CORPUS NO LARGER THAN THE RETRIEVAL LIMIT -> `rate: null`. Arm B is
+ *     recall@`limit`, and below the limit NO FINDING IS EVER CUT FOR BUDGET:
+ *     every document scoring above zero is returned, so the arm measures
+ *     whether a token matched, which is a strictly weaker bar than the one
+ *     production applies when `forTouch` fills a token budget from a ranked
+ *     list. A probe more permissive than the system it measures can only
+ *     overstate recall, so the rate is withheld in that band and the counts are
+ *     published instead. It bites between `MIN_PROBED` and `limit` findings --
+ *     on this machine's project graph, whose one finding had both anchor edges
+ *     "recovered" that way, the observation-count refusal fires first.
+ *  3. NO ANCHOR NODE -> the pair is UNPROBEABLE, not a miss. Reported and
+ *     excluded from the denominator; see `probeEdge`.
+ *  4. STRICT AGGREGATION -> a finding counts as retrieved only if EVERY one of
+ *     its probeable anchor edges is recoverable. A finding reachable from one
+ *     anchor and lost from another is a miss, with the losing anchor named.
+ *     This biases the rate DOWN, which is the safe direction here.
+ *
+ * FAILS OPEN. It runs on a report path; a graph it cannot read must cost a
+ * section, not the report.
+ */
+
+import { load, findingsFor } from './wiki.mjs';
+import { rank } from './lexical.mjs';
+
+/**
+ * Distinct findings that must be probeable before a RATE is published at all.
+ *
+ * NOT AN EFFECT-SIZE CONVENTION -- it is a resolution argument. A proportion
+ * over n observations has a resolution of 1/n, so below ten findings the
+ * published figure moves in steps coarser than ten percentage points, and the
+ * two extremes a small graph actually produces (`1.0` and `0.0`) are the two a
+ * reader is most likely to mistake for a finding about retrieval. At n = 10 and
+ * zero misses the exact binomial 95% upper bound on the true miss rate is still
+ * 1 - 0.05^(1/10) = 0.26, so even a clean sweep here bounds recall loss only
+ * below about a quarter -- which is why the refusal reason says what the number
+ * would and would not have supported rather than just naming the floor.
+ *
+ * THE FLOOR IS ON DISTINCT FINDINGS, NOT ANCHOR EDGES. Two anchors of one
+ * finding are two edges of the same claim, not two independent observations;
+ * counting them would let a single multi-anchored finding unlock a rate.
+ */
+export const MIN_PROBED = 10;
+
+/**
+ * The most findings probed in one call.
+ *
+ * Each probed anchor edge costs a graph-sized edge filter plus one or two real
+ * `findingsFor` walks plus one BM25 pass over the corpus, and this runs on the
+ * on-demand report path. The cap is deterministic (findings sorted by key) and
+ * `truncated` says when it bit, so a large graph gets a smaller, honestly
+ * labelled sample rather than a slow report.
+ */
+export const MAX_FINDINGS = 200;
+
+/** Active findings only. A retired claim is withdrawn; recalling it is not a win. */
+function activeFindings(graph) {
+  return [...graph.nodes.values()]
+    .filter((node) => node && node.kind === 'finding' && !node.retired)
+    .sort((a, b) => String(a.key || '').localeCompare(String(b.key || '')));
+}
+
+/** The `contains` parents of every node, indexed once for the whole probe. */
+function parentIndex(graph) {
+  const parents = new Map();
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contains') continue;
+    const list = parents.get(edge.to);
+    if (list) list.push(edge.from);
+    else parents.set(edge.to, [edge.from]);
+  }
+  return parents;
+}
+
+/** The anchors of one finding: the targets of its own `derived_from` edges. */
+function anchorsOf(graph, findingId) {
+  const out = new Set();
+  for (const edge of graph.edges) {
+    if (edge.edge === 'derived_from' && edge.from === findingId) out.add(edge.to);
+  }
+  return [...out];
+}
+
+/**
+ * The graph minus exactly one anchor edge.
+ *
+ * `nodes` is shared rather than copied: nothing here mutates it, and a
+ * 2,600-node Map copied once per anchor edge is the difference between a probe
+ * and a stall.
+ */
+function withoutAnchorEdge(graph, findingId, anchorId) {
+  return {
+    nodes: graph.nodes,
+    edges: graph.edges.filter(
+      (edge) =>
+        !(
+          edge.edge === 'derived_from' &&
+          edge.from === findingId &&
+          edge.to === anchorId
+        )
+    ),
+  };
+}
+
+/**
+ * One anchor edge, hidden, then asked after. Returns `recovered` with the arm
+ * that found it, or a reason -- and `probeable: false` when the question could
+ * not be put at all.
+ */
+function probeEdge(graph, parents, finding, anchorId, corpus, limit) {
+  const hidden = withoutAnchorEdge(graph, finding.id, anchorId);
+
+  // Arm A. `findingsFor` expands `contains` children itself, so the parent call
+  // covers every sibling of the anchor.
+  const neighbours = [anchorId, ...(parents.get(anchorId) || [])];
+  for (const neighbour of neighbours) {
+    const got = findingsFor(hidden, neighbour, { limit });
+    if (got.some((node) => node.id === finding.id)) {
+      return { recovered: true, arm: 'traversal', anchorId };
+    }
+  }
+
+  // Arm B needs a query, and the query is the anchor's own key. A dangling
+  // anchor edge -- an edge whose target node was never indexed, which
+  // `expand.promote` produces -- leaves nothing to query with. That is a
+  // question that could not be asked, NOT an observed miss: scoring it a miss
+  // would manufacture a recall loss out of a graph-integrity defect.
+  const anchor = graph.nodes.get(anchorId);
+  const key = anchor && typeof anchor.key === 'string' ? anchor.key : '';
+  if (!key) {
+    return {
+      recovered: false,
+      probeable: false,
+      anchorId,
+      reason: `anchor ${anchorId} has no node in the graph, so there is no anchor key to query BM25 with`,
+    };
+  }
+
+  const hits = rank(key, corpus, { limit });
+  if (hits.some((hit) => hit.finding && hit.finding.id === finding.id)) {
+    return { recovered: true, arm: 'lexical', anchorId };
+  }
+
+  return {
+    recovered: false,
+    probeable: true,
+    anchorId,
+    reason: `no neighbouring anchor reaches it and BM25 over ${key} does not rank it in the top ${limit}`,
+  };
+}
+
+/**
+ * The probe. An OFFLINE measurement over the graph as it stands -- it reads,
+ * ranks and traverses, and writes nothing.
+ */
+export function recallProbe(
+  dir,
+  {
+    limit = 20,
+    graph = null,
+    minProbed = MIN_PROBED,
+    maxFindings = MAX_FINDINGS,
+  } = {}
+) {
+  const refuse = (reason) => ({
+    basis: 'offline probe over the current graph',
+    probed: 0,
+    retrieved: 0,
+    rate: null,
+    reason,
+    misses: [],
+    unprobeable: [],
+  });
+
+  let g;
+  try {
+    g = graph || load(dir);
+  } catch {
+    return refuse('the graph could not be read, so recall was not measured.');
+  }
+
+  try {
+    const all = activeFindings(g);
+    const truncated = all.length > maxFindings;
+    const findings = truncated ? all.slice(0, maxFindings) : all;
+    const parents = parentIndex(g);
+    // The corpus BM25 ranks over is the ACTIVE graph, uncapped: the sample is
+    // which findings are probed, not what they compete against. Every reported
+    // figure below reads `corpus.length` rather than `all.length`, so the
+    // published size IS the ranking corpus rather than a parallel claim about
+    // it. The distinction is not pedantry: a mutation that shrank the ranking
+    // corpus to the probed sample -- making retrieval easier, in this project's
+    // favour -- SURVIVED the first mutation run precisely because the reported
+    // number came from the other variable and could not move.
+    const corpus = all;
+
+    const misses = [];
+    const unprobeable = [];
+    const integrityFailures = [];
+    let probed = 0;
+    let retrieved = 0;
+    let integrityOk = 0;
+    let probedEdges = 0;
+    let recoveredEdges = 0;
+    const byArm = { traversal: 0, lexical: 0 };
+
+    for (const finding of findings) {
+      const anchors = anchorsOf(g, finding.id);
+
+      // INTEGRITY, run on the UNTOUCHED graph: the by-construction check. Its
+      // only honest use is as a smoke test, and it is reported as one.
+      if (!anchors.length) {
+        integrityFailures.push({
+          key: finding.key,
+          reason:
+            'active finding with no anchor -- writeHarvested refuses to create one',
+        });
+      } else if (
+        anchors.every((anchorId) =>
+          findingsFor(g, anchorId, { limit }).some((node) => node.id === finding.id)
+        )
+      ) {
+        integrityOk += 1;
+      } else {
+        integrityFailures.push({
+          key: finding.key,
+          reason: `not returned by findingsFor from one of its own anchors at limit ${limit}`,
+        });
+      }
+
+      // An unanchored finding is a definite miss, not an unaskable question:
+      // nothing traverses to it and there is no anchor key to query from, so
+      // the anchor-driven path that serves findings on a file touch can never
+      // surface it. Only an explicit wiki_query naming its own terms would.
+      if (!anchors.length) {
+        probed += 1;
+        misses.push({
+          key: finding.key,
+          reason:
+            'no anchor: nothing traverses to it and there is no anchor key to query with, so only an explicit wiki_query of its own terms would surface it',
+        });
+        continue;
+      }
+
+      const results = anchors.map((anchorId) =>
+        probeEdge(g, parents, finding, anchorId, corpus, limit)
+      );
+      const askable = results.filter((result) => result.probeable !== false);
+      probedEdges += askable.length;
+      recoveredEdges += askable.filter((result) => result.recovered).length;
+      for (const result of askable) {
+        if (result.recovered) byArm[result.arm] += 1;
+      }
+
+      if (!askable.length) {
+        unprobeable.push({ key: finding.key, reason: results[0].reason });
+        continue;
+      }
+
+      probed += 1;
+      const lost = askable.filter((result) => !result.recovered);
+      if (!lost.length) retrieved += 1;
+      else misses.push({ key: finding.key, reason: lost[0].reason });
+    }
+
+    const integrity = {
+      what:
+        'BY CONSTRUCTION: a finding is returned by findingsFor from its own anchor because that edge is what makes it an anchor. Expected 1 for every graph. NOT a recall rate.',
+      probed: findings.length,
+      retrieved: integrityOk,
+      rate: findings.length ? integrityOk / findings.length : null,
+      ok: integrityFailures.length === 0,
+      failures: integrityFailures,
+    };
+
+    // Arm B is recall@`limit`. Over a corpus of at most `limit` findings nothing
+    // is ever cut for budget, so the arm asks only whether a token matched --
+    // weaker than the bar production applies under a token budget, and a probe
+    // more permissive than the system it measures can only overstate recall.
+    const discriminating = corpus.length > limit;
+
+    const common = {
+      basis: 'offline probe over the current graph',
+      probed,
+      retrieved,
+      misses,
+      unprobeable,
+      probedEdges,
+      recoveredEdges,
+      byArm,
+      corpus: corpus.length,
+      discriminating,
+      truncated,
+      minProbed,
+      integrity,
+    };
+
+    if (probed < minProbed) {
+      return {
+        ...common,
+        rate: null,
+        reason:
+          probed === 0
+            ? `no probeable finding: ${unprobeable.length} of ${findings.length} active finding(s) have no anchor node to query from, so recall was not measured. No rate is reported, which is not the same as a rate of zero.`
+            : `${probed} probeable finding(s), below the floor of ${minProbed}: a proportion over ${probed} has a resolution of ${Math.round(
+                100 / probed
+              )} percentage points, so no rate is published. ${retrieved} of ${probed} were recovered without their own anchor edge, which is a count and not a rate.`,
+      };
+    }
+
+    if (!discriminating) {
+      return {
+        ...common,
+        rate: null,
+        reason: `the active corpus holds ${corpus.length} finding(s) and the retrieval limit is ${limit}, so nothing is ever cut for budget and the lexical arm asks only whether a token matched -- a weaker bar than production applies. No rate is published off a probe more permissive than the system it measures; ${retrieved} of ${probed} were recovered, which is a count and not a rate.`,
+      };
+    }
+
+    return { ...common, rate: retrieved / probed, reason: null };
+  } catch {
+    return refuse('the probe failed, so recall was not measured.');
+  }
+}

--- a/integrations/copilot/.github/hooks/lib/redact.mjs
+++ b/integrations/copilot/.github/hooks/lib/redact.mjs
@@ -1,0 +1,30 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/redact.mjs. Regenerate with `npm run sync:hooks`.
+// hooks-core/redact.mjs
+/**
+ * Redaction for anything derived from captured output.
+ *
+ * WHY THIS IS MANDATORY RATHER THAN PRUDENT. derive.mjs builds claims out of
+ * command stderr. A claim is INJECTED into model context and EXPORTED to
+ * markdown, so a secret that reaches a claim reaches two more places than the
+ * terminal it came from. Pattern matching is imperfect and that is stated in the
+ * spec, but "imperfect" beats "absent" by a wide margin here.
+ */
+
+const PATTERNS = [
+  // Bearer / API-key shaped tokens.
+  [/\b(bearer\s+)[A-Za-z0-9._~+/-]{12,}/gi, '$1[redacted]'],
+  [/\b(sk|pk|ghp|gho|github_pat|xox[baprs])[-_][A-Za-z0-9._-]{10,}/gi, '[redacted]'],
+  // KEY=value where the key name suggests a secret.
+  [/\b([A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|APIKEY|API_KEY|PRIVATE_KEY|CREDENTIAL)[A-Z0-9_]*)\s*[=:]\s*\S+/g, '$1=[redacted]'],
+  // Credentials inside a URL.
+  [/\b([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+):[^\s@]+@/gi, '$1:[redacted]@'],
+  // PEM blocks.
+  [/-----BEGIN[^-]*PRIVATE KEY-----[\s\S]*?-----END[^-]*PRIVATE KEY-----/g, '[redacted key]'],
+];
+
+export function redact(text, { max = 400 } = {}) {
+  let out = String(text ?? '');
+  for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
+}

--- a/integrations/copilot/.github/hooks/lib/redact.mjs
+++ b/integrations/copilot/.github/hooks/lib/redact.mjs
@@ -24,7 +24,21 @@ const PATTERNS = [
 ];
 
 export function redact(text, { max = 400 } = {}) {
+  // `?? ''` matters even though String(null)/String(undefined) never throw:
+  // without it a missing value becomes the literal 4-11 character string
+  // "null"/"undefined" -- a garbage claim that silently reaches the graph
+  // and model context instead of surfacing as an error.
   let out = String(text ?? '');
   for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  // Redact BEFORE truncating, never the reverse. Several patterns above rely
+  // on a minimum-length quantifier (e.g. `{10,}`, `{12,}`) plus a prefix.
+  // Truncating first can cut a match down to fewer characters than that
+  // quantifier requires, so the shortened fragment no longer satisfies the
+  // pattern and a live partial secret would pass through in cleartext. By
+  // redacting the full, untruncated string first, every pattern always sees
+  // the complete secret and removes it before any character budget is
+  // spent; the cap below can then only ever cut into already-redacted text
+  // (a label, or the "[redacted]" placeholder itself), never into raw
+  // secret bytes.
   return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
 }

--- a/integrations/copilot/.github/hooks/lib/transcript.mjs
+++ b/integrations/copilot/.github/hooks/lib/transcript.mjs
@@ -19,9 +19,11 @@
  */
 
 import {
-  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, unlinkSync,
+  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync,
+  unlinkSync, openSync, readSync, closeSync,
 } from 'node:fs';
 import { join } from 'node:path';
+import { redact } from './redact.mjs';
 
 /** Where a project's transcripts live, under the graph it belongs to. */
 export const transcriptDir = (dir) => join(dir, 'transcripts');
@@ -210,4 +212,204 @@ export function readArchive(dir, sessionId) {
   } catch {
     return [];
   }
+}
+
+/**
+ * How much of a transcript's TAIL is scanned for failed tool results.
+ *
+ * A transcript is the largest file this project reads: the three real ones on
+ * the measuring machine are 5.8 MB, 22 MB and 45 MB. `archive()` above already
+ * reads the whole thing once at Stop, so an unbounded second pass doubles the
+ * most expensive read on the session-end path for evidence that is, by
+ * construction, mostly old. The tail is the right half to keep for the same
+ * reason `buildFeedbackDigest` keeps the end: what a session learned is
+ * concentrated where the work went wrong, which is later rather than sooner.
+ */
+const FAILED_SCAN_BYTES = () =>
+  Number(process.env.TOKEN_OPTIMIZER_TRANSCRIPT_SCAN_BYTES) || 8 * 1024 * 1024;
+
+/** Failed results kept, most recent first. The pairing detector needs a handful. */
+const FAILED_MAX = 50;
+
+/** Same 4 KB cap `recordToolOutcome` applies to `output`, for the same reason. */
+const FAILED_OUTPUT_MAX = 4096;
+
+/**
+ * The same 120-character truncation `recordToolOutcome` applies to `anchor`.
+ *
+ * ONE COMMAND MUST PRODUCE ONE KEY FROM EITHER SOURCE. A `tool-outcome` stores
+ * the command as `String(tool_input.command).slice(0, 120)`, and `attemptKey`
+ * reads up to three non-flag tokens off whatever it is handed. A long first
+ * token -- a quoted grep pattern, an absolute Windows path, a heredoc -- is cut
+ * by that cap INSIDE those three tokens, so the untruncated transcript copy of
+ * the same command lands in a DIFFERENT group. Measured against one real
+ * session's own evidence: 266 commands present in both sources, and truncating
+ * here made 266 of 266 keys agree where the untruncated text agreed on only
+ * 240.
+ *
+ * WHAT THAT ACTUALLY BUYS, stated precisely rather than generously. `derive`
+ * refuses to build a claim out of a command at or over the cap at all (see
+ * `quotable` there), so agreement on a TRUNCATED key never produces a finding
+ * on its own. It buys two things that still matter: a transcript failure lands
+ * in the same run as the event outcomes of the same command, so the
+ * nearest-preceding-failure rule sees the real sequence rather than a sparse
+ * one; and the no-call-id fallback in `derive`'s deduplication compares command
+ * TEXT against an already-truncated anchor, which cannot match unless this side
+ * is truncated identically.
+ */
+const ANCHOR_MAX = 120;
+
+/**
+ * A tool result that reports a command that RAN and exited non-zero.
+ *
+ * A POSITIVE ALLOWLIST, and the measurement is why. Claude Code sets
+ * `is_error: true` on every kind of unhappy tool result, and across three real
+ * transcripts 214 of them fell into four shapes:
+ *
+ *   83  `Exit code N` + stderr    -- a command ran and failed. THIS ONE.
+ *   109 hook and policy denials   -- overwhelmingly THIS optimizer's own
+ *                                    PreToolUse text ("Recursive shell searches
+ *                                    return unbounded output. Call the
+ *                                    token-optimizer MCP tool smart_grep
+ *                                    instead"), plus `Remove-Item on system
+ *                                    path` blocks.
+ *   18  `<tool_use_error>...`     -- protocol errors: `String to replace not
+ *                                    found`, `File has not been read yet`,
+ *                                    `Blocked: ...`.
+ *   4   a person declined the call.
+ *
+ * Only the first shape is a command failing. In every other shape THE COMMAND
+ * NEVER RAN, so "`X` failed with: ..." would be a false claim about X, and a
+ * later success would pair with a failure that never happened. The 109 are the
+ * dangerous ones: ingesting them would have this tool derive findings from its
+ * own advice, at 0.9 confidence, and serve them back as observations about the
+ * project -- a self-referential loop that also inflates its own finding count.
+ * That is the measurement-bias class this plan tracks, and a denylist would
+ * have let every future denial string through by default.
+ */
+const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
+
+/** Reads at most `bytes` from the END of a file, without loading the rest. */
+function readTail(path, bytes) {
+  let fd;
+  try {
+    const size = statSync(path).size;
+    const length = Math.min(size, bytes);
+    if (!length) return '';
+    fd = openSync(path, 'r');
+    const buffer = Buffer.allocUnsafe(length);
+    readSync(fd, buffer, 0, length, size - length);
+    const text = buffer.toString('utf8');
+    // A tail almost never starts on a line boundary, and half a JSON object is
+    // not a parse failure worth reporting -- it is a partial record. Drop it.
+    return length < size ? text.slice(text.indexOf('\n') + 1) : text;
+  } catch {
+    return '';
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+}
+
+/**
+ * The failed COMMAND results a transcript holds, which no hook event carries.
+ *
+ * WHY THIS READER EXISTS. Claude Code never fires PostToolUse for a failed tool
+ * call: a deliberately failing command produced no event at all, and 2,238 of
+ * 2,238 live `tool-outcome` events on the measuring machine carry
+ * `success: true`. So `derive.mjs`'s two strongest detectors -- command
+ * failed-then-succeeded at 0.90 and test/build red-to-green at 0.85 -- have no
+ * input whatsoever on the primary client, while working normally on the ten
+ * adapter clients. The failures exist; they exist only here.
+ *
+ * WHY NOT THE ARCHIVE, which the plan for this reader assumed. `readTurns`
+ * DROPS tool results by design -- that is where whole file contents would enter
+ * the record -- so `readArchive` returns no failure, ever, and an extractor over
+ * archived turns would find nothing however well it was written. Making the
+ * archive carry them would also push command stderr into `buildFeedbackDigest`,
+ * which is the one code path in this project that sends anything to a model
+ * endpoint. So this reads the transcript and STORES NOTHING NEW: read-only, no
+ * capture path, no new event kind, and no widening of what leaves the machine.
+ *
+ * REDACTED HERE, at this boundary, exactly as `recordToolOutcome` redacts
+ * `output`. Transcript text has never passed a redaction boundary -- that one
+ * never saw it -- and everything returned from here is destined for a claim that
+ * is injected into model context and exported to markdown.
+ *
+ * @returns {Array<{command: string, output: string, exit: number|null,
+ *   at: number, toolCallId: string|null}>} in transcript order, so a caller can
+ *   sort it beside `tool-outcome` events without re-ordering.
+ */
+export function failedResultsFromTranscript(transcriptPath, options = {}) {
+  const { max = FAILED_MAX, scanBytes = FAILED_SCAN_BYTES() } = options || {};
+  if (!transcriptPath) return [];
+  const text = readTail(transcriptPath, scanBytes);
+  if (!text) return [];
+
+  // tool_use_id -> the command that was attempted. The join is EXACT and it is
+  // the only one available: the result block carries no command of its own, and
+  // the id is the same string `episodeMeta` reads into `toolCallId`, so the same
+  // key also deduplicates against events on clients that do report failures.
+  const commands = new Map();
+  const failures = [];
+
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const message = entry.message || entry;
+    const role = message.role || entry.type;
+    const content = message.content;
+    if (!Array.isArray(content)) continue;
+
+    if (role === 'assistant') {
+      for (const block of content) {
+        if (!block || block.type !== 'tool_use' || !block.id) continue;
+        const command = block.input?.command;
+        if (typeof command !== 'string' || !command.trim()) continue;
+        commands.set(String(block.id), command.slice(0, ANCHOR_MAX));
+      }
+      continue;
+    }
+
+    if (role !== 'user') continue;
+    for (const block of content) {
+      if (!block || block.type !== 'tool_result' || block.is_error !== true) continue;
+      // Only a STRING result can be an exit-code report; every failed Claude
+      // Code result observed was one, and a structured body is a shape this
+      // classifier has not measured, so it is refused rather than guessed at.
+      if (typeof block.content !== 'string') continue;
+      const match = EXIT_CODE_RESULT.exec(block.content);
+      if (!match) continue;
+      const command = commands.get(String(block.tool_use_id || ''));
+      // No command means no claim. The result says something failed; without
+      // the text of what failed there is nothing to say about it, and nothing
+      // to group it with.
+      if (!command) continue;
+      failures.push({
+        command,
+        // The exit line itself is stripped: `exit` carries it structurally, and
+        // leaving it in makes every failure claim read "failed with: Exit code 1".
+        output: redact(block.content.slice(match[0].length).trim(), {
+          max: FAILED_OUTPUT_MAX,
+        }),
+        exit: Number(match[1]),
+        at: Date.parse(entry.timestamp || '') || 0,
+        toolCallId: block.tool_use_id ? String(block.tool_use_id) : null,
+      });
+    }
+  }
+
+  // The MOST RECENT `max`, keeping chronological order. A session that failed
+  // two hundred times teaches its last lessons, not its first.
+  return failures.slice(-max);
 }

--- a/integrations/copilot/.github/hooks/lib/usage.mjs
+++ b/integrations/copilot/.github/hooks/lib/usage.mjs
@@ -42,7 +42,7 @@
  * was referenced" and "nothing could be measured" are different answers and
  * this module gives different answers for them.
  */
-import { readMetrics } from './metrics.mjs';
+import { readMetrics, readTruncation } from './metrics.mjs';
 
 /**
  * The events that name a finding, and it is ONE kind, not the two the plan
@@ -129,17 +129,30 @@ export function classify(dir, { events = null } = {}) {
   try {
     const all = inTimeOrder(events || readMetrics(dir));
 
-    // Every reference, keyed on the finding it names. Only references carrying
-    // a session id are usable -- see `unscopedReferences` in `referenceRate`
-    // for the ones this drops and why they are counted rather than credited.
+    // Every reference, keyed on the finding it names and on nothing else.
+    //
+    // NOT SCOPED BY SESSION, and that is a deliberate reversal. Scoping needs
+    // the query's `sessionId`, which `wiki_query` takes as an OPTIONAL input
+    // the model has to volunteer (`options.sessionId ?? null`) -- so the
+    // numerator depended on the model choosing to identify itself, and an
+    // unverifiable model-supplied id is not evidence. Plan 1 settled that for
+    // the `answers` edge and it settles it here: stop depending on the field
+    // rather than hope for cooperation. The finding key is the specific part
+    // anyway; a key is a graph identity, not a guess.
+    //
+    // THE COST, disclosed here and in `referenceNote` because a reader of the
+    // number has to see it: TWO CONCURRENT SESSIONS ON ONE REPOSITORY CAN
+    // CROSS-ATTRIBUTE. Session A's injection of K plus session B's later query
+    // for K reads as a reference. Nothing in the log can separate them once the
+    // session id is gone, so the exposure is real and is stated rather than
+    // priced.
     const references = new Map();
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       const key = referencedKey(event);
-      const session = sessionOf(event);
-      if (!key || !session) continue;
+      if (!key) continue;
       if (!references.has(key)) references.set(key, []);
-      references.get(key).push({ at: event.at || 0, session });
+      references.get(key).push(event.at || 0);
     }
 
     // Which injections the existing outcome join could attribute. An outcome
@@ -170,9 +183,8 @@ export function classify(dir, { events = null } = {}) {
       const injectionId = event.injectionId ? String(event.injectionId) : null;
       const at = event.at || 0;
       const session = sessionOf(event);
-      // STRICTLY AFTER. A query that PRECEDED the injection is the model
-      // asking on its own initiative; crediting it would let the metric take
-      // the credit for a lookup it had nothing to do with.
+      // STRICTLY AFTER here too: activity that predates the injection is not
+      // an opportunity to have used it.
       const followed = (times) => times.some((t) => t > at);
       const continued =
         (injectionId && attributed.has(injectionId)) ||
@@ -181,9 +193,11 @@ export function classify(dir, { events = null } = {}) {
       for (const raw of keys) {
         const findingKey = String(raw);
         const hits = references.get(findingKey) || [];
-        const referenced = session
-          ? hits.some((hit) => hit.session === session && hit.at > at)
-          : false;
+        // TIME ORDER IS THE ONLY REMAINING GUARD, so it carries the whole
+        // weight of the attribution: a query that PRECEDED the injection is
+        // the model asking on its own initiative, and crediting it would let
+        // the metric take the credit for a lookup it had nothing to do with.
+        const referenced = hits.some((hitAt) => hitAt > at);
         rows.push({
           findingKey,
           injectionId,
@@ -204,9 +218,27 @@ export function classify(dir, { events = null } = {}) {
 /**
  * The rate, with everything needed to tell a real 0 from an absent one.
  *
- * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
- * `unattributable` and `unscopedReferences` are reported beside it, never
- * inside it.
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown` and
+ * `unattributable` are reported beside it, never inside it.
+ *
+ * `windowed` SAYS WHETHER THE DENOMINATOR CAN UNDERSTATE, and it is not
+ * decoration. `readMetrics` reads a 2 MB / 5,000-event TAIL of the firehose,
+ * and injections are rare enough on a real project to age out of it: measured
+ * on this repository, both `inject` events sit at lines 502 and 883 of 6,871
+ * and have scrolled away behind ~6,000 later `read` and `tool-outcome` rows,
+ * so the windowed denominator is 0 where the whole-file truth is 1.
+ *
+ * IT IS REPORTED RATHER THAN FIXED, deliberately. `inject` already gets
+ * unwindowed access through `BALANCE_KINDS` / `EVIDENCE_KINDS`, but `query`
+ * does not -- and reading only the INJECTION arm unwindowed would be worse
+ * than the windowing: every old injection would enter the denominator with no
+ * chance of a matching query in the window and score `not-referenced`,
+ * manufacturing a pessimistic rate out of the asymmetry. Making the query arm
+ * unwindowed means adding `query` to `EVIDENCE_KINDS`, which two other
+ * consumers read, and this project's own standard says a shared-classifier
+ * change needs a per-consumer verdict comparison. So the honest move is to
+ * publish the flag: a caller that needs the unwindowed truth passes its own
+ * `events`, which is exactly what the live measurement in the task report did.
  */
 export function referenceRate(dir, { events = null } = {}) {
   const empty = {
@@ -218,10 +250,15 @@ export function referenceRate(dir, { events = null } = {}) {
     unattributable: 0,
     unattributableWithInjectedToolCall: 0,
     referenceEvents: 0,
-    unscopedReferences: 0,
+    windowed: false,
   };
   try {
     const all = events || readMetrics(dir);
+    // OUT OF BAND, and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` reports on the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
     const rows = classify(dir, { events: all });
     const count = (label) => rows.filter((row) => row.label === label).length;
     const referenced = count('referenced');
@@ -231,17 +268,17 @@ export function referenceRate(dir, { events = null } = {}) {
     // Usable reference events in the window: the numerator's producer. If this
     // is zero the channel never fired, and a 0% rate would be measuring the
     // absence of a producer rather than the uselessness of findings.
+    //
+    // NO SESSION REQUIREMENT, matching the attribution above. The former
+    // `unscopedReferences` counted queries dropped for want of a session id;
+    // nothing is dropped for that reason any more, so the field is GONE rather
+    // than kept at a permanent zero that a later reader would misread as
+    // evidence the loss had been fixed.
     let referenceEvents = 0;
-    let unscopedReferences = 0;
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       if (!referencedKey(event)) continue;
-      if (sessionOf(event)) referenceEvents += 1;
-      // Names a finding but cannot be scoped to one injection. `sessionId` is
-      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
-      // is the expected loss rather than an edge case -- counted here so it is
-      // visible instead of silently deflating the numerator.
-      else unscopedReferences += 1;
+      referenceEvents += 1;
     }
 
     // The tool calls that DID receive findings, keyed the way
@@ -292,7 +329,7 @@ export function referenceRate(dir, { events = null } = {}) {
       unattributable,
       unattributableWithInjectedToolCall,
       referenceEvents,
-      unscopedReferences,
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
     };
   } catch {
     return empty;
@@ -300,11 +337,18 @@ export function referenceRate(dir, { events = null } = {}) {
 }
 
 /**
- * One line for the audit, or nothing at all.
+ * One or two lines for the audit, or nothing at all.
  *
  * Says which of the three things is true -- a measured rate, a live channel
  * with no opportunities yet, or no channel at all -- rather than printing a
  * figure and letting the reader assume the first.
+ *
+ * AND IT CARRIES THE CAVEATS, because this is the only place a human meets the
+ * number. A rate attributed on (finding key, time order) can cross-attribute
+ * between two concurrent sessions on one repository, and a windowed read can
+ * understate the denominator. Both are stated beside the figure they qualify.
+ * Putting them only in a task report would be publishing a clean number and
+ * filing the asterisk somewhere nobody quoting it will look.
  */
 export function referenceNote(dir, { events = null } = {}) {
   const r = referenceRate(dir, { events });
@@ -317,6 +361,11 @@ export function referenceNote(dir, { events = null } = {}) {
   }
   return (
     `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
-    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded. ` +
+    'Matched on finding key and time order, so concurrent sessions on this ' +
+    'repository can cross-attribute' +
+    (r.windowed
+      ? '; and the event log was truncated, so the denominator can understate.'
+      : '.')
   );
 }

--- a/integrations/copilot/.github/hooks/lib/usage.mjs
+++ b/integrations/copilot/.github/hooks/lib/usage.mjs
@@ -1,0 +1,322 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/usage.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 1 -- did the model actually go back and use what we injected?
+ *
+ * The cheap behavioural label. One question, answered from the event log alone:
+ * after we put a finding in front of the model, did the model later ASK FOR
+ * THAT FINDING BY NAME?
+ *
+ * WHY EXPLICIT REFERENCE, AND NOT READ-SUPPRESSION. Read-suppression -- "the
+ * file was not re-read, so the finding must have helped" -- is Layer 2's
+ * estimand, measured causally by withholding a finding and comparing. Layer 1
+ * exists to be calibrated AGAINST that. If both layers derived from
+ * suppression, the calibration would compare two spellings of one quantity,
+ * report a strong correlation, and mean nothing. So Layer 1 is deliberately
+ * built on a signal Layer 2 does not touch: an explicit `query` naming the
+ * finding key.
+ *
+ * WHAT THIS DOES NOT DO. It does not invent a join. `recordToolOutcome`
+ * already joins each post-tool result back to the injection that preceded it,
+ * recording `injectionId`, `findingIds` and a `joinMethod` of `tool-call-id`,
+ * `episode-anchor` or `none` -- preferring an exact tool-call id, which is
+ * strictly better evidence than the `(sessionId, findingKey)` approximation an
+ * earlier draft of this plan proposed. This module consumes that join and adds
+ * none of its own. `inject.mjs` needed no change: it has written `findingIds`
+ * at every call site all along.
+ *
+ * WHAT `unknown` IS FOR, and it is the whole reason this file is careful. An
+ * injection whose session simply stopped afterwards is not a miss. Nothing
+ * happened, so nothing can be concluded, and counting it against the finding
+ * would make the metric read worse the more often sessions end -- a number
+ * that moves with session length rather than with usefulness. `unknown` is
+ * therefore EXCLUDED from the denominator rather than scored zero, and
+ * outcomes the join could not attribute at all are reported as
+ * `unattributable` rather than folded into either arm.
+ *
+ * AND WHY THE RATE CAN BE `null`. This project has already shipped two metrics
+ * whose only producer was their own test suite. A rate of 0% that actually
+ * means "no data" is worse than a refusal, because it is a number and numbers
+ * get quoted. So `rate` is null unless there is a denominator AND the
+ * reference channel produced at least one usable event in the window. "Nothing
+ * was referenced" and "nothing could be measured" are different answers and
+ * this module gives different answers for them.
+ */
+import { readMetrics } from './metrics.mjs';
+
+/**
+ * The events that name a finding, and it is ONE kind, not the two the plan
+ * assumed.
+ *
+ * The brief said "a later `query` or `expand` event". Checked against the code
+ * and against every metrics log on this machine, `expand` does not qualify and
+ * cannot be made to:
+ *
+ *   - `recordExpansion` writes `{ ref, tool, shape, asked, sessionId }`. `ref`
+ *     is a TRUNCATION CAPTURE id (a 16-hex digest of captured tool output),
+ *     not a finding key, and `asked` is free text naming a section of that
+ *     output. Neither is a graph key, and no code path ever puts one there.
+ *   - measured: 64 live `expand` events exist on this machine and all 64 carry
+ *     `sessionId: null`, so they could not be scoped to an injection even if
+ *     they did name one.
+ *
+ * Keying the classifier on `expand` would therefore have added a branch that
+ * can never fire -- a metric with no producer, which is the exact defect this
+ * whole effort exists to close. So it is excluded, deliberately and with the
+ * measurement recorded, rather than included for symmetry with the brief.
+ */
+const REFERENCE_KINDS = new Set(['query']);
+
+/**
+ * What counts as the session having CONTINUED past the injection.
+ *
+ * The distinction between `not-referenced` and `unknown` rests entirely on
+ * this, so the set is explicit rather than "any later event". These are the
+ * kinds a tool call produces: if one of them follows the injection in the same
+ * session, the model had the opportunity to ask and did not. If none does, the
+ * session ended and there was no opportunity.
+ *
+ * `inject` is in the set because a later injection means a later tool call
+ * happened. `forecast`, `mcp-client` and `mcp-tool` are NOT: they are written
+ * by session bookkeeping rather than by the model doing something, and
+ * treating them as opportunity would convert `unknown` rows into misses on
+ * bookkeeping alone.
+ */
+const ACTIVITY_KINDS = new Set([
+  'tool-outcome',
+  'read',
+  'query',
+  'expand',
+  'substitute',
+  'inject',
+]);
+
+/** A usable session id: a non-empty string. `null == null` is not a match. */
+const sessionOf = (event) => {
+  const id = event?.sessionId;
+  return typeof id === 'string' && id ? id : null;
+};
+
+/** The finding key a reference event names, or null if it names none. */
+const referencedKey = (event) => {
+  const key = event?.key;
+  return typeof key === 'string' && key ? key : null;
+};
+
+/** Ordering by the caller's timestamp, with log order breaking ties. */
+function inTimeOrder(events) {
+  return events
+    .map((event, index) => ({ event, index }))
+    .sort(
+      (a, b) =>
+        (a.event.at || 0) - (b.event.at || 0) || a.index - b.index
+    )
+    .map((row) => row.event);
+}
+
+/**
+ * One row per (injection, finding) pair, labelled.
+ *
+ * Per injection rather than per finding: the same finding injected twice is two
+ * separate opportunities, and collapsing them would let one reference excuse
+ * every later injection of that key.
+ *
+ * FAILS OPEN. A malformed log yields an empty classification, never a throw:
+ * this runs on report paths that must not break a tool call.
+ */
+export function classify(dir, { events = null } = {}) {
+  let rows = [];
+  try {
+    const all = inTimeOrder(events || readMetrics(dir));
+
+    // Every reference, keyed on the finding it names. Only references carrying
+    // a session id are usable -- see `unscopedReferences` in `referenceRate`
+    // for the ones this drops and why they are counted rather than credited.
+    const references = new Map();
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      const key = referencedKey(event);
+      const session = sessionOf(event);
+      if (!key || !session) continue;
+      if (!references.has(key)) references.set(key, []);
+      references.get(key).push({ at: event.at || 0, session });
+    }
+
+    // Which injections the existing outcome join could attribute. An outcome
+    // carrying our injectionId is proof the tool call completed, which is
+    // opportunity even when the session id is missing from the log.
+    const attributed = new Set();
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) continue;
+      attributed.add(String(event.injectionId));
+    }
+
+    // Activity per session, so "did anything follow?" is one lookup rather
+    // than a scan per injection.
+    const activity = new Map();
+    for (const event of all) {
+      if (!ACTIVITY_KINDS.has(event.kind)) continue;
+      const session = sessionOf(event);
+      if (!session) continue;
+      if (!activity.has(session)) activity.set(session, []);
+      activity.get(session).push(event.at || 0);
+    }
+
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+      if (!keys.length) continue;
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const at = event.at || 0;
+      const session = sessionOf(event);
+      // STRICTLY AFTER. A query that PRECEDED the injection is the model
+      // asking on its own initiative; crediting it would let the metric take
+      // the credit for a lookup it had nothing to do with.
+      const followed = (times) => times.some((t) => t > at);
+      const continued =
+        (injectionId && attributed.has(injectionId)) ||
+        (session ? followed(activity.get(session) || []) : false);
+
+      for (const raw of keys) {
+        const findingKey = String(raw);
+        const hits = references.get(findingKey) || [];
+        const referenced = session
+          ? hits.some((hit) => hit.session === session && hit.at > at)
+          : false;
+        rows.push({
+          findingKey,
+          injectionId,
+          label: referenced
+            ? 'referenced'
+            : continued
+              ? 'not-referenced'
+              : 'unknown',
+        });
+      }
+    }
+  } catch {
+    rows = [];
+  }
+  return rows;
+}
+
+/**
+ * The rate, with everything needed to tell a real 0 from an absent one.
+ *
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
+ * `unattributable` and `unscopedReferences` are reported beside it, never
+ * inside it.
+ */
+export function referenceRate(dir, { events = null } = {}) {
+  const empty = {
+    referenced: 0,
+    notReferenced: 0,
+    unknown: 0,
+    denominator: 0,
+    rate: null,
+    unattributable: 0,
+    unattributableWithInjectedToolCall: 0,
+    referenceEvents: 0,
+    unscopedReferences: 0,
+  };
+  try {
+    const all = events || readMetrics(dir);
+    const rows = classify(dir, { events: all });
+    const count = (label) => rows.filter((row) => row.label === label).length;
+    const referenced = count('referenced');
+    const notReferenced = count('not-referenced');
+    const denominator = referenced + notReferenced;
+
+    // Usable reference events in the window: the numerator's producer. If this
+    // is zero the channel never fired, and a 0% rate would be measuring the
+    // absence of a producer rather than the uselessness of findings.
+    let referenceEvents = 0;
+    let unscopedReferences = 0;
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      if (!referencedKey(event)) continue;
+      if (sessionOf(event)) referenceEvents += 1;
+      // Names a finding but cannot be scoped to one injection. `sessionId` is
+      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
+      // is the expected loss rather than an edge case -- counted here so it is
+      // visible instead of silently deflating the numerator.
+      else unscopedReferences += 1;
+    }
+
+    // The tool calls that DID receive findings, keyed the way
+    // `recordToolOutcome` keys its own primary join: the tool-call id. An
+    // unattributable outcome for one of these is a join that FAILED. An
+    // unattributable outcome for any other tool call had nothing to join to.
+    //
+    // KEYED ON THE TOOL CALL, NOT THE EPISODE, and the first draft of this
+    // got it wrong in a way worth recording because it is the exact
+    // measurement-bias class this plan hunts. `episodeId` equals the SESSION
+    // id, so "unattributable outcomes in an episode that had an injection"
+    // scored all 2,559 tool calls of a session in which ONE injection
+    // happened. It would have published 2,559 join failures where the true
+    // number is zero -- correct code, lying number, and biased pessimistic
+    // rather than flattering, which is no better.
+    const injectedToolCalls = new Set();
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      if (!Array.isArray(event.findingIds) || !event.findingIds.length)
+        continue;
+      if (event.toolCallId) injectedToolCalls.add(String(event.toolCallId));
+    }
+    let unattributable = 0;
+    let unattributableWithInjectedToolCall = 0;
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome' || event.joinMethod !== 'none')
+        continue;
+      unattributable += 1;
+      // BOTH FIGURES, because the raw one alone lies in the pessimistic
+      // direction. Measured on this machine: 2,991 of 2,992 live outcomes
+      // report `joinMethod: 'none'`, and every one of them because NO
+      // INJECTION EXISTED for that tool call -- the graph holds one finding.
+      // Quoting only the raw count would read as a join that fails 99.97% of
+      // the time, which is a different and false claim.
+      if (event.toolCallId && injectedToolCalls.has(String(event.toolCallId)))
+        unattributableWithInjectedToolCall += 1;
+    }
+
+    return {
+      referenced,
+      notReferenced,
+      unknown: count('unknown'),
+      denominator,
+      rate:
+        denominator > 0 && referenceEvents > 0
+          ? referenced / denominator
+          : null,
+      unattributable,
+      unattributableWithInjectedToolCall,
+      referenceEvents,
+      unscopedReferences,
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/**
+ * One line for the audit, or nothing at all.
+ *
+ * Says which of the three things is true -- a measured rate, a live channel
+ * with no opportunities yet, or no channel at all -- rather than printing a
+ * figure and letting the reader assume the first.
+ */
+export function referenceNote(dir, { events = null } = {}) {
+  const r = referenceRate(dir, { events });
+  if (!r.denominator && !r.unknown && !r.referenceEvents) return null;
+  if (r.rate == null) {
+    const why = !r.referenceEvents
+      ? 'no finding was ever queried by key in this window'
+      : `no injection had a chance to be referenced yet (${r.unknown} unknown)`;
+    return `Injected findings referenced later: not measurable -- ${why}.`;
+  }
+  return (
+    `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+  );
+}

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -103,6 +103,44 @@ const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
 
 /**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because FOUR readers depend on it -- mutation accounting,
+ * success classification, output capture and exit-code capture -- and clients
+ * disagree on the envelope name and on nothing else. Letting each reader name
+ * its own subset is exactly how both classifiers came to miss MCP's failure
+ * flag: `toolSucceeded` listed four envelopes and `mutationSucceeded` listed
+ * three, and neither list mentioned `isError` at all.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/**
+ * Did an MCP result declare itself an error?
+ *
+ * `isError` is the ONLY failure signal an MCP result carries -- there is no
+ * `error` field and no `status` -- and `src/server/index.ts` sets it in seven
+ * places. Shared by both classifiers so they cannot disagree about what a
+ * failed call from this project's own tools looks like.
+ *
+ * `=== true` EXACTLY. A client using the key for anything else must not have
+ * its successful calls silently reclassified, and `isError: false` is a
+ * successful MCP call, not a missing verdict.
+ */
+function reportedMcpError(raw) {
+  return [...responseEnvelopes(raw), raw].some(
+    (envelope) => envelope?.isError === true
+  );
+}
+
+/**
  * A post-tool event is not universally proof of success. Some clients split
  * success and failure into distinct events; others expose a result status.
  * Keep mutation accounting conservative so a failed edit cannot arm Stop.
@@ -112,6 +150,19 @@ export function mutationSucceeded(clientName, raw) {
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
     return false;
+  // BEFORE the status read, the explicit-success read AND the client
+  // allowlist, because all three would otherwise pass a failed MCP write. The
+  // allowlist is the one that actually bit: it returns true for claude-code,
+  // codex, qwen, opencode, kilo and windsurf on any post-tool event with no
+  // error and no status, which is precisely the shape of a failed smart_write.
+  //
+  // WHY THIS IS THE SAME BUG AS THE ONE IN `toolSucceeded` AND NOT A COSMETIC
+  // ECHO OF IT: this function gates edit counting and harvest pressure, so
+  // counting a failed write to THE OPTIMIZER'S OWN TOOLS as a mutation
+  // inflates "the optimizer successfully edited a file". Different consumers
+  // from the effectiveness figures, same direction of bias -- toward
+  // flattering the thing being measured.
+  if (reportedMcpError(raw)) return false;
 
   const status =
     raw?.tool_response?.status ??
@@ -145,24 +196,6 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * Spelled out ONCE because three readers depend on it -- success
- * classification, output capture and exit-code capture -- and clients disagree
- * on the envelope name and on nothing else. Letting each reader name its own
- * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
-}
-
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
@@ -181,8 +214,7 @@ export function toolSucceeded(raw) {
   // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
   // optimizer's favour. A measurement that flatters the thing being measured
   // is worse than no measurement.
-  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
-    return false;
+  if (reportedMcpError(raw)) return false;
   const status =
     raw?.tool_response?.status ??
     raw?.toolResponse?.status ??

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -957,10 +957,12 @@ async function runHook(clientName, event, invocation) {
       // accumulates structure and no verdicts at all. These detectors read only
       // what is already on disk and send nothing anywhere.
       //
-      // The COUNT is recorded rather than the candidates: how many findings a
-      // session's own evidence supports is the number that says whether this is
-      // working, and it is measurable before anything is stored. Storage is the
-      // caller's next step, under a budget.
+      // COUNTS are recorded rather than the candidates, and BOTH counts: how
+      // many findings a session's own evidence supports, and how many of them
+      // survived the storage budget and the anchor discipline. The gap between
+      // the two is the number that says whether the bound is doing anything --
+      // one figure alone cannot distinguish "nothing to derive" from "derived
+      // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
       const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
       const dir = wikiDir(projectRoot);
@@ -976,6 +978,7 @@ async function runHook(clientName, event, invocation) {
         sessionId,
         candidates: derived.candidates.length,
         observations: derived.observations.length,
+        written: derived.written.length,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -172,6 +172,136 @@ export function toolSucceeded(raw) {
   return true;
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * The same family `toolSucceeded` reads above, hoisted so the three readers
+ * cannot drift apart. Clients disagree on the envelope name and on nothing
+ * else, so this is the one place that disagreement is spelled out.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/** A non-empty string, or null.  Blank output is the same as none. */
+function nonEmpty(value) {
+  const text = String(value ?? '');
+  return text.trim() ? text : null;
+}
+
+/**
+ * The human-readable result text inside one envelope, or null.
+ *
+ * RETURNS NULL RATHER THAN GUESSING. An envelope shape nobody here has seen
+ * produces no capture at all, which costs one finding. Stringifying it instead
+ * would put `[object Object]` or a wall of JSON metadata into a claim that gets
+ * injected into model context -- a wrong observation, which is strictly worse
+ * than a missing one.
+ */
+function resultText(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'string') return nonEmpty(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return null;
+
+  // MCP content blocks, which is how THIS PROJECT'S OWN tools now arrive:
+  // `normalizeTool` resolves `mcp__<server>__smart_edit`, so smart_edit and
+  // smart_write reach the post-tool path for the first time and their results
+  // are `{ content: [{ type: 'text', text }], isError }` rather than a shell
+  // result. Both the bare array and the wrapping object are accepted because
+  // hosts differ on whether they hand the hook the result or its content.
+  if (Array.isArray(value)) {
+    const blocks = value
+      .map((block) =>
+        typeof block === 'string' ? block : nonEmpty(block?.text)
+      )
+      .filter(Boolean);
+    return blocks.length ? nonEmpty(blocks.join('\n')) : null;
+  }
+  if (typeof value !== 'object') return null;
+
+  // STDERR FIRST, and not because that is the order it was produced in. The
+  // cap can only ever cut the tail, and the diagnostic that explains a failure
+  // is almost always on stderr while the volume is almost always on stdout --
+  // so appending stderr would let a 3 MB build log push the one line worth
+  // capturing out of the window.
+  const streams = [nonEmpty(value.stderr), nonEmpty(value.stdout)].filter(
+    Boolean
+  );
+  if (streams.length) return streams.join('\n');
+
+  if (Array.isArray(value.content)) {
+    const inner = resultText(value.content);
+    if (inner) return inner;
+  }
+
+  const error = value.error;
+  if (error) {
+    const message =
+      typeof error === 'string' ? error : nonEmpty(error.message ?? error.msg);
+    if (message) return message;
+  }
+
+  return (
+    nonEmpty(value.output) ??
+    nonEmpty(value.text) ??
+    nonEmpty(value.message) ??
+    (typeof value.result === 'string' ? nonEmpty(value.result) : null)
+  );
+}
+
+/**
+ * The result text of a completed tool call, or null when the client reports
+ * none.  Redaction and the size cap are NOT applied here -- they belong at the
+ * `recordToolOutcome` boundary, which is the only place every caller passes.
+ */
+export function outputFrom(raw) {
+  for (const envelope of responseEnvelopes(raw)) {
+    const text = resultText(envelope);
+    if (text) return text;
+  }
+  return resultText(raw?.output) ?? resultText(raw?.stdout) ?? null;
+}
+
+/**
+ * Key names that mean "process exit code" and nothing else.
+ *
+ * `code` is deliberately ABSENT. JSON-RPC errors (`code: -32602`), Node errno
+ * objects (`code: 'ENOENT'`) and HTTP wrappers all reuse that name, so reading
+ * it would record a confident exit code for calls that never had one. A null
+ * here is honest; a -32602 claiming to be an exit status is not.
+ */
+const EXIT_KEYS = [
+  'exit_code',
+  'exitCode',
+  'exit',
+  'exit_status',
+  'exitStatus',
+  'return_code',
+  'returncode',
+];
+
+/** The numeric exit code a client reported, or null when it reported none. */
+export function exitFrom(raw) {
+  for (const envelope of [...responseEnvelopes(raw), raw]) {
+    if (!envelope || typeof envelope !== 'object') continue;
+    for (const key of EXIT_KEYS) {
+      const value = envelope[key];
+      if (Number.isInteger(value)) return value;
+      // A client that serializes the code as a digit string still reported it.
+      // Bounded so a hash or an id cannot be mistaken for a status.
+      if (typeof value === 'string' && /^-?\d{1,5}$/.test(value.trim()))
+        return Number(value.trim());
+    }
+  }
+  return null;
+}
+
 function contextOutput(client, eventName, additionalContext) {
   if (client.contextStyle === 'top-level') return { additionalContext };
   if (client.contextStyle === 'cline') {
@@ -890,6 +1020,11 @@ async function runHook(clientName, event, invocation) {
         anchor,
         toolName: payload.tool_name,
         success: toolSucceeded(raw),
+        // The two fields a boolean cannot carry: which KIND of failure this
+        // was. Read through the same normalisers as `success`, never off `raw`
+        // at this call site.
+        output: outputFrom(raw),
+        exit: exitFrom(raw),
         durationMs:
           Number(
             raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -145,11 +145,43 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because three readers depend on it -- success
+ * classification, output capture and exit-code capture -- and clients disagree
+ * on the envelope name and on nothing else. Letting each reader name its own
+ * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
+    return false;
+  // MCP'S OWN FAILURE FLAG, which this function did not read for as long as it
+  // existed. It did not matter while `normalizeTool` dropped MCP names before
+  // any accounting ran; it matters now that `mcp__<server>__smart_edit` and
+  // `smart_write` reach the post-tool path, because an MCP result carries no
+  // `error` field and no `status` -- only `isError` -- so a failed smart_edit
+  // fell through to the optimistic `return true` below.
+  //
+  // WHY THIS IS A MEASUREMENT BUG AND NOT A COSMETIC ONE: this boolean feeds
+  // episode outcomes and effectiveness accounting, so recording every failed
+  // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
+  // optimizer's favour. A measurement that flatters the thing being measured
+  // is worse than no measurement.
+  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
     return false;
   const status =
     raw?.tool_response?.status ??
@@ -170,23 +202,6 @@ export function toolSucceeded(raw) {
   // that its output proved the task.  `success` here is deliberately scoped to
   // the tool call; task correctness comes only from an eval grader.
   return true;
-}
-
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * The same family `toolSucceeded` reads above, hoisted so the three readers
- * cannot drift apart. Clients disagree on the envelope name and on nothing
- * else, so this is the one place that disagreement is spelled out.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
 }
 
 /** A non-empty string, or null.  Blank output is the same as none. */

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -58,6 +58,7 @@ import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { briefing } from './remedy.mjs';
 import { stableText, transcriptFor } from './cache.mjs';
+import { scoreRefreshes } from './keepwarm.mjs';
 import { cachedRoutingBriefing } from './routing.mjs';
 import {
   forCommand,
@@ -1010,6 +1011,26 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE KEEP-WARM FEEDBACK ARM, at the boundary where a turn has just
+      // ended -- which is the only place the arrival question can be answered.
+      // Every refresh whose TTL has since elapsed is scored here as used or
+      // unused; anything the log cannot settle is left unscored rather than
+      // recorded as a miss, because an absent signal is not a miss.
+      //
+      // Nothing in this repository issues a refresh today -- cache_audit only
+      // recommends one -- so this scores nothing, and what it costs while
+      // dormant is one readBalance: median 70 ms on this machine's 3.5 MB log,
+      // against derive's 71-111 ms a few lines below on the same path. The
+      // firehose is read for ARRIVALS only if an unscored refresh exists, so
+      // the dormant case never pays for that. The moment an issuer exists, the
+      // decision starts learning with no second wiring change.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      scoreRefreshes(dir);
+    } catch {
+      // A refresh that cannot be scored costs a measurement, not a session.
     }
     try {
       // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -40,11 +40,13 @@ import {
   touchedFiles,
 } from './decide.mjs';
 import {
+  record,
   recordRead,
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
 } from './metrics.mjs';
+import { derive } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -948,6 +950,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // ZERO-COST DERIVATION, on every client, with no credential. The semantic
+      // harvest below needs an API key, so on a machine without one the graph
+      // accumulates structure and no verdicts at all. These detectors read only
+      // what is already on disk and send nothing anywhere.
+      //
+      // The COUNT is recorded rather than the candidates: how many findings a
+      // session's own evidence supports is the number that says whether this is
+      // working, and it is measurable before anything is stored. Storage is the
+      // caller's next step, under a budget.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      const dir = wikiDir(projectRoot);
+      const derived = derive(dir, {
+        sessionId,
+        projectRoot,
+        transcriptPath: agentScope,
+        // The hook payload's own identity, not a value a model typed.
+        authoritativeSessionId: sessionId,
+      });
+      record(dir, {
+        kind: 'derive',
+        sessionId,
+        candidates: derived.candidates.length,
+        observations: derived.observations.length,
+      });
+    } catch {
+      // A detector failing must never cost a user the end of their session.
     }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -72,7 +72,8 @@ import {
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
-import { isArchived } from './transcript.mjs';
+import { archive, isArchived } from './transcript.mjs';
+import { harvestMode } from './harvest.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
@@ -577,6 +578,65 @@ function emit(object) {
   process.stdout.write(serialized);
 }
 
+/**
+ * What will and will not extract findings after this session, in one sentence.
+ *
+ * THE STATE WAS ONLY EVER LEGIBLE FROM THE DOCTOR, and the doctor is a place
+ * someone visits after they already suspect something is wrong. A user watching
+ * a graph fill with structural nodes and no verdicts has no reason to suspect
+ * anything, which is the failure this project has now measured twice.
+ *
+ * IT IS ADDRESSED TO THE MODEL, NOT ONLY TO THE READER, which is why it earns a
+ * place in the prefix rather than a systemMessage. "Nothing else will write this
+ * down in words" changes what the model does with a conclusion it is holding;
+ * "here is a configuration variable" would not.
+ *
+ * CACHE-SAFE: derived from configuration, so it differs between sessions only
+ * when the configuration does -- the same standard the rest of this block is
+ * held to, and it carries no digits for `stableText` to reject.
+ *
+ * A local endpoint is named FIRST in the off case on purpose. It is the option
+ * that costs nothing and sends nothing, and it was the one buried deepest.
+ */
+function extractionNotice() {
+  switch (harvestMode()) {
+    case 'local':
+      return (
+        '\n\nA local model endpoint is configured, so semantic extraction also runs after this ' +
+        'session -- free and private, with nothing leaving this machine.'
+      );
+    case 'remote':
+      return (
+        '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
+        'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
+    case 'off:mode':
+      // The whole optimizer is off and this text is not emitted anyway. Saying
+      // anything here would be noise stacked on an explicit choice.
+      return '';
+    case 'off:opted-out':
+      // A DELIBERATE CHOICE, SO NO PITCH. The consequence is stated because the
+      // model needs it; the setting that would reverse it is not, because
+      // arguing with a configured decision on every session is how a notice
+      // stops being read. doctor.mjs draws the same line for the same reason.
+      return (
+        '\n\nFallback extraction is off by configuration, so a conclusion you do not record is ' +
+        'not written down in words anywhere. Findings are still derived locally from exit codes, ' +
+        'red-to-green transitions and corrections.'
+      );
+    default:
+      // off:no-key, and any mode a future harvest adds: no extractor is running
+      // and nobody chose that, so the free option is worth naming.
+      return (
+        '\n\nNo separate extractor will run after this session, so a conclusion you do not record ' +
+        'is not written down in words anywhere. Findings are still derived locally from exit ' +
+        'codes, red-to-green transitions and corrections. Pointing ' +
+        'TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model adds semantic extraction, free and ' +
+        'private.'
+      );
+  }
+}
+
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
 export function policyText(
   canDeny,
@@ -635,7 +695,7 @@ export function policyText(
     .filter(Boolean)
     .join(' ');
   const recording = tools.has('wiki_write')
-    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.`
+    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.${extractionNotice()}`
     : '\n\nStructural graph capture remains active through lifecycle hooks. Durable semantic MCP writes are not requested because the writer schema is not proven available.';
 
   return `# Token optimization is active\n\nLive graph capture is active through the lifecycle adapter.\n\n${connection}${routing}${enforcement}${utilities ? `\n\n${utilities}` : ''}${recording}${projectBriefing()}`;
@@ -950,6 +1010,27 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.
+      //
+      // This was lost rather than retired. `plugin/hooks/stop-harvest.mjs` called
+      // `archive()` at Stop, and #300 replaced that entry in `hooks.json` with the
+      // generated `stop.mjs`, which routes here -- so on Claude Code no session has
+      // been archived since. Nothing failed loudly: `readArchive` simply returns an
+      // empty list, so `derive`'s correction detector fell through to the live
+      // transcript (present only for a client that reports one) and `lessons.mjs`
+      // lost the only corpus it can verify a verbatim quote against, which is the
+      // single test that grants a feedback finding human origin.
+      //
+      // BEFORE `derive`, deliberately: the correction detector reads the archive
+      // first and treats the live transcript as the fallback, and the archive is
+      // the copy that survives into later sessions.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      if (agentScope) archive(dir, agentScope, { sessionId });
+    } catch {
+      // The archive is a record, not a result. A session still ends.
     }
     try {
       // ZERO-COST DERIVATION, on every client, with no credential. The semantic

--- a/integrations/cursor/hooks/lib/audit.mjs
+++ b/integrations/cursor/hooks/lib/audit.mjs
@@ -32,6 +32,7 @@
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
+import { looNote } from './loo.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -401,6 +402,16 @@ export function renderAudit(
   // project with no injections and no queries gains no line at all.
   const reference = referenceNote(dir);
   if (reference) body.push('', reference);
+
+  // WHAT ONE FINDING IS CAUSALLY WORTH (Layer 2).
+  //
+  // The same reasoning as above, and the same refusal: `looNote` returns null
+  // until the leave-one-out experiment has collected an observation, and says
+  // NOT MEASURABLE YET rather than printing a mean until it clears the floor.
+  // A causal number is the most quotable thing this project can produce, so it
+  // is the one that most needs to be absent when it is not earned.
+  const causal = looNote(dir);
+  if (causal) body.push('', causal);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/cursor/hooks/lib/audit.mjs
+++ b/integrations/cursor/hooks/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
 import { looNote } from './loo.mjs';
+import { calibrationNote } from './crosslayer.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -244,9 +245,15 @@ export function renderAudit(
     lines.push(text);
   }
 
+  // SCOPED TO THE QUEUE, because that is all it ever described. The bare
+  // sentence "Nothing addressable found." was printed directly above a Layer 1
+  // reference note and a published Layer 2 causal verdict -- so a reader was
+  // told nothing had been found immediately before being shown a finding. The
+  // headline is about the remediation queue and nothing else, and saying so
+  // costs four words and removes a false negative shown to a human.
   const head = shown.length
     ? ['What to do next, most expensive first:', ...lines]
-    : ['Nothing addressable found.'];
+    : ['Nothing addressable found in the remediation queue.'];
 
   const body = [...head];
 
@@ -412,6 +419,16 @@ export function renderAudit(
   // is the one that most needs to be absent when it is not earned.
   const causal = looNote(dir);
   if (causal) body.push('', causal);
+
+  // WHETHER LAYER 1'S CHEAP LABEL PREDICTS LAYER 2'S EXPENSIVE EFFECT.
+  //
+  // The reason this is printed rather than kept for a dashboard: the reference
+  // rate is the number a reader is most likely to quote as a saving, and it is
+  // not one until this comparison says so. `calibrationNote` returns null while
+  // both layers are silent, and otherwise prints the refusal -- naming which
+  // input was insufficient -- rather than a gap of zero.
+  const calibrated = calibrationNote(dir);
+  if (calibrated) body.push('', calibrated);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/cursor/hooks/lib/audit.mjs
+++ b/integrations/cursor/hooks/lib/audit.mjs
@@ -61,6 +61,28 @@ export function declines(dir, { events = readMetrics(dir) } = {}) {
   return counts;
 }
 
+/**
+ * What the local Stop-time derivation path produced in the visible event log.
+ *
+ * The producer records all three counts because any one of them alone is
+ * ambiguous: zero stored can mean no evidence, no candidates, or a binding
+ * storage/anchor filter. This reader keeps those states distinct and prevents
+ * the telemetry itself from becoming an unobserved cost.
+ */
+export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
+  const runs = events.filter((event) => event.kind === 'derive');
+  if (!runs.length) return null;
+
+  const sum = (field) =>
+    runs.reduce((total, event) => total + Math.max(0, Number(event[field]) || 0), 0);
+  const candidates = sum('candidates');
+  const observations = sum('observations');
+  const written = sum('written');
+  return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
+    `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
+    `across ${runs.length.toLocaleString()} Stop run(s).`;
+}
+
 const idOf = (finding) =>
   finding.remedy
     ? `${finding.remedy.type}:${finding.remedy.anchor || finding.remedy.file || (finding.remedy.anchors || []).join(',')}`
@@ -399,6 +421,15 @@ export function renderAudit(
       );
     }
   }
+
+  // WHAT THE DEFAULT, LOCAL DERIVATION PATH ACTUALLY PRODUCED.
+  //
+  // This event used to have a producer and no reader. Keep its three states
+  // together: evidence seen, candidates derived, and findings that survived
+  // selection/storage. A lone stored count would turn every earlier refusal
+  // into an apparent "nothing found" result.
+  const derived = derivationNote(dir);
+  if (derived) body.push('', derived);
 
   // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
   //

--- a/integrations/cursor/hooks/lib/audit.mjs
+++ b/integrations/cursor/hooks/lib/audit.mjs
@@ -31,6 +31,7 @@
  */
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
+import { referenceNote } from './usage.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -390,6 +391,16 @@ export function renderAudit(
       );
     }
   }
+
+  // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
+  //
+  // Printed here because this is the report that already asks "did the advice
+  // change anything", and because a measurement with no reader is how this
+  // project shipped two metrics whose only consumer was their own test suite.
+  // `referenceNote` returns null when it has nothing honest to say, so a
+  // project with no injections and no queries gains no line at all.
+  const reference = referenceNote(dir);
+  if (reference) body.push('', reference);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/cursor/hooks/lib/consolidate.mjs
+++ b/integrations/cursor/hooks/lib/consolidate.mjs
@@ -142,7 +142,8 @@ const ALWAYS_KEEP = new Set(['failure', 'decision']);
  * Chooses what to promote into the graph, under a token budget.
  *
  * @param {object} graph      Loaded wiki graph, for reuse probability.
- * @param {Array}  candidates Extracted conclusions, each { type, summary, anchors, evidence, at }.
+ * @param {Array}  candidates Extracted conclusions, each { type, claim (or summary),
+ *                              anchors, evidence, at }.
  * @param {object} options    budget: tokens available for promoted findings.
  */
 export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}) {
@@ -221,4 +222,3 @@ export function aggregateConsolidation(findings) {
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
-

--- a/integrations/cursor/hooks/lib/crosslayer.mjs
+++ b/integrations/cursor/hooks/lib/crosslayer.mjs
@@ -1,0 +1,351 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/crosslayer.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The calibration loop: does Layer 1's LABEL predict Layer 2's EFFECT?
+ *
+ * Layer 1 (`usage.mjs`) classifies an injected finding by whether the model
+ * later NAMED it. Layer 2 (`loo.mjs`) measures, by leave-one-out, how many
+ * tokens of reading a finding actually SUPPRESSED. Those are two different
+ * quantities, and the whole point of putting them side by side is that the
+ * cheap one (a label, available on every injection) might stand in for the
+ * expensive one (a causal effect, costing three withheld sessions per finding).
+ *
+ * WHY THIS IS A REAL QUESTION AND NOT A TAUTOLOGY. Task 7 established the
+ * independence three ways -- statically (`loo.mjs` contains no `query` or
+ * `reference`; `usage.mjs` contains no `tokens`, `cost` or `bytes`),
+ * behaviourally in both directions, and by naming the one overlap that does
+ * exist (`recordToolOutcome`'s join, which supplies ATTRIBUTABILITY to both and
+ * the measured quantity to neither). This module is built to preserve that:
+ *
+ *   - from Layer 1 it takes ONLY the categorical label per finding key. No
+ *     rate, no count, no magnitude -- Layer 1 has no magnitude to give.
+ *   - from Layer 2 it takes ONLY the effect magnitude per finding key.
+ *   - the join is the finding key, which is a graph identity and not a
+ *     measurement.
+ *
+ * If a magnitude common to both ever entered, this would correlate a quantity
+ * with itself and report a strong result that means nothing. Two tests pin the
+ * separation from opposite sides: flipping the labels while holding the effects
+ * fixed must move the gap, and changing Layer 1's rate WITHOUT changing any
+ * label must leave the gap byte-identical.
+ *
+ * MEASURED UTILITY RANKS A FINDING. IT MUST NEVER RAISE ITS CONFIDENCE.
+ * A confidently WRONG finding suppresses reads better than a hedged true one,
+ * so utility alone optimises directly against "wrong findings are worse than
+ * none". The plan called for a `mayPromote` gate over
+ * `hasOutstandingContradiction` here. There is nothing to gate: every write of
+ * `confidence` in `hooks-core` happens at CREATION (a per-producer constant in
+ * `derive.mjs` / `lessons.mjs` / `harvest.mjs`, or a human's own number in
+ * `curate.mjs`), and no code path updates a stored finding's confidence
+ * afterwards. `assessFindings` in `utility.mjs` READS confidence into an
+ * ephemeral `netUtility` used for ordering and writes nothing back. So a gate
+ * here would be unreachable, and an unreachable gate is the exact defect class
+ * this work exists to close. `hasOutstandingContradiction` already has its
+ * real consumer -- `staleness.mjs` calls it as the dispute gate on serve.
+ * What is enforceable is the invariant itself, and it is: this module never
+ * writes to the graph, and `tests/hooks/calibration-loop.test.mjs` asserts that
+ * neither it nor either layer under it can move a stored confidence.
+ *
+ * NOTHING HERE IS PRICED. A calibration verdict, a holdout estimate and a
+ * consolidation ratio are all estimates; currency belongs only on a measured
+ * counterfactual, and `balanceSheet`'s `measuredCounterfactual` is the one
+ * section in the sheet below that qualifies.
+ */
+
+import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
+import { classify, referenceRate } from './usage.mjs';
+import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Distinct findings needed in EACH arm before a gap is reported at all.
+ *
+ * Two findings per arm is a difference of two numbers; the comparison would be
+ * dominated by whichever finding happened to sit on a big file. Three is still
+ * small, and the refusal says so rather than implying the gap is solid.
+ */
+export const MIN_FINDINGS_PER_ARM = 3;
+
+/**
+ * The smallest gap that may be PUBLISHED, in tokens per touch.
+ *
+ * Not an effect-size convention: it is tied to the unit the verdict prints. The
+ * published sentence rounds the gap to whole tokens, so a gap of 1e-13 -- which
+ * is what two arms of equal means produce once floating point has had its say --
+ * would publish as "referenced findings suppress 0 more tokens/touch". That is a
+ * calibration claim resting on arithmetic noise, and it leans the only direction
+ * a measurement of this project by this project must never lean.
+ */
+export const MIN_GAP_TOKENS = 1;
+
+/**
+ * The per-finding Layer 1 label, folded from per-injection rows.
+ *
+ * ANY reference wins. `classify` emits one row per (injection, finding) because
+ * one reference must not excuse every later injection -- that is the right unit
+ * for a RATE. For a label the question is different: did the model ever name
+ * this finding? A finding referenced once and ignored nine times is a finding
+ * the model reads, and averaging it into `not-referenced` would put it in the
+ * arm whose mean effect it is meant to predict.
+ *
+ * `unknown` rows are dropped rather than defaulted, exactly as Layer 1 drops
+ * them from its own denominator.
+ */
+export function labelsByFinding(rows) {
+  const labels = new Map();
+  for (const row of rows || []) {
+    const key = row?.findingKey;
+    if (typeof key !== 'string' || !key) continue;
+    if (row.label === 'referenced') labels.set(key, 'referenced');
+    else if (row.label === 'not-referenced' && !labels.has(key))
+      labels.set(key, 'not-referenced');
+  }
+  return labels;
+}
+
+const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * Does Layer 1's label predict Layer 2's effect?
+ *
+ * Returns `publishable`, a `verdict` in English, and `gap` ONLY when a gap was
+ * actually computed. There is no `gap: 0` for the unmeasured case, and that is
+ * deliberate: a permanent zero reads as "measured, and the two agree", which is
+ * the opposite of "nothing was measured". Task 7 deleted a field rather than
+ * zero it for the same reason.
+ *
+ * FAILS OPEN. This runs on report paths that must not break a tool call.
+ */
+export function calibration(dir, options = {}) {
+  const refuse = (verdict, extra = {}) => ({
+    publishable: false,
+    verdict,
+    ...extra,
+  });
+
+  try {
+    // ONE READ for both layers, so the two arms of the comparison cannot cover
+    // different spans of the log. `referenceRate` reports `windowed: false`
+    // when the caller supplies events -- correctly, since the bounds are then
+    // the caller's -- so the truncation flag is taken here, from the read that
+    // actually set it, and republished.
+    const supplied = options.events || null;
+    const events = supplied || readMetrics(dir);
+    const truncation = supplied ? null : readTruncation();
+    const truncated = Boolean(
+      truncation && (truncation.byBytes || truncation.byEvents)
+    );
+
+    const layer1 = referenceRate(dir, { events });
+    const labels = labelsByFinding(classify(dir, { events }));
+
+    const obs = observations(dir, { ...options, events });
+    const rows = effects(dir, { ...options, events, obs });
+
+    // ONE POLICY VERSION. Layer 2 refuses to pool arms across serving
+    // policies; a calibration that pooled them would undo that guard one level
+    // up. Rows from any other policy are excluded and counted.
+    const policy = servingPolicyVersion();
+    const inPolicy = rows.filter((row) => row.policy === policy);
+
+    const layer2 = {
+      rows: rows.length,
+      inPolicy: inPolicy.length,
+      published: rows.filter((row) => row.published).length,
+      observations: obs.rows.length,
+      policy,
+    };
+    const l1 = {
+      referenced: layer1.referenced,
+      notReferenced: layer1.notReferenced,
+      unknown: layer1.unknown,
+      denominator: layer1.denominator,
+      rate: layer1.rate,
+      referenceEvents: layer1.referenceEvents,
+    };
+
+    const excluded = { layer1Unknown: layer1.unknown, unlabelled: 0, noEffect: 0 };
+    const arms = { referenced: [], notReferenced: [] };
+    for (const row of inPolicy) {
+      // THE SHRUNK ESTIMATE, not the raw one. Shrinkage pulls every finding
+      // toward the population mean, so it pulls the GAP toward zero -- the
+      // bias runs against publishing, which is the only direction a
+      // measurement of this project by this project may lean.
+      if (row.shrunk === null || !Number.isFinite(row.shrunk)) {
+        excluded.noEffect += 1;
+        continue;
+      }
+      const label = labels.get(row.findingKey);
+      if (label === 'referenced') arms.referenced.push(row.shrunk);
+      else if (label === 'not-referenced') arms.notReferenced.push(row.shrunk);
+      else excluded.unlabelled += 1;
+    }
+
+    const context = { layer1: l1, layer2, arms: { referenced: arms.referenced.length, notReferenced: arms.notReferenced.length }, excluded, windowed: truncated };
+    const caveat = truncated
+      ? ' The event log was truncated, so both sides can understate.'
+      : '';
+
+    // WHICH INPUT WAS INSUFFICIENT, named. "Not enough data" tells a reader
+    // nothing about which half of the loop to go and fix.
+    const l1Silent = layer1.rate === null;
+    const l2Silent = layer2.observations === 0;
+    if (l1Silent || l2Silent) {
+      const why = [];
+      if (l1Silent)
+        why.push(
+          `Layer 1 has ${layer1.denominator} classifiable observation(s) and ` +
+            `${layer1.referenceEvents} reference event(s), so it publishes no rate`
+        );
+      if (l2Silent)
+        why.push(
+          `Layer 2 has ${layer2.observations} observation(s), so it publishes no effect`
+        );
+      return refuse(
+        `not calibrated: ${why.join('; and ')}. No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+    }
+
+    // A POLICY CHANGE RESETS THE CALIBRATION, and says so rather than reporting
+    // an empty arm. Layer 2 refuses to pool arms across serving policies, so
+    // rows generated under an older one cannot answer a question about how the
+    // graph serves findings today -- but "0 findings per arm" would send a
+    // reader hunting for missing observations that are right there in the log.
+    if (rows.length > 0 && inPolicy.length === 0)
+      return refuse(
+        `not calibrated: all ${rows.length} Layer 2 effect row(s) were measured under a different serving ` +
+          `policy than the current ${policy}, and arms are never pooled across policies. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (layer2.published === 0)
+      return refuse(
+        `not calibrated: Layer 2 has ${layer2.observations} observation(s) but no published effect at q=0.1, ` +
+          'so its per-finding numbers are noise and a difference between two means of them would be too. ' +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (
+      arms.referenced.length < MIN_FINDINGS_PER_ARM ||
+      arms.notReferenced.length < MIN_FINDINGS_PER_ARM
+    )
+      return refuse(
+        `not calibrated: ${arms.referenced.length} referenced and ${arms.notReferenced.length} not-referenced ` +
+          `finding(s) carry a Layer 2 effect, below the floor of ${MIN_FINDINGS_PER_ARM} per arm. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    const referencedMean = mean(arms.referenced);
+    const notReferencedMean = mean(arms.notReferenced);
+    const gap = referencedMean - notReferencedMean;
+    const measured = { ...context, gap, referencedMean, notReferencedMean };
+
+    if (!(gap >= MIN_GAP_TOKENS))
+      return refuse(
+        `uncalibrated: Layer 1's "referenced" label does not predict a larger Layer 2 effect ` +
+          `(referenced ${Math.round(referencedMean).toLocaleString()} vs not-referenced ` +
+          `${Math.round(notReferencedMean).toLocaleString()} tokens/touch, gap ${Math.round(gap).toLocaleString()}). ` +
+          `Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
+    return {
+      publishable: true,
+      verdict:
+        `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
+      ...measured,
+    };
+  } catch {
+    return refuse(
+      'not calibrated: the calibration inputs could not be read. No gap is reported, which is not the same as a gap of zero.'
+    );
+  }
+}
+
+/**
+ * What the graph cost to build against what it carries -- AN ESTIMATE, and
+ * never priced.
+ *
+ * `consolidationRatio` is the per-finding form and the aggregate is the fold.
+ * Both need `derivedCost`, which `expand.promote` persists onto the finding
+ * node it creates (`src/server/disclosure.ts` is its caller) and which
+ * `harvest-write.mjs` does not yet carry through -- so a graph built only by
+ * the harvest reports nothing here rather than a ratio of one.
+ */
+export function consolidation(dir, { graph = null } = {}) {
+  try {
+    const g = graph || load(dir);
+    const findings = [...g.nodes.values()].filter(
+      (node) => node.kind === 'finding' && !node.retired
+    );
+    const rated = [];
+    for (const finding of findings) {
+      const ratio = consolidationRatio(finding);
+      if (ratio === null) continue;
+      rated.push({ key: finding.key, ratio, derivedCost: finding.derivedCost });
+    }
+    const aggregate = aggregateConsolidation(findings);
+    return {
+      what: 'cost to derive against cost to carry',
+      // SAID IN THE DATA, not only in the prose above it, because this is the
+      // field a dashboard will read and a dashboard will not read a comment.
+      basis: 'estimate',
+      priced: false,
+      findings: findings.length,
+      withDerivedCost: rated.length,
+      aggregate,
+      best: rated.sort((a, b) => b.ratio - a.ratio).slice(0, 5),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The balance sheet with the graph's own three measurements attached.
+ *
+ * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
+ * imports, so it cannot import them back. This is where the two meet, and it
+ * is the shape `get_optimization_report` serves.
+ */
+export function graphBalanceSheet(dir, options = {}) {
+  const sheet = balanceSheet(dir);
+  const cal = calibration(dir, options);
+  const { layer1 = null, layer2 = null } = cal;
+  return {
+    ...sheet,
+    layer1,
+    layer2,
+    calibration: cal,
+    consolidation: consolidation(dir, options),
+  };
+}
+
+/**
+ * One audit line, or null when there is nothing honest to say.
+ *
+ * Silent when NEITHER layer has produced anything: a reader of a graph that has
+ * never injected a finding is owed no paragraph about a loop that has not
+ * started. The moment either side speaks, the refusal is worth printing --
+ * because at that point a reader could otherwise take Layer 1's rate for a
+ * saving, which is precisely what this loop exists to stop.
+ */
+export function calibrationNote(dir, options = {}) {
+  try {
+    const result = calibration(dir, options);
+    const l1 = result.layer1;
+    const l2 = result.layer2;
+    if (!l1 || !l2) return null;
+    if (l1.denominator === 0 && l2.observations === 0) return null;
+    return `Layer 1 against Layer 2: ${result.verdict}`;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/cursor/hooks/lib/crosslayer.mjs
+++ b/integrations/cursor/hooks/lib/crosslayer.mjs
@@ -54,7 +54,13 @@
 
 import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
-import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import {
+  effects,
+  observations,
+  servingPolicyVersion,
+  permutationP,
+  FDR_Q,
+} from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
 import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
@@ -106,6 +112,32 @@ export function labelsByFinding(rows) {
 }
 
 const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * A deterministic, label-symmetric permutation test for the headline gap.
+ *
+ * Layer 2 only publishes a per-finding row after a two-sided permutation test.
+ * The calibration headline summarises those rows, so a positive difference of
+ * arm means must clear the same evidential bar rather than being promoted just
+ * because it points in this project's favour.
+ *
+ * Sorting within each arm and then sorting the two arms makes the sampled path
+ * invariant to event order and to swapping the labels. The seed is derived
+ * from that canonical data instead of shared globally, so two different
+ * datasets do not reuse one arbitrary sequence of sampled relabellings.
+ */
+export function calibrationP(referenced, notReferenced) {
+  const arms = [referenced, notReferenced]
+    .map((values) => [...values].sort((a, b) => a - b))
+    .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  const encoded = JSON.stringify(arms);
+  let seed = 2166136261;
+  for (const char of encoded) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return permutationP(arms[0], arms[1], { seed: seed >>> 0 });
+}
 
 /**
  * Does Layer 1's label predict Layer 2's effect?
@@ -244,7 +276,16 @@ export function calibration(dir, options = {}) {
     const referencedMean = mean(arms.referenced);
     const notReferencedMean = mean(arms.notReferenced);
     const gap = referencedMean - notReferencedMean;
-    const measured = { ...context, gap, referencedMean, notReferencedMean };
+    const p = calibrationP(arms.referenced, arms.notReferenced);
+    const measured = {
+      ...context,
+      gap,
+      referencedMean,
+      notReferencedMean,
+      p,
+      alpha: FDR_Q,
+      test: 'two-sided permutation',
+    };
 
     if (!(gap >= MIN_GAP_TOKENS))
       return refuse(
@@ -255,11 +296,20 @@ export function calibration(dir, options = {}) {
         measured
       );
 
+    if (p === null || p > FDR_Q)
+      return refuse(
+        `not calibrated: the positive Layer 1/Layer 2 gap is not statistically resolved by the ` +
+          `two-sided permutation test (p=${p === null ? 'unavailable' : p.toFixed(3)}, ` +
+          `alpha=${FDR_Q.toFixed(3)}). Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
     return {
       publishable: true,
       verdict:
         `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
-        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, ` +
+        `shrunk estimates, two-sided permutation p=${p.toFixed(3)}). ` +
         `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
       ...measured,
     };

--- a/integrations/cursor/hooks/lib/crosslayer.mjs
+++ b/integrations/cursor/hooks/lib/crosslayer.mjs
@@ -56,6 +56,7 @@ import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
 import { effects, observations, servingPolicyVersion } from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
 
 /**
@@ -309,11 +310,19 @@ export function consolidation(dir, { graph = null } = {}) {
 }
 
 /**
- * The balance sheet with the graph's own three measurements attached.
+ * The balance sheet with the graph's own measurements attached.
  *
  * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
  * imports, so it cannot import them back. This is where the two meet, and it
  * is the shape `get_optimization_report` serves.
+ *
+ * `recall` joins them as an OFFLINE PROBE, and that label travels in the data
+ * (`recall.basis`) as well as in the rendered line. It is not an observation of
+ * anything a session did: it deletes an anchor edge in memory and re-runs the
+ * real retrieval primitives over the graph as it stands right now. `recall.mjs`
+ * imports only `wiki.mjs` and `lexical.mjs`, neither of which imports anything
+ * in this direction, so no cycle -- the same reason `calibration` had to live
+ * here rather than in `metrics.mjs`.
  */
 export function graphBalanceSheet(dir, options = {}) {
   const sheet = balanceSheet(dir);
@@ -325,6 +334,7 @@ export function graphBalanceSheet(dir, options = {}) {
     layer2,
     calibration: cal,
     consolidation: consolidation(dir, options),
+    recall: recallProbe(dir, options),
   };
 }
 

--- a/integrations/cursor/hooks/lib/derive.mjs
+++ b/integrations/cursor/hooks/lib/derive.mjs
@@ -23,13 +23,21 @@
  * the observation supports no claim at all are refused rather than downgraded
  * (see `attemptKey` and the identical-text guard below).
  *
- * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
- * budget, belongs to the caller.
+ * WHAT IS STORED IS BOUNDED. Candidates go through `selectForConsolidation`
+ * before `writeHarvested`, so a long session cannot spend the whole retrieval
+ * budget of every later session on one afternoon's exit codes. Nothing enters
+ * the graph unbudgeted, and nothing enters it wearing a human origin.
  */
 
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
 import { readArchive, readTurns } from './transcript.mjs';
 import { redact } from './redact.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { load } from './wiki.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -106,6 +114,92 @@ const triggerFor = (command) =>
   attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
 
 /**
+ * Literal root-level files that define how a project is BUILT, RUN and TESTED,
+ * best first. A `command` claim is a claim about this project's commands, and
+ * this is the file those commands are declared in.
+ */
+const PROJECT_MARKERS = [
+  'package.json', 'pyproject.toml', 'Cargo.toml', 'go.mod', 'pom.xml',
+  'build.gradle.kts', 'build.gradle', 'build.sbt', 'mix.exs', 'composer.json',
+  'Gemfile', 'Package.swift', 'CMakeLists.txt', 'Makefile', 'Taskfile.yml',
+  'requirements.txt', 'setup.py', 'deno.json', 'bun.lockb',
+];
+
+/** .NET has no single literal marker; the solution or project file is one. */
+const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
+
+/**
+ * A REAL FILE to anchor a derived claim to, inside the project root.
+ *
+ * WHY NOT THE PROJECT ROOT ITSELF, which is what the extraction step reaches
+ * for and what `promoteToShared` uses in the shared tier. Because
+ * `writeHarvested` resolves every anchor through `indexFile`, `indexFile` reads
+ * the path, and reading a DIRECTORY returns null -- so a candidate anchored to
+ * `projectRoot` resolves to nothing, is refused as unanchorable, and the whole
+ * pipeline stores zero findings while reporting a healthy candidate count.
+ * Verified directly: `indexFile(dir, dir)` returns null. That refusal is
+ * correct and must not be weakened -- an anchor that cannot be indexed is an
+ * anchor that can never be invalidated -- so the anchor has to be a file.
+ *
+ * STALENESS DOES NOT MISFIRE ON THIS. `command`, `failure` and `feedback` are
+ * all outside `CONTENT_DEPENDENT` (staleness.mjs), so the anchor is a RETRIEVAL
+ * AND EXISTENCE hook rather than a contents claim: editing the manifest does
+ * not mark these findings stale. staleness.mjs names this exact case in its own
+ * comment -- "a claim about `npm test` anchored to package.json" -- and calls
+ * missing that invalidation the better error.
+ *
+ * A project with no recognisable marker gets the root back, which will not
+ * resolve, so its candidates are derived and then refused rather than stored
+ * against a fabricated anchor. That is the fail-open direction: no finding
+ * beats a finding anchored to something that is not what the claim is about.
+ */
+export function projectAnchor(projectRoot) {
+  if (!projectRoot) return null;
+  let entries;
+  try {
+    entries = readdirSync(projectRoot);
+  } catch {
+    return projectRoot;
+  }
+  const present = new Set(entries);
+  for (const marker of PROJECT_MARKERS) {
+    if (!present.has(marker)) continue;
+    const path = join(projectRoot, marker);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // A marker that cannot be stat'ed is not a marker.
+    }
+  }
+  // Sorted so two sessions in the same repository pick the SAME solution file:
+  // readdir order is not guaranteed stable across hosts, and an anchor that
+  // varies by host splits one finding into two nodes.
+  for (const entry of [...entries].sort()) {
+    if (!DOTNET_MARKER.test(entry)) continue;
+    const path = join(projectRoot, entry);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // Same.
+    }
+  }
+  return projectRoot;
+}
+
+/**
+ * Tokens of claim text one session may add to the graph.
+ *
+ * SCALED TO THE RETRIEVAL BUDGET IT COMPETES FOR, not picked round. A single
+ * command's injection budget is 500 tokens (`TOKEN_OPTIMIZER_TOUCH_BUDGET`),
+ * and everything stored here is competing for that budget on every later
+ * command, forever. Two touch-budgets per session is the bound: enough for a
+ * few dozen real claims, and short of one session's exit codes crowding out
+ * every finding a human or a model ever wrote.
+ */
+const storageBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_DERIVE_BUDGET) || 1000;
+
+/**
  * Derives finding candidates from one project's local evidence.
  *
  * @param {string} dir wiki directory.
@@ -118,11 +212,18 @@ const triggerFor = (command) =>
  *   and is refused by `writeHarvested` anyway, so emitting one would only spend
  *   the caller's budget on junk.
  * @param {string|null} options.authoritativeSessionId the session id as the HOOK
- *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
- *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
- *   edge -- `taskForAnchors` returns null without one, so an unverified string
- *   would silently produce no edge. Threaded rather than defaulted from
- *   `sessionId`: defaulting would promote any caller's string to trusted.
+ *   PAYLOAD reported it, never a value a model typed. Passed straight to
+ *   `writeHarvested`, which needs it to resolve the `answers` edge --
+ *   `taskForAnchors` returns null without one, so an unverified string would
+ *   silently produce no edge. Threaded rather than defaulted from `sessionId`:
+ *   defaulting would promote any caller's string to trusted. Also returned, so a
+ *   caller can see what it handed over.
+ * @returns {object} `{ candidates, observations, written, selected, dropped,
+ *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
+ *   everything derived; `written` is the subset of keys the graph actually
+ *   holds, which is smaller for three independent reasons -- the budget, the
+ *   anchor discipline, and the duplicate collapse that returns an EXISTING key
+ *   when a later session derives the same claim again.
  */
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
@@ -152,6 +253,11 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // ONE anchor for the whole run, so every candidate from this session points at
+  // the same node and the duplicate collapse in `writeHarvested` can recognise
+  // the same lesson across sessions.
+  const anchorPath = projectAnchor(projectRoot);
 
   const seen = new Set();
   const add = (candidate) => {
@@ -246,7 +352,7 @@ export function derive(dir, options = {}) {
               `observed in one session: \`${failed.command}\` failed` +
                 `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
                 `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
-                'an intervening edit or a flaky run explains the same pair.',
+                'an intervening edit or an unrelated environment change explains the same pair.',
               { max: EVIDENCE_MAX }
             ),
             applicability: 'when about to run this command in this project',
@@ -255,7 +361,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the failing form later succeeds unchanged'],
             trigger: triggerFor(outcome.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: outcome.at || Date.now(),
@@ -280,7 +386,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the same command later succeeds unchanged'],
             trigger: triggerFor(failed.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: failed.at || Date.now(),
@@ -330,7 +436,7 @@ export function derive(dir, options = {}) {
           confidenceLabel: labelFor(CONFIDENCE.correction),
           scope: 'project',
           invalidators: ['the user later asks for the corrected behaviour'],
-          anchors: [projectRoot],
+          anchors: [anchorPath],
           derivedBy: 'correction',
           sessionId,
           at: Date.parse(turn.at || '') || Date.now(),
@@ -379,6 +485,48 @@ export function derive(dir, options = {}) {
     }
   } catch {
     // One detector, never the session.
+  }
+
+  // ---- storage, under a budget -------------------------------------------
+  //
+  // NOTHING ENTERS THE GRAPH UNBUDGETED. `selectForConsolidation` existed for
+  // exactly this and had no caller, which meant that until now nothing bounded
+  // what a session could add. It admits `failure` and `decision` on a FLOOR
+  // before ranking -- a dead end exists nowhere else and is small, and cheap to
+  // find is not cheap to find again -- then fills the remainder by
+  // cost x irrecoverability x reuse-probability.
+  //
+  // ORIGIN_HARVESTED, EXPLICITLY, never ORIGIN_HUMAN. These are machine
+  // derivations; `curate.mjs` states the reason in its own header -- "a
+  // hand-written assertion and a machine guess look identical three months
+  // later, which quietly destroys the reader's ability to calibrate trust".
+  // `writeHarvested` would refuse a batch-wide human origin anyway, and a
+  // candidate here carries neither `origin` nor `quote`, so it cannot earn one
+  // per finding either. That is deliberate: whether a turn was a correction at
+  // all is a lexical guess, and the standing-rules layer selects on human
+  // origin to inject on EVERY turn.
+  try {
+    if (result.candidates.length) {
+      const selected = selectForConsolidation(load(dir), result.candidates, {
+        budget: storageBudget(),
+      });
+      result.selected = selected.kept.length;
+      result.dropped = selected.dropped;
+      result.selectedTokens = selected.tokens;
+      result.written = writeHarvested(dir, selected.kept, {
+        sessionId,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        // The hook payload's own identity, passed through untouched. Without it
+        // `taskForAnchors` returns null and the `answers` edge never fires --
+        // which is the state a default install has been in, because its only
+        // other producer is credential-gated.
+        authoritativeSessionId,
+      });
+    }
+  } catch {
+    // Storage is the last step and the session is already over. A graph write
+    // that fails must not turn a completed session into a hook error.
   }
 
   return result;

--- a/integrations/cursor/hooks/lib/derive.mjs
+++ b/integrations/cursor/hooks/lib/derive.mjs
@@ -139,17 +139,19 @@ const quotable = (command) => {
  * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
  * found across 163 transcripts on this machine it refuses 2 and keeps 6.
  *
- * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
- * building the key, so the claim is about `npm test` rather than about the `cd`.
- * That changes `attemptKey` for every client and every finding already derived
- * from it, so it belongs in its own change with its own comparison.
+ * `commandBody` below now skips a leading `cd <path> &&`, so those two are
+ * recovered and this guard is left holding only the keys that reached a
+ * separator which is NOT a directory change -- `git fetch && <anything>`, a
+ * pipeline, a `;`-joined pair. Those still name no single attempt.
  */
 const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
 
 /**
  * Did `attemptKey` actually capture a command, or only how one was chained?
  *
- * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart --
+ * which now means AFTER `commandBody` has removed any leading `cd`, so this no
+ * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
 const hasAttemptIdentity = (command) =>
@@ -177,6 +179,81 @@ const CORRECTION_OPENER =
   /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
 
 /**
+ * A leading directory change, stripped before the key is built.
+ *
+ * THE MEASURED CASE, AND ONLY THE MEASURED CASE. `attemptKey` spends up to
+ * three non-flag tokens on identity and the habit on this machine is
+ * `cd <absolute path> && <the real command>`, which spends all three on `cd`,
+ * the path and the separator. This repository's own corpus: 1,400 of 2,243
+ * command outcomes open with a `cd`, and the single key
+ * `cd c:/users/.../token-optimizer-mcp &&` covered 547 distinct command lines.
+ * A `cd` says WHERE a command ran; it says nothing about WHAT ran, so it cannot
+ * be part of the identity of an attempt.
+ *
+ * THE SEPARATOR SET IS THE ONE THAT WAS OBSERVED: `&&` (1,147), a newline (204)
+ * and `;` (38) after a leading `cd`. All three mean "then run this". `||` is
+ * DELIBERATELY EXCLUDED even though it costs one line to add: `cd x || echo
+ * failed` puts an error branch after the separator, not the next step, so
+ * stripping there would key the attempt on a failure handler. It occurred zero
+ * times.
+ *
+ * AND NOTHING WIDER, each refusal for a reason from the same corpus:
+ *
+ *   Environment assignments (`FOO=bar cmd`) DO carry information about what
+ *   ran. The one true instance here is
+ *   `TOKEN_OPTIMIZER_HOLDOUT=1 node ... jest.js ...`, and the holdout arm is a
+ *   genuinely different attempt from the same command without it. The other 20
+ *   are shell variable assignments joined by `;` -- statements, not prefixes --
+ *   whose value is usually a 120-character path that would be stripped down to
+ *   nothing useful.
+ *
+ *   `time`, `env`, `nice`, `sudo`, `bash -c`, `pushd`, `Set-Location`: ZERO
+ *   occurrences in 2,243 commands. Code for an unmeasured prefix is a way to
+ *   over-strip that no evidence asked for, and over-stripping merges commands
+ *   that genuinely differ -- the same bug in the other direction. `bash -c` is
+ *   worse than unmeasured: the command sits inside a quoted string, so stripping
+ *   the wrapper leaves a key beginning with a quote character.
+ *
+ *   `cd /d C:\path &&` and `cd "C:/a b" &&` need no extra rule -- the match runs
+ *   to the separator rather than counting tokens, so flags and quoted paths
+ *   containing spaces are consumed for free. Neither appears here, so neither is
+ *   claimed as tested behaviour beyond its unit test.
+ *
+ * A `cd` with NO separator is left alone: `cd <path>` on its own ran no command,
+ * and its key is as meaningless afterwards as before -- there is nothing to
+ * recover. Stripping is repeated up to `MAX_DIR_PREFIXES` times so
+ * `cd a && cd b && cmd` reaches `cmd`; the bound exists only so a pathological
+ * line cannot loop, since each pass must consume a whole `cd ... <sep>`.
+ *
+ * APPLIED IDENTICALLY TO BOTH SOURCES because it is applied INSIDE `attemptKey`,
+ * which is the single function both the event path and the transcript reader's
+ * output pass through. The 120-character anchor cap that makes the two agree on
+ * 266 of 266 keys is untouched and still applied on both sides before this runs.
+ */
+const DIR_PREFIX = /^\s*cd\s[^\r\n;&|]*?(?:&&|;|\r?\n)\s*/i;
+const MAX_DIR_PREFIXES = 4;
+
+/**
+ * The command text with any leading directory change removed.
+ *
+ * Used for the key AND for the identical-text refusal, which is the half that
+ * keeps this from becoming a licence to pair more loosely: without it,
+ * `cd repo && npm test` failing and `npm test` succeeding would emit
+ * "`npm test` succeeded where `cd repo && npm test` failed" at 0.90 -- two
+ * spellings of one attempt, dressed up as a difference that mattered. The
+ * claim itself still quotes the RAW command, because that is what ran.
+ */
+export function commandBody(command) {
+  let text = String(command || '');
+  for (let i = 0; i < MAX_DIR_PREFIXES; i++) {
+    const stripped = text.replace(DIR_PREFIX, '');
+    if (stripped === text) break;
+    text = stripped;
+  }
+  return text;
+}
+
+/**
  * The prefix that makes two invocations "the same attempt".
  *
  * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
@@ -194,7 +271,7 @@ const CORRECTION_OPENER =
  * ships a false claim into model context.
  */
 export function attemptKey(command) {
-  return String(command || '')
+  return commandBody(command)
     .trim()
     .split(/\s+/)
     .filter((token) => token && !token.startsWith('-'))
@@ -494,7 +571,14 @@ export function derive(dir, options = {}) {
           // is real and supports NEITHER claim, so nothing is emitted. This is
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
-          if (failed.command === outcome.command) continue;
+          // COMPARED WITH THE DIRECTORY CHANGE REMOVED, for the same reason
+          // the key is. `cd repo && npm test` and `npm test` are one attempt
+          // spelled two ways; before `commandBody` they landed in different
+          // groups and never met, and letting them meet without widening this
+          // guard would emit "`npm test` succeeded where `cd repo && npm test`
+          // failed" at 0.90 -- a difference in the claim that is not a
+          // difference in what ran. Same for two `cd`s to different paths.
+          if (commandBody(failed.command) === commandBody(outcome.command)) continue;
 
           // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
           // client both sides of almost every pair are truncated multi-line
@@ -502,10 +586,12 @@ export function derive(dir, options = {}) {
           // spending the retrieval budget of every later session.
           if (!quotable(failed.command) || !quotable(outcome.command)) continue;
 
-          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
-          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
-          // command lines in this repository alone, and any pair drawn from that
-          // group is a false claim about both halves.
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`. The
+          // `cd <path> &&` case that grouped 547 unrelated command lines in this
+          // repository is now handled earlier by `commandBody`; what is left
+          // here is every OTHER separator -- `git fetch && <anything>`, a
+          // pipeline, a `;`-joined pair -- where the key still names no single
+          // attempt and any pair drawn from it is false about both halves.
           if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =

--- a/integrations/cursor/hooks/lib/derive.mjs
+++ b/integrations/cursor/hooks/lib/derive.mjs
@@ -1,0 +1,385 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/derive.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Findings from data we already hold, with no model call.
+ *
+ * WHY THIS EXISTS. The semantic harvest is on by default but its real gate is a
+ * credential: `harvestMode()` returns `off:no-key` on any machine without one,
+ * which is CI, corporate laptops, and every subscription-only login. This
+ * repository's own graph is the evidence -- 2,965 symbol nodes, 904 file nodes,
+ * 128 task nodes and ONE finding -- because the structural layer accumulates
+ * from ordinary tool traffic while every verdict needed an API key this machine
+ * does not have.
+ *
+ * Everything here is derived from outcomes, transitions and corrections that are
+ * ALREADY RECORDED LOCALLY. Nothing is sent anywhere, nothing is billed, so
+ * there is nothing to consent to and this runs by default. It is the only
+ * finding producer on a machine without a key.
+ *
+ * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
+ * second command fixed the first -- an intervening edit, a dependency install or
+ * a flaky test explains it just as well. So each detector carries a confidence
+ * ceiling, the claim text says only what was OBSERVED, and the two shapes where
+ * the observation supports no claim at all are refused rather than downgraded
+ * (see `attemptKey` and the identical-text guard below).
+ *
+ * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
+ * budget, belongs to the caller.
+ */
+
+import { readMetrics, rereadsByAnchor } from './metrics.mjs';
+import { readArchive, readTurns } from './transcript.mjs';
+import { redact } from './redact.mjs';
+
+/**
+ * Ceilings, ordered by how much the evidence actually supports.
+ *
+ * A command that succeeded where a DIFFERENT command failed is close to a direct
+ * observation. A test or build going red-to-green is weaker, because the usual
+ * cause is the code changing between the two runs rather than anything about the
+ * command. A correction is a lexical guess about what a human meant. Churn
+ * describes our own reading behaviour and says nothing about the code at all.
+ */
+export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+
+/** Claim text cap. A finding is one sentence; a paragraph is evidence. */
+const CLAIM_MAX = 300;
+const EVIDENCE_MAX = 400;
+
+/** Bounded so a pathological log cannot turn session end into real work. */
+const MAX_CANDIDATES = 200;
+
+/**
+ * Commands whose red-to-green transition is usually explained by the CODE
+ * changing rather than by the command. They get the lower ceiling.
+ */
+const CODE_SENSITIVE = /\b(test|tests|jest|vitest|pytest|mocha|build|compile|tsc|lint|typecheck)\b/i;
+
+/**
+ * Openers that mark a user turn as a correction rather than an instruction.
+ *
+ * DELIBERATELY NARROW, and anchored to the START of the turn. The model-based
+ * extractor in `lessons.mjs` can read intent; this cannot, so it only claims the
+ * shapes where the first few words carry the whole signal. Recall is poor by
+ * design: a missed correction costs one finding, a false one puts words in the
+ * user's mouth at 0.6 confidence.
+ */
+const CORRECTION_OPENER =
+  /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
+
+/**
+ * The prefix that makes two invocations "the same attempt".
+ *
+ * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
+ * through what the alternatives do to real command lines:
+ *
+ *   Two tokens conflates `npm run build` with `npm run test`, and the pair then
+ *   produces "`npm run test` works where `npm run build` failed" -- a claim that
+ *   is simply false.
+ *
+ *   Counting flags splits `deploy` from `deploy --retry`, which is the single
+ *   most useful pair this detector can find, into two groups that never meet.
+ *
+ * Conservative in the remaining direction: `npm run build:prod` and
+ * `npm run build` do not pair. A missed pair costs one finding; a wrong pair
+ * ships a false claim into model context.
+ */
+export function attemptKey(command) {
+  return String(command || '')
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'))
+    .slice(0, 3)
+    .join(' ')
+    .toLowerCase();
+}
+
+/** Normalised claim text, so the same lesson derived twice is one candidate. */
+const claimKey = (type, claim) =>
+  `${type}|${String(claim).toLowerCase().replace(/\s+/g, ' ').trim()}`;
+
+/** 0.95 is reserved for verified; everything here is inference. */
+const labelFor = (confidence) => (confidence >= 0.75 ? 'probable' : 'speculative');
+
+/** A literal command prefix, safe to hand to `safeTrigger`. */
+const triggerFor = (command) =>
+  attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
+
+/**
+ * Derives finding candidates from one project's local evidence.
+ *
+ * @param {string} dir wiki directory.
+ * @param {object} options
+ * @param {string|null} options.sessionId session this ran for, for provenance.
+ * @param {string|null} options.transcriptPath live transcript, read only when the
+ *   archive holds nothing for this session yet.
+ * @param {string|null} options.projectRoot the anchor every derived claim gets.
+ *   Without it nothing is derived: an unanchored finding cannot be invalidated
+ *   and is refused by `writeHarvested` anyway, so emitting one would only spend
+ *   the caller's budget on junk.
+ * @param {string|null} options.authoritativeSessionId the session id as the HOOK
+ *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
+ *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
+ *   edge -- `taskForAnchors` returns null without one, so an unverified string
+ *   would silently produce no edge. Threaded rather than defaulted from
+ *   `sessionId`: defaulting would promote any caller's string to trusted.
+ */
+export function derive(dir, options = {}) {
+  // `options || {}` rather than a destructuring default. A default only fires on
+  // `undefined`, so a caller passing an explicitly null options object -- which
+  // is what a hook does when it has nothing to say -- threw a TypeError out of
+  // the parameter list itself, before any of the try/catch below could fail open.
+  const {
+    sessionId = null,
+    transcriptPath = null,
+    projectRoot = null,
+    authoritativeSessionId = null,
+  } = options || {};
+
+  const result = {
+    candidates: [],
+    observations: [],
+    written: [],
+    sessionId,
+    authoritativeSessionId,
+  };
+
+  let events;
+  try {
+    events = readMetrics(dir);
+  } catch {
+    // Session end must cost nothing. No evidence is not an error.
+    return result;
+  }
+  if (!Array.isArray(events)) return result;
+
+  const seen = new Set();
+  const add = (candidate) => {
+    if (result.candidates.length >= MAX_CANDIDATES) return;
+    const key = claimKey(candidate.type, candidate.claim);
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.candidates.push(candidate);
+  };
+
+  // ---- 1 & 2: a failed attempt followed by a succeeding one ---------------
+  //
+  // The event is `tool-outcome` and THE COMMAND TEXT IS IN `anchor`: there is no
+  // separate command field, because the anchor of a command surface IS the
+  // command. It is capped at 120 characters at the boundary, so a very long
+  // command line is compared and quoted truncated.
+  try {
+    if (projectRoot) {
+      const outcomes = events
+        .filter(
+          (e) =>
+            e &&
+            e.kind === 'tool-outcome' &&
+            e.surface === 'command' &&
+            typeof e.anchor === 'string' &&
+            e.anchor.trim()
+        )
+        .map((e) => ({
+          command: e.anchor.trim(),
+          output: typeof e.output === 'string' ? e.output : '',
+          exit: Number.isInteger(e.exit) ? e.exit : null,
+          at: e.at ?? 0,
+          // `success` FIRST, `exit` only as a refinement. MCP tools report no
+          // numeric code at all, so a classifier keyed on `exit !== 0` would be
+          // inert for most clients -- and `exit` is null rather than 0 precisely
+          // so that absence is not read as a clean exit.
+          failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
+        }))
+        .sort((a, b) => a.at - b.at);
+
+      const byAttempt = new Map();
+      for (const outcome of outcomes) {
+        const key = attemptKey(outcome.command);
+        if (!key) continue;
+        if (!byAttempt.has(key)) byAttempt.set(key, []);
+        byAttempt.get(key).push(outcome);
+      }
+
+      for (const run of byAttempt.values()) {
+        // The NEAREST preceding failure, not the first one in the session. With
+        // `find` over the whole run, a command that failed at 09:00 and
+        // succeeded at 17:00 after nine unrelated attempts is reported as one
+        // story.
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          // One pair per failure: a command that succeeds twice afterwards has
+          // not taught two lessons.
+          lastFailure = null;
+
+          // THE GUARD THAT REMOVES THE LARGEST JUNK CLASS. The commonest shape
+          // in a coding session is `npm run build` failing, the code being
+          // fixed, and `npm run build` succeeding -- identical text. From that
+          // pair the two available claims are "`npm run build` works where
+          // `npm run build` failed", which is incoherent, and "`npm run build`
+          // fails", which the same evidence has just disproved. The observation
+          // is real and supports NEITHER claim, so nothing is emitted. This is
+          // not a confidence question; a ceiling cannot rescue a claim whose
+          // content is wrong.
+          if (failed.command === outcome.command) continue;
+
+          const codeSensitive =
+            CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);
+          const confidence = codeSensitive ? CONFIDENCE.test : CONFIDENCE.command;
+          const derivedBy = codeSensitive ? 'test-transition' : 'command-transition';
+
+          // "SUCCEEDED WHERE", NOT "FIXES". What is observed is two outcomes in
+          // order on the same attempt; that the difference in the command line
+          // CAUSED the difference in outcome is not observed and is not claimed.
+          add({
+            type: 'command',
+            claim: redact(
+              `\`${outcome.command}\` succeeded in this project where \`${failed.command}\` failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
+                'an intervening edit or a flaky run explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: 'when about to run this command in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the failing form later succeeds unchanged'],
+            trigger: triggerFor(outcome.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+
+          // The error text, only when there is error text. Without it the claim
+          // degrades to "`X` failed with:" and nothing after the colon, which
+          // carries no information and still costs budget.
+          const firstLine = failed.output.split('\n').find((line) => line.trim()) || '';
+          if (firstLine.trim().length < 8) continue;
+          add({
+            type: 'failure',
+            claim: redact(`\`${failed.command}\` failed with: ${firstLine.trim()}`, {
+              max: CLAIM_MAX,
+            }),
+            evidence: redact(`captured output of the failing run:\n${failed.output}`, {
+              max: EVIDENCE_MAX,
+            }),
+            applicability: 'when this command is about to be run in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the same command later succeeds unchanged'],
+            trigger: triggerFor(failed.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: failed.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 3: user corrections ------------------------------------------------
+  //
+  // A `feedback` finding -- the one type whose source is a person saying the
+  // agent was wrong. The MODEL-BASED extractor for this lives in `lessons.mjs`
+  // and needs the credential this module exists to do without, so here the
+  // signal is lexical: the opening words of the user's own turn.
+  //
+  // ORIGIN IS NOT PROMOTED. `writeHarvested` grants ORIGIN_HUMAN to a finding
+  // carrying a verified verbatim quote, and the standing-rules layer selects on
+  // that origin to inject a claim on EVERY turn. The quote here would be
+  // verbatim -- it is copied out of the archive -- but whether the turn was a
+  // correction at all is a guess, and a guess must not buy always-on injection.
+  // So no `origin` and no `quote` field: this stays harvested provenance.
+  try {
+    if (projectRoot) {
+      let turns = readArchive(dir, sessionId);
+      // The archive is written by the Stop hook too, and the order of the two is
+      // not this module's to assume, so fall back to the live transcript.
+      if (!turns.length && transcriptPath) turns = readTurns(transcriptPath);
+
+      for (const turn of turns) {
+        if (!turn || turn.role !== 'user') continue;
+        const text = String(turn.text || '').trim();
+        // Long turns are new instructions with a complaint somewhere inside
+        // them; truncating one into a claim would misquote the user.
+        if (text.length < 12 || text.length > 300) continue;
+        if (!CORRECTION_OPENER.test(text)) continue;
+        add({
+          type: 'feedback',
+          claim: redact(text, { max: CLAIM_MAX }),
+          evidence: redact(`the user opened a turn with a correction: "${text}"`, {
+            max: EVIDENCE_MAX,
+          }),
+          applicability: 'when working in this project, before repeating what was corrected',
+          confidence: CONFIDENCE.correction,
+          confidenceLabel: labelFor(CONFIDENCE.correction),
+          scope: 'project',
+          invalidators: ['the user later asks for the corrected behaviour'],
+          anchors: [projectRoot],
+          derivedBy: 'correction',
+          sessionId,
+          at: Date.parse(turn.at || '') || Date.now(),
+        });
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 4: re-read churn ---------------------------------------------------
+  //
+  // NOT A FINDING, AND THAT IS THE DECISION RATHER THAN AN OMISSION.
+  //
+  // Churn is a claim about OUR OWN reading behaviour: "this file was read three
+  // times unchanged". Every finding type available is a claim about the work --
+  // `map` describes how an area of the codebase is laid out, and is
+  // content-dependent, so a churn claim filed as `map` would be checked for
+  // staleness against contents it makes no claim about and flip stale on the
+  // first edit to a file it never described. Worse, the anchors it would take
+  // are by construction the HOTTEST files in the project, which are exactly the
+  // files that already carry real findings, so a 0.4-confidence row saying
+  // nothing actionable would sit in the injection budget beside them and render
+  // on the same reads. Nothing a future agent could DO differently follows from
+  // it: it does not say what the file contains, so it cannot substitute for
+  // reading it.
+  //
+  // The signal is still worth having -- as the measurement it already is.
+  // `rereadWaste` reports it on the balance sheet, `rereadsByAnchor` names the
+  // offenders, and this returns those rows as OBSERVATIONS: computed, carried,
+  // and deliberately not competing for context. Three detectors produce
+  // findings; the fourth produces a number.
+  try {
+    for (const row of rereadsByAnchor(events).slice(0, 3)) {
+      if (!row.anchor || row.wasteful < 2) continue;
+      result.observations.push({
+        kind: 'churn',
+        anchor: row.anchor,
+        repeats: row.repeats,
+        wasteful: row.wasteful,
+        tokens: row.tokens,
+        confidence: CONFIDENCE.churn,
+        derivedBy: 'churn',
+        note: `re-read ${row.repeats} times, ${row.wasteful} of them unchanged`,
+      });
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  return result;
+}

--- a/integrations/cursor/hooks/lib/derive.mjs
+++ b/integrations/cursor/hooks/lib/derive.mjs
@@ -16,6 +16,13 @@
  * there is nothing to consent to and this runs by default. It is the only
  * finding producer on a machine without a key.
  *
+ * THREE SOURCES, NOT TWO. `tool-outcome` events, the transcript archive, and --
+ * since the transition detectors were measured to have no input at all on the
+ * primary client -- the raw transcript's FAILED tool results, which is the only
+ * place a Claude Code failure is recorded (`failedResultsFromTranscript` in
+ * transcript.mjs, and the note above `quotable` for what that measurement
+ * actually yielded).
+ *
  * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
  * second command fixed the first -- an intervening edit, a dependency install or
  * a flaky test explains it just as well. So each detector carries a confidence
@@ -32,7 +39,11 @@
 import { readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
-import { readArchive, readTurns } from './transcript.mjs';
+import {
+  readArchive,
+  readTurns,
+  failedResultsFromTranscript,
+} from './transcript.mjs';
 import { redact } from './redact.mjs';
 import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
@@ -56,6 +67,96 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * The anchor cap a command surface is stored under, restated here as a TEST.
+ *
+ * `recordToolOutcome` truncates `anchor` to 120 characters, so a command at or
+ * over that length reached this module already cut -- and `quotable` below
+ * refuses to build a claim out of the fragment.
+ */
+const COMMAND_ANCHOR_MAX = 120;
+
+/**
+ * Can this command text be QUOTED in a claim a reader could act on?
+ *
+ * THE SECOND REFUSAL OF ITS KIND, and it exists because measurement forced it.
+ * Wiring the transcript reader gave the transition detectors their first real
+ * input on this client and immediately produced four candidates at 0.9
+ * confidence whose claim text read:
+ *
+ *   `cd /c/Users/.../token-optimizer-mcp\ncat >> docs/superpowers/plans/2026-` succeeded
+ *   in this project where `cd /c/Users/.../token-optimizer-mcp\ncat > /tmp/probe3.mjs
+ *   <<'EOF'\nimport { readdirSync, readFileSync, sta` failed
+ *
+ * -- two truncated fragments of throwaway shell scripts, grouped together only
+ * because `attemptKey`'s three tokens were spent on `cd`, the absolute path, and
+ * the verb. Then measured properly across three real transcripts: **0 of 83**
+ * captured command failures are single-line and inside the cap. 65% of this
+ * project's 2,178 successful command outcomes are not either. On this client a
+ * "command" is usually a whole shell script, so the attempt identity the
+ * transition detectors are built on does not fit most of the traffic.
+ *
+ * This is the same judgement as the identical-text guard below rather than a
+ * confidence question: a claim whose subject is a truncated fragment of a
+ * program is not a weaker claim, it is not a claim. A raised cap would not
+ * rescue it -- quoting the whole 500-character heredoc is no more actionable.
+ *
+ * What survives is exactly what the detector was designed for: `npm test`,
+ * `dotnet build X`, `deploy --retry` -- a repeatable command someone could run
+ * again. This machine captured none failing, which is why the honest yield here
+ * is zero and why that is reported rather than dressed up.
+ *
+ * Applied to BOTH sources. Where the evidence arrived from has no bearing on
+ * whether the resulting sentence says anything, and a rule that let events
+ * through would ship the junk on the ten clients that do report failures.
+ */
+const quotable = (command) => {
+  const text = String(command || '');
+  return (
+    text.trim().length > 0 &&
+    !/[\r\n]/.test(text) &&
+    text.length < COMMAND_ANCHOR_MAX
+  );
+};
+
+/**
+ * Tokens that separate one command from the next rather than naming one.
+ *
+ * MEASURED, LIKE EVERY OTHER REFUSAL HERE. `attemptKey` spends up to three
+ * non-flag tokens on identity, and the habit on this machine is
+ * `cd <absolute path> && <the real command>` -- which spends all three on `cd`,
+ * the path and `&&`, so the real command never enters the key. This project's
+ * own evidence: the single key `cd c:/users/.../token-optimizer-mcp &&` covers
+ * **539 distinct command lines**. One quotable failure in that group would pair
+ * with an arbitrary unrelated success and claim "`cd repo && grep -n ...`
+ * succeeded where `cd repo && git merge ...` failed", which is false about both.
+ *
+ * A KEY THAT REACHED A SEPARATOR NEVER REACHED A COMMAND, so there is no attempt
+ * to compare and nothing to claim -- the same judgement as the identical-text
+ * guard rather than a lower ceiling. Narrow on purpose: `2>&1` and `/F` are not
+ * separators and do not trip this, so `cat commitlint.config.mjs 2>&1` and
+ * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
+ * found across 163 transcripts on this machine it refuses 2 and keeps 6.
+ *
+ * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
+ * building the key, so the claim is about `npm test` rather than about the `cd`.
+ * That changes `attemptKey` for every client and every finding already derived
+ * from it, so it belongs in its own change with its own comparison.
+ */
+const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
+
+/**
+ * Did `attemptKey` actually capture a command, or only how one was chained?
+ *
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * One check per pair is enough: both halves share the key by construction.
+ */
+const hasAttemptIdentity = (command) =>
+  attemptKey(command)
+    .split(' ')
+    .filter(Boolean)
+    .every((token) => !COMMAND_SEPARATORS.has(token));
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -274,6 +375,17 @@ export function derive(dir, options = {}) {
   // separate command field, because the anchor of a command surface IS the
   // command. It is capped at 120 characters at the boundary, so a very long
   // command line is compared and quoted truncated.
+  //
+  // TWO SOURCES OF FAILURE, ONE PAIRING LOOP. Claude Code never fires
+  // PostToolUse for a failed tool call -- 2,238 of 2,238 live `tool-outcome`
+  // events on the measuring machine carry `success: true`, and a deliberately
+  // failing command produced no event at all -- so on the primary client these
+  // two detectors had NO INPUT WHATSOEVER while working normally on the ten
+  // adapter clients. `failedResultsFromTranscript` supplies the missing half
+  // from the only place it exists. The successes still come from events only:
+  // a transcript failure that pairs with nothing stays unclaimed, which is also
+  // what keeps a failure from ANOTHER project's directory out of this project's
+  // graph -- a candidate cannot be emitted without a success recorded HERE.
   try {
     if (projectRoot) {
       const outcomes = events
@@ -290,6 +402,9 @@ export function derive(dir, options = {}) {
           output: typeof e.output === 'string' ? e.output : '',
           exit: Number.isInteger(e.exit) ? e.exit : null,
           at: e.at ?? 0,
+          // Carried purely so the transcript merge below can recognise the same
+          // tool call arriving from the other source.
+          toolCallId: e.toolCallId ? String(e.toolCallId) : null,
           // `success` FIRST, `exit` only as a refinement. MCP tools report no
           // numeric code at all, so a classifier keyed on `exit !== 0` would be
           // inert for most clients -- and `exit` is null rather than 0 precisely
@@ -297,6 +412,53 @@ export function derive(dir, options = {}) {
           failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
         }))
         .sort((a, b) => a.at - b.at);
+
+      // DEDUPLICATED ON `toolCallId`, which is the SAME STRING in both sources:
+      // `episodeMeta` reads `raw.tool_use_id` into `toolCallId`, and that is the
+      // transcript's `tool_use_id` verbatim -- verified against live evidence
+      // (`toolu_01L4Nwr...` in metrics.jsonl, the same ids in the transcript).
+      // So on the ten clients that DO report failures, the event copy wins and
+      // the transcript copy is dropped before grouping. Without this the two
+      // copies of one failure would sit in the same run and the second of them
+      // would be paired against the first as a failed-then-succeeded story about
+      // itself.
+      //
+      // The fallback covers a client that reports a failure with no call id:
+      // identical command text within two seconds is one failure recorded twice,
+      // not two failures, because nothing re-runs a command that fast.
+      const eventIds = new Set(
+        outcomes.map((o) => o.toolCallId).filter(Boolean)
+      );
+      const eventFailures = outcomes.filter((o) => o.failed);
+      const alreadyRecorded = (failure) => {
+        if (failure.toolCallId && eventIds.has(failure.toolCallId)) return true;
+        return eventFailures.some(
+          (o) =>
+            o.command === failure.command &&
+            Math.abs((o.at || 0) - (failure.at || 0)) <= 2000
+        );
+      };
+
+      let transcriptFailures = [];
+      try {
+        transcriptFailures = failedResultsFromTranscript(transcriptPath).filter(
+          (failure) => failure.command.trim() && !alreadyRecorded(failure)
+        );
+      } catch {
+        // The reader is an extra source, never a reason the detector stops.
+      }
+      for (const failure of transcriptFailures) {
+        outcomes.push({
+          command: failure.command.trim(),
+          output: failure.output,
+          exit: failure.exit,
+          at: failure.at,
+          toolCallId: failure.toolCallId,
+          // Read from `Exit code N`, which is the only shape the reader admits.
+          failed: true,
+        });
+      }
+      if (transcriptFailures.length) outcomes.sort((a, b) => a.at - b.at);
 
       const byAttempt = new Map();
       for (const outcome of outcomes) {
@@ -333,6 +495,18 @@ export function derive(dir, options = {}) {
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
           if (failed.command === outcome.command) continue;
+
+          // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
+          // client both sides of almost every pair are truncated multi-line
+          // shell scripts, and a claim quoting a fragment of one is noise
+          // spending the retrieval budget of every later session.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
+          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
+          // command lines in this repository alone, and any pair drawn from that
+          // group is a false claim about both halves.
+          if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =
             CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);

--- a/integrations/cursor/hooks/lib/doctor.mjs
+++ b/integrations/cursor/hooks/lib/doctor.mjs
@@ -197,7 +197,8 @@ function hooksDirFor({ hooksDir, install, root }) {
  * identical from outside: a graph that fills with structural nodes either way.
  *
  * Measured on a real 5.4.0 install: 484 symbol, 286 file and 122 task nodes and
- * ZERO findings, because harvestMode() was 'off:not-opted-in'. Fifteen checks
+ * ZERO findings, because harvestMode() then returned an opt-in refusal (the mode has
+ * since been renamed: it is 'off:no-key' now, and opting in is no longer the gate). Fifteen checks
  * passed and none mentioned harvest. stop-harvest.mjs names this exact gap --
  * "nothing in doctor, audit or waste mentions harvest, so a user sees a graph
  * filling with structural nodes and no findings and has no way to learn why" --
@@ -221,9 +222,15 @@ export function probeHarvest() {
   // optimizer is off" is noise, which is why stop-harvest maps it to no notice.
   if (mode === 'off:mode') return [];
 
+  // SAID PLAINLY, because this is the configuration a user would choose if they
+  // knew it existed and the previous wording buried it in machinery. A local
+  // endpoint is the only setting under which the semantic harvest runs with no
+  // credential, no billing and no digest leaving the machine -- so the two facts
+  // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
     return [ok('finding extraction is available',
-      'active-model wiki_write is primary; local endpoint also enables fallback extraction')];
+      'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
+      'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
@@ -233,10 +240,19 @@ export function probeHarvest() {
 
   // No second-model credential is required for the primary path. The Codex/agent session that
   // already paid to derive the conclusion is the extractor and wiki_write is local.
+  // NAME THE TRADE, not just the missing variable. This is the default state on
+  // every machine without a credential, so it is the text most users will read,
+  // and "unavailable" alone tells them neither what they are missing nor that
+  // the free option exists. Local findings still accumulate: derive.mjs reads
+  // exit codes, red-to-green transitions, corrections and churn out of evidence
+  // already on disk and sends nothing anywhere.
   if (mode === 'off:no-key') {
     return [ok('finding extraction is available',
-      'active model records durable conclusions through local wiki_write; no separate-model ' +
-      'credential is configured, so fallback transcript extraction is unavailable')];
+      'active model records durable conclusions through local wiki_write, and derive runs at ' +
+      'session end with no credential. No separate-model credential is configured, so fallback ' +
+      'transcript extraction is unavailable: point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local ' +
+      'model to run it free and private, or set TOKEN_OPTIMIZER_API_KEY to run it from a bounded ' +
+      'digest of paths, commands, prompts and conclusions -- never file contents')];
   }
 
   // off:opted-out -- a deliberate choice, reported as one. Nagging about a setting somebody chose

--- a/integrations/cursor/hooks/lib/inject.mjs
+++ b/integrations/cursor/hooks/lib/inject.mjs
@@ -1134,10 +1134,25 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // injected more than the budget allowed and recorded fewer tokens than it
   // spent -- in a block whose entire justification is that it is tightly
   // bounded and measured against the control arm.
+  // THE LAST LINE IS HOW THE NEXT RULE GETS HERE, and it is one line because
+  // this block is charged on every session forever. A rule reaches this list
+  // only by being pinned or by being a person's verified correction, and both
+  // start as a `wiki_write` -- so a model reading a set of standing rules with
+  // no idea how they were produced has no way to add to it. Stated at the point
+  // of the evidence rather than as a separate always-on block: the reader is
+  // already looking at the output of the mechanism being described.
+  //
+  // THE COLD GRAPH IS COVERED ELSEWHERE, deliberately. Nothing here renders
+  // until at least one rule qualifies, which is the property the always-on
+  // budget depends on, so this line cannot be the first-session nudge --
+  // `policyText`'s "Record what you work out" section is, and it is emitted at
+  // SessionStart whether or not the graph holds anything.
   const HEADING =
     '# Standing rules for this project' +
     '\n\nEstablished in previous sessions and expected to hold. ' +
-    'These are not suggestions.\n\n';
+    'These are not suggestions.\n\n' +
+    'Record what you work out with wiki_write and a real file anchor; ' +
+    'that is how a rule reaches this list.\n\n';
   const noticeFor = (n) =>
     n
       ? `\n(${n} further standing rule${n === 1 ? '' : 's'} did not fit this budget; ` +

--- a/integrations/cursor/hooks/lib/inject.mjs
+++ b/integrations/cursor/hooks/lib/inject.mjs
@@ -35,6 +35,7 @@ import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
 import { cacheOrdered } from './cache.mjs';
+import { withheldFor, exploreOrder, servingPolicyVersion, LOO_ENABLED } from './loo.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -311,8 +312,38 @@ export function forTouch(
     });
     for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
   }
-  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  // LAYER 2 EXPLORATION, BEFORE the budget decides.
+  //
+  // `assessed.eligible` arrives in net-utility order and `fit` keeps that order
+  // until the budget runs out -- so the ranking decides which findings are ever
+  // served, which decides which ever accumulate observations, which decides
+  // their utility. A tenth of touches therefore promote the least-served
+  // candidate first. This is the only place it can go: after `fit` the choice
+  // has already been made.
+  const ordered = exploreOrder(assessed.eligible, dir, { sessionId, anchor: filePath });
+  const { kept, spent } = fit(ordered.map((item) => item.finding), budget);
   if (!kept.length) return null;
+
+  // LAYER 2 WITHHOLDING, AFTER the budget decides, which is the only ordering
+  // that produces a leave-one-out rather than a substitution: withholding first
+  // would let the next-ranked finding take the freed tokens, so the withheld
+  // arm would differ from the served arm by two findings instead of one and the
+  // effect would belong to neither.
+  //
+  // `holdout` is passed so the two experiments cannot compose into "withhold
+  // everything and call it a leave-one-out": that arm already serves nothing.
+  const withheld = withheldFor(kept.map((finding) => finding.key), sessionId, graph, dir, {
+    surface: 'file',
+    anchor: filePath,
+    holdout,
+  });
+  const delivered = withheld ? kept.filter((finding) => finding.key !== withheld) : kept;
+  // RE-PRICED, because `fit` priced what it KEPT and this delivers less. Using
+  // `spent` would bill the injection-cost side of the balance sheet for text
+  // the model never received.
+  const deliveredSpent = withheld
+    ? delivered.reduce((sum, finding) => sum + estimate(render(finding)), 0)
+    : spent;
 
   record(dir, {
     kind: 'inject',
@@ -321,15 +352,20 @@ export function forTouch(
     surface: 'file',
     anchor: filePath,
     holdout,
-    tokens: holdout ? 0 : spent,
-    deliveredTokens: holdout ? 0 : spent,
+    tokens: holdout ? 0 : deliveredSpent,
+    deliveredTokens: holdout ? 0 : deliveredSpent,
     shadowTokens: spent,
-    count: holdout ? 0 : kept.length,
+    count: holdout ? 0 : delivered.length,
     candidateCount: kept.length,
-    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    findingIds: holdout ? [] : delivered.map((finding) => finding.key),
     shadowFindingIds: kept.map((finding) => finding.key),
-    stale: kept.some((f) => f.stale),
+    stale: delivered.some((f) => f.stale),
     sessionId,
+    // ON EVERY RECORD, not only the withheld ones. A served observation needs
+    // the policy version as much as a withheld one does, or `effects` cannot
+    // keep the two arms of one comparison inside one policy.
+    ...(LOO_ENABLED() ? { looPolicy: servingPolicyVersion() } : {}),
+    ...(withheld ? { loo: withheld } : {}),
   });
 
   // MARKED SEEN IN BOTH ARMS, for the same reason as the command path: a file
@@ -339,11 +375,16 @@ export function forTouch(
   // grow faster purely from repetition.
   //
   // This is the identical defect that was fixed in `forCommand` and not here.
+  //
+  // THE WITHHELD KEY IS MARKED TOO, and that is load-bearing rather than tidy:
+  // an unmarked one would be a candidate again on the next touch of this file,
+  // where the one-per-touch tiebreak could serve it -- flipping its arm inside
+  // the very session the arm hash exists to pin it for.
   for (const f of kept) alreadyInjected.add(f.key);
 
-  if (holdout || !kept.length) return null;
+  if (holdout || !delivered.length) return null;
 
-  return `Known about ${filePath} (from previous sessions):\n${kept.map(render).join('\n')}`;
+  return `Known about ${filePath} (from previous sessions):\n${delivered.map(render).join('\n')}`;
 }
 
 /**

--- a/integrations/cursor/hooks/lib/keepwarm.mjs
+++ b/integrations/cursor/hooks/lib/keepwarm.mjs
@@ -30,6 +30,15 @@ import { record, readMetrics, readBalance } from './metrics.mjs';
 import { WRITE_MULTIPLIER, READ_MULTIPLIER } from './cache.mjs';
 
 /**
+ * The shortest gap that counts as a NEW turn rather than a burst inside one.
+ *
+ * Shared by the gap distribution and by the hit test, because they have to
+ * agree about what a turn is. Two copies of this number would let the decision
+ * be fitted to one definition of a turn and scored against another.
+ */
+export const TURN_GAP_MS = 250;
+
+/**
  * TTL tiers, with what a WRITE costs at each.
  *
  * A five-minute entry is written at 1.25x a plain input token; the one-hour
@@ -85,7 +94,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
     for (let i = 1; i < session.length; i++) {
       const gap = session[i] - session[i - 1];
       // A burst of events inside one turn is not a gap between turns.
-      if (gap > 250) gaps.push(gap);
+      if (gap > TURN_GAP_MS) gaps.push(gap);
     }
   }
   if (gaps.length < 6) return null;
@@ -105,10 +114,91 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
 }
 
 /**
+ * Refreshes to observe at a tier before the observation may bound the decision.
+ *
+ * THE SAME NUMBER THE BACKSTOP DEMANDS, deliberately. The decision and the
+ * tripwire read the same ledger, so letting them disagree about when there is
+ * enough evidence would mean one of them acting on a sample the other calls too
+ * small. Below the floor the decision keeps its expected-value answer, so a
+ * single unlucky miss changes nothing at all.
+ *
+ * NOT A CONFIDENCE INTERVAL, and the reason is arithmetic rather than taste. A
+ * Wilson 95% upper bound at ten refreshes and zero hits is 0.28 -- so a policy
+ * that missed ten times out of ten would still be recommended, which is exactly
+ * the case the loop exists to catch. The point estimate is safe here because of
+ * the bound below: an observation may only ever LOWER the modelled probability,
+ * so sampling noise cannot manufacture a refresh, and the tripwire's realised
+ * ledger is a second guard underneath.
+ */
+export const OBSERVATION_FLOOR = TRIPWIRE_MIN;
+
+/**
+ * The measured hit rate per tier, from recorded outcomes.
+ *
+ * Tiers below the floor are ABSENT rather than present with a small n, because
+ * a rate carrying no weight is the thing most likely to be used as though it
+ * did.
+ */
+export function observedHitRates(outcomes = []) {
+  const byTier = new Map();
+  for (const event of outcomes) {
+    if (event?.kind !== 'keepwarm' || event.action !== 'outcome') continue;
+    const name = TIERS.some((t) => t.name === event.tier) ? event.tier : TIERS[0].name;
+    const row = byTier.get(name) || { refreshes: 0, hits: 0 };
+    row.refreshes += 1;
+    if (event.hit) row.hits += 1;
+    byTier.set(name, row);
+  }
+
+  const qualified = new Map();
+  for (const [name, row] of byTier) {
+    if (row.refreshes < OBSERVATION_FLOOR) continue;
+    qualified.set(name, { ...row, rate: row.hits / row.refreshes });
+  }
+  return qualified;
+}
+
+/**
+ * What the refreshes at this tier actually did, if enough of them have.
+ *
+ * Tolerates being handed anything -- null, a plain object, a Map -- because the
+ * callers are two public functions whose options object is assembled by other
+ * people's code.
+ */
+function observationsFor(observed, tierName) {
+  const row = observed instanceof Map ? observed.get(tierName) : null;
+  return row && Number.isFinite(row.rate) ? row : null;
+}
+
+/**
+ * The modelled probability, BOUNDED BY what was observed and never raised by it.
+ *
+ * The asymmetry is the whole point and runs against this project's interest. A
+ * recorded `hit` says only that a turn arrived before the entry expired; it
+ * cannot say the refresh is what kept the entry alive, because a turn arriving
+ * one minute after a five-minute ping would have found the entry warm anyway.
+ * So the observed rate is an UPPER bound on a refresh's value, and substituting
+ * it for the model would flatter keep-warm badly: on the machine this was
+ * written on, the modelled ping probability is 0.2% and the observable
+ * before-expiry rate is 99.5%, so the substitution would recommend refreshing
+ * forever. A low rate, by contrast, is real evidence against: if turns do not
+ * even arrive inside the TTL, the refresh certainly bought nothing.
+ */
+function bounded(modelled, seen) {
+  return seen ? Math.min(modelled, seen.rate) : modelled;
+}
+
+/**
  * Should we refresh this prefix now?
  *
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
+ *
+ * `observed` is passed IN rather than read from disk here: this function is
+ * pure, its purity is what lets the tests build a distribution by hand, and
+ * `shouldKeepWarm` has already read the outcome log for the tripwire -- so
+ * threading the reader in here would be a second read of the same file and a
+ * second place for the window discipline to be got wrong.
  */
 export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
@@ -125,42 +215,30 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
   const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
-
-  // MEASURED BEATS MODELLED, once there is enough of it.
-  //
-  // The module header already commits to this -- "an expected-value decision is
-  // only as good as the distribution it was fitted to, and distributions
-  // shift" -- and the tripwire underneath was the only thing acting on it, as
-  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
-  // entirely" there was nothing, because the observed hit rate was never
-  // computed: both recording halves had no call site, so ten refreshes that
-  // bought nothing would keep recommending refresh right up to the moment the
-  // tripwire cut the whole feature off.
-  //
-  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
-  // handful of samples would swing the decision harder than the distribution
-  // they replace.
-  const probability = observed ? observed.rate : modelled;
+  const seen = observationsFor(observed, tier.name);
+  const probability = bounded(modelled, seen);
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
-  const basis = observed
-    ? `measured over ${observed.observations} refreshes`
-    : 'modelled from the gap distribution';
+  const note = seen && probability < modelled
+    ? `; bounded by ${seen.refreshes} observed refreshes, ` +
+      `${Math.round(seen.rate * 100)}% used before expiry`
+    : '';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
     modelledProbability: modelled,
-    basis,
+    observedHitRate: seen ? seen.rate : null,
+    observedRefreshes: seen ? seen.refreshes : 0,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
-    reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
+    reason: (ev > 0
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
-        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`) + note,
   };
 }
 
@@ -171,7 +249,12 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
  * long enough that the short tier keeps missing. Returns null when neither tier
  * pays, which is a real answer and the one a default-on product never gives.
  */
-export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS }) {
+export function ttlTier({
+  prefixTokens,
+  gaps,
+  turnsPerSession = DEFAULT_TURNS,
+  observed = null,
+}) {
   if (!prefixTokens || !gaps) return null;
 
   // Expected cost of a turn under each tier, as a multiple of what the prefix
@@ -179,7 +262,16 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   // again; and the FIRST write is amortised over the session, which is what
   // stops the expensive tier from looking free whenever gaps are short.
   const costOf = (tier) => {
-    const hit = gaps.probabilityWithin(tier.ms);
+    // THE SAME QUANTITY THE OUTCOMES RECORD, which is what makes the
+    // observation admissible here at all. `hit` is P(a turn arrives before the
+    // entry expires) and `recordRefreshOutcome`'s `hit` is exactly that event,
+    // measured -- unlike keepWarmDecision, whose probability is the narrower
+    // ping window and for which the same observation is only an upper bound.
+    // Bounded rather than replaced even so: a sample drawn only from moments we
+    // CHOSE to refresh is not a sample of gaps, and its bias runs our way.
+    const modelled = gaps.probabilityWithin(tier.ms);
+    const seen = observationsFor(observed, tier.name);
+    const hit = bounded(modelled, seen);
     const perTurn = hit * READ_MULTIPLIER + (1 - hit) * tier.writeMultiplier;
     // THE SUPPLIED VALUE, not only the computed one. Math.max(1, NaN) is NaN -- Math.max
     // propagates it rather than clamping -- so perTurn became NaN, the `perTurn >= 1` guard below
@@ -192,6 +284,8 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     return {
       tier,
       hit,
+      seen,
+      boundedByObservation: Boolean(seen) && hit < modelled,
       perTurn: (tier.writeMultiplier + (turns - 1) * perTurn) / turns,
     };
   };
@@ -208,99 +302,53 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     action: 'refresh',
     tier: best.tier.name,
     hitProbability: best.hit,
+    observedHitRate: best.seen ? best.seen.rate : null,
+    observedRefreshes: best.seen ? best.seen.refreshes : 0,
     expectedCostPerTurn: Number(best.perTurn.toFixed(3)),
     expectedValue: Math.round((1 - best.perTurn) * prefixTokens),
     reason: `${Math.round(best.hit * 100)}% of gaps land inside ${best.tier.name}; ` +
-      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached`,
+      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached` +
+      (best.boundedByObservation
+        ? `, bounded by ${best.seen.refreshes} observed refreshes ` +
+          `(${Math.round(best.seen.rate * 100)}% used before expiry)`
+        : ''),
   };
 }
 
-/** Observations of a tier before its measured hit rate may override the model. */
-export const OBSERVATION_FLOOR = 5;
-
-/** Records a refresh so its outcome can be scored. */
-export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
-  record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
-}
-
 /**
- * Scores every refresh whose window has since resolved.
+ * Records a refresh so its outcome can be scored.
  *
- * THE MISSING HALF, and it was missing because nobody could see where the
- * signal would come from. `recordRefreshOutcome` needs to know whether a real
- * turn arrived before the entry expired -- and that is not a thing anyone has
- * to instrument, because the event log already records when every turn
- * happened. The answer was in the data the whole time.
+ * `sessionId` IS REQUIRED FOR THE REFRESH TO BE SCOREABLE, and is not defaulted
+ * to anything. The hit test asks whether a turn of THIS conversation arrived
+ * before expiry; pooling arrivals across sessions would let a second concurrent
+ * session's turn pay for this one's ping, which manufactures hits. A refresh
+ * recorded without one is kept in the ledger and reported as unattributable
+ * rather than guessed at.
  *
- * For each unscored refresh at time T on a tier with TTL `ms`:
- *
- *   - a later event within `ms`            -> HIT, observed
- *   - a later event after `ms`             -> MISS, observed
- *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
- *                                             demonstrably closed unused
- *   - no later event, window still open    -> NOTHING RECORDED
- *
- * That last line is the important one and it is Plan 2's own instruction: "if
- * no signal is available for a tier, record nothing rather than guessing
- * `hit: false`". A refresh whose window has not closed yet is not a miss, and
- * scoring it as one would drive the tripwire negative on the newest and least
- * informative records.
- *
- * DRAINED AT READ TIME, which is the pattern this codebase already uses for
- * staleness: the producer cannot know the outcome at the moment it acts, so the
- * next reader resolves what has become knowable since.
+ * Returns the stored record, whose `id` is what `scoreRefreshes` pairs the
+ * outcome to, so an issuer can hold onto it.
  */
-export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
-  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
-  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
-  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
-
-  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
-  // so everything past the number already scored is outstanding. Pairing by
-  // timestamp instead would double-count two refreshes recorded in the same
-  // millisecond, which is reachable: a tool run twice in a loop.
-  const outstanding = refreshes.slice(scored);
-  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
-
-  let recorded = 0;
-  for (const refresh of outstanding) {
-    const at = Number(refresh.at) || 0;
-    if (!at) continue;
-    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
-    const next = timeline.find((t) => t > at);
-
-    let hit;
-    if (next !== undefined) hit = next - at <= tierSpec.ms;
-    else if (now - at > tierSpec.ms) hit = false;
-    else continue; // window still open: not yet knowable
-
-    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
-    recorded += 1;
-  }
-  return { outstanding: outstanding.length, recorded };
-}
-
-/**
- * The measured hit rate for a tier, or null below the observation floor.
- *
- * Null rather than a small-sample number, because the caller substitutes it for
- * a modelled probability and three observations would swing the decision harder
- * than the model they replace.
- */
-export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
-  const relevant = outcomes.filter(
-    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
-  );
-  if (relevant.length < OBSERVATION_FLOOR) return null;
-  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
+export function recordRefresh(dir, { tier, prefixTokens, expectedValue, sessionId, at }) {
+  return record(dir, {
+    kind: 'keepwarm',
+    action: 'refresh',
+    tier,
+    prefixTokens,
+    expectedValue,
+    sessionId,
+    at,
+  });
 }
 
 /**
  * Records whether the refresh was used.
  *
  * `hit` means a real turn arrived before expiry, so the write bought a read.
+ * `refreshId` names the refresh this scores, so the same one cannot be scored
+ * twice -- once per turn for the rest of the session, which is what an
+ * unpaired outcome would become.
  */
-export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
+export function recordRefreshOutcome(dir, { tier, prefixTokens, hit, refreshId = null }) {
   const tierSpec = TIERS.find((t) => t.name === tier) || TIERS[0];
   // THE SAME LEDGER keepWarmDecision BUYS THE REFRESH WITH. That function is explicit that a
   // refresh is a PING, which READS the prefix -- costOfPing = prefixTokens * READ_MULTIPLIER --
@@ -317,7 +365,125 @@ export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
   const realised = hit
     ? prefixTokens * (tierSpec.writeMultiplier - READ_MULTIPLIER) - prefixTokens * READ_MULTIPLIER
     : -prefixTokens * READ_MULTIPLIER;
-  record(dir, { kind: 'keepwarm', action: 'outcome', tier, prefixTokens, hit: Boolean(hit), realised: Math.round(realised) });
+  record(dir, {
+    kind: 'keepwarm',
+    action: 'outcome',
+    tier,
+    prefixTokens,
+    hit: Boolean(hit),
+    refreshId,
+    realised: Math.round(realised),
+  });
+}
+
+/**
+ * Scores every recorded refresh whose window has closed -- and NOTHING ELSE.
+ *
+ * This is the arm that was missing. `recordRefresh` and `recordRefreshOutcome`
+ * were both correct and both called by nothing, so the decision spent money on
+ * refreshes and could never find out whether one bought a read.
+ *
+ * THE SIGNAL IS REAL, not invented. `gapDistribution` already treats this log's
+ * timestamps as turn arrivals -- that is the distribution the whole decision is
+ * fitted to -- so the same log answers the outcome question directly: a refresh
+ * at tier `5m` was used if a turn of the same session arrived within five
+ * minutes of it. Four cases refuse to answer rather than guess, and every one
+ * of them refuses in the direction that costs this project its own good news:
+ *
+ *   - `pending`: the window has not closed yet. A hit could be scored the
+ *     instant it arrives while a miss must wait out the whole TTL, so scoring
+ *     early would mean the recorded hits are always complete and the recorded
+ *     misses always lagging -- right-censoring, biased upward, invisible in any
+ *     test. So a hit waits exactly as long as a miss.
+ *   - `uncovered`: the arrival log no longer reaches back to the refresh, so
+ *     absence of an arrival is absence of evidence. RECORDING `hit: false` HERE
+ *     WOULD BE THE INVENTION THIS IS FORBIDDEN TO MAKE: an absent signal is not
+ *     a miss, and treating it as one biases every rate downward and would
+ *     eventually switch keep-warm off on no evidence at all.
+ *   - `unattributable`: the refresh names no session, so no arrival can be
+ *     shown to belong to it.
+ *   - already scored: an outcome already names this refresh.
+ *
+ * The firehose is READ LAZILY, and only when there is something to score. On a
+ * machine where nothing issues refreshes -- which is every machine today, since
+ * nothing in this repository issues one -- the whole cost is the outcome-log
+ * read: median 70 ms on a 3.5 MB log, of which readBalance is 49 ms, because
+ * that reader also scans the firehose tail for pre-split records.
+ */
+export function scoreRefreshes(dir, {
+  refreshes = readBalance(dir),
+  arrivals = null,
+  now = Date.now(),
+} = {}) {
+  const summary = { scored: 0, hits: 0, pending: 0, uncovered: 0, unattributable: 0 };
+  const keepwarm = refreshes.filter((event) => event?.kind === 'keepwarm');
+  const alreadyScored = new Set(
+    keepwarm
+      .filter((event) => event.action === 'outcome' && event.refreshId)
+      .map((event) => event.refreshId)
+  );
+  const unscored = keepwarm.filter(
+    (event) =>
+      event.action === 'refresh' &&
+      Number.isFinite(event.at) &&
+      event.id &&
+      !alreadyScored.has(event.id)
+  );
+
+  // A refresh with no id cannot be paired, so scoring it would write a fresh
+  // outcome on every turn forever. Reported, not silently dropped.
+  summary.unattributable += keepwarm.filter(
+    (event) => event.action === 'refresh' && (!event.id || !Number.isFinite(event.at))
+  ).length;
+
+  if (!unscored.length) return summary;
+
+  const events = (arrivals ? arrivals() : readMetrics(dir)).filter((event) =>
+    Number.isFinite(event?.at)
+  );
+  // Coverage is judged over EVERY event, including our own bookkeeping: the
+  // refresh's own copy in the firehose is what proves the window is still
+  // inside the read. Arrivals are judged over everything else, because a record
+  // keep-warm wrote about itself is not a turn -- and counting one would
+  // manufacture a hit out of the act of measuring.
+  const earliest = events.reduce((min, event) => Math.min(min, event.at), Infinity);
+  const turns = events.filter((event) => event.kind !== 'keepwarm');
+
+  for (const refresh of unscored) {
+    const tier = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    if (now - refresh.at < tier.ms) {
+      summary.pending += 1;
+      continue;
+    }
+    const session = refresh.sessionId;
+    if (!session) {
+      summary.unattributable += 1;
+      continue;
+    }
+    if (!(earliest <= refresh.at)) {
+      summary.uncovered += 1;
+      continue;
+    }
+
+    const opens = refresh.at + TURN_GAP_MS;
+    const closes = refresh.at + tier.ms;
+    const hit = turns.some(
+      (event) =>
+        (event.sessionId ?? event.episodeId) === session &&
+        event.at > opens &&
+        event.at <= closes
+    );
+    recordRefreshOutcome(dir, {
+      tier: refresh.tier,
+      prefixTokens: refresh.prefixTokens,
+      hit,
+      refreshId: refresh.id,
+    });
+    summary.scored += 1;
+    if (hit) summary.hits += 1;
+  }
+
+  return summary;
 }
 
 /**
@@ -372,23 +538,15 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
-  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
-  // becomes evidence now, so the decision below and the tripwire above both see
-  // the most that is currently knowable -- the same read-time drain the
-  // staleness path uses, and for the same reason: the producer cannot know the
-  // outcome at the moment it acts.
-  try {
-    scoreOutstandingRefreshes(dir, { events, outcomes });
-    outcomes = readBalance(dir);
-  } catch {
-    /* scoring is evidence, never a reason to refuse a decision */
-  }
-
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
+  // THE SAME ARRAY THE TRIPWIRE JUST READ, so closing the loop costs no extra
+  // I/O -- and so the decision and its backstop cannot be looking at different
+  // evidence about the same refreshes.
+  const observed = observedHitRates(outcomes);
   const gaps = gapDistribution(dir, { events });
-  const best = ttlTier({ prefixTokens, gaps });
+  const best = ttlTier({ prefixTokens, gaps, observed });
   if (!best) {
     // THE TWO MODELS ANSWER DIFFERENT QUESTIONS, so they may legitimately disagree. ttlTier asks
     // whether holding a cache beats not caching at all; keepWarmDecision asks whether ONE ping
@@ -397,11 +555,7 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({
-      prefixTokens,
-      gaps,
-      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
-    });
+    const decision = keepWarmDecision({ prefixTokens, gaps, observed });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/integrations/cursor/hooks/lib/loo.mjs
+++ b/integrations/cursor/hooks/lib/loo.mjs
@@ -1,0 +1,788 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/loo.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 2 -- what one finding is actually worth, measured by withholding it.
+ *
+ * Layer 1 asks whether the model went back and named a finding. This asks the
+ * harder question and answers it causally: WITHHOLD ONE FINDING while serving
+ * every other finding for the same touch, and compare what the session spent
+ * READING that anchor afterwards. Nobody in this space measures per-item value
+ * this way in production; the state of the art is an offline evaluation set.
+ * That is also why this file is more refusal than statistics -- a causal claim
+ * from four observations is worse than no claim, because it is a number and
+ * numbers get quoted.
+ *
+ * THE ESTIMAND IS READ-SUPPRESSION, and it is deliberately DISJOINT from Layer
+ * 1. Layer 1 keys on an explicit `query` naming a finding key. This keys on
+ * `read` events against the injection's anchor. Neither signal appears in the
+ * other's arithmetic: no `query` event is consulted here, and `usage.mjs`
+ * consults no `read` event. Task 8 calibrates one against the other, and if
+ * both derived from the same channel that calibration would report a strong
+ * correlation between two spellings of one quantity and mean nothing.
+ *
+ * IT INVENTS NO JOIN. `recordToolOutcome` already joins each post-tool result
+ * back to the injection that preceded it, recording `injectionId`,
+ * `findingIds` and a `joinMethod` of `tool-call-id` / `episode-anchor` /
+ * `none`. Every observation here is GATED on that join: an injection with no
+ * joined outcome is unattributable and enters neither arm, exactly as Layer 1
+ * treats `joinMethod: 'none'`. An earlier draft of this plan proposed a fresh
+ * `(sessionId, findingKey)` join; it was rejected and is not here.
+ *
+ * WHAT IT COSTS THE USER, because an experiment that degrades a turn owes an
+ * accounting. One withheld finding means the model may re-derive what it was
+ * told last time, and the worst case is one read of that anchor: measured on
+ * this machine, a median read is 3,769 tokens and the 90th percentile is
+ * 14,082. Five guards bound that exposure, and they are the reason the numbers
+ * below are as small as they are:
+ *
+ *   1. only on a FILE touch, because a command injection has no anchor a read
+ *      event can be joined to -- withholding there would cost a user a finding
+ *      and buy no observation at all (see `buildReport`, which excludes command
+ *      injections from the holdout balance for the same reason);
+ *   2. never when fewer than two findings were kept, so "leave one out" always
+ *      leaves something in -- otherwise it degenerates into `inHoldout`, which
+ *      withholds EVERY finding for an anchor and is a different experiment;
+ *   3. never in the same breath as `inHoldout`: if that arm already withheld
+ *      everything, there is nothing to leave out and a Layer 2 arm recorded
+ *      there would be a fabricated observation;
+ *   4. at most ONE finding per touch, or the effect is attributable to neither;
+ *   5. at most ONE withheld finding per SESSION, so the worst case a user can
+ *      experience is a single re-read -- not one per file they open.
+ *
+ * AND IT NEVER OVERRIDES A PERSON. A `pinned` or `origin: 'human'` finding is
+ * an explicit human decision to keep something in front of the model.
+ * Withholding it to run an experiment would overrule that decision for the
+ * convenience of the measurement, so those findings are exempt: they are
+ * always served, they get no causal score, and `looNote` says so rather than
+ * leaving a reader to wonder why they are missing from the table.
+ */
+
+import { createHash } from 'node:crypto';
+import { readEvidence, readMetrics, readTruncation, isFixtureAnchor } from './metrics.mjs';
+import { retrievalPolicy } from './utility.mjs';
+import { ORIGIN_HUMAN } from './curate.mjs';
+import { canonicalPath } from './paths.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Injections of a finding before it may enter the experiment.
+ *
+ * A finding nobody has served yet has no established value to measure the
+ * absence of, and withholding it would be measuring the cold start rather than
+ * the finding. Four is also what makes the ratio below reachable: at a quarter
+ * of (key, session) pairs armed, a key needs roughly a dozen enrolled
+ * injections before it can reach a verdict at all.
+ */
+export const MIN_PRIOR_INJECTIONS = 4;
+
+/** The observation floor. Below this there is no verdict -- and NOT a zero. */
+export const MIN_SERVED = 6;
+export const MIN_WITHHELD = 3;
+
+/** Benjamini-Hochberg false-discovery rate for published verdicts. */
+export const FDR_Q = 0.1;
+
+/**
+ * Exploration rate.
+ *
+ * Without this, utility feeds the ranking, the ranking feeds injection
+ * frequency, injection frequency feeds the observation count, and a low score
+ * becomes self-fulfilling: the finding is never served often enough to earn a
+ * better one. A tenth of touches therefore ignore the utility order and
+ * promote the LEAST-served candidate instead.
+ */
+export const EPSILON = 0.1;
+
+/**
+ * The share of (finding, session) pairs assigned to the withheld arm.
+ *
+ * Chosen against the floors rather than picked: MIN_SERVED / MIN_WITHHELD is
+ * 2:1, so a quarter withheld reaches both floors at about the same time while
+ * leaving three touches in four undamaged.
+ */
+export const WITHHOLD_FRACTION = 0.25;
+
+/**
+ * Withheld findings allowed per session. ONE.
+ *
+ * The per-touch cap alone bounds nothing across a session: a session that
+ * opens twelve files with enrolled findings could have withheld twelve. This
+ * makes the worst case a user can experience one re-read, at the price of a
+ * mild confound that is stated rather than hidden -- when the cap binds, the
+ * other armed findings in that session are served, so the served arm is
+ * slightly enriched by sessions that touch many enrolled findings.
+ */
+export const MAX_WITHHELD_PER_SESSION = 1;
+
+/**
+ * Fallback shrinkage weight when the between-finding variance cannot be
+ * estimated (fewer than two findings with both arms, or no dispersion at all).
+ *
+ * MIN_SERVED + MIN_WITHHELD, deliberately: a finding's own data outweighs the
+ * population prior only once it has reached the publication floor.
+ */
+export const SHRINKAGE_K = MIN_SERVED + MIN_WITHHELD;
+
+/** Bounds on the estimated shrinkage weight, so a degenerate variance ratio cannot run away. */
+const K_MIN = 1;
+const K_MAX = 100;
+
+/**
+ * Bumped BY HAND when the serving code changes in a way that could move a
+ * finding's measured effect. It is the part of the policy version a hash of the
+ * configuration cannot see.
+ */
+export const LOO_POLICY_GENERATION = 1;
+
+/** Permutation budget before the exact null distribution is sampled instead of enumerated. */
+const MAX_EXACT_PERMUTATIONS = 20_000;
+const SAMPLED_PERMUTATIONS = 10_000;
+
+/**
+ * On by default, off by `TOKEN_OPTIMIZER_LOO=off`.
+ *
+ * Read per call rather than at module load, for the reason `holdoutFraction`
+ * gives: a long-lived process started before the setting changed would
+ * otherwise honour the old value forever with no way to tell.
+ */
+export function LOO_ENABLED() {
+  return String(process.env.TOKEN_OPTIMIZER_LOO || '').trim().toLowerCase() !== 'off';
+}
+
+/**
+ * The serving policy an observation was collected under.
+ *
+ * WHY EVERY OBSERVATION CARRIES ONE. An effect is only meaningful against a
+ * fixed policy. Halve the touch budget or move the minimum net utility and the
+ * same finding is served in different company, at a different rank, against a
+ * different counterfactual -- so pooling observations from before and after
+ * that change would average two different experiments and call the result
+ * causal. `effects()` therefore groups by (finding, policy) and never across.
+ *
+ * IT IS DELIBERATELY ABSENT FROM THE ARM HASH. Including it would reassign
+ * arms the moment a setting changed, which is precisely the mid-session flip
+ * the arm hash exists to prevent. Configuration decides which experiment an
+ * observation belongs to; it must never decide which arm.
+ */
+export function servingPolicyVersion() {
+  const policy = retrievalPolicy();
+  const parts = [
+    `g${LOO_POLICY_GENERATION}`,
+    `touch=${Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500}`,
+    `benefit=${policy.baseBenefitTokens}`,
+    `minutility=${policy.minimumNetUtility}`,
+    `cooldown=${policy.cooldownMs}`,
+    `quarantine=${policy.quarantineHarmCount}`,
+    `holdout=${process.env.TOKEN_OPTIMIZER_HOLDOUT ?? 'default'}`,
+    `withhold=${WITHHOLD_FRACTION}`,
+    `prior=${MIN_PRIOR_INJECTIONS}`,
+    `epsilon=${EPSILON}`,
+  ];
+  const digest = createHash('sha256').update(parts.join('|')).digest('hex');
+  return `${LOO_POLICY_GENERATION}-${digest.slice(0, 8)}`;
+}
+
+/**
+ * A stable number in [0, 1) from a string.
+ *
+ * SHA-256 rather than SHA-1 for the same reason `inHoldout` uses it: this is a
+ * bucketing hash and nothing here is secret, but arguing that a CodeQL finding
+ * is benign is a worse habit than paying a cost that rounds to nothing.
+ */
+function bucket(text) {
+  return createHash('sha256').update(String(text)).digest().readUInt32BE(0) / 4_294_967_296;
+}
+
+/**
+ * The arm of one finding in one session.
+ *
+ * Keyed on (findingKey, sessionId) AND NOTHING ELSE, so a finding cannot
+ * change arms partway through a session: not when the candidate set changes,
+ * not when the budget changes, not when the graph grows. The measurement is a
+ * comparison between sessions, and an arm that flips inside one contaminates
+ * both sides of it.
+ */
+function armed(findingKey, sessionId) {
+  return bucket(`loo-arm:${findingKey}:${sessionId}`) < WITHHOLD_FRACTION;
+}
+
+/** Deterministic tiebreak among armed candidates: lowest bucket, then key order. */
+function armRank(findingKey, sessionId) {
+  return bucket(`loo-rank:${findingKey}:${sessionId}`);
+}
+
+/** The graph node for a finding key, or null. Keys are unique per graph. */
+function findingNode(graph, key) {
+  const nodes = graph?.nodes;
+  if (!nodes || typeof nodes.values !== 'function') return null;
+  for (const node of nodes.values()) {
+    if (node?.kind === 'finding' && node.key === key) return node;
+    // A fixture graph may omit `kind`; key identity is what this needs.
+    if (node?.key === key && node.kind === undefined) return node;
+  }
+  return null;
+}
+
+/**
+ * May this finding ever be withheld?
+ *
+ * FAILS CLOSED ON AN UNKNOWN KEY, which is the opposite of how the rest of
+ * this module fails. Everywhere else a missing input costs a measurement; here
+ * it could cost a human their explicit decision, because a key whose node
+ * cannot be read is a key whose `pinned` and `origin` cannot be checked.
+ */
+function withholdable(graph, key) {
+  const node = findingNode(graph, key);
+  if (!node) return false;
+  if (node.pinned) return false;
+  if (node.origin === ORIGIN_HUMAN) return false;
+  if (node.retired) return false;
+  return true;
+}
+
+/** Prior SERVED injections per finding key, and withheld injections per session. */
+function history(dir, { evidence = null } = {}) {
+  const priorServed = new Map();
+  const withheldPerSession = new Map();
+  const events = evidence || readEvidence(dir);
+  for (const event of events) {
+    if (event.kind !== 'inject') continue;
+    if (typeof event.loo === 'string' && event.loo) {
+      const session = typeof event.sessionId === 'string' ? event.sessionId : '';
+      withheldPerSession.set(session, (withheldPerSession.get(session) || 0) + 1);
+    }
+    if (event.holdout) continue;
+    const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+    for (const raw of keys) {
+      const key = String(raw);
+      priorServed.set(key, (priorServed.get(key) || 0) + 1);
+    }
+  }
+  return { priorServed, withheldPerSession };
+}
+
+/**
+ * Which single finding to withhold from this touch, or null.
+ *
+ * Called from `forTouch` AFTER `fit` has decided what would have been served,
+ * which is the only ordering that produces a true leave-one-out. Withholding
+ * BEFORE the budget runs would let a lower-ranked finding take the freed
+ * tokens, so the withheld arm would receive different company as well as one
+ * fewer finding, and the comparison would confound the two.
+ *
+ * @param {string[]} findingKeys keys that would otherwise be delivered
+ * @param {string} sessionId the session, which pins the arm
+ * @param {object} graph the loaded graph, for `pinned` / `origin`
+ * @param {string|null} dir graph directory, for the injection history
+ */
+export function withheldFor(findingKeys, sessionId, graph, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return null;
+
+    // Every guard that needs no I/O runs first: this is the PreToolUse path,
+    // and on a project with one finding per anchor the answer is null before
+    // anything is read.
+    const keys = [...new Set((findingKeys || []).map((k) => String(k)).filter(Boolean))];
+    if (keys.length < 2) return null;
+    if (!sessionId || typeof sessionId !== 'string') return null;
+
+    // FILE SURFACE ONLY. A command injection's anchor is the command text, and
+    // no read event will ever match it -- so both arms would score zero
+    // downstream and the finding would be scored on nothing.
+    const { surface = 'file', anchor = '', holdout = false } = options;
+    if (surface !== 'file' || !anchor) return null;
+    // The all-findings holdout already withheld everything for this anchor.
+    if (holdout) return null;
+
+    const eligible = keys.filter((key) => withholdable(graph, key));
+    if (!eligible.length) return null;
+
+    const { priorServed, withheldPerSession } = history(dir, options);
+    if ((withheldPerSession.get(sessionId) || 0) >= MAX_WITHHELD_PER_SESSION) return null;
+
+    const enrolled = eligible.filter(
+      (key) => (priorServed.get(key) || 0) >= MIN_PRIOR_INJECTIONS
+    );
+    if (!enrolled.length) return null;
+
+    const candidates = enrolled.filter((key) => armed(key, sessionId));
+    if (!candidates.length) return null;
+
+    // AT MOST ONE. Sorted deterministically so the same touch always yields the
+    // same choice; the findings that lose the tiebreak are SERVED, and the
+    // observation records what actually happened rather than what the arm hash
+    // intended.
+    candidates.sort(
+      (a, b) => armRank(a, sessionId) - armRank(b, sessionId) || (a < b ? -1 : a > b ? 1 : 0)
+    );
+    return candidates[0];
+  } catch {
+    // An experiment must never break a tool call. Failing open here means
+    // serving everything, which is the undegraded behaviour.
+    return null;
+  }
+}
+
+/**
+ * Reorders candidates so exploration can break the feedback loop.
+ *
+ * A tenth of touches -- deterministic in (session, anchor), not random, so the
+ * same touch behaves the same way twice -- promote the LEAST-served candidate
+ * ahead of the utility order, giving it a chance to survive `fit` and accrue
+ * the observations it needs to earn a score. The other nine tenths are
+ * untouched.
+ *
+ * @param {Array<{finding:{key:string}}>} items assessed candidates, best first
+ */
+export function exploreOrder(items, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return items;
+    const list = Array.isArray(items) ? items : [];
+    if (list.length < 2) return list;
+    const { sessionId = '', anchor = '' } = options;
+    if (bucket(`loo-explore:${sessionId}:${anchor}`) >= EPSILON) return list;
+
+    const keyOf = (item) => String(item?.finding?.key ?? item?.key ?? '');
+    const { priorServed } = history(dir, options);
+    let promoted = 0;
+    for (let i = 1; i < list.length; i += 1) {
+      const a = priorServed.get(keyOf(list[i])) || 0;
+      const b = priorServed.get(keyOf(list[promoted])) || 0;
+      if (a < b || (a === b && keyOf(list[i]) < keyOf(list[promoted]))) promoted = i;
+    }
+    if (promoted === 0) return list;
+    return [list[promoted], ...list.filter((_, i) => i !== promoted)];
+  } catch {
+    return Array.isArray(items) ? items : [];
+  }
+}
+
+const mean = (values) =>
+  values.length ? values.reduce((sum, v) => sum + v, 0) / values.length : 0;
+
+/** Sample variance (n-1). Zero for a single observation: dispersion is unknown, not large. */
+function variance(values) {
+  if (values.length < 2) return 0;
+  const m = mean(values);
+  return values.reduce((sum, v) => sum + (v - m) * (v - m), 0) / (values.length - 1);
+}
+
+/**
+ * Every attributable Layer 2 observation, one per (injection, finding, arm).
+ *
+ * THREE THINGS ARE REPORTED SEPARATELY RATHER THAN FOLDED IN, because each of
+ * them would otherwise turn an absence into a zero:
+ *
+ *   `unattributable`  the outcome join could not attach a tool call to the
+ *                     injection, so nothing is known about what followed it.
+ *   `excluded`        the injection could never produce a read-join at all
+ *                     (command surface, session-start, fixture anchor) or was
+ *                     already in the all-findings holdout.
+ *   `costObservations` how many observations saw a non-zero read cost. If this
+ *                     is zero, "withholding changed nothing" and "the read
+ *                     channel never fired" are the same picture, and only one
+ *                     of them is a finding about findings.
+ */
+export function observations(dir, { events = null, evidence = null } = {}) {
+  const empty = {
+    rows: [],
+    unattributable: 0,
+    unattributableOutcomes: 0,
+    excluded: { command: 0, holdout: 0, fixture: 0, unanchored: 0 },
+    injections: 0,
+    withheldInjections: 0,
+    costObservations: 0,
+    policies: [],
+    windowed: false,
+  };
+  try {
+    const causal = evidence || readEvidence(dir);
+    const all = events || readMetrics(dir);
+    // OUT OF BAND and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` describes the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
+
+    // THE JOIN THIS MODULE CONSUMES AND DOES NOT REPLACE.
+    const joined = new Set();
+    let unattributableOutcomes = 0;
+    for (const event of causal) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) {
+        unattributableOutcomes += 1;
+        continue;
+      }
+      joined.add(String(event.injectionId));
+    }
+
+    // Read cost, grouped the way `buildReport` groups it: (session, anchor),
+    // canonicalised on both sides so two spellings of one file are one anchor.
+    // A mismatch here would make every read invisible and report a clean zero
+    // effect in both arms -- correct code, absent measurement.
+    const reads = new Map();
+    for (const event of all) {
+      if (event.kind !== 'read' || !event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      if (!reads.has(key)) reads.set(key, []);
+      reads.get(key).push(event);
+    }
+
+    const injects = causal
+      .filter((event) => event.kind === 'inject')
+      .map((event, index) => ({ event, index }))
+      .sort((a, b) => (a.event.at || 0) - (b.event.at || 0) || a.index - b.index)
+      .map((row) => row.event);
+
+    // How many injections share each (session, anchor), so a key's read total
+    // is SPLIT between them rather than charged in full to each -- the same
+    // correction `buildReport` applies, and for the same reason: without it the
+    // arm means scale with injections-per-anchor instead of per-touch cost.
+    const perKey = new Map();
+    for (const event of injects) {
+      if (!event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      perKey.set(key, (perKey.get(key) || 0) + 1);
+    }
+
+    const rows = [];
+    const excluded = { command: 0, holdout: 0, fixture: 0, unanchored: 0 };
+    const priorServed = new Map();
+    const policies = new Set();
+    let unattributable = 0;
+    let considered = 0;
+    let withheldInjections = 0;
+
+    for (const event of injects) {
+      const served = (Array.isArray(event.findingIds) ? event.findingIds : []).map(String);
+      const withheldKey = typeof event.loo === 'string' && event.loo ? event.loo : null;
+      const bump = () => {
+        for (const key of served) priorServed.set(key, (priorServed.get(key) || 0) + 1);
+      };
+
+      const isCommand =
+        event.surface === 'command' ||
+        event.trigger === 'command' ||
+        event.surface === 'session-start';
+      if (isCommand) {
+        excluded.command += 1;
+        bump();
+        continue;
+      }
+      if (!event.anchor) {
+        excluded.unanchored += 1;
+        bump();
+        continue;
+      }
+      if (isFixtureAnchor(event.anchor)) {
+        excluded.fixture += 1;
+        bump();
+        continue;
+      }
+      if (event.holdout) {
+        excluded.holdout += 1;
+        bump();
+        continue;
+      }
+
+      considered += 1;
+      if (withheldKey) withheldInjections += 1;
+      const policy = typeof event.looPolicy === 'string' && event.looPolicy
+        ? event.looPolicy
+        : 'unversioned';
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const attributable = Boolean(injectionId && joined.has(injectionId));
+
+      // DOWNSTREAM MEANS AFTER, STRICTLY. The read that triggered the touch is
+      // not caused by the advice; it happened before the advice existed.
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      const at = event.at || 0;
+      const total = (reads.get(key) || []).reduce(
+        (sum, read) => sum + ((read.at || 0) > at ? read.tokens || 0 : 0),
+        0
+      );
+      const cost = total / Math.max(1, perKey.get(key) || 1);
+
+      const observe = (findingKey, arm) => {
+        // ENROLMENT IS RE-DERIVED FROM THE LOG rather than trusted from the
+        // serving decision. It is the one field an old or hand-written record
+        // could contradict, and a served observation from before a finding was
+        // enrolled would compare an established finding against its own cold
+        // start.
+        //
+        // CHECKED BEFORE ATTRIBUTABILITY, so `unattributable` counts only
+        // observations the experiment actually wanted. Counting the rest there
+        // would report a join failure for every finding that was never in the
+        // experiment to begin with -- the same shape as the 2,559-row
+        // measurement-bias defect Layer 1 found in its own first draft.
+        if ((priorServed.get(findingKey) || 0) < MIN_PRIOR_INJECTIONS) return;
+        if (!attributable) {
+          unattributable += 1;
+          return;
+        }
+        policies.add(policy);
+        rows.push({ findingKey, arm, cost, policy, injectionId, anchor: event.anchor });
+      };
+
+      if (withheldKey) observe(withheldKey, 'withheld');
+      for (const findingKey of served) observe(findingKey, 'served');
+      bump();
+    }
+
+    return {
+      rows,
+      unattributable,
+      unattributableOutcomes,
+      excluded,
+      injections: considered,
+      withheldInjections,
+      costObservations: rows.filter((row) => row.cost > 0).length,
+      policies: [...policies].sort(),
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
+function permutationP(servedCosts, withheldCosts) {
+  const pooled = [...servedCosts, ...withheldCosts];
+  const n = pooled.length;
+  const k = withheldCosts.length;
+  if (!k || k === n) return null;
+  const observed = Math.abs(mean(withheldCosts) - mean(servedCosts));
+  const total = pooled.reduce((sum, v) => sum + v, 0);
+  // Mean difference from the withheld-arm sum alone: the served sum is the
+  // complement, so one number decides the statistic.
+  const diffFrom = (withheldSum) =>
+    Math.abs(withheldSum / k - (total - withheldSum) / (n - k));
+
+  const choose = (a, b) => {
+    let out = 1;
+    for (let i = 1; i <= b; i += 1) out = (out * (a - b + i)) / i;
+    return out;
+  };
+
+  const tolerance = 1e-9;
+  if (choose(n, k) <= MAX_EXACT_PERMUTATIONS) {
+    let extreme = 0;
+    let count = 0;
+    const walk = (start, chosen, sum) => {
+      if (chosen === k) {
+        count += 1;
+        if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+        return;
+      }
+      for (let i = start; i <= n - (k - chosen); i += 1) walk(i + 1, chosen + 1, sum + pooled[i]);
+    };
+    walk(0, 0, 0);
+    return count ? extreme / count : null;
+  }
+
+  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
+  // the same p-value and a verdict cannot flicker between two audit runs.
+  let state = 0x9e3779b9;
+  const random = () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4_294_967_296;
+  };
+  let extreme = 0;
+  const order = [...pooled];
+  for (let round = 0; round < SAMPLED_PERMUTATIONS; round += 1) {
+    for (let i = order.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(random() * (i + 1));
+      [order[i], order[j]] = [order[j], order[i]];
+    }
+    let sum = 0;
+    for (let i = 0; i < k; i += 1) sum += order[i];
+    if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+  }
+  return (extreme + 1) / (SAMPLED_PERMUTATIONS + 1);
+}
+
+/**
+ * The per-finding causal effect, shrunk, and whether it may be published.
+ *
+ * `raw` is `mean(withheld) - mean(served)`: POSITIVE means the session read the
+ * anchor more when the finding was withheld, which is the finding earning its
+ * place. `shrunk` is the number a reader should use.
+ *
+ * EMPIRICAL BAYES, and both halves of it come from the data. The prior mean is
+ * the population effect across findings; the weight `k` is the ratio of
+ * within-finding noise to between-finding spread, so a population where every
+ * finding behaves alike shrinks hard and one where they genuinely differ
+ * shrinks little. `SHRINKAGE_K` is the fallback when that spread cannot be
+ * estimated at all. Two observations therefore cannot post a wild score.
+ *
+ * PUBLICATION IS NOT THE SAME QUESTION as having an estimate. A row is
+ * published only if it clears the observation floor AND its permutation
+ * p-value survives Benjamini-Hochberg at q = 0.10 across every candidate row.
+ * Everything else gets `published: false` -- which is not a zero effect, and
+ * `looNote` says which of the two it is. An all-zero-cost population needs no
+ * separate guard: p is exactly 1 there, so nothing can publish anyway.
+ *
+ * NEVER POOLED ACROSS POLICY VERSIONS: rows are keyed on (findingKey, policy).
+ */
+export function effects(dir, options = {}) {
+  try {
+    // `obs` is accepted so `looNote` can read the logs once for both.
+    const obs = options.obs || observations(dir, options);
+    const groups = new Map();
+    for (const row of obs.rows) {
+      const id = JSON.stringify([row.findingKey, row.policy]);
+      if (!groups.has(id))
+        groups.set(id, { findingKey: row.findingKey, policy: row.policy, served: [], withheld: [] });
+      groups.get(id)[row.arm === 'withheld' ? 'withheld' : 'served'].push(row.cost);
+    }
+
+    const raws = [];
+    const withinVars = [];
+    for (const group of groups.values()) {
+      if (!group.served.length || !group.withheld.length) continue;
+      raws.push(mean(group.withheld) - mean(group.served));
+      withinVars.push(
+        variance(group.withheld) / group.withheld.length +
+          variance(group.served) / group.served.length
+      );
+    }
+    const prior = raws.length ? mean(raws) : 0;
+    const within = withinVars.length ? mean(withinVars) : 0;
+    const between = raws.length > 1 ? Math.max(0, variance(raws) - within) : 0;
+    const weight =
+      between > 0 && within > 0
+        ? Math.min(K_MAX, Math.max(K_MIN, within / between))
+        : SHRINKAGE_K;
+
+    const rows = [...groups.values()]
+      .map((group) => {
+        const served = group.served.length;
+        const withheld = group.withheld.length;
+        const both = served > 0 && withheld > 0;
+        const raw = both ? mean(group.withheld) - mean(group.served) : null;
+        const n = served + withheld;
+        const shrunk = raw === null ? null : (n * raw + weight * prior) / (n + weight);
+        const eligible = served >= MIN_SERVED && withheld >= MIN_WITHHELD;
+        return {
+          findingKey: group.findingKey,
+          policy: group.policy,
+          served,
+          withheld,
+          servedMean: mean(group.served),
+          withheldMean: mean(group.withheld),
+          raw,
+          shrunk,
+          p: eligible ? permutationP(group.served, group.withheld) : null,
+          published: false,
+        };
+      })
+      .sort((a, b) =>
+        a.findingKey < b.findingKey ? -1 : a.findingKey > b.findingKey ? 1 : a.policy < b.policy ? -1 : 1
+      );
+
+    // BENJAMINI-HOCHBERG at q = 0.10 over every row that cleared the floor.
+    // One finding tested in isolation would publish at p < 0.10; a hundred
+    // would publish ten false ones, and this module's whole claim is that its
+    // numbers can be quoted.
+    //
+    // THERE IS NO SEPARATE "WAS ANY READ COST OBSERVED" GATE HERE, and its
+    // absence is deliberate rather than an omission. One was written, and
+    // mutation testing showed it could not change a single verdict: if every
+    // observation has zero cost then both arm means are zero, the permutation
+    // statistic is zero for every relabelling, and p is exactly 1 -- which no
+    // BH threshold can pass. The guard was unfalsifiable, and an unfalsifiable
+    // guard is worse than none because it reads as protection nobody can test.
+    // `costObservations` survives as what it can honestly be: a DISCLOSURE, so
+    // `looNote` can say the read channel never fired instead of letting a
+    // reader take an arithmetic zero for a measured one.
+    const candidates = rows
+      .filter((row) => row.p !== null)
+      .sort((a, b) => a.p - b.p);
+    const m = candidates.length;
+    let cutoff = 0;
+    for (let i = 0; i < m; i += 1) {
+      if (candidates[i].p <= ((i + 1) / m) * FDR_Q) cutoff = i + 1;
+    }
+    for (let i = 0; i < cutoff; i += 1) candidates[i].published = true;
+
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * One or two lines for the audit, or nothing at all.
+ *
+ * THE REFUSAL IS THE PRODUCT HERE. On a machine with two injections in sixteen
+ * thousand events, the only honest output is that nothing is measurable yet,
+ * and this says so with the counts that make it checkable rather than printing
+ * a mean of nothing. It returns `null` when Layer 2 has not collected a single
+ * observation, so an idle experiment costs the reader no line at all -- the
+ * same standard `referenceNote` holds itself to.
+ */
+export function looNote(dir, options = {}) {
+  try {
+    const obs = options.obs || observations(dir, options);
+    const rows = effects(dir, { ...options, obs });
+    if (!obs.rows.length && !obs.withheldInjections) return null;
+
+    let graph = options.graph;
+    if (graph === undefined) {
+      try {
+        graph = load(dir);
+      } catch {
+        graph = null;
+      }
+    }
+    let exempt = 0;
+    if (graph?.nodes?.values) {
+      for (const node of graph.nodes.values()) {
+        if (node?.kind !== 'finding' || node.retired) continue;
+        if (node.pinned || node.origin === ORIGIN_HUMAN) exempt += 1;
+      }
+    }
+
+    const published = rows.filter((row) => row.published);
+    const head = published.length
+      ? `Per-finding causal value (leave-one-out): ${published.length} of ${rows.length} ` +
+        `findings show a verdict at q=${FDR_Q}` +
+        published
+          .slice(0, 3)
+          .map(
+            (row) =>
+              `; ${row.findingKey} saves ~${Math.round(row.shrunk)} tokens/touch ` +
+              `(${row.served} served, ${row.withheld} withheld, p=${row.p.toFixed(3)})`
+          )
+          .join('') +
+        '.'
+      : `Per-finding causal value (leave-one-out): NOT MEASURABLE YET -- ` +
+        `${obs.rows.length} attributable observations across ${rows.length} findings, ` +
+        `${obs.withheldInjections} withheld touches; the floor is ${MIN_SERVED} served ` +
+        `and ${MIN_WITHHELD} withheld per finding` +
+        (obs.costObservations ? '' : ', and no read cost has been observed in either arm') +
+        '. No effect is reported, which is not the same as an effect of zero.';
+
+    const caveats = [];
+    if (obs.unattributable)
+      caveats.push(
+        `${obs.unattributable} observations were unattributable (no joined tool outcome) and are in neither arm`
+      );
+    if (exempt)
+      caveats.push(
+        `${exempt} pinned or human-origin findings are exempt from withholding and get no causal score`
+      );
+    if (obs.policies.length > 1)
+      caveats.push(
+        `observations span ${obs.policies.length} serving-policy versions and are never pooled across them`
+      );
+    if (obs.windowed)
+      caveats.push('the read log was truncated, so downstream cost can understate');
+    return caveats.length ? `${head} ${caveats.join('; ')}.` : head;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/cursor/hooks/lib/loo.mjs
+++ b/integrations/cursor/hooks/lib/loo.mjs
@@ -545,8 +545,22 @@ export function observations(dir, { events = null, evidence = null } = {}) {
   }
 }
 
-/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
-function permutationP(servedCosts, withheldCosts) {
+/**
+ * Enumerates or samples arm relabellings and returns a two-sided p-value.
+ *
+ * EXPORTED so the cross-layer headline can be held to the same standard as the
+ * per-finding rows it summarises. `crosslayer.mjs` runs this over the two ARMS
+ * of shrunk effect estimates; the statistic, the enumerate-or-sample switch and the
+ * tolerance are therefore shared rather than reimplemented, and there is one
+ * place where "two-sided" is decided.
+ *
+ * `seed` exists for that caller. The default reproduces the fixed seed this
+ * function has always used, so Layer 2's own p-values are byte-identical; the
+ * cross-layer caller passes a seed DERIVED FROM ITS DATA, because a verdict
+ * printed to a human must not depend on `Math.random()` or on which module
+ * happened to call first.
+ */
+export function permutationP(servedCosts, withheldCosts, { seed = 0x9e3779b9 } = {}) {
   const pooled = [...servedCosts, ...withheldCosts];
   const n = pooled.length;
   const k = withheldCosts.length;
@@ -580,9 +594,10 @@ function permutationP(servedCosts, withheldCosts) {
     return count ? extreme / count : null;
   }
 
-  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
-  // the same p-value and a verdict cannot flicker between two audit runs.
-  let state = 0x9e3779b9;
+  // Mulberry32 off the caller's seed: reproducible, so the same data always
+  // yields the same p-value and a verdict cannot flicker between two audit
+  // runs.
+  let state = seed | 0;
   const random = () => {
     state = (state + 0x6d2b79f5) | 0;
     let t = state;

--- a/integrations/cursor/hooks/lib/metrics.mjs
+++ b/integrations/cursor/hooks/lib/metrics.mjs
@@ -31,6 +31,7 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { createHash, randomBytes } from 'node:crypto';
+import { redact } from './redact.mjs';
 
 /**
  * Read per call, not once at module load.
@@ -517,6 +518,15 @@ export function readEvidence(dir) {
 }
 
 /**
+ * The captured-output budget, in characters.
+ *
+ * Small enough that a 3 MB test log cannot bloat the evidence log or a single
+ * injected claim, large enough to hold the stack trace or compiler diagnostic
+ * that makes a failure finding worth anything.
+ */
+const OUTPUT_MAX_BYTES = 4096;
+
+/**
  * Joins a post-tool result to the most recent matching injection.  The exact
  * tool-call id wins; clients that omit it fall back to episode + surface +
  * anchor, in timestamp order, and the report states the weaker join method.
@@ -545,10 +555,31 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
+  // text is INJECTED into model context and EXPORTED to markdown, so the
+  // boundary is the only place that can guarantee it: a second caller added
+  // later would otherwise have to remember, and the one that forgot would leak
+  // a secret into two more places than the terminal it came from. `undefined`
+  // rather than `''` when nothing was captured, so JSON.stringify omits the
+  // key entirely and an absent capture is distinguishable from an empty one.
+  const output =
+    outcome.output === undefined || outcome.output === null
+      ? undefined
+      : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
+  // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric
+  // code at all, and 0 is the success value -- defaulting to it would claim
+  // every unreported call exited cleanly, which is a fabricated observation
+  // rather than a missing one.
+  const exit = Number.isInteger(outcome.exit) ? outcome.exit : null;
+
   return record(dir, {
     kind: 'tool-outcome',
     ...outcome,
     anchor,
+    // AFTER the spread, so a caller cannot smuggle raw text past the boundary
+    // by setting the field itself.
+    output,
+    exit,
     injectionId: injection?.injectionId || null,
     findingIds: injection?.findingIds || [],
     joinMethod,

--- a/integrations/cursor/hooks/lib/metrics.mjs
+++ b/integrations/cursor/hooks/lib/metrics.mjs
@@ -555,6 +555,22 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // FAILURES ONLY, and that is a deliberate override of the original plan.
+  // The plan predates MCP tool names reaching this path, so it never
+  // considered that a SUCCESSFUL `smart_read` would deposit 4 KB of file
+  // content into the evidence log on every call -- the log would grow with
+  // file text and the privacy surface would be every file the session opened.
+  //
+  // Nothing downstream loses anything. A failure claim quotes the error text;
+  // a "this command works" claim needs only the fact that it worked, which
+  // `success` and `exit` already carry. So the stored text narrows to text
+  // that is already an error message.
+  //
+  // GATED ON `success === true`, not on `!== false`: an outcome that never
+  // said whether it worked is unclassified, not successful, and dropping its
+  // text would lose exactly the failures a client too terse to report status
+  // produces.
+  const captureOutput = outcome.success !== true;
   // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
   // text is INJECTED into model context and EXPORTED to markdown, so the
   // boundary is the only place that can guarantee it: a second caller added
@@ -563,7 +579,7 @@ export function recordToolOutcome(dir, outcome) {
   // rather than `''` when nothing was captured, so JSON.stringify omits the
   // key entirely and an absent capture is distinguishable from an empty one.
   const output =
-    outcome.output === undefined || outcome.output === null
+    !captureOutput || outcome.output === undefined || outcome.output === null
       ? undefined
       : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
   // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric

--- a/integrations/cursor/hooks/lib/metrics.mjs
+++ b/integrations/cursor/hooks/lib/metrics.mjs
@@ -663,6 +663,89 @@ export function isFixtureAnchor(anchor) {
  * Fixture anchors are excluded from both.
  */
 /**
+ * Re-reads grouped by anchor -- the one place that decides what "wasteful" means.
+ *
+ * `rereadWaste` needed only the totals, so the grouping lived inside it and the
+ * per-anchor rows were thrown away. `derive.mjs`'s churn detector needs the
+ * rows, and re-deriving them there would put TWO definitions of "a repeat read
+ * of an unchanged file is waste" in the codebase, free to drift apart -- the
+ * exact divergence `npm run sync:hooks` exists to prevent between hooks-core and
+ * its generated copies. So the grouping lives here and both consumers read it.
+ *
+ * A re-read is only a re-read INSIDE ONE SESSION: grouping is keyed on
+ * session + canonical anchor, and rows are then merged per anchor so a file
+ * re-read across three sessions reports as one anchor with the sum of its
+ * repeats rather than three rows the caller has to add up. Merging cannot move
+ * the totals -- a sum of sums -- which is what makes it safe for `rereadWaste`.
+ *
+ * `tokens` is the WASTEFUL token count, not the total: it is the only one of the
+ * three that names something recoverable, and a row whose headline number
+ * included legitimate re-reads would overstate exactly the way the first
+ * version of this measurement did.
+ *
+ * @returns {Array<{anchor: string, repeats: number, wasteful: number,
+ *   tokens: number, legitimate: number, legitimateTokens: number,
+ *   undecidable: number, undecidableTokens: number}>} descending by `wasteful`,
+ *   then by `repeats`.
+ */
+export function rereadsByAnchor(events = [], { includeFixtures = false } = {}) {
+  const groups = new Map();
+  for (const e of events) {
+    if (!e || e.kind !== 'read' || !e.anchor) continue;
+    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
+    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(e);
+  }
+
+  const rows = new Map();
+  for (const list of groups.values()) {
+    if (list.length < 2) continue;
+    list.sort((a, b) => (a.at || 0) - (b.at || 0));
+
+    const anchorKey = canonicalKeyish(list[0].anchor);
+    let row = rows.get(anchorKey);
+    if (!row) {
+      row = {
+        anchor: list[0].anchor,
+        repeats: 0,
+        wasteful: 0,
+        tokens: 0,
+        legitimate: 0,
+        legitimateTokens: 0,
+        undecidable: 0,
+        undecidableTokens: 0,
+      };
+      rows.set(anchorKey, row);
+    }
+
+    for (let i = 1; i < list.length; i++) {
+      const prev = list[i - 1];
+      const cur = list[i];
+      const tokens = cur.tokens || 0;
+      row.repeats += 1;
+      // THE JUDGEMENT, in one place. A repeat read of a file that CHANGED is
+      // correct behaviour, not waste; a read written before fingerprints
+      // existed cannot be judged at all and says so.
+      if (!prev.fp || !cur.fp) {
+        row.undecidable += 1;
+        row.undecidableTokens += tokens;
+      } else if (prev.fp === cur.fp) {
+        row.wasteful += 1;
+        row.tokens += tokens;
+      } else {
+        row.legitimate += 1;
+        row.legitimateTokens += tokens;
+      }
+    }
+  }
+
+  return [...rows.values()].sort(
+    (a, b) => b.wasteful - a.wasteful || b.repeats - a.repeats
+  );
+}
+
+/**
  * Re-read waste, split into what is KNOWN and what is not.
  *
  * The question is narrow on purpose: how often does one session read the same
@@ -677,6 +760,9 @@ export function isFixtureAnchor(anchor) {
  * `undecidable` is reported rather than hidden. Reads written before the
  * fingerprint existed cannot be classified, and a measurement that quietly
  * counted them either way would be inventing its own answer.
+ *
+ * The aggregate fields are UNCHANGED -- `balanceSheet` reads them -- and are now
+ * a fold over `rereadsByAnchor`'s rows. `worst` is purely additive.
  */
 export function rereadWaste(
   dir,
@@ -685,14 +771,7 @@ export function rereadWaste(
   // excludes by design, making the real path untestable.
   { events = readMetrics(dir), includeFixtures = false } = {}
 ) {
-  const groups = new Map();
-  for (const e of events) {
-    if (e.kind !== 'read' || !e.anchor) continue;
-    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
-    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key).push(e);
-  }
+  const rows = rereadsByAnchor(events, { includeFixtures });
 
   const out = {
     repeats: 0,
@@ -704,29 +783,21 @@ export function rereadWaste(
     undecidableTokens: 0,
   };
 
-  for (const list of groups.values()) {
-    if (list.length < 2) continue;
-    list.sort((a, b) => (a.at || 0) - (b.at || 0));
-    for (let i = 1; i < list.length; i++) {
-      const prev = list[i - 1];
-      const cur = list[i];
-      const tokens = cur.tokens || 0;
-      out.repeats += 1;
-      if (!prev.fp || !cur.fp) {
-        out.undecidable += 1;
-        out.undecidableTokens += tokens;
-      } else if (prev.fp === cur.fp) {
-        out.wasteful += 1;
-        out.wastefulTokens += tokens;
-      } else {
-        out.legitimate += 1;
-        out.legitimateTokens += tokens;
-      }
-    }
+  for (const row of rows) {
+    out.repeats += row.repeats;
+    out.wasteful += row.wasteful;
+    out.wastefulTokens += row.tokens;
+    out.legitimate += row.legitimate;
+    out.legitimateTokens += row.legitimateTokens;
+    out.undecidable += row.undecidable;
+    out.undecidableTokens += row.undecidableTokens;
   }
 
   const decided = out.wasteful + out.legitimate;
   out.coverage = out.repeats ? decided / out.repeats : null;
+  // The offenders behind the totals, bounded: a report needs the handful worth
+  // acting on, not one row per file the session touched twice.
+  out.worst = rows.slice(0, 10);
   return out;
 }
 

--- a/integrations/cursor/hooks/lib/recall.mjs
+++ b/integrations/cursor/hooks/lib/recall.mjs
@@ -1,0 +1,390 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/recall.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Does retrieval FIND a finding, or does it only find what it was told where
+ * to look?
+ *
+ * `docs/WIKI_GRAPH.md` says embeddings get added "if measurement shows real
+ * recall loss". Nothing measured recall, so the no-embeddings stance was
+ * unfalsifiable -- a claim with no observation that could contradict it. This
+ * module is the observation.
+ *
+ * ---------------------------------------------------------------------------
+ * THE TAUTOLOGY THIS DELIBERATELY DOES NOT SHIP, AND WHY IT IS RECORDED HERE
+ * ---------------------------------------------------------------------------
+ * The obvious probe -- for each finding, take its anchors and ask whether
+ * `findingsFor` returns it from each -- CANNOT FAIL. `findingsFor(graph, A)`
+ * walks `derived_from` edges backwards into A, and the edge F -> A is the very
+ * thing that makes A an anchor of F. So F is in the result by CONSTRUCTION, not
+ * by retrieval quality, for every graph, forever. Its rate is 1.0 always, and a
+ * permanent 1.0 published as a recall rate reads to a human as "retrieval is
+ * perfect, embeddings unnecessary" -- one unfalsifiable claim swapped for
+ * another, leaning the one direction a measurement of this project by this
+ * project must never lean.
+ *
+ * That check is still worth running -- if it ever fails, traversal is broken
+ * rather than merely lossy -- so it is kept, and reported as `integrity` with
+ * its own `what` string saying it is not a recall rate. It is NEVER `rate`.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT IS MEASURED INSTEAD: LEAVE-ONE-EDGE-OUT
+ * ---------------------------------------------------------------------------
+ * For each active finding F and each anchor A of F, delete the edge F -> A and
+ * ask whether touching A would STILL surface F. Two independent arms, both of
+ * which can genuinely miss, which is what makes this a measurement:
+ *
+ *   Arm A -- TRAVERSAL FROM THE NEIGHBOURHOOD. Run the real `findingsFor` over
+ *   the edge-deleted graph from A itself and from A's `contains` parents. This
+ *   hits only when F has some OTHER structural route in: a second anchor on the
+ *   same file, or an anchor on a sibling symbol under the same parent. A's
+ *   `contains` children need no separate call because `findingsFor` expands
+ *   them itself -- calling the parent therefore covers every sibling, which is
+ *   why the neighbour list is `[A, ...parents(A)]` and not a hop-counted
+ *   frontier. The REAL primitive is used rather than an equivalent inlined
+ *   here, because a probe that reimplements the thing it measures drifts from
+ *   it and then measures itself.
+ *
+ *   Arm B -- BM25 FROM THE ANCHOR'S OWN KEY. Rank the whole active corpus with
+ *   `lexical.rank`, querying with A's key -- the file path or symbol name the
+ *   user actually touched -- and hit if F comes back inside `limit`.
+ *
+ * WHY ARM B IS NOT QUERIED WITH THE FINDING'S OWN CLAIM. The plan's literal
+ * form was "the finding's claim terms against the rest of the corpus", and both
+ * readings of it are degenerate. Querying F's claim against a corpus that
+ * INCLUDES F is the tautology again: BM25 scores a document against its own
+ * text, so F wins its own query every time. Querying F's claim against a corpus
+ * that EXCLUDES F cannot return F at all, so a "hit" would mean some DIFFERENT
+ * finding matched -- that is redundancy of storage, not recall of F, and it
+ * would score a graph better for holding duplicates. The anchor's key is the
+ * one query text that is available offline, is not derived from F, and matches
+ * the production question: a session touches a file, and the only lexical
+ * handle on it is its own path. It misses exactly when a finding's claim never
+ * names the code it is about, which is the recall gap embeddings are supposed
+ * to close.
+ *
+ * ---------------------------------------------------------------------------
+ * REFUSALS -- four, and each costs this project its own good news
+ * ---------------------------------------------------------------------------
+ *  1. TOO FEW OBSERVATIONS -> `rate: null` with a reason. See `MIN_PROBED`.
+ *  2. A CORPUS NO LARGER THAN THE RETRIEVAL LIMIT -> `rate: null`. Arm B is
+ *     recall@`limit`, and below the limit NO FINDING IS EVER CUT FOR BUDGET:
+ *     every document scoring above zero is returned, so the arm measures
+ *     whether a token matched, which is a strictly weaker bar than the one
+ *     production applies when `forTouch` fills a token budget from a ranked
+ *     list. A probe more permissive than the system it measures can only
+ *     overstate recall, so the rate is withheld in that band and the counts are
+ *     published instead. It bites between `MIN_PROBED` and `limit` findings --
+ *     on this machine's project graph, whose one finding had both anchor edges
+ *     "recovered" that way, the observation-count refusal fires first.
+ *  3. NO ANCHOR NODE -> the pair is UNPROBEABLE, not a miss. Reported and
+ *     excluded from the denominator; see `probeEdge`.
+ *  4. STRICT AGGREGATION -> a finding counts as retrieved only if EVERY one of
+ *     its probeable anchor edges is recoverable. A finding reachable from one
+ *     anchor and lost from another is a miss, with the losing anchor named.
+ *     This biases the rate DOWN, which is the safe direction here.
+ *
+ * FAILS OPEN. It runs on a report path; a graph it cannot read must cost a
+ * section, not the report.
+ */
+
+import { load, findingsFor } from './wiki.mjs';
+import { rank } from './lexical.mjs';
+
+/**
+ * Distinct findings that must be probeable before a RATE is published at all.
+ *
+ * NOT AN EFFECT-SIZE CONVENTION -- it is a resolution argument. A proportion
+ * over n observations has a resolution of 1/n, so below ten findings the
+ * published figure moves in steps coarser than ten percentage points, and the
+ * two extremes a small graph actually produces (`1.0` and `0.0`) are the two a
+ * reader is most likely to mistake for a finding about retrieval. At n = 10 and
+ * zero misses the exact binomial 95% upper bound on the true miss rate is still
+ * 1 - 0.05^(1/10) = 0.26, so even a clean sweep here bounds recall loss only
+ * below about a quarter -- which is why the refusal reason says what the number
+ * would and would not have supported rather than just naming the floor.
+ *
+ * THE FLOOR IS ON DISTINCT FINDINGS, NOT ANCHOR EDGES. Two anchors of one
+ * finding are two edges of the same claim, not two independent observations;
+ * counting them would let a single multi-anchored finding unlock a rate.
+ */
+export const MIN_PROBED = 10;
+
+/**
+ * The most findings probed in one call.
+ *
+ * Each probed anchor edge costs a graph-sized edge filter plus one or two real
+ * `findingsFor` walks plus one BM25 pass over the corpus, and this runs on the
+ * on-demand report path. The cap is deterministic (findings sorted by key) and
+ * `truncated` says when it bit, so a large graph gets a smaller, honestly
+ * labelled sample rather than a slow report.
+ */
+export const MAX_FINDINGS = 200;
+
+/** Active findings only. A retired claim is withdrawn; recalling it is not a win. */
+function activeFindings(graph) {
+  return [...graph.nodes.values()]
+    .filter((node) => node && node.kind === 'finding' && !node.retired)
+    .sort((a, b) => String(a.key || '').localeCompare(String(b.key || '')));
+}
+
+/** The `contains` parents of every node, indexed once for the whole probe. */
+function parentIndex(graph) {
+  const parents = new Map();
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contains') continue;
+    const list = parents.get(edge.to);
+    if (list) list.push(edge.from);
+    else parents.set(edge.to, [edge.from]);
+  }
+  return parents;
+}
+
+/** The anchors of one finding: the targets of its own `derived_from` edges. */
+function anchorsOf(graph, findingId) {
+  const out = new Set();
+  for (const edge of graph.edges) {
+    if (edge.edge === 'derived_from' && edge.from === findingId) out.add(edge.to);
+  }
+  return [...out];
+}
+
+/**
+ * The graph minus exactly one anchor edge.
+ *
+ * `nodes` is shared rather than copied: nothing here mutates it, and a
+ * 2,600-node Map copied once per anchor edge is the difference between a probe
+ * and a stall.
+ */
+function withoutAnchorEdge(graph, findingId, anchorId) {
+  return {
+    nodes: graph.nodes,
+    edges: graph.edges.filter(
+      (edge) =>
+        !(
+          edge.edge === 'derived_from' &&
+          edge.from === findingId &&
+          edge.to === anchorId
+        )
+    ),
+  };
+}
+
+/**
+ * One anchor edge, hidden, then asked after. Returns `recovered` with the arm
+ * that found it, or a reason -- and `probeable: false` when the question could
+ * not be put at all.
+ */
+function probeEdge(graph, parents, finding, anchorId, corpus, limit) {
+  const hidden = withoutAnchorEdge(graph, finding.id, anchorId);
+
+  // Arm A. `findingsFor` expands `contains` children itself, so the parent call
+  // covers every sibling of the anchor.
+  const neighbours = [anchorId, ...(parents.get(anchorId) || [])];
+  for (const neighbour of neighbours) {
+    const got = findingsFor(hidden, neighbour, { limit });
+    if (got.some((node) => node.id === finding.id)) {
+      return { recovered: true, arm: 'traversal', anchorId };
+    }
+  }
+
+  // Arm B needs a query, and the query is the anchor's own key. A dangling
+  // anchor edge -- an edge whose target node was never indexed, which
+  // `expand.promote` produces -- leaves nothing to query with. That is a
+  // question that could not be asked, NOT an observed miss: scoring it a miss
+  // would manufacture a recall loss out of a graph-integrity defect.
+  const anchor = graph.nodes.get(anchorId);
+  const key = anchor && typeof anchor.key === 'string' ? anchor.key : '';
+  if (!key) {
+    return {
+      recovered: false,
+      probeable: false,
+      anchorId,
+      reason: `anchor ${anchorId} has no node in the graph, so there is no anchor key to query BM25 with`,
+    };
+  }
+
+  const hits = rank(key, corpus, { limit });
+  if (hits.some((hit) => hit.finding && hit.finding.id === finding.id)) {
+    return { recovered: true, arm: 'lexical', anchorId };
+  }
+
+  return {
+    recovered: false,
+    probeable: true,
+    anchorId,
+    reason: `no neighbouring anchor reaches it and BM25 over ${key} does not rank it in the top ${limit}`,
+  };
+}
+
+/**
+ * The probe. An OFFLINE measurement over the graph as it stands -- it reads,
+ * ranks and traverses, and writes nothing.
+ */
+export function recallProbe(
+  dir,
+  {
+    limit = 20,
+    graph = null,
+    minProbed = MIN_PROBED,
+    maxFindings = MAX_FINDINGS,
+  } = {}
+) {
+  const refuse = (reason) => ({
+    basis: 'offline probe over the current graph',
+    probed: 0,
+    retrieved: 0,
+    rate: null,
+    reason,
+    misses: [],
+    unprobeable: [],
+  });
+
+  let g;
+  try {
+    g = graph || load(dir);
+  } catch {
+    return refuse('the graph could not be read, so recall was not measured.');
+  }
+
+  try {
+    const all = activeFindings(g);
+    const truncated = all.length > maxFindings;
+    const findings = truncated ? all.slice(0, maxFindings) : all;
+    const parents = parentIndex(g);
+    // The corpus BM25 ranks over is the ACTIVE graph, uncapped: the sample is
+    // which findings are probed, not what they compete against. Every reported
+    // figure below reads `corpus.length` rather than `all.length`, so the
+    // published size IS the ranking corpus rather than a parallel claim about
+    // it. The distinction is not pedantry: a mutation that shrank the ranking
+    // corpus to the probed sample -- making retrieval easier, in this project's
+    // favour -- SURVIVED the first mutation run precisely because the reported
+    // number came from the other variable and could not move.
+    const corpus = all;
+
+    const misses = [];
+    const unprobeable = [];
+    const integrityFailures = [];
+    let probed = 0;
+    let retrieved = 0;
+    let integrityOk = 0;
+    let probedEdges = 0;
+    let recoveredEdges = 0;
+    const byArm = { traversal: 0, lexical: 0 };
+
+    for (const finding of findings) {
+      const anchors = anchorsOf(g, finding.id);
+
+      // INTEGRITY, run on the UNTOUCHED graph: the by-construction check. Its
+      // only honest use is as a smoke test, and it is reported as one.
+      if (!anchors.length) {
+        integrityFailures.push({
+          key: finding.key,
+          reason:
+            'active finding with no anchor -- writeHarvested refuses to create one',
+        });
+      } else if (
+        anchors.every((anchorId) =>
+          findingsFor(g, anchorId, { limit }).some((node) => node.id === finding.id)
+        )
+      ) {
+        integrityOk += 1;
+      } else {
+        integrityFailures.push({
+          key: finding.key,
+          reason: `not returned by findingsFor from one of its own anchors at limit ${limit}`,
+        });
+      }
+
+      // An unanchored finding is a definite miss, not an unaskable question:
+      // nothing traverses to it and there is no anchor key to query from, so
+      // the anchor-driven path that serves findings on a file touch can never
+      // surface it. Only an explicit wiki_query naming its own terms would.
+      if (!anchors.length) {
+        probed += 1;
+        misses.push({
+          key: finding.key,
+          reason:
+            'no anchor: nothing traverses to it and there is no anchor key to query with, so only an explicit wiki_query of its own terms would surface it',
+        });
+        continue;
+      }
+
+      const results = anchors.map((anchorId) =>
+        probeEdge(g, parents, finding, anchorId, corpus, limit)
+      );
+      const askable = results.filter((result) => result.probeable !== false);
+      probedEdges += askable.length;
+      recoveredEdges += askable.filter((result) => result.recovered).length;
+      for (const result of askable) {
+        if (result.recovered) byArm[result.arm] += 1;
+      }
+
+      if (!askable.length) {
+        unprobeable.push({ key: finding.key, reason: results[0].reason });
+        continue;
+      }
+
+      probed += 1;
+      const lost = askable.filter((result) => !result.recovered);
+      if (!lost.length) retrieved += 1;
+      else misses.push({ key: finding.key, reason: lost[0].reason });
+    }
+
+    const integrity = {
+      what:
+        'BY CONSTRUCTION: a finding is returned by findingsFor from its own anchor because that edge is what makes it an anchor. Expected 1 for every graph. NOT a recall rate.',
+      probed: findings.length,
+      retrieved: integrityOk,
+      rate: findings.length ? integrityOk / findings.length : null,
+      ok: integrityFailures.length === 0,
+      failures: integrityFailures,
+    };
+
+    // Arm B is recall@`limit`. Over a corpus of at most `limit` findings nothing
+    // is ever cut for budget, so the arm asks only whether a token matched --
+    // weaker than the bar production applies under a token budget, and a probe
+    // more permissive than the system it measures can only overstate recall.
+    const discriminating = corpus.length > limit;
+
+    const common = {
+      basis: 'offline probe over the current graph',
+      probed,
+      retrieved,
+      misses,
+      unprobeable,
+      probedEdges,
+      recoveredEdges,
+      byArm,
+      corpus: corpus.length,
+      discriminating,
+      truncated,
+      minProbed,
+      integrity,
+    };
+
+    if (probed < minProbed) {
+      return {
+        ...common,
+        rate: null,
+        reason:
+          probed === 0
+            ? `no probeable finding: ${unprobeable.length} of ${findings.length} active finding(s) have no anchor node to query from, so recall was not measured. No rate is reported, which is not the same as a rate of zero.`
+            : `${probed} probeable finding(s), below the floor of ${minProbed}: a proportion over ${probed} has a resolution of ${Math.round(
+                100 / probed
+              )} percentage points, so no rate is published. ${retrieved} of ${probed} were recovered without their own anchor edge, which is a count and not a rate.`,
+      };
+    }
+
+    if (!discriminating) {
+      return {
+        ...common,
+        rate: null,
+        reason: `the active corpus holds ${corpus.length} finding(s) and the retrieval limit is ${limit}, so nothing is ever cut for budget and the lexical arm asks only whether a token matched -- a weaker bar than production applies. No rate is published off a probe more permissive than the system it measures; ${retrieved} of ${probed} were recovered, which is a count and not a rate.`,
+      };
+    }
+
+    return { ...common, rate: retrieved / probed, reason: null };
+  } catch {
+    return refuse('the probe failed, so recall was not measured.');
+  }
+}

--- a/integrations/cursor/hooks/lib/redact.mjs
+++ b/integrations/cursor/hooks/lib/redact.mjs
@@ -1,0 +1,30 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/redact.mjs. Regenerate with `npm run sync:hooks`.
+// hooks-core/redact.mjs
+/**
+ * Redaction for anything derived from captured output.
+ *
+ * WHY THIS IS MANDATORY RATHER THAN PRUDENT. derive.mjs builds claims out of
+ * command stderr. A claim is INJECTED into model context and EXPORTED to
+ * markdown, so a secret that reaches a claim reaches two more places than the
+ * terminal it came from. Pattern matching is imperfect and that is stated in the
+ * spec, but "imperfect" beats "absent" by a wide margin here.
+ */
+
+const PATTERNS = [
+  // Bearer / API-key shaped tokens.
+  [/\b(bearer\s+)[A-Za-z0-9._~+/-]{12,}/gi, '$1[redacted]'],
+  [/\b(sk|pk|ghp|gho|github_pat|xox[baprs])[-_][A-Za-z0-9._-]{10,}/gi, '[redacted]'],
+  // KEY=value where the key name suggests a secret.
+  [/\b([A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|APIKEY|API_KEY|PRIVATE_KEY|CREDENTIAL)[A-Z0-9_]*)\s*[=:]\s*\S+/g, '$1=[redacted]'],
+  // Credentials inside a URL.
+  [/\b([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+):[^\s@]+@/gi, '$1:[redacted]@'],
+  // PEM blocks.
+  [/-----BEGIN[^-]*PRIVATE KEY-----[\s\S]*?-----END[^-]*PRIVATE KEY-----/g, '[redacted key]'],
+];
+
+export function redact(text, { max = 400 } = {}) {
+  let out = String(text ?? '');
+  for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
+}

--- a/integrations/cursor/hooks/lib/redact.mjs
+++ b/integrations/cursor/hooks/lib/redact.mjs
@@ -24,7 +24,21 @@ const PATTERNS = [
 ];
 
 export function redact(text, { max = 400 } = {}) {
+  // `?? ''` matters even though String(null)/String(undefined) never throw:
+  // without it a missing value becomes the literal 4-11 character string
+  // "null"/"undefined" -- a garbage claim that silently reaches the graph
+  // and model context instead of surfacing as an error.
   let out = String(text ?? '');
   for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  // Redact BEFORE truncating, never the reverse. Several patterns above rely
+  // on a minimum-length quantifier (e.g. `{10,}`, `{12,}`) plus a prefix.
+  // Truncating first can cut a match down to fewer characters than that
+  // quantifier requires, so the shortened fragment no longer satisfies the
+  // pattern and a live partial secret would pass through in cleartext. By
+  // redacting the full, untruncated string first, every pattern always sees
+  // the complete secret and removes it before any character budget is
+  // spent; the cap below can then only ever cut into already-redacted text
+  // (a label, or the "[redacted]" placeholder itself), never into raw
+  // secret bytes.
   return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
 }

--- a/integrations/cursor/hooks/lib/transcript.mjs
+++ b/integrations/cursor/hooks/lib/transcript.mjs
@@ -19,9 +19,11 @@
  */
 
 import {
-  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, unlinkSync,
+  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync,
+  unlinkSync, openSync, readSync, closeSync,
 } from 'node:fs';
 import { join } from 'node:path';
+import { redact } from './redact.mjs';
 
 /** Where a project's transcripts live, under the graph it belongs to. */
 export const transcriptDir = (dir) => join(dir, 'transcripts');
@@ -210,4 +212,204 @@ export function readArchive(dir, sessionId) {
   } catch {
     return [];
   }
+}
+
+/**
+ * How much of a transcript's TAIL is scanned for failed tool results.
+ *
+ * A transcript is the largest file this project reads: the three real ones on
+ * the measuring machine are 5.8 MB, 22 MB and 45 MB. `archive()` above already
+ * reads the whole thing once at Stop, so an unbounded second pass doubles the
+ * most expensive read on the session-end path for evidence that is, by
+ * construction, mostly old. The tail is the right half to keep for the same
+ * reason `buildFeedbackDigest` keeps the end: what a session learned is
+ * concentrated where the work went wrong, which is later rather than sooner.
+ */
+const FAILED_SCAN_BYTES = () =>
+  Number(process.env.TOKEN_OPTIMIZER_TRANSCRIPT_SCAN_BYTES) || 8 * 1024 * 1024;
+
+/** Failed results kept, most recent first. The pairing detector needs a handful. */
+const FAILED_MAX = 50;
+
+/** Same 4 KB cap `recordToolOutcome` applies to `output`, for the same reason. */
+const FAILED_OUTPUT_MAX = 4096;
+
+/**
+ * The same 120-character truncation `recordToolOutcome` applies to `anchor`.
+ *
+ * ONE COMMAND MUST PRODUCE ONE KEY FROM EITHER SOURCE. A `tool-outcome` stores
+ * the command as `String(tool_input.command).slice(0, 120)`, and `attemptKey`
+ * reads up to three non-flag tokens off whatever it is handed. A long first
+ * token -- a quoted grep pattern, an absolute Windows path, a heredoc -- is cut
+ * by that cap INSIDE those three tokens, so the untruncated transcript copy of
+ * the same command lands in a DIFFERENT group. Measured against one real
+ * session's own evidence: 266 commands present in both sources, and truncating
+ * here made 266 of 266 keys agree where the untruncated text agreed on only
+ * 240.
+ *
+ * WHAT THAT ACTUALLY BUYS, stated precisely rather than generously. `derive`
+ * refuses to build a claim out of a command at or over the cap at all (see
+ * `quotable` there), so agreement on a TRUNCATED key never produces a finding
+ * on its own. It buys two things that still matter: a transcript failure lands
+ * in the same run as the event outcomes of the same command, so the
+ * nearest-preceding-failure rule sees the real sequence rather than a sparse
+ * one; and the no-call-id fallback in `derive`'s deduplication compares command
+ * TEXT against an already-truncated anchor, which cannot match unless this side
+ * is truncated identically.
+ */
+const ANCHOR_MAX = 120;
+
+/**
+ * A tool result that reports a command that RAN and exited non-zero.
+ *
+ * A POSITIVE ALLOWLIST, and the measurement is why. Claude Code sets
+ * `is_error: true` on every kind of unhappy tool result, and across three real
+ * transcripts 214 of them fell into four shapes:
+ *
+ *   83  `Exit code N` + stderr    -- a command ran and failed. THIS ONE.
+ *   109 hook and policy denials   -- overwhelmingly THIS optimizer's own
+ *                                    PreToolUse text ("Recursive shell searches
+ *                                    return unbounded output. Call the
+ *                                    token-optimizer MCP tool smart_grep
+ *                                    instead"), plus `Remove-Item on system
+ *                                    path` blocks.
+ *   18  `<tool_use_error>...`     -- protocol errors: `String to replace not
+ *                                    found`, `File has not been read yet`,
+ *                                    `Blocked: ...`.
+ *   4   a person declined the call.
+ *
+ * Only the first shape is a command failing. In every other shape THE COMMAND
+ * NEVER RAN, so "`X` failed with: ..." would be a false claim about X, and a
+ * later success would pair with a failure that never happened. The 109 are the
+ * dangerous ones: ingesting them would have this tool derive findings from its
+ * own advice, at 0.9 confidence, and serve them back as observations about the
+ * project -- a self-referential loop that also inflates its own finding count.
+ * That is the measurement-bias class this plan tracks, and a denylist would
+ * have let every future denial string through by default.
+ */
+const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
+
+/** Reads at most `bytes` from the END of a file, without loading the rest. */
+function readTail(path, bytes) {
+  let fd;
+  try {
+    const size = statSync(path).size;
+    const length = Math.min(size, bytes);
+    if (!length) return '';
+    fd = openSync(path, 'r');
+    const buffer = Buffer.allocUnsafe(length);
+    readSync(fd, buffer, 0, length, size - length);
+    const text = buffer.toString('utf8');
+    // A tail almost never starts on a line boundary, and half a JSON object is
+    // not a parse failure worth reporting -- it is a partial record. Drop it.
+    return length < size ? text.slice(text.indexOf('\n') + 1) : text;
+  } catch {
+    return '';
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+}
+
+/**
+ * The failed COMMAND results a transcript holds, which no hook event carries.
+ *
+ * WHY THIS READER EXISTS. Claude Code never fires PostToolUse for a failed tool
+ * call: a deliberately failing command produced no event at all, and 2,238 of
+ * 2,238 live `tool-outcome` events on the measuring machine carry
+ * `success: true`. So `derive.mjs`'s two strongest detectors -- command
+ * failed-then-succeeded at 0.90 and test/build red-to-green at 0.85 -- have no
+ * input whatsoever on the primary client, while working normally on the ten
+ * adapter clients. The failures exist; they exist only here.
+ *
+ * WHY NOT THE ARCHIVE, which the plan for this reader assumed. `readTurns`
+ * DROPS tool results by design -- that is where whole file contents would enter
+ * the record -- so `readArchive` returns no failure, ever, and an extractor over
+ * archived turns would find nothing however well it was written. Making the
+ * archive carry them would also push command stderr into `buildFeedbackDigest`,
+ * which is the one code path in this project that sends anything to a model
+ * endpoint. So this reads the transcript and STORES NOTHING NEW: read-only, no
+ * capture path, no new event kind, and no widening of what leaves the machine.
+ *
+ * REDACTED HERE, at this boundary, exactly as `recordToolOutcome` redacts
+ * `output`. Transcript text has never passed a redaction boundary -- that one
+ * never saw it -- and everything returned from here is destined for a claim that
+ * is injected into model context and exported to markdown.
+ *
+ * @returns {Array<{command: string, output: string, exit: number|null,
+ *   at: number, toolCallId: string|null}>} in transcript order, so a caller can
+ *   sort it beside `tool-outcome` events without re-ordering.
+ */
+export function failedResultsFromTranscript(transcriptPath, options = {}) {
+  const { max = FAILED_MAX, scanBytes = FAILED_SCAN_BYTES() } = options || {};
+  if (!transcriptPath) return [];
+  const text = readTail(transcriptPath, scanBytes);
+  if (!text) return [];
+
+  // tool_use_id -> the command that was attempted. The join is EXACT and it is
+  // the only one available: the result block carries no command of its own, and
+  // the id is the same string `episodeMeta` reads into `toolCallId`, so the same
+  // key also deduplicates against events on clients that do report failures.
+  const commands = new Map();
+  const failures = [];
+
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const message = entry.message || entry;
+    const role = message.role || entry.type;
+    const content = message.content;
+    if (!Array.isArray(content)) continue;
+
+    if (role === 'assistant') {
+      for (const block of content) {
+        if (!block || block.type !== 'tool_use' || !block.id) continue;
+        const command = block.input?.command;
+        if (typeof command !== 'string' || !command.trim()) continue;
+        commands.set(String(block.id), command.slice(0, ANCHOR_MAX));
+      }
+      continue;
+    }
+
+    if (role !== 'user') continue;
+    for (const block of content) {
+      if (!block || block.type !== 'tool_result' || block.is_error !== true) continue;
+      // Only a STRING result can be an exit-code report; every failed Claude
+      // Code result observed was one, and a structured body is a shape this
+      // classifier has not measured, so it is refused rather than guessed at.
+      if (typeof block.content !== 'string') continue;
+      const match = EXIT_CODE_RESULT.exec(block.content);
+      if (!match) continue;
+      const command = commands.get(String(block.tool_use_id || ''));
+      // No command means no claim. The result says something failed; without
+      // the text of what failed there is nothing to say about it, and nothing
+      // to group it with.
+      if (!command) continue;
+      failures.push({
+        command,
+        // The exit line itself is stripped: `exit` carries it structurally, and
+        // leaving it in makes every failure claim read "failed with: Exit code 1".
+        output: redact(block.content.slice(match[0].length).trim(), {
+          max: FAILED_OUTPUT_MAX,
+        }),
+        exit: Number(match[1]),
+        at: Date.parse(entry.timestamp || '') || 0,
+        toolCallId: block.tool_use_id ? String(block.tool_use_id) : null,
+      });
+    }
+  }
+
+  // The MOST RECENT `max`, keeping chronological order. A session that failed
+  // two hundred times teaches its last lessons, not its first.
+  return failures.slice(-max);
 }

--- a/integrations/cursor/hooks/lib/usage.mjs
+++ b/integrations/cursor/hooks/lib/usage.mjs
@@ -42,7 +42,7 @@
  * was referenced" and "nothing could be measured" are different answers and
  * this module gives different answers for them.
  */
-import { readMetrics } from './metrics.mjs';
+import { readMetrics, readTruncation } from './metrics.mjs';
 
 /**
  * The events that name a finding, and it is ONE kind, not the two the plan
@@ -129,17 +129,30 @@ export function classify(dir, { events = null } = {}) {
   try {
     const all = inTimeOrder(events || readMetrics(dir));
 
-    // Every reference, keyed on the finding it names. Only references carrying
-    // a session id are usable -- see `unscopedReferences` in `referenceRate`
-    // for the ones this drops and why they are counted rather than credited.
+    // Every reference, keyed on the finding it names and on nothing else.
+    //
+    // NOT SCOPED BY SESSION, and that is a deliberate reversal. Scoping needs
+    // the query's `sessionId`, which `wiki_query` takes as an OPTIONAL input
+    // the model has to volunteer (`options.sessionId ?? null`) -- so the
+    // numerator depended on the model choosing to identify itself, and an
+    // unverifiable model-supplied id is not evidence. Plan 1 settled that for
+    // the `answers` edge and it settles it here: stop depending on the field
+    // rather than hope for cooperation. The finding key is the specific part
+    // anyway; a key is a graph identity, not a guess.
+    //
+    // THE COST, disclosed here and in `referenceNote` because a reader of the
+    // number has to see it: TWO CONCURRENT SESSIONS ON ONE REPOSITORY CAN
+    // CROSS-ATTRIBUTE. Session A's injection of K plus session B's later query
+    // for K reads as a reference. Nothing in the log can separate them once the
+    // session id is gone, so the exposure is real and is stated rather than
+    // priced.
     const references = new Map();
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       const key = referencedKey(event);
-      const session = sessionOf(event);
-      if (!key || !session) continue;
+      if (!key) continue;
       if (!references.has(key)) references.set(key, []);
-      references.get(key).push({ at: event.at || 0, session });
+      references.get(key).push(event.at || 0);
     }
 
     // Which injections the existing outcome join could attribute. An outcome
@@ -170,9 +183,8 @@ export function classify(dir, { events = null } = {}) {
       const injectionId = event.injectionId ? String(event.injectionId) : null;
       const at = event.at || 0;
       const session = sessionOf(event);
-      // STRICTLY AFTER. A query that PRECEDED the injection is the model
-      // asking on its own initiative; crediting it would let the metric take
-      // the credit for a lookup it had nothing to do with.
+      // STRICTLY AFTER here too: activity that predates the injection is not
+      // an opportunity to have used it.
       const followed = (times) => times.some((t) => t > at);
       const continued =
         (injectionId && attributed.has(injectionId)) ||
@@ -181,9 +193,11 @@ export function classify(dir, { events = null } = {}) {
       for (const raw of keys) {
         const findingKey = String(raw);
         const hits = references.get(findingKey) || [];
-        const referenced = session
-          ? hits.some((hit) => hit.session === session && hit.at > at)
-          : false;
+        // TIME ORDER IS THE ONLY REMAINING GUARD, so it carries the whole
+        // weight of the attribution: a query that PRECEDED the injection is
+        // the model asking on its own initiative, and crediting it would let
+        // the metric take the credit for a lookup it had nothing to do with.
+        const referenced = hits.some((hitAt) => hitAt > at);
         rows.push({
           findingKey,
           injectionId,
@@ -204,9 +218,27 @@ export function classify(dir, { events = null } = {}) {
 /**
  * The rate, with everything needed to tell a real 0 from an absent one.
  *
- * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
- * `unattributable` and `unscopedReferences` are reported beside it, never
- * inside it.
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown` and
+ * `unattributable` are reported beside it, never inside it.
+ *
+ * `windowed` SAYS WHETHER THE DENOMINATOR CAN UNDERSTATE, and it is not
+ * decoration. `readMetrics` reads a 2 MB / 5,000-event TAIL of the firehose,
+ * and injections are rare enough on a real project to age out of it: measured
+ * on this repository, both `inject` events sit at lines 502 and 883 of 6,871
+ * and have scrolled away behind ~6,000 later `read` and `tool-outcome` rows,
+ * so the windowed denominator is 0 where the whole-file truth is 1.
+ *
+ * IT IS REPORTED RATHER THAN FIXED, deliberately. `inject` already gets
+ * unwindowed access through `BALANCE_KINDS` / `EVIDENCE_KINDS`, but `query`
+ * does not -- and reading only the INJECTION arm unwindowed would be worse
+ * than the windowing: every old injection would enter the denominator with no
+ * chance of a matching query in the window and score `not-referenced`,
+ * manufacturing a pessimistic rate out of the asymmetry. Making the query arm
+ * unwindowed means adding `query` to `EVIDENCE_KINDS`, which two other
+ * consumers read, and this project's own standard says a shared-classifier
+ * change needs a per-consumer verdict comparison. So the honest move is to
+ * publish the flag: a caller that needs the unwindowed truth passes its own
+ * `events`, which is exactly what the live measurement in the task report did.
  */
 export function referenceRate(dir, { events = null } = {}) {
   const empty = {
@@ -218,10 +250,15 @@ export function referenceRate(dir, { events = null } = {}) {
     unattributable: 0,
     unattributableWithInjectedToolCall: 0,
     referenceEvents: 0,
-    unscopedReferences: 0,
+    windowed: false,
   };
   try {
     const all = events || readMetrics(dir);
+    // OUT OF BAND, and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` reports on the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
     const rows = classify(dir, { events: all });
     const count = (label) => rows.filter((row) => row.label === label).length;
     const referenced = count('referenced');
@@ -231,17 +268,17 @@ export function referenceRate(dir, { events = null } = {}) {
     // Usable reference events in the window: the numerator's producer. If this
     // is zero the channel never fired, and a 0% rate would be measuring the
     // absence of a producer rather than the uselessness of findings.
+    //
+    // NO SESSION REQUIREMENT, matching the attribution above. The former
+    // `unscopedReferences` counted queries dropped for want of a session id;
+    // nothing is dropped for that reason any more, so the field is GONE rather
+    // than kept at a permanent zero that a later reader would misread as
+    // evidence the loss had been fixed.
     let referenceEvents = 0;
-    let unscopedReferences = 0;
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       if (!referencedKey(event)) continue;
-      if (sessionOf(event)) referenceEvents += 1;
-      // Names a finding but cannot be scoped to one injection. `sessionId` is
-      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
-      // is the expected loss rather than an edge case -- counted here so it is
-      // visible instead of silently deflating the numerator.
-      else unscopedReferences += 1;
+      referenceEvents += 1;
     }
 
     // The tool calls that DID receive findings, keyed the way
@@ -292,7 +329,7 @@ export function referenceRate(dir, { events = null } = {}) {
       unattributable,
       unattributableWithInjectedToolCall,
       referenceEvents,
-      unscopedReferences,
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
     };
   } catch {
     return empty;
@@ -300,11 +337,18 @@ export function referenceRate(dir, { events = null } = {}) {
 }
 
 /**
- * One line for the audit, or nothing at all.
+ * One or two lines for the audit, or nothing at all.
  *
  * Says which of the three things is true -- a measured rate, a live channel
  * with no opportunities yet, or no channel at all -- rather than printing a
  * figure and letting the reader assume the first.
+ *
+ * AND IT CARRIES THE CAVEATS, because this is the only place a human meets the
+ * number. A rate attributed on (finding key, time order) can cross-attribute
+ * between two concurrent sessions on one repository, and a windowed read can
+ * understate the denominator. Both are stated beside the figure they qualify.
+ * Putting them only in a task report would be publishing a clean number and
+ * filing the asterisk somewhere nobody quoting it will look.
  */
 export function referenceNote(dir, { events = null } = {}) {
   const r = referenceRate(dir, { events });
@@ -317,6 +361,11 @@ export function referenceNote(dir, { events = null } = {}) {
   }
   return (
     `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
-    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded. ` +
+    'Matched on finding key and time order, so concurrent sessions on this ' +
+    'repository can cross-attribute' +
+    (r.windowed
+      ? '; and the event log was truncated, so the denominator can understate.'
+      : '.')
   );
 }

--- a/integrations/cursor/hooks/lib/usage.mjs
+++ b/integrations/cursor/hooks/lib/usage.mjs
@@ -1,0 +1,322 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/usage.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 1 -- did the model actually go back and use what we injected?
+ *
+ * The cheap behavioural label. One question, answered from the event log alone:
+ * after we put a finding in front of the model, did the model later ASK FOR
+ * THAT FINDING BY NAME?
+ *
+ * WHY EXPLICIT REFERENCE, AND NOT READ-SUPPRESSION. Read-suppression -- "the
+ * file was not re-read, so the finding must have helped" -- is Layer 2's
+ * estimand, measured causally by withholding a finding and comparing. Layer 1
+ * exists to be calibrated AGAINST that. If both layers derived from
+ * suppression, the calibration would compare two spellings of one quantity,
+ * report a strong correlation, and mean nothing. So Layer 1 is deliberately
+ * built on a signal Layer 2 does not touch: an explicit `query` naming the
+ * finding key.
+ *
+ * WHAT THIS DOES NOT DO. It does not invent a join. `recordToolOutcome`
+ * already joins each post-tool result back to the injection that preceded it,
+ * recording `injectionId`, `findingIds` and a `joinMethod` of `tool-call-id`,
+ * `episode-anchor` or `none` -- preferring an exact tool-call id, which is
+ * strictly better evidence than the `(sessionId, findingKey)` approximation an
+ * earlier draft of this plan proposed. This module consumes that join and adds
+ * none of its own. `inject.mjs` needed no change: it has written `findingIds`
+ * at every call site all along.
+ *
+ * WHAT `unknown` IS FOR, and it is the whole reason this file is careful. An
+ * injection whose session simply stopped afterwards is not a miss. Nothing
+ * happened, so nothing can be concluded, and counting it against the finding
+ * would make the metric read worse the more often sessions end -- a number
+ * that moves with session length rather than with usefulness. `unknown` is
+ * therefore EXCLUDED from the denominator rather than scored zero, and
+ * outcomes the join could not attribute at all are reported as
+ * `unattributable` rather than folded into either arm.
+ *
+ * AND WHY THE RATE CAN BE `null`. This project has already shipped two metrics
+ * whose only producer was their own test suite. A rate of 0% that actually
+ * means "no data" is worse than a refusal, because it is a number and numbers
+ * get quoted. So `rate` is null unless there is a denominator AND the
+ * reference channel produced at least one usable event in the window. "Nothing
+ * was referenced" and "nothing could be measured" are different answers and
+ * this module gives different answers for them.
+ */
+import { readMetrics } from './metrics.mjs';
+
+/**
+ * The events that name a finding, and it is ONE kind, not the two the plan
+ * assumed.
+ *
+ * The brief said "a later `query` or `expand` event". Checked against the code
+ * and against every metrics log on this machine, `expand` does not qualify and
+ * cannot be made to:
+ *
+ *   - `recordExpansion` writes `{ ref, tool, shape, asked, sessionId }`. `ref`
+ *     is a TRUNCATION CAPTURE id (a 16-hex digest of captured tool output),
+ *     not a finding key, and `asked` is free text naming a section of that
+ *     output. Neither is a graph key, and no code path ever puts one there.
+ *   - measured: 64 live `expand` events exist on this machine and all 64 carry
+ *     `sessionId: null`, so they could not be scoped to an injection even if
+ *     they did name one.
+ *
+ * Keying the classifier on `expand` would therefore have added a branch that
+ * can never fire -- a metric with no producer, which is the exact defect this
+ * whole effort exists to close. So it is excluded, deliberately and with the
+ * measurement recorded, rather than included for symmetry with the brief.
+ */
+const REFERENCE_KINDS = new Set(['query']);
+
+/**
+ * What counts as the session having CONTINUED past the injection.
+ *
+ * The distinction between `not-referenced` and `unknown` rests entirely on
+ * this, so the set is explicit rather than "any later event". These are the
+ * kinds a tool call produces: if one of them follows the injection in the same
+ * session, the model had the opportunity to ask and did not. If none does, the
+ * session ended and there was no opportunity.
+ *
+ * `inject` is in the set because a later injection means a later tool call
+ * happened. `forecast`, `mcp-client` and `mcp-tool` are NOT: they are written
+ * by session bookkeeping rather than by the model doing something, and
+ * treating them as opportunity would convert `unknown` rows into misses on
+ * bookkeeping alone.
+ */
+const ACTIVITY_KINDS = new Set([
+  'tool-outcome',
+  'read',
+  'query',
+  'expand',
+  'substitute',
+  'inject',
+]);
+
+/** A usable session id: a non-empty string. `null == null` is not a match. */
+const sessionOf = (event) => {
+  const id = event?.sessionId;
+  return typeof id === 'string' && id ? id : null;
+};
+
+/** The finding key a reference event names, or null if it names none. */
+const referencedKey = (event) => {
+  const key = event?.key;
+  return typeof key === 'string' && key ? key : null;
+};
+
+/** Ordering by the caller's timestamp, with log order breaking ties. */
+function inTimeOrder(events) {
+  return events
+    .map((event, index) => ({ event, index }))
+    .sort(
+      (a, b) =>
+        (a.event.at || 0) - (b.event.at || 0) || a.index - b.index
+    )
+    .map((row) => row.event);
+}
+
+/**
+ * One row per (injection, finding) pair, labelled.
+ *
+ * Per injection rather than per finding: the same finding injected twice is two
+ * separate opportunities, and collapsing them would let one reference excuse
+ * every later injection of that key.
+ *
+ * FAILS OPEN. A malformed log yields an empty classification, never a throw:
+ * this runs on report paths that must not break a tool call.
+ */
+export function classify(dir, { events = null } = {}) {
+  let rows = [];
+  try {
+    const all = inTimeOrder(events || readMetrics(dir));
+
+    // Every reference, keyed on the finding it names. Only references carrying
+    // a session id are usable -- see `unscopedReferences` in `referenceRate`
+    // for the ones this drops and why they are counted rather than credited.
+    const references = new Map();
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      const key = referencedKey(event);
+      const session = sessionOf(event);
+      if (!key || !session) continue;
+      if (!references.has(key)) references.set(key, []);
+      references.get(key).push({ at: event.at || 0, session });
+    }
+
+    // Which injections the existing outcome join could attribute. An outcome
+    // carrying our injectionId is proof the tool call completed, which is
+    // opportunity even when the session id is missing from the log.
+    const attributed = new Set();
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) continue;
+      attributed.add(String(event.injectionId));
+    }
+
+    // Activity per session, so "did anything follow?" is one lookup rather
+    // than a scan per injection.
+    const activity = new Map();
+    for (const event of all) {
+      if (!ACTIVITY_KINDS.has(event.kind)) continue;
+      const session = sessionOf(event);
+      if (!session) continue;
+      if (!activity.has(session)) activity.set(session, []);
+      activity.get(session).push(event.at || 0);
+    }
+
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+      if (!keys.length) continue;
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const at = event.at || 0;
+      const session = sessionOf(event);
+      // STRICTLY AFTER. A query that PRECEDED the injection is the model
+      // asking on its own initiative; crediting it would let the metric take
+      // the credit for a lookup it had nothing to do with.
+      const followed = (times) => times.some((t) => t > at);
+      const continued =
+        (injectionId && attributed.has(injectionId)) ||
+        (session ? followed(activity.get(session) || []) : false);
+
+      for (const raw of keys) {
+        const findingKey = String(raw);
+        const hits = references.get(findingKey) || [];
+        const referenced = session
+          ? hits.some((hit) => hit.session === session && hit.at > at)
+          : false;
+        rows.push({
+          findingKey,
+          injectionId,
+          label: referenced
+            ? 'referenced'
+            : continued
+              ? 'not-referenced'
+              : 'unknown',
+        });
+      }
+    }
+  } catch {
+    rows = [];
+  }
+  return rows;
+}
+
+/**
+ * The rate, with everything needed to tell a real 0 from an absent one.
+ *
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
+ * `unattributable` and `unscopedReferences` are reported beside it, never
+ * inside it.
+ */
+export function referenceRate(dir, { events = null } = {}) {
+  const empty = {
+    referenced: 0,
+    notReferenced: 0,
+    unknown: 0,
+    denominator: 0,
+    rate: null,
+    unattributable: 0,
+    unattributableWithInjectedToolCall: 0,
+    referenceEvents: 0,
+    unscopedReferences: 0,
+  };
+  try {
+    const all = events || readMetrics(dir);
+    const rows = classify(dir, { events: all });
+    const count = (label) => rows.filter((row) => row.label === label).length;
+    const referenced = count('referenced');
+    const notReferenced = count('not-referenced');
+    const denominator = referenced + notReferenced;
+
+    // Usable reference events in the window: the numerator's producer. If this
+    // is zero the channel never fired, and a 0% rate would be measuring the
+    // absence of a producer rather than the uselessness of findings.
+    let referenceEvents = 0;
+    let unscopedReferences = 0;
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      if (!referencedKey(event)) continue;
+      if (sessionOf(event)) referenceEvents += 1;
+      // Names a finding but cannot be scoped to one injection. `sessionId` is
+      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
+      // is the expected loss rather than an edge case -- counted here so it is
+      // visible instead of silently deflating the numerator.
+      else unscopedReferences += 1;
+    }
+
+    // The tool calls that DID receive findings, keyed the way
+    // `recordToolOutcome` keys its own primary join: the tool-call id. An
+    // unattributable outcome for one of these is a join that FAILED. An
+    // unattributable outcome for any other tool call had nothing to join to.
+    //
+    // KEYED ON THE TOOL CALL, NOT THE EPISODE, and the first draft of this
+    // got it wrong in a way worth recording because it is the exact
+    // measurement-bias class this plan hunts. `episodeId` equals the SESSION
+    // id, so "unattributable outcomes in an episode that had an injection"
+    // scored all 2,559 tool calls of a session in which ONE injection
+    // happened. It would have published 2,559 join failures where the true
+    // number is zero -- correct code, lying number, and biased pessimistic
+    // rather than flattering, which is no better.
+    const injectedToolCalls = new Set();
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      if (!Array.isArray(event.findingIds) || !event.findingIds.length)
+        continue;
+      if (event.toolCallId) injectedToolCalls.add(String(event.toolCallId));
+    }
+    let unattributable = 0;
+    let unattributableWithInjectedToolCall = 0;
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome' || event.joinMethod !== 'none')
+        continue;
+      unattributable += 1;
+      // BOTH FIGURES, because the raw one alone lies in the pessimistic
+      // direction. Measured on this machine: 2,991 of 2,992 live outcomes
+      // report `joinMethod: 'none'`, and every one of them because NO
+      // INJECTION EXISTED for that tool call -- the graph holds one finding.
+      // Quoting only the raw count would read as a join that fails 99.97% of
+      // the time, which is a different and false claim.
+      if (event.toolCallId && injectedToolCalls.has(String(event.toolCallId)))
+        unattributableWithInjectedToolCall += 1;
+    }
+
+    return {
+      referenced,
+      notReferenced,
+      unknown: count('unknown'),
+      denominator,
+      rate:
+        denominator > 0 && referenceEvents > 0
+          ? referenced / denominator
+          : null,
+      unattributable,
+      unattributableWithInjectedToolCall,
+      referenceEvents,
+      unscopedReferences,
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/**
+ * One line for the audit, or nothing at all.
+ *
+ * Says which of the three things is true -- a measured rate, a live channel
+ * with no opportunities yet, or no channel at all -- rather than printing a
+ * figure and letting the reader assume the first.
+ */
+export function referenceNote(dir, { events = null } = {}) {
+  const r = referenceRate(dir, { events });
+  if (!r.denominator && !r.unknown && !r.referenceEvents) return null;
+  if (r.rate == null) {
+    const why = !r.referenceEvents
+      ? 'no finding was ever queried by key in this window'
+      : `no injection had a chance to be referenced yet (${r.unknown} unknown)`;
+    return `Injected findings referenced later: not measurable -- ${why}.`;
+  }
+  return (
+    `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+  );
+}

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -103,6 +103,44 @@ const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
 
 /**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because FOUR readers depend on it -- mutation accounting,
+ * success classification, output capture and exit-code capture -- and clients
+ * disagree on the envelope name and on nothing else. Letting each reader name
+ * its own subset is exactly how both classifiers came to miss MCP's failure
+ * flag: `toolSucceeded` listed four envelopes and `mutationSucceeded` listed
+ * three, and neither list mentioned `isError` at all.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/**
+ * Did an MCP result declare itself an error?
+ *
+ * `isError` is the ONLY failure signal an MCP result carries -- there is no
+ * `error` field and no `status` -- and `src/server/index.ts` sets it in seven
+ * places. Shared by both classifiers so they cannot disagree about what a
+ * failed call from this project's own tools looks like.
+ *
+ * `=== true` EXACTLY. A client using the key for anything else must not have
+ * its successful calls silently reclassified, and `isError: false` is a
+ * successful MCP call, not a missing verdict.
+ */
+function reportedMcpError(raw) {
+  return [...responseEnvelopes(raw), raw].some(
+    (envelope) => envelope?.isError === true
+  );
+}
+
+/**
  * A post-tool event is not universally proof of success. Some clients split
  * success and failure into distinct events; others expose a result status.
  * Keep mutation accounting conservative so a failed edit cannot arm Stop.
@@ -112,6 +150,19 @@ export function mutationSucceeded(clientName, raw) {
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
     return false;
+  // BEFORE the status read, the explicit-success read AND the client
+  // allowlist, because all three would otherwise pass a failed MCP write. The
+  // allowlist is the one that actually bit: it returns true for claude-code,
+  // codex, qwen, opencode, kilo and windsurf on any post-tool event with no
+  // error and no status, which is precisely the shape of a failed smart_write.
+  //
+  // WHY THIS IS THE SAME BUG AS THE ONE IN `toolSucceeded` AND NOT A COSMETIC
+  // ECHO OF IT: this function gates edit counting and harvest pressure, so
+  // counting a failed write to THE OPTIMIZER'S OWN TOOLS as a mutation
+  // inflates "the optimizer successfully edited a file". Different consumers
+  // from the effectiveness figures, same direction of bias -- toward
+  // flattering the thing being measured.
+  if (reportedMcpError(raw)) return false;
 
   const status =
     raw?.tool_response?.status ??
@@ -145,24 +196,6 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * Spelled out ONCE because three readers depend on it -- success
- * classification, output capture and exit-code capture -- and clients disagree
- * on the envelope name and on nothing else. Letting each reader name its own
- * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
-}
-
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
@@ -181,8 +214,7 @@ export function toolSucceeded(raw) {
   // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
   // optimizer's favour. A measurement that flatters the thing being measured
   // is worse than no measurement.
-  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
-    return false;
+  if (reportedMcpError(raw)) return false;
   const status =
     raw?.tool_response?.status ??
     raw?.toolResponse?.status ??

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -957,10 +957,12 @@ async function runHook(clientName, event, invocation) {
       // accumulates structure and no verdicts at all. These detectors read only
       // what is already on disk and send nothing anywhere.
       //
-      // The COUNT is recorded rather than the candidates: how many findings a
-      // session's own evidence supports is the number that says whether this is
-      // working, and it is measurable before anything is stored. Storage is the
-      // caller's next step, under a budget.
+      // COUNTS are recorded rather than the candidates, and BOTH counts: how
+      // many findings a session's own evidence supports, and how many of them
+      // survived the storage budget and the anchor discipline. The gap between
+      // the two is the number that says whether the bound is doing anything --
+      // one figure alone cannot distinguish "nothing to derive" from "derived
+      // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
       const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
       const dir = wikiDir(projectRoot);
@@ -976,6 +978,7 @@ async function runHook(clientName, event, invocation) {
         sessionId,
         candidates: derived.candidates.length,
         observations: derived.observations.length,
+        written: derived.written.length,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -172,6 +172,136 @@ export function toolSucceeded(raw) {
   return true;
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * The same family `toolSucceeded` reads above, hoisted so the three readers
+ * cannot drift apart. Clients disagree on the envelope name and on nothing
+ * else, so this is the one place that disagreement is spelled out.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/** A non-empty string, or null.  Blank output is the same as none. */
+function nonEmpty(value) {
+  const text = String(value ?? '');
+  return text.trim() ? text : null;
+}
+
+/**
+ * The human-readable result text inside one envelope, or null.
+ *
+ * RETURNS NULL RATHER THAN GUESSING. An envelope shape nobody here has seen
+ * produces no capture at all, which costs one finding. Stringifying it instead
+ * would put `[object Object]` or a wall of JSON metadata into a claim that gets
+ * injected into model context -- a wrong observation, which is strictly worse
+ * than a missing one.
+ */
+function resultText(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'string') return nonEmpty(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return null;
+
+  // MCP content blocks, which is how THIS PROJECT'S OWN tools now arrive:
+  // `normalizeTool` resolves `mcp__<server>__smart_edit`, so smart_edit and
+  // smart_write reach the post-tool path for the first time and their results
+  // are `{ content: [{ type: 'text', text }], isError }` rather than a shell
+  // result. Both the bare array and the wrapping object are accepted because
+  // hosts differ on whether they hand the hook the result or its content.
+  if (Array.isArray(value)) {
+    const blocks = value
+      .map((block) =>
+        typeof block === 'string' ? block : nonEmpty(block?.text)
+      )
+      .filter(Boolean);
+    return blocks.length ? nonEmpty(blocks.join('\n')) : null;
+  }
+  if (typeof value !== 'object') return null;
+
+  // STDERR FIRST, and not because that is the order it was produced in. The
+  // cap can only ever cut the tail, and the diagnostic that explains a failure
+  // is almost always on stderr while the volume is almost always on stdout --
+  // so appending stderr would let a 3 MB build log push the one line worth
+  // capturing out of the window.
+  const streams = [nonEmpty(value.stderr), nonEmpty(value.stdout)].filter(
+    Boolean
+  );
+  if (streams.length) return streams.join('\n');
+
+  if (Array.isArray(value.content)) {
+    const inner = resultText(value.content);
+    if (inner) return inner;
+  }
+
+  const error = value.error;
+  if (error) {
+    const message =
+      typeof error === 'string' ? error : nonEmpty(error.message ?? error.msg);
+    if (message) return message;
+  }
+
+  return (
+    nonEmpty(value.output) ??
+    nonEmpty(value.text) ??
+    nonEmpty(value.message) ??
+    (typeof value.result === 'string' ? nonEmpty(value.result) : null)
+  );
+}
+
+/**
+ * The result text of a completed tool call, or null when the client reports
+ * none.  Redaction and the size cap are NOT applied here -- they belong at the
+ * `recordToolOutcome` boundary, which is the only place every caller passes.
+ */
+export function outputFrom(raw) {
+  for (const envelope of responseEnvelopes(raw)) {
+    const text = resultText(envelope);
+    if (text) return text;
+  }
+  return resultText(raw?.output) ?? resultText(raw?.stdout) ?? null;
+}
+
+/**
+ * Key names that mean "process exit code" and nothing else.
+ *
+ * `code` is deliberately ABSENT. JSON-RPC errors (`code: -32602`), Node errno
+ * objects (`code: 'ENOENT'`) and HTTP wrappers all reuse that name, so reading
+ * it would record a confident exit code for calls that never had one. A null
+ * here is honest; a -32602 claiming to be an exit status is not.
+ */
+const EXIT_KEYS = [
+  'exit_code',
+  'exitCode',
+  'exit',
+  'exit_status',
+  'exitStatus',
+  'return_code',
+  'returncode',
+];
+
+/** The numeric exit code a client reported, or null when it reported none. */
+export function exitFrom(raw) {
+  for (const envelope of [...responseEnvelopes(raw), raw]) {
+    if (!envelope || typeof envelope !== 'object') continue;
+    for (const key of EXIT_KEYS) {
+      const value = envelope[key];
+      if (Number.isInteger(value)) return value;
+      // A client that serializes the code as a digit string still reported it.
+      // Bounded so a hash or an id cannot be mistaken for a status.
+      if (typeof value === 'string' && /^-?\d{1,5}$/.test(value.trim()))
+        return Number(value.trim());
+    }
+  }
+  return null;
+}
+
 function contextOutput(client, eventName, additionalContext) {
   if (client.contextStyle === 'top-level') return { additionalContext };
   if (client.contextStyle === 'cline') {
@@ -890,6 +1020,11 @@ async function runHook(clientName, event, invocation) {
         anchor,
         toolName: payload.tool_name,
         success: toolSucceeded(raw),
+        // The two fields a boolean cannot carry: which KIND of failure this
+        // was. Read through the same normalisers as `success`, never off `raw`
+        // at this call site.
+        output: outputFrom(raw),
+        exit: exitFrom(raw),
         durationMs:
           Number(
             raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -145,11 +145,43 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because three readers depend on it -- success
+ * classification, output capture and exit-code capture -- and clients disagree
+ * on the envelope name and on nothing else. Letting each reader name its own
+ * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
+    return false;
+  // MCP'S OWN FAILURE FLAG, which this function did not read for as long as it
+  // existed. It did not matter while `normalizeTool` dropped MCP names before
+  // any accounting ran; it matters now that `mcp__<server>__smart_edit` and
+  // `smart_write` reach the post-tool path, because an MCP result carries no
+  // `error` field and no `status` -- only `isError` -- so a failed smart_edit
+  // fell through to the optimistic `return true` below.
+  //
+  // WHY THIS IS A MEASUREMENT BUG AND NOT A COSMETIC ONE: this boolean feeds
+  // episode outcomes and effectiveness accounting, so recording every failed
+  // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
+  // optimizer's favour. A measurement that flatters the thing being measured
+  // is worse than no measurement.
+  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
     return false;
   const status =
     raw?.tool_response?.status ??
@@ -170,23 +202,6 @@ export function toolSucceeded(raw) {
   // that its output proved the task.  `success` here is deliberately scoped to
   // the tool call; task correctness comes only from an eval grader.
   return true;
-}
-
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * The same family `toolSucceeded` reads above, hoisted so the three readers
- * cannot drift apart. Clients disagree on the envelope name and on nothing
- * else, so this is the one place that disagreement is spelled out.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
 }
 
 /** A non-empty string, or null.  Blank output is the same as none. */

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -58,6 +58,7 @@ import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { briefing } from './remedy.mjs';
 import { stableText, transcriptFor } from './cache.mjs';
+import { scoreRefreshes } from './keepwarm.mjs';
 import { cachedRoutingBriefing } from './routing.mjs';
 import {
   forCommand,
@@ -1010,6 +1011,26 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE KEEP-WARM FEEDBACK ARM, at the boundary where a turn has just
+      // ended -- which is the only place the arrival question can be answered.
+      // Every refresh whose TTL has since elapsed is scored here as used or
+      // unused; anything the log cannot settle is left unscored rather than
+      // recorded as a miss, because an absent signal is not a miss.
+      //
+      // Nothing in this repository issues a refresh today -- cache_audit only
+      // recommends one -- so this scores nothing, and what it costs while
+      // dormant is one readBalance: median 70 ms on this machine's 3.5 MB log,
+      // against derive's 71-111 ms a few lines below on the same path. The
+      // firehose is read for ARRIVALS only if an unscored refresh exists, so
+      // the dormant case never pays for that. The moment an issuer exists, the
+      // decision starts learning with no second wiring change.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      scoreRefreshes(dir);
+    } catch {
+      // A refresh that cannot be scored costs a measurement, not a session.
     }
     try {
       // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -40,11 +40,13 @@ import {
   touchedFiles,
 } from './decide.mjs';
 import {
+  record,
   recordRead,
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
 } from './metrics.mjs';
+import { derive } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -948,6 +950,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // ZERO-COST DERIVATION, on every client, with no credential. The semantic
+      // harvest below needs an API key, so on a machine without one the graph
+      // accumulates structure and no verdicts at all. These detectors read only
+      // what is already on disk and send nothing anywhere.
+      //
+      // The COUNT is recorded rather than the candidates: how many findings a
+      // session's own evidence supports is the number that says whether this is
+      // working, and it is measurable before anything is stored. Storage is the
+      // caller's next step, under a budget.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      const dir = wikiDir(projectRoot);
+      const derived = derive(dir, {
+        sessionId,
+        projectRoot,
+        transcriptPath: agentScope,
+        // The hook payload's own identity, not a value a model typed.
+        authoritativeSessionId: sessionId,
+      });
+      record(dir, {
+        kind: 'derive',
+        sessionId,
+        candidates: derived.candidates.length,
+        observations: derived.observations.length,
+      });
+    } catch {
+      // A detector failing must never cost a user the end of their session.
     }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -72,7 +72,8 @@ import {
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
-import { isArchived } from './transcript.mjs';
+import { archive, isArchived } from './transcript.mjs';
+import { harvestMode } from './harvest.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
@@ -577,6 +578,65 @@ function emit(object) {
   process.stdout.write(serialized);
 }
 
+/**
+ * What will and will not extract findings after this session, in one sentence.
+ *
+ * THE STATE WAS ONLY EVER LEGIBLE FROM THE DOCTOR, and the doctor is a place
+ * someone visits after they already suspect something is wrong. A user watching
+ * a graph fill with structural nodes and no verdicts has no reason to suspect
+ * anything, which is the failure this project has now measured twice.
+ *
+ * IT IS ADDRESSED TO THE MODEL, NOT ONLY TO THE READER, which is why it earns a
+ * place in the prefix rather than a systemMessage. "Nothing else will write this
+ * down in words" changes what the model does with a conclusion it is holding;
+ * "here is a configuration variable" would not.
+ *
+ * CACHE-SAFE: derived from configuration, so it differs between sessions only
+ * when the configuration does -- the same standard the rest of this block is
+ * held to, and it carries no digits for `stableText` to reject.
+ *
+ * A local endpoint is named FIRST in the off case on purpose. It is the option
+ * that costs nothing and sends nothing, and it was the one buried deepest.
+ */
+function extractionNotice() {
+  switch (harvestMode()) {
+    case 'local':
+      return (
+        '\n\nA local model endpoint is configured, so semantic extraction also runs after this ' +
+        'session -- free and private, with nothing leaving this machine.'
+      );
+    case 'remote':
+      return (
+        '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
+        'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
+    case 'off:mode':
+      // The whole optimizer is off and this text is not emitted anyway. Saying
+      // anything here would be noise stacked on an explicit choice.
+      return '';
+    case 'off:opted-out':
+      // A DELIBERATE CHOICE, SO NO PITCH. The consequence is stated because the
+      // model needs it; the setting that would reverse it is not, because
+      // arguing with a configured decision on every session is how a notice
+      // stops being read. doctor.mjs draws the same line for the same reason.
+      return (
+        '\n\nFallback extraction is off by configuration, so a conclusion you do not record is ' +
+        'not written down in words anywhere. Findings are still derived locally from exit codes, ' +
+        'red-to-green transitions and corrections.'
+      );
+    default:
+      // off:no-key, and any mode a future harvest adds: no extractor is running
+      // and nobody chose that, so the free option is worth naming.
+      return (
+        '\n\nNo separate extractor will run after this session, so a conclusion you do not record ' +
+        'is not written down in words anywhere. Findings are still derived locally from exit ' +
+        'codes, red-to-green transitions and corrections. Pointing ' +
+        'TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model adds semantic extraction, free and ' +
+        'private.'
+      );
+  }
+}
+
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
 export function policyText(
   canDeny,
@@ -635,7 +695,7 @@ export function policyText(
     .filter(Boolean)
     .join(' ');
   const recording = tools.has('wiki_write')
-    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.`
+    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.${extractionNotice()}`
     : '\n\nStructural graph capture remains active through lifecycle hooks. Durable semantic MCP writes are not requested because the writer schema is not proven available.';
 
   return `# Token optimization is active\n\nLive graph capture is active through the lifecycle adapter.\n\n${connection}${routing}${enforcement}${utilities ? `\n\n${utilities}` : ''}${recording}${projectBriefing()}`;
@@ -950,6 +1010,27 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.
+      //
+      // This was lost rather than retired. `plugin/hooks/stop-harvest.mjs` called
+      // `archive()` at Stop, and #300 replaced that entry in `hooks.json` with the
+      // generated `stop.mjs`, which routes here -- so on Claude Code no session has
+      // been archived since. Nothing failed loudly: `readArchive` simply returns an
+      // empty list, so `derive`'s correction detector fell through to the live
+      // transcript (present only for a client that reports one) and `lessons.mjs`
+      // lost the only corpus it can verify a verbatim quote against, which is the
+      // single test that grants a feedback finding human origin.
+      //
+      // BEFORE `derive`, deliberately: the correction detector reads the archive
+      // first and treats the live transcript as the fallback, and the archive is
+      // the copy that survives into later sessions.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      if (agentScope) archive(dir, agentScope, { sessionId });
+    } catch {
+      // The archive is a record, not a result. A session still ends.
     }
     try {
       // ZERO-COST DERIVATION, on every client, with no credential. The semantic

--- a/integrations/gemini/hooks/lib/audit.mjs
+++ b/integrations/gemini/hooks/lib/audit.mjs
@@ -32,6 +32,7 @@
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
+import { looNote } from './loo.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -401,6 +402,16 @@ export function renderAudit(
   // project with no injections and no queries gains no line at all.
   const reference = referenceNote(dir);
   if (reference) body.push('', reference);
+
+  // WHAT ONE FINDING IS CAUSALLY WORTH (Layer 2).
+  //
+  // The same reasoning as above, and the same refusal: `looNote` returns null
+  // until the leave-one-out experiment has collected an observation, and says
+  // NOT MEASURABLE YET rather than printing a mean until it clears the floor.
+  // A causal number is the most quotable thing this project can produce, so it
+  // is the one that most needs to be absent when it is not earned.
+  const causal = looNote(dir);
+  if (causal) body.push('', causal);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/gemini/hooks/lib/audit.mjs
+++ b/integrations/gemini/hooks/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
 import { looNote } from './loo.mjs';
+import { calibrationNote } from './crosslayer.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -244,9 +245,15 @@ export function renderAudit(
     lines.push(text);
   }
 
+  // SCOPED TO THE QUEUE, because that is all it ever described. The bare
+  // sentence "Nothing addressable found." was printed directly above a Layer 1
+  // reference note and a published Layer 2 causal verdict -- so a reader was
+  // told nothing had been found immediately before being shown a finding. The
+  // headline is about the remediation queue and nothing else, and saying so
+  // costs four words and removes a false negative shown to a human.
   const head = shown.length
     ? ['What to do next, most expensive first:', ...lines]
-    : ['Nothing addressable found.'];
+    : ['Nothing addressable found in the remediation queue.'];
 
   const body = [...head];
 
@@ -412,6 +419,16 @@ export function renderAudit(
   // is the one that most needs to be absent when it is not earned.
   const causal = looNote(dir);
   if (causal) body.push('', causal);
+
+  // WHETHER LAYER 1'S CHEAP LABEL PREDICTS LAYER 2'S EXPENSIVE EFFECT.
+  //
+  // The reason this is printed rather than kept for a dashboard: the reference
+  // rate is the number a reader is most likely to quote as a saving, and it is
+  // not one until this comparison says so. `calibrationNote` returns null while
+  // both layers are silent, and otherwise prints the refusal -- naming which
+  // input was insufficient -- rather than a gap of zero.
+  const calibrated = calibrationNote(dir);
+  if (calibrated) body.push('', calibrated);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/gemini/hooks/lib/audit.mjs
+++ b/integrations/gemini/hooks/lib/audit.mjs
@@ -61,6 +61,28 @@ export function declines(dir, { events = readMetrics(dir) } = {}) {
   return counts;
 }
 
+/**
+ * What the local Stop-time derivation path produced in the visible event log.
+ *
+ * The producer records all three counts because any one of them alone is
+ * ambiguous: zero stored can mean no evidence, no candidates, or a binding
+ * storage/anchor filter. This reader keeps those states distinct and prevents
+ * the telemetry itself from becoming an unobserved cost.
+ */
+export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
+  const runs = events.filter((event) => event.kind === 'derive');
+  if (!runs.length) return null;
+
+  const sum = (field) =>
+    runs.reduce((total, event) => total + Math.max(0, Number(event[field]) || 0), 0);
+  const candidates = sum('candidates');
+  const observations = sum('observations');
+  const written = sum('written');
+  return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
+    `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
+    `across ${runs.length.toLocaleString()} Stop run(s).`;
+}
+
 const idOf = (finding) =>
   finding.remedy
     ? `${finding.remedy.type}:${finding.remedy.anchor || finding.remedy.file || (finding.remedy.anchors || []).join(',')}`
@@ -399,6 +421,15 @@ export function renderAudit(
       );
     }
   }
+
+  // WHAT THE DEFAULT, LOCAL DERIVATION PATH ACTUALLY PRODUCED.
+  //
+  // This event used to have a producer and no reader. Keep its three states
+  // together: evidence seen, candidates derived, and findings that survived
+  // selection/storage. A lone stored count would turn every earlier refusal
+  // into an apparent "nothing found" result.
+  const derived = derivationNote(dir);
+  if (derived) body.push('', derived);
 
   // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
   //

--- a/integrations/gemini/hooks/lib/audit.mjs
+++ b/integrations/gemini/hooks/lib/audit.mjs
@@ -31,6 +31,7 @@
  */
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
+import { referenceNote } from './usage.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -390,6 +391,16 @@ export function renderAudit(
       );
     }
   }
+
+  // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
+  //
+  // Printed here because this is the report that already asks "did the advice
+  // change anything", and because a measurement with no reader is how this
+  // project shipped two metrics whose only consumer was their own test suite.
+  // `referenceNote` returns null when it has nothing honest to say, so a
+  // project with no injections and no queries gains no line at all.
+  const reference = referenceNote(dir);
+  if (reference) body.push('', reference);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/gemini/hooks/lib/consolidate.mjs
+++ b/integrations/gemini/hooks/lib/consolidate.mjs
@@ -142,7 +142,8 @@ const ALWAYS_KEEP = new Set(['failure', 'decision']);
  * Chooses what to promote into the graph, under a token budget.
  *
  * @param {object} graph      Loaded wiki graph, for reuse probability.
- * @param {Array}  candidates Extracted conclusions, each { type, summary, anchors, evidence, at }.
+ * @param {Array}  candidates Extracted conclusions, each { type, claim (or summary),
+ *                              anchors, evidence, at }.
  * @param {object} options    budget: tokens available for promoted findings.
  */
 export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}) {
@@ -221,4 +222,3 @@ export function aggregateConsolidation(findings) {
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
-

--- a/integrations/gemini/hooks/lib/crosslayer.mjs
+++ b/integrations/gemini/hooks/lib/crosslayer.mjs
@@ -1,0 +1,351 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/crosslayer.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The calibration loop: does Layer 1's LABEL predict Layer 2's EFFECT?
+ *
+ * Layer 1 (`usage.mjs`) classifies an injected finding by whether the model
+ * later NAMED it. Layer 2 (`loo.mjs`) measures, by leave-one-out, how many
+ * tokens of reading a finding actually SUPPRESSED. Those are two different
+ * quantities, and the whole point of putting them side by side is that the
+ * cheap one (a label, available on every injection) might stand in for the
+ * expensive one (a causal effect, costing three withheld sessions per finding).
+ *
+ * WHY THIS IS A REAL QUESTION AND NOT A TAUTOLOGY. Task 7 established the
+ * independence three ways -- statically (`loo.mjs` contains no `query` or
+ * `reference`; `usage.mjs` contains no `tokens`, `cost` or `bytes`),
+ * behaviourally in both directions, and by naming the one overlap that does
+ * exist (`recordToolOutcome`'s join, which supplies ATTRIBUTABILITY to both and
+ * the measured quantity to neither). This module is built to preserve that:
+ *
+ *   - from Layer 1 it takes ONLY the categorical label per finding key. No
+ *     rate, no count, no magnitude -- Layer 1 has no magnitude to give.
+ *   - from Layer 2 it takes ONLY the effect magnitude per finding key.
+ *   - the join is the finding key, which is a graph identity and not a
+ *     measurement.
+ *
+ * If a magnitude common to both ever entered, this would correlate a quantity
+ * with itself and report a strong result that means nothing. Two tests pin the
+ * separation from opposite sides: flipping the labels while holding the effects
+ * fixed must move the gap, and changing Layer 1's rate WITHOUT changing any
+ * label must leave the gap byte-identical.
+ *
+ * MEASURED UTILITY RANKS A FINDING. IT MUST NEVER RAISE ITS CONFIDENCE.
+ * A confidently WRONG finding suppresses reads better than a hedged true one,
+ * so utility alone optimises directly against "wrong findings are worse than
+ * none". The plan called for a `mayPromote` gate over
+ * `hasOutstandingContradiction` here. There is nothing to gate: every write of
+ * `confidence` in `hooks-core` happens at CREATION (a per-producer constant in
+ * `derive.mjs` / `lessons.mjs` / `harvest.mjs`, or a human's own number in
+ * `curate.mjs`), and no code path updates a stored finding's confidence
+ * afterwards. `assessFindings` in `utility.mjs` READS confidence into an
+ * ephemeral `netUtility` used for ordering and writes nothing back. So a gate
+ * here would be unreachable, and an unreachable gate is the exact defect class
+ * this work exists to close. `hasOutstandingContradiction` already has its
+ * real consumer -- `staleness.mjs` calls it as the dispute gate on serve.
+ * What is enforceable is the invariant itself, and it is: this module never
+ * writes to the graph, and `tests/hooks/calibration-loop.test.mjs` asserts that
+ * neither it nor either layer under it can move a stored confidence.
+ *
+ * NOTHING HERE IS PRICED. A calibration verdict, a holdout estimate and a
+ * consolidation ratio are all estimates; currency belongs only on a measured
+ * counterfactual, and `balanceSheet`'s `measuredCounterfactual` is the one
+ * section in the sheet below that qualifies.
+ */
+
+import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
+import { classify, referenceRate } from './usage.mjs';
+import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Distinct findings needed in EACH arm before a gap is reported at all.
+ *
+ * Two findings per arm is a difference of two numbers; the comparison would be
+ * dominated by whichever finding happened to sit on a big file. Three is still
+ * small, and the refusal says so rather than implying the gap is solid.
+ */
+export const MIN_FINDINGS_PER_ARM = 3;
+
+/**
+ * The smallest gap that may be PUBLISHED, in tokens per touch.
+ *
+ * Not an effect-size convention: it is tied to the unit the verdict prints. The
+ * published sentence rounds the gap to whole tokens, so a gap of 1e-13 -- which
+ * is what two arms of equal means produce once floating point has had its say --
+ * would publish as "referenced findings suppress 0 more tokens/touch". That is a
+ * calibration claim resting on arithmetic noise, and it leans the only direction
+ * a measurement of this project by this project must never lean.
+ */
+export const MIN_GAP_TOKENS = 1;
+
+/**
+ * The per-finding Layer 1 label, folded from per-injection rows.
+ *
+ * ANY reference wins. `classify` emits one row per (injection, finding) because
+ * one reference must not excuse every later injection -- that is the right unit
+ * for a RATE. For a label the question is different: did the model ever name
+ * this finding? A finding referenced once and ignored nine times is a finding
+ * the model reads, and averaging it into `not-referenced` would put it in the
+ * arm whose mean effect it is meant to predict.
+ *
+ * `unknown` rows are dropped rather than defaulted, exactly as Layer 1 drops
+ * them from its own denominator.
+ */
+export function labelsByFinding(rows) {
+  const labels = new Map();
+  for (const row of rows || []) {
+    const key = row?.findingKey;
+    if (typeof key !== 'string' || !key) continue;
+    if (row.label === 'referenced') labels.set(key, 'referenced');
+    else if (row.label === 'not-referenced' && !labels.has(key))
+      labels.set(key, 'not-referenced');
+  }
+  return labels;
+}
+
+const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * Does Layer 1's label predict Layer 2's effect?
+ *
+ * Returns `publishable`, a `verdict` in English, and `gap` ONLY when a gap was
+ * actually computed. There is no `gap: 0` for the unmeasured case, and that is
+ * deliberate: a permanent zero reads as "measured, and the two agree", which is
+ * the opposite of "nothing was measured". Task 7 deleted a field rather than
+ * zero it for the same reason.
+ *
+ * FAILS OPEN. This runs on report paths that must not break a tool call.
+ */
+export function calibration(dir, options = {}) {
+  const refuse = (verdict, extra = {}) => ({
+    publishable: false,
+    verdict,
+    ...extra,
+  });
+
+  try {
+    // ONE READ for both layers, so the two arms of the comparison cannot cover
+    // different spans of the log. `referenceRate` reports `windowed: false`
+    // when the caller supplies events -- correctly, since the bounds are then
+    // the caller's -- so the truncation flag is taken here, from the read that
+    // actually set it, and republished.
+    const supplied = options.events || null;
+    const events = supplied || readMetrics(dir);
+    const truncation = supplied ? null : readTruncation();
+    const truncated = Boolean(
+      truncation && (truncation.byBytes || truncation.byEvents)
+    );
+
+    const layer1 = referenceRate(dir, { events });
+    const labels = labelsByFinding(classify(dir, { events }));
+
+    const obs = observations(dir, { ...options, events });
+    const rows = effects(dir, { ...options, events, obs });
+
+    // ONE POLICY VERSION. Layer 2 refuses to pool arms across serving
+    // policies; a calibration that pooled them would undo that guard one level
+    // up. Rows from any other policy are excluded and counted.
+    const policy = servingPolicyVersion();
+    const inPolicy = rows.filter((row) => row.policy === policy);
+
+    const layer2 = {
+      rows: rows.length,
+      inPolicy: inPolicy.length,
+      published: rows.filter((row) => row.published).length,
+      observations: obs.rows.length,
+      policy,
+    };
+    const l1 = {
+      referenced: layer1.referenced,
+      notReferenced: layer1.notReferenced,
+      unknown: layer1.unknown,
+      denominator: layer1.denominator,
+      rate: layer1.rate,
+      referenceEvents: layer1.referenceEvents,
+    };
+
+    const excluded = { layer1Unknown: layer1.unknown, unlabelled: 0, noEffect: 0 };
+    const arms = { referenced: [], notReferenced: [] };
+    for (const row of inPolicy) {
+      // THE SHRUNK ESTIMATE, not the raw one. Shrinkage pulls every finding
+      // toward the population mean, so it pulls the GAP toward zero -- the
+      // bias runs against publishing, which is the only direction a
+      // measurement of this project by this project may lean.
+      if (row.shrunk === null || !Number.isFinite(row.shrunk)) {
+        excluded.noEffect += 1;
+        continue;
+      }
+      const label = labels.get(row.findingKey);
+      if (label === 'referenced') arms.referenced.push(row.shrunk);
+      else if (label === 'not-referenced') arms.notReferenced.push(row.shrunk);
+      else excluded.unlabelled += 1;
+    }
+
+    const context = { layer1: l1, layer2, arms: { referenced: arms.referenced.length, notReferenced: arms.notReferenced.length }, excluded, windowed: truncated };
+    const caveat = truncated
+      ? ' The event log was truncated, so both sides can understate.'
+      : '';
+
+    // WHICH INPUT WAS INSUFFICIENT, named. "Not enough data" tells a reader
+    // nothing about which half of the loop to go and fix.
+    const l1Silent = layer1.rate === null;
+    const l2Silent = layer2.observations === 0;
+    if (l1Silent || l2Silent) {
+      const why = [];
+      if (l1Silent)
+        why.push(
+          `Layer 1 has ${layer1.denominator} classifiable observation(s) and ` +
+            `${layer1.referenceEvents} reference event(s), so it publishes no rate`
+        );
+      if (l2Silent)
+        why.push(
+          `Layer 2 has ${layer2.observations} observation(s), so it publishes no effect`
+        );
+      return refuse(
+        `not calibrated: ${why.join('; and ')}. No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+    }
+
+    // A POLICY CHANGE RESETS THE CALIBRATION, and says so rather than reporting
+    // an empty arm. Layer 2 refuses to pool arms across serving policies, so
+    // rows generated under an older one cannot answer a question about how the
+    // graph serves findings today -- but "0 findings per arm" would send a
+    // reader hunting for missing observations that are right there in the log.
+    if (rows.length > 0 && inPolicy.length === 0)
+      return refuse(
+        `not calibrated: all ${rows.length} Layer 2 effect row(s) were measured under a different serving ` +
+          `policy than the current ${policy}, and arms are never pooled across policies. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (layer2.published === 0)
+      return refuse(
+        `not calibrated: Layer 2 has ${layer2.observations} observation(s) but no published effect at q=0.1, ` +
+          'so its per-finding numbers are noise and a difference between two means of them would be too. ' +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (
+      arms.referenced.length < MIN_FINDINGS_PER_ARM ||
+      arms.notReferenced.length < MIN_FINDINGS_PER_ARM
+    )
+      return refuse(
+        `not calibrated: ${arms.referenced.length} referenced and ${arms.notReferenced.length} not-referenced ` +
+          `finding(s) carry a Layer 2 effect, below the floor of ${MIN_FINDINGS_PER_ARM} per arm. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    const referencedMean = mean(arms.referenced);
+    const notReferencedMean = mean(arms.notReferenced);
+    const gap = referencedMean - notReferencedMean;
+    const measured = { ...context, gap, referencedMean, notReferencedMean };
+
+    if (!(gap >= MIN_GAP_TOKENS))
+      return refuse(
+        `uncalibrated: Layer 1's "referenced" label does not predict a larger Layer 2 effect ` +
+          `(referenced ${Math.round(referencedMean).toLocaleString()} vs not-referenced ` +
+          `${Math.round(notReferencedMean).toLocaleString()} tokens/touch, gap ${Math.round(gap).toLocaleString()}). ` +
+          `Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
+    return {
+      publishable: true,
+      verdict:
+        `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
+      ...measured,
+    };
+  } catch {
+    return refuse(
+      'not calibrated: the calibration inputs could not be read. No gap is reported, which is not the same as a gap of zero.'
+    );
+  }
+}
+
+/**
+ * What the graph cost to build against what it carries -- AN ESTIMATE, and
+ * never priced.
+ *
+ * `consolidationRatio` is the per-finding form and the aggregate is the fold.
+ * Both need `derivedCost`, which `expand.promote` persists onto the finding
+ * node it creates (`src/server/disclosure.ts` is its caller) and which
+ * `harvest-write.mjs` does not yet carry through -- so a graph built only by
+ * the harvest reports nothing here rather than a ratio of one.
+ */
+export function consolidation(dir, { graph = null } = {}) {
+  try {
+    const g = graph || load(dir);
+    const findings = [...g.nodes.values()].filter(
+      (node) => node.kind === 'finding' && !node.retired
+    );
+    const rated = [];
+    for (const finding of findings) {
+      const ratio = consolidationRatio(finding);
+      if (ratio === null) continue;
+      rated.push({ key: finding.key, ratio, derivedCost: finding.derivedCost });
+    }
+    const aggregate = aggregateConsolidation(findings);
+    return {
+      what: 'cost to derive against cost to carry',
+      // SAID IN THE DATA, not only in the prose above it, because this is the
+      // field a dashboard will read and a dashboard will not read a comment.
+      basis: 'estimate',
+      priced: false,
+      findings: findings.length,
+      withDerivedCost: rated.length,
+      aggregate,
+      best: rated.sort((a, b) => b.ratio - a.ratio).slice(0, 5),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The balance sheet with the graph's own three measurements attached.
+ *
+ * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
+ * imports, so it cannot import them back. This is where the two meet, and it
+ * is the shape `get_optimization_report` serves.
+ */
+export function graphBalanceSheet(dir, options = {}) {
+  const sheet = balanceSheet(dir);
+  const cal = calibration(dir, options);
+  const { layer1 = null, layer2 = null } = cal;
+  return {
+    ...sheet,
+    layer1,
+    layer2,
+    calibration: cal,
+    consolidation: consolidation(dir, options),
+  };
+}
+
+/**
+ * One audit line, or null when there is nothing honest to say.
+ *
+ * Silent when NEITHER layer has produced anything: a reader of a graph that has
+ * never injected a finding is owed no paragraph about a loop that has not
+ * started. The moment either side speaks, the refusal is worth printing --
+ * because at that point a reader could otherwise take Layer 1's rate for a
+ * saving, which is precisely what this loop exists to stop.
+ */
+export function calibrationNote(dir, options = {}) {
+  try {
+    const result = calibration(dir, options);
+    const l1 = result.layer1;
+    const l2 = result.layer2;
+    if (!l1 || !l2) return null;
+    if (l1.denominator === 0 && l2.observations === 0) return null;
+    return `Layer 1 against Layer 2: ${result.verdict}`;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/gemini/hooks/lib/crosslayer.mjs
+++ b/integrations/gemini/hooks/lib/crosslayer.mjs
@@ -54,7 +54,13 @@
 
 import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
-import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import {
+  effects,
+  observations,
+  servingPolicyVersion,
+  permutationP,
+  FDR_Q,
+} from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
 import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
@@ -106,6 +112,32 @@ export function labelsByFinding(rows) {
 }
 
 const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * A deterministic, label-symmetric permutation test for the headline gap.
+ *
+ * Layer 2 only publishes a per-finding row after a two-sided permutation test.
+ * The calibration headline summarises those rows, so a positive difference of
+ * arm means must clear the same evidential bar rather than being promoted just
+ * because it points in this project's favour.
+ *
+ * Sorting within each arm and then sorting the two arms makes the sampled path
+ * invariant to event order and to swapping the labels. The seed is derived
+ * from that canonical data instead of shared globally, so two different
+ * datasets do not reuse one arbitrary sequence of sampled relabellings.
+ */
+export function calibrationP(referenced, notReferenced) {
+  const arms = [referenced, notReferenced]
+    .map((values) => [...values].sort((a, b) => a - b))
+    .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  const encoded = JSON.stringify(arms);
+  let seed = 2166136261;
+  for (const char of encoded) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return permutationP(arms[0], arms[1], { seed: seed >>> 0 });
+}
 
 /**
  * Does Layer 1's label predict Layer 2's effect?
@@ -244,7 +276,16 @@ export function calibration(dir, options = {}) {
     const referencedMean = mean(arms.referenced);
     const notReferencedMean = mean(arms.notReferenced);
     const gap = referencedMean - notReferencedMean;
-    const measured = { ...context, gap, referencedMean, notReferencedMean };
+    const p = calibrationP(arms.referenced, arms.notReferenced);
+    const measured = {
+      ...context,
+      gap,
+      referencedMean,
+      notReferencedMean,
+      p,
+      alpha: FDR_Q,
+      test: 'two-sided permutation',
+    };
 
     if (!(gap >= MIN_GAP_TOKENS))
       return refuse(
@@ -255,11 +296,20 @@ export function calibration(dir, options = {}) {
         measured
       );
 
+    if (p === null || p > FDR_Q)
+      return refuse(
+        `not calibrated: the positive Layer 1/Layer 2 gap is not statistically resolved by the ` +
+          `two-sided permutation test (p=${p === null ? 'unavailable' : p.toFixed(3)}, ` +
+          `alpha=${FDR_Q.toFixed(3)}). Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
     return {
       publishable: true,
       verdict:
         `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
-        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, ` +
+        `shrunk estimates, two-sided permutation p=${p.toFixed(3)}). ` +
         `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
       ...measured,
     };

--- a/integrations/gemini/hooks/lib/crosslayer.mjs
+++ b/integrations/gemini/hooks/lib/crosslayer.mjs
@@ -56,6 +56,7 @@ import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
 import { effects, observations, servingPolicyVersion } from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
 
 /**
@@ -309,11 +310,19 @@ export function consolidation(dir, { graph = null } = {}) {
 }
 
 /**
- * The balance sheet with the graph's own three measurements attached.
+ * The balance sheet with the graph's own measurements attached.
  *
  * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
  * imports, so it cannot import them back. This is where the two meet, and it
  * is the shape `get_optimization_report` serves.
+ *
+ * `recall` joins them as an OFFLINE PROBE, and that label travels in the data
+ * (`recall.basis`) as well as in the rendered line. It is not an observation of
+ * anything a session did: it deletes an anchor edge in memory and re-runs the
+ * real retrieval primitives over the graph as it stands right now. `recall.mjs`
+ * imports only `wiki.mjs` and `lexical.mjs`, neither of which imports anything
+ * in this direction, so no cycle -- the same reason `calibration` had to live
+ * here rather than in `metrics.mjs`.
  */
 export function graphBalanceSheet(dir, options = {}) {
   const sheet = balanceSheet(dir);
@@ -325,6 +334,7 @@ export function graphBalanceSheet(dir, options = {}) {
     layer2,
     calibration: cal,
     consolidation: consolidation(dir, options),
+    recall: recallProbe(dir, options),
   };
 }
 

--- a/integrations/gemini/hooks/lib/derive.mjs
+++ b/integrations/gemini/hooks/lib/derive.mjs
@@ -23,13 +23,21 @@
  * the observation supports no claim at all are refused rather than downgraded
  * (see `attemptKey` and the identical-text guard below).
  *
- * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
- * budget, belongs to the caller.
+ * WHAT IS STORED IS BOUNDED. Candidates go through `selectForConsolidation`
+ * before `writeHarvested`, so a long session cannot spend the whole retrieval
+ * budget of every later session on one afternoon's exit codes. Nothing enters
+ * the graph unbudgeted, and nothing enters it wearing a human origin.
  */
 
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
 import { readArchive, readTurns } from './transcript.mjs';
 import { redact } from './redact.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { load } from './wiki.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -106,6 +114,92 @@ const triggerFor = (command) =>
   attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
 
 /**
+ * Literal root-level files that define how a project is BUILT, RUN and TESTED,
+ * best first. A `command` claim is a claim about this project's commands, and
+ * this is the file those commands are declared in.
+ */
+const PROJECT_MARKERS = [
+  'package.json', 'pyproject.toml', 'Cargo.toml', 'go.mod', 'pom.xml',
+  'build.gradle.kts', 'build.gradle', 'build.sbt', 'mix.exs', 'composer.json',
+  'Gemfile', 'Package.swift', 'CMakeLists.txt', 'Makefile', 'Taskfile.yml',
+  'requirements.txt', 'setup.py', 'deno.json', 'bun.lockb',
+];
+
+/** .NET has no single literal marker; the solution or project file is one. */
+const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
+
+/**
+ * A REAL FILE to anchor a derived claim to, inside the project root.
+ *
+ * WHY NOT THE PROJECT ROOT ITSELF, which is what the extraction step reaches
+ * for and what `promoteToShared` uses in the shared tier. Because
+ * `writeHarvested` resolves every anchor through `indexFile`, `indexFile` reads
+ * the path, and reading a DIRECTORY returns null -- so a candidate anchored to
+ * `projectRoot` resolves to nothing, is refused as unanchorable, and the whole
+ * pipeline stores zero findings while reporting a healthy candidate count.
+ * Verified directly: `indexFile(dir, dir)` returns null. That refusal is
+ * correct and must not be weakened -- an anchor that cannot be indexed is an
+ * anchor that can never be invalidated -- so the anchor has to be a file.
+ *
+ * STALENESS DOES NOT MISFIRE ON THIS. `command`, `failure` and `feedback` are
+ * all outside `CONTENT_DEPENDENT` (staleness.mjs), so the anchor is a RETRIEVAL
+ * AND EXISTENCE hook rather than a contents claim: editing the manifest does
+ * not mark these findings stale. staleness.mjs names this exact case in its own
+ * comment -- "a claim about `npm test` anchored to package.json" -- and calls
+ * missing that invalidation the better error.
+ *
+ * A project with no recognisable marker gets the root back, which will not
+ * resolve, so its candidates are derived and then refused rather than stored
+ * against a fabricated anchor. That is the fail-open direction: no finding
+ * beats a finding anchored to something that is not what the claim is about.
+ */
+export function projectAnchor(projectRoot) {
+  if (!projectRoot) return null;
+  let entries;
+  try {
+    entries = readdirSync(projectRoot);
+  } catch {
+    return projectRoot;
+  }
+  const present = new Set(entries);
+  for (const marker of PROJECT_MARKERS) {
+    if (!present.has(marker)) continue;
+    const path = join(projectRoot, marker);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // A marker that cannot be stat'ed is not a marker.
+    }
+  }
+  // Sorted so two sessions in the same repository pick the SAME solution file:
+  // readdir order is not guaranteed stable across hosts, and an anchor that
+  // varies by host splits one finding into two nodes.
+  for (const entry of [...entries].sort()) {
+    if (!DOTNET_MARKER.test(entry)) continue;
+    const path = join(projectRoot, entry);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // Same.
+    }
+  }
+  return projectRoot;
+}
+
+/**
+ * Tokens of claim text one session may add to the graph.
+ *
+ * SCALED TO THE RETRIEVAL BUDGET IT COMPETES FOR, not picked round. A single
+ * command's injection budget is 500 tokens (`TOKEN_OPTIMIZER_TOUCH_BUDGET`),
+ * and everything stored here is competing for that budget on every later
+ * command, forever. Two touch-budgets per session is the bound: enough for a
+ * few dozen real claims, and short of one session's exit codes crowding out
+ * every finding a human or a model ever wrote.
+ */
+const storageBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_DERIVE_BUDGET) || 1000;
+
+/**
  * Derives finding candidates from one project's local evidence.
  *
  * @param {string} dir wiki directory.
@@ -118,11 +212,18 @@ const triggerFor = (command) =>
  *   and is refused by `writeHarvested` anyway, so emitting one would only spend
  *   the caller's budget on junk.
  * @param {string|null} options.authoritativeSessionId the session id as the HOOK
- *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
- *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
- *   edge -- `taskForAnchors` returns null without one, so an unverified string
- *   would silently produce no edge. Threaded rather than defaulted from
- *   `sessionId`: defaulting would promote any caller's string to trusted.
+ *   PAYLOAD reported it, never a value a model typed. Passed straight to
+ *   `writeHarvested`, which needs it to resolve the `answers` edge --
+ *   `taskForAnchors` returns null without one, so an unverified string would
+ *   silently produce no edge. Threaded rather than defaulted from `sessionId`:
+ *   defaulting would promote any caller's string to trusted. Also returned, so a
+ *   caller can see what it handed over.
+ * @returns {object} `{ candidates, observations, written, selected, dropped,
+ *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
+ *   everything derived; `written` is the subset of keys the graph actually
+ *   holds, which is smaller for three independent reasons -- the budget, the
+ *   anchor discipline, and the duplicate collapse that returns an EXISTING key
+ *   when a later session derives the same claim again.
  */
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
@@ -152,6 +253,11 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // ONE anchor for the whole run, so every candidate from this session points at
+  // the same node and the duplicate collapse in `writeHarvested` can recognise
+  // the same lesson across sessions.
+  const anchorPath = projectAnchor(projectRoot);
 
   const seen = new Set();
   const add = (candidate) => {
@@ -246,7 +352,7 @@ export function derive(dir, options = {}) {
               `observed in one session: \`${failed.command}\` failed` +
                 `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
                 `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
-                'an intervening edit or a flaky run explains the same pair.',
+                'an intervening edit or an unrelated environment change explains the same pair.',
               { max: EVIDENCE_MAX }
             ),
             applicability: 'when about to run this command in this project',
@@ -255,7 +361,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the failing form later succeeds unchanged'],
             trigger: triggerFor(outcome.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: outcome.at || Date.now(),
@@ -280,7 +386,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the same command later succeeds unchanged'],
             trigger: triggerFor(failed.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: failed.at || Date.now(),
@@ -330,7 +436,7 @@ export function derive(dir, options = {}) {
           confidenceLabel: labelFor(CONFIDENCE.correction),
           scope: 'project',
           invalidators: ['the user later asks for the corrected behaviour'],
-          anchors: [projectRoot],
+          anchors: [anchorPath],
           derivedBy: 'correction',
           sessionId,
           at: Date.parse(turn.at || '') || Date.now(),
@@ -379,6 +485,48 @@ export function derive(dir, options = {}) {
     }
   } catch {
     // One detector, never the session.
+  }
+
+  // ---- storage, under a budget -------------------------------------------
+  //
+  // NOTHING ENTERS THE GRAPH UNBUDGETED. `selectForConsolidation` existed for
+  // exactly this and had no caller, which meant that until now nothing bounded
+  // what a session could add. It admits `failure` and `decision` on a FLOOR
+  // before ranking -- a dead end exists nowhere else and is small, and cheap to
+  // find is not cheap to find again -- then fills the remainder by
+  // cost x irrecoverability x reuse-probability.
+  //
+  // ORIGIN_HARVESTED, EXPLICITLY, never ORIGIN_HUMAN. These are machine
+  // derivations; `curate.mjs` states the reason in its own header -- "a
+  // hand-written assertion and a machine guess look identical three months
+  // later, which quietly destroys the reader's ability to calibrate trust".
+  // `writeHarvested` would refuse a batch-wide human origin anyway, and a
+  // candidate here carries neither `origin` nor `quote`, so it cannot earn one
+  // per finding either. That is deliberate: whether a turn was a correction at
+  // all is a lexical guess, and the standing-rules layer selects on human
+  // origin to inject on EVERY turn.
+  try {
+    if (result.candidates.length) {
+      const selected = selectForConsolidation(load(dir), result.candidates, {
+        budget: storageBudget(),
+      });
+      result.selected = selected.kept.length;
+      result.dropped = selected.dropped;
+      result.selectedTokens = selected.tokens;
+      result.written = writeHarvested(dir, selected.kept, {
+        sessionId,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        // The hook payload's own identity, passed through untouched. Without it
+        // `taskForAnchors` returns null and the `answers` edge never fires --
+        // which is the state a default install has been in, because its only
+        // other producer is credential-gated.
+        authoritativeSessionId,
+      });
+    }
+  } catch {
+    // Storage is the last step and the session is already over. A graph write
+    // that fails must not turn a completed session into a hook error.
   }
 
   return result;

--- a/integrations/gemini/hooks/lib/derive.mjs
+++ b/integrations/gemini/hooks/lib/derive.mjs
@@ -139,17 +139,19 @@ const quotable = (command) => {
  * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
  * found across 163 transcripts on this machine it refuses 2 and keeps 6.
  *
- * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
- * building the key, so the claim is about `npm test` rather than about the `cd`.
- * That changes `attemptKey` for every client and every finding already derived
- * from it, so it belongs in its own change with its own comparison.
+ * `commandBody` below now skips a leading `cd <path> &&`, so those two are
+ * recovered and this guard is left holding only the keys that reached a
+ * separator which is NOT a directory change -- `git fetch && <anything>`, a
+ * pipeline, a `;`-joined pair. Those still name no single attempt.
  */
 const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
 
 /**
  * Did `attemptKey` actually capture a command, or only how one was chained?
  *
- * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart --
+ * which now means AFTER `commandBody` has removed any leading `cd`, so this no
+ * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
 const hasAttemptIdentity = (command) =>
@@ -177,6 +179,81 @@ const CORRECTION_OPENER =
   /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
 
 /**
+ * A leading directory change, stripped before the key is built.
+ *
+ * THE MEASURED CASE, AND ONLY THE MEASURED CASE. `attemptKey` spends up to
+ * three non-flag tokens on identity and the habit on this machine is
+ * `cd <absolute path> && <the real command>`, which spends all three on `cd`,
+ * the path and the separator. This repository's own corpus: 1,400 of 2,243
+ * command outcomes open with a `cd`, and the single key
+ * `cd c:/users/.../token-optimizer-mcp &&` covered 547 distinct command lines.
+ * A `cd` says WHERE a command ran; it says nothing about WHAT ran, so it cannot
+ * be part of the identity of an attempt.
+ *
+ * THE SEPARATOR SET IS THE ONE THAT WAS OBSERVED: `&&` (1,147), a newline (204)
+ * and `;` (38) after a leading `cd`. All three mean "then run this". `||` is
+ * DELIBERATELY EXCLUDED even though it costs one line to add: `cd x || echo
+ * failed` puts an error branch after the separator, not the next step, so
+ * stripping there would key the attempt on a failure handler. It occurred zero
+ * times.
+ *
+ * AND NOTHING WIDER, each refusal for a reason from the same corpus:
+ *
+ *   Environment assignments (`FOO=bar cmd`) DO carry information about what
+ *   ran. The one true instance here is
+ *   `TOKEN_OPTIMIZER_HOLDOUT=1 node ... jest.js ...`, and the holdout arm is a
+ *   genuinely different attempt from the same command without it. The other 20
+ *   are shell variable assignments joined by `;` -- statements, not prefixes --
+ *   whose value is usually a 120-character path that would be stripped down to
+ *   nothing useful.
+ *
+ *   `time`, `env`, `nice`, `sudo`, `bash -c`, `pushd`, `Set-Location`: ZERO
+ *   occurrences in 2,243 commands. Code for an unmeasured prefix is a way to
+ *   over-strip that no evidence asked for, and over-stripping merges commands
+ *   that genuinely differ -- the same bug in the other direction. `bash -c` is
+ *   worse than unmeasured: the command sits inside a quoted string, so stripping
+ *   the wrapper leaves a key beginning with a quote character.
+ *
+ *   `cd /d C:\path &&` and `cd "C:/a b" &&` need no extra rule -- the match runs
+ *   to the separator rather than counting tokens, so flags and quoted paths
+ *   containing spaces are consumed for free. Neither appears here, so neither is
+ *   claimed as tested behaviour beyond its unit test.
+ *
+ * A `cd` with NO separator is left alone: `cd <path>` on its own ran no command,
+ * and its key is as meaningless afterwards as before -- there is nothing to
+ * recover. Stripping is repeated up to `MAX_DIR_PREFIXES` times so
+ * `cd a && cd b && cmd` reaches `cmd`; the bound exists only so a pathological
+ * line cannot loop, since each pass must consume a whole `cd ... <sep>`.
+ *
+ * APPLIED IDENTICALLY TO BOTH SOURCES because it is applied INSIDE `attemptKey`,
+ * which is the single function both the event path and the transcript reader's
+ * output pass through. The 120-character anchor cap that makes the two agree on
+ * 266 of 266 keys is untouched and still applied on both sides before this runs.
+ */
+const DIR_PREFIX = /^\s*cd\s[^\r\n;&|]*?(?:&&|;|\r?\n)\s*/i;
+const MAX_DIR_PREFIXES = 4;
+
+/**
+ * The command text with any leading directory change removed.
+ *
+ * Used for the key AND for the identical-text refusal, which is the half that
+ * keeps this from becoming a licence to pair more loosely: without it,
+ * `cd repo && npm test` failing and `npm test` succeeding would emit
+ * "`npm test` succeeded where `cd repo && npm test` failed" at 0.90 -- two
+ * spellings of one attempt, dressed up as a difference that mattered. The
+ * claim itself still quotes the RAW command, because that is what ran.
+ */
+export function commandBody(command) {
+  let text = String(command || '');
+  for (let i = 0; i < MAX_DIR_PREFIXES; i++) {
+    const stripped = text.replace(DIR_PREFIX, '');
+    if (stripped === text) break;
+    text = stripped;
+  }
+  return text;
+}
+
+/**
  * The prefix that makes two invocations "the same attempt".
  *
  * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
@@ -194,7 +271,7 @@ const CORRECTION_OPENER =
  * ships a false claim into model context.
  */
 export function attemptKey(command) {
-  return String(command || '')
+  return commandBody(command)
     .trim()
     .split(/\s+/)
     .filter((token) => token && !token.startsWith('-'))
@@ -494,7 +571,14 @@ export function derive(dir, options = {}) {
           // is real and supports NEITHER claim, so nothing is emitted. This is
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
-          if (failed.command === outcome.command) continue;
+          // COMPARED WITH THE DIRECTORY CHANGE REMOVED, for the same reason
+          // the key is. `cd repo && npm test` and `npm test` are one attempt
+          // spelled two ways; before `commandBody` they landed in different
+          // groups and never met, and letting them meet without widening this
+          // guard would emit "`npm test` succeeded where `cd repo && npm test`
+          // failed" at 0.90 -- a difference in the claim that is not a
+          // difference in what ran. Same for two `cd`s to different paths.
+          if (commandBody(failed.command) === commandBody(outcome.command)) continue;
 
           // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
           // client both sides of almost every pair are truncated multi-line
@@ -502,10 +586,12 @@ export function derive(dir, options = {}) {
           // spending the retrieval budget of every later session.
           if (!quotable(failed.command) || !quotable(outcome.command)) continue;
 
-          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
-          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
-          // command lines in this repository alone, and any pair drawn from that
-          // group is a false claim about both halves.
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`. The
+          // `cd <path> &&` case that grouped 547 unrelated command lines in this
+          // repository is now handled earlier by `commandBody`; what is left
+          // here is every OTHER separator -- `git fetch && <anything>`, a
+          // pipeline, a `;`-joined pair -- where the key still names no single
+          // attempt and any pair drawn from it is false about both halves.
           if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =

--- a/integrations/gemini/hooks/lib/derive.mjs
+++ b/integrations/gemini/hooks/lib/derive.mjs
@@ -1,0 +1,385 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/derive.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Findings from data we already hold, with no model call.
+ *
+ * WHY THIS EXISTS. The semantic harvest is on by default but its real gate is a
+ * credential: `harvestMode()` returns `off:no-key` on any machine without one,
+ * which is CI, corporate laptops, and every subscription-only login. This
+ * repository's own graph is the evidence -- 2,965 symbol nodes, 904 file nodes,
+ * 128 task nodes and ONE finding -- because the structural layer accumulates
+ * from ordinary tool traffic while every verdict needed an API key this machine
+ * does not have.
+ *
+ * Everything here is derived from outcomes, transitions and corrections that are
+ * ALREADY RECORDED LOCALLY. Nothing is sent anywhere, nothing is billed, so
+ * there is nothing to consent to and this runs by default. It is the only
+ * finding producer on a machine without a key.
+ *
+ * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
+ * second command fixed the first -- an intervening edit, a dependency install or
+ * a flaky test explains it just as well. So each detector carries a confidence
+ * ceiling, the claim text says only what was OBSERVED, and the two shapes where
+ * the observation supports no claim at all are refused rather than downgraded
+ * (see `attemptKey` and the identical-text guard below).
+ *
+ * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
+ * budget, belongs to the caller.
+ */
+
+import { readMetrics, rereadsByAnchor } from './metrics.mjs';
+import { readArchive, readTurns } from './transcript.mjs';
+import { redact } from './redact.mjs';
+
+/**
+ * Ceilings, ordered by how much the evidence actually supports.
+ *
+ * A command that succeeded where a DIFFERENT command failed is close to a direct
+ * observation. A test or build going red-to-green is weaker, because the usual
+ * cause is the code changing between the two runs rather than anything about the
+ * command. A correction is a lexical guess about what a human meant. Churn
+ * describes our own reading behaviour and says nothing about the code at all.
+ */
+export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+
+/** Claim text cap. A finding is one sentence; a paragraph is evidence. */
+const CLAIM_MAX = 300;
+const EVIDENCE_MAX = 400;
+
+/** Bounded so a pathological log cannot turn session end into real work. */
+const MAX_CANDIDATES = 200;
+
+/**
+ * Commands whose red-to-green transition is usually explained by the CODE
+ * changing rather than by the command. They get the lower ceiling.
+ */
+const CODE_SENSITIVE = /\b(test|tests|jest|vitest|pytest|mocha|build|compile|tsc|lint|typecheck)\b/i;
+
+/**
+ * Openers that mark a user turn as a correction rather than an instruction.
+ *
+ * DELIBERATELY NARROW, and anchored to the START of the turn. The model-based
+ * extractor in `lessons.mjs` can read intent; this cannot, so it only claims the
+ * shapes where the first few words carry the whole signal. Recall is poor by
+ * design: a missed correction costs one finding, a false one puts words in the
+ * user's mouth at 0.6 confidence.
+ */
+const CORRECTION_OPENER =
+  /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
+
+/**
+ * The prefix that makes two invocations "the same attempt".
+ *
+ * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
+ * through what the alternatives do to real command lines:
+ *
+ *   Two tokens conflates `npm run build` with `npm run test`, and the pair then
+ *   produces "`npm run test` works where `npm run build` failed" -- a claim that
+ *   is simply false.
+ *
+ *   Counting flags splits `deploy` from `deploy --retry`, which is the single
+ *   most useful pair this detector can find, into two groups that never meet.
+ *
+ * Conservative in the remaining direction: `npm run build:prod` and
+ * `npm run build` do not pair. A missed pair costs one finding; a wrong pair
+ * ships a false claim into model context.
+ */
+export function attemptKey(command) {
+  return String(command || '')
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'))
+    .slice(0, 3)
+    .join(' ')
+    .toLowerCase();
+}
+
+/** Normalised claim text, so the same lesson derived twice is one candidate. */
+const claimKey = (type, claim) =>
+  `${type}|${String(claim).toLowerCase().replace(/\s+/g, ' ').trim()}`;
+
+/** 0.95 is reserved for verified; everything here is inference. */
+const labelFor = (confidence) => (confidence >= 0.75 ? 'probable' : 'speculative');
+
+/** A literal command prefix, safe to hand to `safeTrigger`. */
+const triggerFor = (command) =>
+  attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
+
+/**
+ * Derives finding candidates from one project's local evidence.
+ *
+ * @param {string} dir wiki directory.
+ * @param {object} options
+ * @param {string|null} options.sessionId session this ran for, for provenance.
+ * @param {string|null} options.transcriptPath live transcript, read only when the
+ *   archive holds nothing for this session yet.
+ * @param {string|null} options.projectRoot the anchor every derived claim gets.
+ *   Without it nothing is derived: an unanchored finding cannot be invalidated
+ *   and is refused by `writeHarvested` anyway, so emitting one would only spend
+ *   the caller's budget on junk.
+ * @param {string|null} options.authoritativeSessionId the session id as the HOOK
+ *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
+ *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
+ *   edge -- `taskForAnchors` returns null without one, so an unverified string
+ *   would silently produce no edge. Threaded rather than defaulted from
+ *   `sessionId`: defaulting would promote any caller's string to trusted.
+ */
+export function derive(dir, options = {}) {
+  // `options || {}` rather than a destructuring default. A default only fires on
+  // `undefined`, so a caller passing an explicitly null options object -- which
+  // is what a hook does when it has nothing to say -- threw a TypeError out of
+  // the parameter list itself, before any of the try/catch below could fail open.
+  const {
+    sessionId = null,
+    transcriptPath = null,
+    projectRoot = null,
+    authoritativeSessionId = null,
+  } = options || {};
+
+  const result = {
+    candidates: [],
+    observations: [],
+    written: [],
+    sessionId,
+    authoritativeSessionId,
+  };
+
+  let events;
+  try {
+    events = readMetrics(dir);
+  } catch {
+    // Session end must cost nothing. No evidence is not an error.
+    return result;
+  }
+  if (!Array.isArray(events)) return result;
+
+  const seen = new Set();
+  const add = (candidate) => {
+    if (result.candidates.length >= MAX_CANDIDATES) return;
+    const key = claimKey(candidate.type, candidate.claim);
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.candidates.push(candidate);
+  };
+
+  // ---- 1 & 2: a failed attempt followed by a succeeding one ---------------
+  //
+  // The event is `tool-outcome` and THE COMMAND TEXT IS IN `anchor`: there is no
+  // separate command field, because the anchor of a command surface IS the
+  // command. It is capped at 120 characters at the boundary, so a very long
+  // command line is compared and quoted truncated.
+  try {
+    if (projectRoot) {
+      const outcomes = events
+        .filter(
+          (e) =>
+            e &&
+            e.kind === 'tool-outcome' &&
+            e.surface === 'command' &&
+            typeof e.anchor === 'string' &&
+            e.anchor.trim()
+        )
+        .map((e) => ({
+          command: e.anchor.trim(),
+          output: typeof e.output === 'string' ? e.output : '',
+          exit: Number.isInteger(e.exit) ? e.exit : null,
+          at: e.at ?? 0,
+          // `success` FIRST, `exit` only as a refinement. MCP tools report no
+          // numeric code at all, so a classifier keyed on `exit !== 0` would be
+          // inert for most clients -- and `exit` is null rather than 0 precisely
+          // so that absence is not read as a clean exit.
+          failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
+        }))
+        .sort((a, b) => a.at - b.at);
+
+      const byAttempt = new Map();
+      for (const outcome of outcomes) {
+        const key = attemptKey(outcome.command);
+        if (!key) continue;
+        if (!byAttempt.has(key)) byAttempt.set(key, []);
+        byAttempt.get(key).push(outcome);
+      }
+
+      for (const run of byAttempt.values()) {
+        // The NEAREST preceding failure, not the first one in the session. With
+        // `find` over the whole run, a command that failed at 09:00 and
+        // succeeded at 17:00 after nine unrelated attempts is reported as one
+        // story.
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          // One pair per failure: a command that succeeds twice afterwards has
+          // not taught two lessons.
+          lastFailure = null;
+
+          // THE GUARD THAT REMOVES THE LARGEST JUNK CLASS. The commonest shape
+          // in a coding session is `npm run build` failing, the code being
+          // fixed, and `npm run build` succeeding -- identical text. From that
+          // pair the two available claims are "`npm run build` works where
+          // `npm run build` failed", which is incoherent, and "`npm run build`
+          // fails", which the same evidence has just disproved. The observation
+          // is real and supports NEITHER claim, so nothing is emitted. This is
+          // not a confidence question; a ceiling cannot rescue a claim whose
+          // content is wrong.
+          if (failed.command === outcome.command) continue;
+
+          const codeSensitive =
+            CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);
+          const confidence = codeSensitive ? CONFIDENCE.test : CONFIDENCE.command;
+          const derivedBy = codeSensitive ? 'test-transition' : 'command-transition';
+
+          // "SUCCEEDED WHERE", NOT "FIXES". What is observed is two outcomes in
+          // order on the same attempt; that the difference in the command line
+          // CAUSED the difference in outcome is not observed and is not claimed.
+          add({
+            type: 'command',
+            claim: redact(
+              `\`${outcome.command}\` succeeded in this project where \`${failed.command}\` failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
+                'an intervening edit or a flaky run explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: 'when about to run this command in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the failing form later succeeds unchanged'],
+            trigger: triggerFor(outcome.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+
+          // The error text, only when there is error text. Without it the claim
+          // degrades to "`X` failed with:" and nothing after the colon, which
+          // carries no information and still costs budget.
+          const firstLine = failed.output.split('\n').find((line) => line.trim()) || '';
+          if (firstLine.trim().length < 8) continue;
+          add({
+            type: 'failure',
+            claim: redact(`\`${failed.command}\` failed with: ${firstLine.trim()}`, {
+              max: CLAIM_MAX,
+            }),
+            evidence: redact(`captured output of the failing run:\n${failed.output}`, {
+              max: EVIDENCE_MAX,
+            }),
+            applicability: 'when this command is about to be run in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the same command later succeeds unchanged'],
+            trigger: triggerFor(failed.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: failed.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 3: user corrections ------------------------------------------------
+  //
+  // A `feedback` finding -- the one type whose source is a person saying the
+  // agent was wrong. The MODEL-BASED extractor for this lives in `lessons.mjs`
+  // and needs the credential this module exists to do without, so here the
+  // signal is lexical: the opening words of the user's own turn.
+  //
+  // ORIGIN IS NOT PROMOTED. `writeHarvested` grants ORIGIN_HUMAN to a finding
+  // carrying a verified verbatim quote, and the standing-rules layer selects on
+  // that origin to inject a claim on EVERY turn. The quote here would be
+  // verbatim -- it is copied out of the archive -- but whether the turn was a
+  // correction at all is a guess, and a guess must not buy always-on injection.
+  // So no `origin` and no `quote` field: this stays harvested provenance.
+  try {
+    if (projectRoot) {
+      let turns = readArchive(dir, sessionId);
+      // The archive is written by the Stop hook too, and the order of the two is
+      // not this module's to assume, so fall back to the live transcript.
+      if (!turns.length && transcriptPath) turns = readTurns(transcriptPath);
+
+      for (const turn of turns) {
+        if (!turn || turn.role !== 'user') continue;
+        const text = String(turn.text || '').trim();
+        // Long turns are new instructions with a complaint somewhere inside
+        // them; truncating one into a claim would misquote the user.
+        if (text.length < 12 || text.length > 300) continue;
+        if (!CORRECTION_OPENER.test(text)) continue;
+        add({
+          type: 'feedback',
+          claim: redact(text, { max: CLAIM_MAX }),
+          evidence: redact(`the user opened a turn with a correction: "${text}"`, {
+            max: EVIDENCE_MAX,
+          }),
+          applicability: 'when working in this project, before repeating what was corrected',
+          confidence: CONFIDENCE.correction,
+          confidenceLabel: labelFor(CONFIDENCE.correction),
+          scope: 'project',
+          invalidators: ['the user later asks for the corrected behaviour'],
+          anchors: [projectRoot],
+          derivedBy: 'correction',
+          sessionId,
+          at: Date.parse(turn.at || '') || Date.now(),
+        });
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 4: re-read churn ---------------------------------------------------
+  //
+  // NOT A FINDING, AND THAT IS THE DECISION RATHER THAN AN OMISSION.
+  //
+  // Churn is a claim about OUR OWN reading behaviour: "this file was read three
+  // times unchanged". Every finding type available is a claim about the work --
+  // `map` describes how an area of the codebase is laid out, and is
+  // content-dependent, so a churn claim filed as `map` would be checked for
+  // staleness against contents it makes no claim about and flip stale on the
+  // first edit to a file it never described. Worse, the anchors it would take
+  // are by construction the HOTTEST files in the project, which are exactly the
+  // files that already carry real findings, so a 0.4-confidence row saying
+  // nothing actionable would sit in the injection budget beside them and render
+  // on the same reads. Nothing a future agent could DO differently follows from
+  // it: it does not say what the file contains, so it cannot substitute for
+  // reading it.
+  //
+  // The signal is still worth having -- as the measurement it already is.
+  // `rereadWaste` reports it on the balance sheet, `rereadsByAnchor` names the
+  // offenders, and this returns those rows as OBSERVATIONS: computed, carried,
+  // and deliberately not competing for context. Three detectors produce
+  // findings; the fourth produces a number.
+  try {
+    for (const row of rereadsByAnchor(events).slice(0, 3)) {
+      if (!row.anchor || row.wasteful < 2) continue;
+      result.observations.push({
+        kind: 'churn',
+        anchor: row.anchor,
+        repeats: row.repeats,
+        wasteful: row.wasteful,
+        tokens: row.tokens,
+        confidence: CONFIDENCE.churn,
+        derivedBy: 'churn',
+        note: `re-read ${row.repeats} times, ${row.wasteful} of them unchanged`,
+      });
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  return result;
+}

--- a/integrations/gemini/hooks/lib/derive.mjs
+++ b/integrations/gemini/hooks/lib/derive.mjs
@@ -16,6 +16,13 @@
  * there is nothing to consent to and this runs by default. It is the only
  * finding producer on a machine without a key.
  *
+ * THREE SOURCES, NOT TWO. `tool-outcome` events, the transcript archive, and --
+ * since the transition detectors were measured to have no input at all on the
+ * primary client -- the raw transcript's FAILED tool results, which is the only
+ * place a Claude Code failure is recorded (`failedResultsFromTranscript` in
+ * transcript.mjs, and the note above `quotable` for what that measurement
+ * actually yielded).
+ *
  * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
  * second command fixed the first -- an intervening edit, a dependency install or
  * a flaky test explains it just as well. So each detector carries a confidence
@@ -32,7 +39,11 @@
 import { readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
-import { readArchive, readTurns } from './transcript.mjs';
+import {
+  readArchive,
+  readTurns,
+  failedResultsFromTranscript,
+} from './transcript.mjs';
 import { redact } from './redact.mjs';
 import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
@@ -56,6 +67,96 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * The anchor cap a command surface is stored under, restated here as a TEST.
+ *
+ * `recordToolOutcome` truncates `anchor` to 120 characters, so a command at or
+ * over that length reached this module already cut -- and `quotable` below
+ * refuses to build a claim out of the fragment.
+ */
+const COMMAND_ANCHOR_MAX = 120;
+
+/**
+ * Can this command text be QUOTED in a claim a reader could act on?
+ *
+ * THE SECOND REFUSAL OF ITS KIND, and it exists because measurement forced it.
+ * Wiring the transcript reader gave the transition detectors their first real
+ * input on this client and immediately produced four candidates at 0.9
+ * confidence whose claim text read:
+ *
+ *   `cd /c/Users/.../token-optimizer-mcp\ncat >> docs/superpowers/plans/2026-` succeeded
+ *   in this project where `cd /c/Users/.../token-optimizer-mcp\ncat > /tmp/probe3.mjs
+ *   <<'EOF'\nimport { readdirSync, readFileSync, sta` failed
+ *
+ * -- two truncated fragments of throwaway shell scripts, grouped together only
+ * because `attemptKey`'s three tokens were spent on `cd`, the absolute path, and
+ * the verb. Then measured properly across three real transcripts: **0 of 83**
+ * captured command failures are single-line and inside the cap. 65% of this
+ * project's 2,178 successful command outcomes are not either. On this client a
+ * "command" is usually a whole shell script, so the attempt identity the
+ * transition detectors are built on does not fit most of the traffic.
+ *
+ * This is the same judgement as the identical-text guard below rather than a
+ * confidence question: a claim whose subject is a truncated fragment of a
+ * program is not a weaker claim, it is not a claim. A raised cap would not
+ * rescue it -- quoting the whole 500-character heredoc is no more actionable.
+ *
+ * What survives is exactly what the detector was designed for: `npm test`,
+ * `dotnet build X`, `deploy --retry` -- a repeatable command someone could run
+ * again. This machine captured none failing, which is why the honest yield here
+ * is zero and why that is reported rather than dressed up.
+ *
+ * Applied to BOTH sources. Where the evidence arrived from has no bearing on
+ * whether the resulting sentence says anything, and a rule that let events
+ * through would ship the junk on the ten clients that do report failures.
+ */
+const quotable = (command) => {
+  const text = String(command || '');
+  return (
+    text.trim().length > 0 &&
+    !/[\r\n]/.test(text) &&
+    text.length < COMMAND_ANCHOR_MAX
+  );
+};
+
+/**
+ * Tokens that separate one command from the next rather than naming one.
+ *
+ * MEASURED, LIKE EVERY OTHER REFUSAL HERE. `attemptKey` spends up to three
+ * non-flag tokens on identity, and the habit on this machine is
+ * `cd <absolute path> && <the real command>` -- which spends all three on `cd`,
+ * the path and `&&`, so the real command never enters the key. This project's
+ * own evidence: the single key `cd c:/users/.../token-optimizer-mcp &&` covers
+ * **539 distinct command lines**. One quotable failure in that group would pair
+ * with an arbitrary unrelated success and claim "`cd repo && grep -n ...`
+ * succeeded where `cd repo && git merge ...` failed", which is false about both.
+ *
+ * A KEY THAT REACHED A SEPARATOR NEVER REACHED A COMMAND, so there is no attempt
+ * to compare and nothing to claim -- the same judgement as the identical-text
+ * guard rather than a lower ceiling. Narrow on purpose: `2>&1` and `/F` are not
+ * separators and do not trip this, so `cat commitlint.config.mjs 2>&1` and
+ * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
+ * found across 163 transcripts on this machine it refuses 2 and keeps 6.
+ *
+ * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
+ * building the key, so the claim is about `npm test` rather than about the `cd`.
+ * That changes `attemptKey` for every client and every finding already derived
+ * from it, so it belongs in its own change with its own comparison.
+ */
+const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
+
+/**
+ * Did `attemptKey` actually capture a command, or only how one was chained?
+ *
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * One check per pair is enough: both halves share the key by construction.
+ */
+const hasAttemptIdentity = (command) =>
+  attemptKey(command)
+    .split(' ')
+    .filter(Boolean)
+    .every((token) => !COMMAND_SEPARATORS.has(token));
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -274,6 +375,17 @@ export function derive(dir, options = {}) {
   // separate command field, because the anchor of a command surface IS the
   // command. It is capped at 120 characters at the boundary, so a very long
   // command line is compared and quoted truncated.
+  //
+  // TWO SOURCES OF FAILURE, ONE PAIRING LOOP. Claude Code never fires
+  // PostToolUse for a failed tool call -- 2,238 of 2,238 live `tool-outcome`
+  // events on the measuring machine carry `success: true`, and a deliberately
+  // failing command produced no event at all -- so on the primary client these
+  // two detectors had NO INPUT WHATSOEVER while working normally on the ten
+  // adapter clients. `failedResultsFromTranscript` supplies the missing half
+  // from the only place it exists. The successes still come from events only:
+  // a transcript failure that pairs with nothing stays unclaimed, which is also
+  // what keeps a failure from ANOTHER project's directory out of this project's
+  // graph -- a candidate cannot be emitted without a success recorded HERE.
   try {
     if (projectRoot) {
       const outcomes = events
@@ -290,6 +402,9 @@ export function derive(dir, options = {}) {
           output: typeof e.output === 'string' ? e.output : '',
           exit: Number.isInteger(e.exit) ? e.exit : null,
           at: e.at ?? 0,
+          // Carried purely so the transcript merge below can recognise the same
+          // tool call arriving from the other source.
+          toolCallId: e.toolCallId ? String(e.toolCallId) : null,
           // `success` FIRST, `exit` only as a refinement. MCP tools report no
           // numeric code at all, so a classifier keyed on `exit !== 0` would be
           // inert for most clients -- and `exit` is null rather than 0 precisely
@@ -297,6 +412,53 @@ export function derive(dir, options = {}) {
           failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
         }))
         .sort((a, b) => a.at - b.at);
+
+      // DEDUPLICATED ON `toolCallId`, which is the SAME STRING in both sources:
+      // `episodeMeta` reads `raw.tool_use_id` into `toolCallId`, and that is the
+      // transcript's `tool_use_id` verbatim -- verified against live evidence
+      // (`toolu_01L4Nwr...` in metrics.jsonl, the same ids in the transcript).
+      // So on the ten clients that DO report failures, the event copy wins and
+      // the transcript copy is dropped before grouping. Without this the two
+      // copies of one failure would sit in the same run and the second of them
+      // would be paired against the first as a failed-then-succeeded story about
+      // itself.
+      //
+      // The fallback covers a client that reports a failure with no call id:
+      // identical command text within two seconds is one failure recorded twice,
+      // not two failures, because nothing re-runs a command that fast.
+      const eventIds = new Set(
+        outcomes.map((o) => o.toolCallId).filter(Boolean)
+      );
+      const eventFailures = outcomes.filter((o) => o.failed);
+      const alreadyRecorded = (failure) => {
+        if (failure.toolCallId && eventIds.has(failure.toolCallId)) return true;
+        return eventFailures.some(
+          (o) =>
+            o.command === failure.command &&
+            Math.abs((o.at || 0) - (failure.at || 0)) <= 2000
+        );
+      };
+
+      let transcriptFailures = [];
+      try {
+        transcriptFailures = failedResultsFromTranscript(transcriptPath).filter(
+          (failure) => failure.command.trim() && !alreadyRecorded(failure)
+        );
+      } catch {
+        // The reader is an extra source, never a reason the detector stops.
+      }
+      for (const failure of transcriptFailures) {
+        outcomes.push({
+          command: failure.command.trim(),
+          output: failure.output,
+          exit: failure.exit,
+          at: failure.at,
+          toolCallId: failure.toolCallId,
+          // Read from `Exit code N`, which is the only shape the reader admits.
+          failed: true,
+        });
+      }
+      if (transcriptFailures.length) outcomes.sort((a, b) => a.at - b.at);
 
       const byAttempt = new Map();
       for (const outcome of outcomes) {
@@ -333,6 +495,18 @@ export function derive(dir, options = {}) {
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
           if (failed.command === outcome.command) continue;
+
+          // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
+          // client both sides of almost every pair are truncated multi-line
+          // shell scripts, and a claim quoting a fragment of one is noise
+          // spending the retrieval budget of every later session.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
+          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
+          // command lines in this repository alone, and any pair drawn from that
+          // group is a false claim about both halves.
+          if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =
             CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);

--- a/integrations/gemini/hooks/lib/doctor.mjs
+++ b/integrations/gemini/hooks/lib/doctor.mjs
@@ -197,7 +197,8 @@ function hooksDirFor({ hooksDir, install, root }) {
  * identical from outside: a graph that fills with structural nodes either way.
  *
  * Measured on a real 5.4.0 install: 484 symbol, 286 file and 122 task nodes and
- * ZERO findings, because harvestMode() was 'off:not-opted-in'. Fifteen checks
+ * ZERO findings, because harvestMode() then returned an opt-in refusal (the mode has
+ * since been renamed: it is 'off:no-key' now, and opting in is no longer the gate). Fifteen checks
  * passed and none mentioned harvest. stop-harvest.mjs names this exact gap --
  * "nothing in doctor, audit or waste mentions harvest, so a user sees a graph
  * filling with structural nodes and no findings and has no way to learn why" --
@@ -221,9 +222,15 @@ export function probeHarvest() {
   // optimizer is off" is noise, which is why stop-harvest maps it to no notice.
   if (mode === 'off:mode') return [];
 
+  // SAID PLAINLY, because this is the configuration a user would choose if they
+  // knew it existed and the previous wording buried it in machinery. A local
+  // endpoint is the only setting under which the semantic harvest runs with no
+  // credential, no billing and no digest leaving the machine -- so the two facts
+  // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
     return [ok('finding extraction is available',
-      'active-model wiki_write is primary; local endpoint also enables fallback extraction')];
+      'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
+      'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
@@ -233,10 +240,19 @@ export function probeHarvest() {
 
   // No second-model credential is required for the primary path. The Codex/agent session that
   // already paid to derive the conclusion is the extractor and wiki_write is local.
+  // NAME THE TRADE, not just the missing variable. This is the default state on
+  // every machine without a credential, so it is the text most users will read,
+  // and "unavailable" alone tells them neither what they are missing nor that
+  // the free option exists. Local findings still accumulate: derive.mjs reads
+  // exit codes, red-to-green transitions, corrections and churn out of evidence
+  // already on disk and sends nothing anywhere.
   if (mode === 'off:no-key') {
     return [ok('finding extraction is available',
-      'active model records durable conclusions through local wiki_write; no separate-model ' +
-      'credential is configured, so fallback transcript extraction is unavailable')];
+      'active model records durable conclusions through local wiki_write, and derive runs at ' +
+      'session end with no credential. No separate-model credential is configured, so fallback ' +
+      'transcript extraction is unavailable: point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local ' +
+      'model to run it free and private, or set TOKEN_OPTIMIZER_API_KEY to run it from a bounded ' +
+      'digest of paths, commands, prompts and conclusions -- never file contents')];
   }
 
   // off:opted-out -- a deliberate choice, reported as one. Nagging about a setting somebody chose

--- a/integrations/gemini/hooks/lib/inject.mjs
+++ b/integrations/gemini/hooks/lib/inject.mjs
@@ -1134,10 +1134,25 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // injected more than the budget allowed and recorded fewer tokens than it
   // spent -- in a block whose entire justification is that it is tightly
   // bounded and measured against the control arm.
+  // THE LAST LINE IS HOW THE NEXT RULE GETS HERE, and it is one line because
+  // this block is charged on every session forever. A rule reaches this list
+  // only by being pinned or by being a person's verified correction, and both
+  // start as a `wiki_write` -- so a model reading a set of standing rules with
+  // no idea how they were produced has no way to add to it. Stated at the point
+  // of the evidence rather than as a separate always-on block: the reader is
+  // already looking at the output of the mechanism being described.
+  //
+  // THE COLD GRAPH IS COVERED ELSEWHERE, deliberately. Nothing here renders
+  // until at least one rule qualifies, which is the property the always-on
+  // budget depends on, so this line cannot be the first-session nudge --
+  // `policyText`'s "Record what you work out" section is, and it is emitted at
+  // SessionStart whether or not the graph holds anything.
   const HEADING =
     '# Standing rules for this project' +
     '\n\nEstablished in previous sessions and expected to hold. ' +
-    'These are not suggestions.\n\n';
+    'These are not suggestions.\n\n' +
+    'Record what you work out with wiki_write and a real file anchor; ' +
+    'that is how a rule reaches this list.\n\n';
   const noticeFor = (n) =>
     n
       ? `\n(${n} further standing rule${n === 1 ? '' : 's'} did not fit this budget; ` +

--- a/integrations/gemini/hooks/lib/inject.mjs
+++ b/integrations/gemini/hooks/lib/inject.mjs
@@ -35,6 +35,7 @@ import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
 import { cacheOrdered } from './cache.mjs';
+import { withheldFor, exploreOrder, servingPolicyVersion, LOO_ENABLED } from './loo.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -311,8 +312,38 @@ export function forTouch(
     });
     for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
   }
-  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  // LAYER 2 EXPLORATION, BEFORE the budget decides.
+  //
+  // `assessed.eligible` arrives in net-utility order and `fit` keeps that order
+  // until the budget runs out -- so the ranking decides which findings are ever
+  // served, which decides which ever accumulate observations, which decides
+  // their utility. A tenth of touches therefore promote the least-served
+  // candidate first. This is the only place it can go: after `fit` the choice
+  // has already been made.
+  const ordered = exploreOrder(assessed.eligible, dir, { sessionId, anchor: filePath });
+  const { kept, spent } = fit(ordered.map((item) => item.finding), budget);
   if (!kept.length) return null;
+
+  // LAYER 2 WITHHOLDING, AFTER the budget decides, which is the only ordering
+  // that produces a leave-one-out rather than a substitution: withholding first
+  // would let the next-ranked finding take the freed tokens, so the withheld
+  // arm would differ from the served arm by two findings instead of one and the
+  // effect would belong to neither.
+  //
+  // `holdout` is passed so the two experiments cannot compose into "withhold
+  // everything and call it a leave-one-out": that arm already serves nothing.
+  const withheld = withheldFor(kept.map((finding) => finding.key), sessionId, graph, dir, {
+    surface: 'file',
+    anchor: filePath,
+    holdout,
+  });
+  const delivered = withheld ? kept.filter((finding) => finding.key !== withheld) : kept;
+  // RE-PRICED, because `fit` priced what it KEPT and this delivers less. Using
+  // `spent` would bill the injection-cost side of the balance sheet for text
+  // the model never received.
+  const deliveredSpent = withheld
+    ? delivered.reduce((sum, finding) => sum + estimate(render(finding)), 0)
+    : spent;
 
   record(dir, {
     kind: 'inject',
@@ -321,15 +352,20 @@ export function forTouch(
     surface: 'file',
     anchor: filePath,
     holdout,
-    tokens: holdout ? 0 : spent,
-    deliveredTokens: holdout ? 0 : spent,
+    tokens: holdout ? 0 : deliveredSpent,
+    deliveredTokens: holdout ? 0 : deliveredSpent,
     shadowTokens: spent,
-    count: holdout ? 0 : kept.length,
+    count: holdout ? 0 : delivered.length,
     candidateCount: kept.length,
-    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    findingIds: holdout ? [] : delivered.map((finding) => finding.key),
     shadowFindingIds: kept.map((finding) => finding.key),
-    stale: kept.some((f) => f.stale),
+    stale: delivered.some((f) => f.stale),
     sessionId,
+    // ON EVERY RECORD, not only the withheld ones. A served observation needs
+    // the policy version as much as a withheld one does, or `effects` cannot
+    // keep the two arms of one comparison inside one policy.
+    ...(LOO_ENABLED() ? { looPolicy: servingPolicyVersion() } : {}),
+    ...(withheld ? { loo: withheld } : {}),
   });
 
   // MARKED SEEN IN BOTH ARMS, for the same reason as the command path: a file
@@ -339,11 +375,16 @@ export function forTouch(
   // grow faster purely from repetition.
   //
   // This is the identical defect that was fixed in `forCommand` and not here.
+  //
+  // THE WITHHELD KEY IS MARKED TOO, and that is load-bearing rather than tidy:
+  // an unmarked one would be a candidate again on the next touch of this file,
+  // where the one-per-touch tiebreak could serve it -- flipping its arm inside
+  // the very session the arm hash exists to pin it for.
   for (const f of kept) alreadyInjected.add(f.key);
 
-  if (holdout || !kept.length) return null;
+  if (holdout || !delivered.length) return null;
 
-  return `Known about ${filePath} (from previous sessions):\n${kept.map(render).join('\n')}`;
+  return `Known about ${filePath} (from previous sessions):\n${delivered.map(render).join('\n')}`;
 }
 
 /**

--- a/integrations/gemini/hooks/lib/keepwarm.mjs
+++ b/integrations/gemini/hooks/lib/keepwarm.mjs
@@ -30,6 +30,15 @@ import { record, readMetrics, readBalance } from './metrics.mjs';
 import { WRITE_MULTIPLIER, READ_MULTIPLIER } from './cache.mjs';
 
 /**
+ * The shortest gap that counts as a NEW turn rather than a burst inside one.
+ *
+ * Shared by the gap distribution and by the hit test, because they have to
+ * agree about what a turn is. Two copies of this number would let the decision
+ * be fitted to one definition of a turn and scored against another.
+ */
+export const TURN_GAP_MS = 250;
+
+/**
  * TTL tiers, with what a WRITE costs at each.
  *
  * A five-minute entry is written at 1.25x a plain input token; the one-hour
@@ -85,7 +94,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
     for (let i = 1; i < session.length; i++) {
       const gap = session[i] - session[i - 1];
       // A burst of events inside one turn is not a gap between turns.
-      if (gap > 250) gaps.push(gap);
+      if (gap > TURN_GAP_MS) gaps.push(gap);
     }
   }
   if (gaps.length < 6) return null;
@@ -105,10 +114,91 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
 }
 
 /**
+ * Refreshes to observe at a tier before the observation may bound the decision.
+ *
+ * THE SAME NUMBER THE BACKSTOP DEMANDS, deliberately. The decision and the
+ * tripwire read the same ledger, so letting them disagree about when there is
+ * enough evidence would mean one of them acting on a sample the other calls too
+ * small. Below the floor the decision keeps its expected-value answer, so a
+ * single unlucky miss changes nothing at all.
+ *
+ * NOT A CONFIDENCE INTERVAL, and the reason is arithmetic rather than taste. A
+ * Wilson 95% upper bound at ten refreshes and zero hits is 0.28 -- so a policy
+ * that missed ten times out of ten would still be recommended, which is exactly
+ * the case the loop exists to catch. The point estimate is safe here because of
+ * the bound below: an observation may only ever LOWER the modelled probability,
+ * so sampling noise cannot manufacture a refresh, and the tripwire's realised
+ * ledger is a second guard underneath.
+ */
+export const OBSERVATION_FLOOR = TRIPWIRE_MIN;
+
+/**
+ * The measured hit rate per tier, from recorded outcomes.
+ *
+ * Tiers below the floor are ABSENT rather than present with a small n, because
+ * a rate carrying no weight is the thing most likely to be used as though it
+ * did.
+ */
+export function observedHitRates(outcomes = []) {
+  const byTier = new Map();
+  for (const event of outcomes) {
+    if (event?.kind !== 'keepwarm' || event.action !== 'outcome') continue;
+    const name = TIERS.some((t) => t.name === event.tier) ? event.tier : TIERS[0].name;
+    const row = byTier.get(name) || { refreshes: 0, hits: 0 };
+    row.refreshes += 1;
+    if (event.hit) row.hits += 1;
+    byTier.set(name, row);
+  }
+
+  const qualified = new Map();
+  for (const [name, row] of byTier) {
+    if (row.refreshes < OBSERVATION_FLOOR) continue;
+    qualified.set(name, { ...row, rate: row.hits / row.refreshes });
+  }
+  return qualified;
+}
+
+/**
+ * What the refreshes at this tier actually did, if enough of them have.
+ *
+ * Tolerates being handed anything -- null, a plain object, a Map -- because the
+ * callers are two public functions whose options object is assembled by other
+ * people's code.
+ */
+function observationsFor(observed, tierName) {
+  const row = observed instanceof Map ? observed.get(tierName) : null;
+  return row && Number.isFinite(row.rate) ? row : null;
+}
+
+/**
+ * The modelled probability, BOUNDED BY what was observed and never raised by it.
+ *
+ * The asymmetry is the whole point and runs against this project's interest. A
+ * recorded `hit` says only that a turn arrived before the entry expired; it
+ * cannot say the refresh is what kept the entry alive, because a turn arriving
+ * one minute after a five-minute ping would have found the entry warm anyway.
+ * So the observed rate is an UPPER bound on a refresh's value, and substituting
+ * it for the model would flatter keep-warm badly: on the machine this was
+ * written on, the modelled ping probability is 0.2% and the observable
+ * before-expiry rate is 99.5%, so the substitution would recommend refreshing
+ * forever. A low rate, by contrast, is real evidence against: if turns do not
+ * even arrive inside the TTL, the refresh certainly bought nothing.
+ */
+function bounded(modelled, seen) {
+  return seen ? Math.min(modelled, seen.rate) : modelled;
+}
+
+/**
  * Should we refresh this prefix now?
  *
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
+ *
+ * `observed` is passed IN rather than read from disk here: this function is
+ * pure, its purity is what lets the tests build a distribution by hand, and
+ * `shouldKeepWarm` has already read the outcome log for the tripwire -- so
+ * threading the reader in here would be a second read of the same file and a
+ * second place for the window discipline to be got wrong.
  */
 export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
@@ -125,42 +215,30 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
   const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
-
-  // MEASURED BEATS MODELLED, once there is enough of it.
-  //
-  // The module header already commits to this -- "an expected-value decision is
-  // only as good as the distribution it was fitted to, and distributions
-  // shift" -- and the tripwire underneath was the only thing acting on it, as
-  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
-  // entirely" there was nothing, because the observed hit rate was never
-  // computed: both recording halves had no call site, so ten refreshes that
-  // bought nothing would keep recommending refresh right up to the moment the
-  // tripwire cut the whole feature off.
-  //
-  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
-  // handful of samples would swing the decision harder than the distribution
-  // they replace.
-  const probability = observed ? observed.rate : modelled;
+  const seen = observationsFor(observed, tier.name);
+  const probability = bounded(modelled, seen);
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
-  const basis = observed
-    ? `measured over ${observed.observations} refreshes`
-    : 'modelled from the gap distribution';
+  const note = seen && probability < modelled
+    ? `; bounded by ${seen.refreshes} observed refreshes, ` +
+      `${Math.round(seen.rate * 100)}% used before expiry`
+    : '';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
     modelledProbability: modelled,
-    basis,
+    observedHitRate: seen ? seen.rate : null,
+    observedRefreshes: seen ? seen.refreshes : 0,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
-    reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
+    reason: (ev > 0
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
-        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`) + note,
   };
 }
 
@@ -171,7 +249,12 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
  * long enough that the short tier keeps missing. Returns null when neither tier
  * pays, which is a real answer and the one a default-on product never gives.
  */
-export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS }) {
+export function ttlTier({
+  prefixTokens,
+  gaps,
+  turnsPerSession = DEFAULT_TURNS,
+  observed = null,
+}) {
   if (!prefixTokens || !gaps) return null;
 
   // Expected cost of a turn under each tier, as a multiple of what the prefix
@@ -179,7 +262,16 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   // again; and the FIRST write is amortised over the session, which is what
   // stops the expensive tier from looking free whenever gaps are short.
   const costOf = (tier) => {
-    const hit = gaps.probabilityWithin(tier.ms);
+    // THE SAME QUANTITY THE OUTCOMES RECORD, which is what makes the
+    // observation admissible here at all. `hit` is P(a turn arrives before the
+    // entry expires) and `recordRefreshOutcome`'s `hit` is exactly that event,
+    // measured -- unlike keepWarmDecision, whose probability is the narrower
+    // ping window and for which the same observation is only an upper bound.
+    // Bounded rather than replaced even so: a sample drawn only from moments we
+    // CHOSE to refresh is not a sample of gaps, and its bias runs our way.
+    const modelled = gaps.probabilityWithin(tier.ms);
+    const seen = observationsFor(observed, tier.name);
+    const hit = bounded(modelled, seen);
     const perTurn = hit * READ_MULTIPLIER + (1 - hit) * tier.writeMultiplier;
     // THE SUPPLIED VALUE, not only the computed one. Math.max(1, NaN) is NaN -- Math.max
     // propagates it rather than clamping -- so perTurn became NaN, the `perTurn >= 1` guard below
@@ -192,6 +284,8 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     return {
       tier,
       hit,
+      seen,
+      boundedByObservation: Boolean(seen) && hit < modelled,
       perTurn: (tier.writeMultiplier + (turns - 1) * perTurn) / turns,
     };
   };
@@ -208,99 +302,53 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     action: 'refresh',
     tier: best.tier.name,
     hitProbability: best.hit,
+    observedHitRate: best.seen ? best.seen.rate : null,
+    observedRefreshes: best.seen ? best.seen.refreshes : 0,
     expectedCostPerTurn: Number(best.perTurn.toFixed(3)),
     expectedValue: Math.round((1 - best.perTurn) * prefixTokens),
     reason: `${Math.round(best.hit * 100)}% of gaps land inside ${best.tier.name}; ` +
-      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached`,
+      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached` +
+      (best.boundedByObservation
+        ? `, bounded by ${best.seen.refreshes} observed refreshes ` +
+          `(${Math.round(best.seen.rate * 100)}% used before expiry)`
+        : ''),
   };
 }
 
-/** Observations of a tier before its measured hit rate may override the model. */
-export const OBSERVATION_FLOOR = 5;
-
-/** Records a refresh so its outcome can be scored. */
-export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
-  record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
-}
-
 /**
- * Scores every refresh whose window has since resolved.
+ * Records a refresh so its outcome can be scored.
  *
- * THE MISSING HALF, and it was missing because nobody could see where the
- * signal would come from. `recordRefreshOutcome` needs to know whether a real
- * turn arrived before the entry expired -- and that is not a thing anyone has
- * to instrument, because the event log already records when every turn
- * happened. The answer was in the data the whole time.
+ * `sessionId` IS REQUIRED FOR THE REFRESH TO BE SCOREABLE, and is not defaulted
+ * to anything. The hit test asks whether a turn of THIS conversation arrived
+ * before expiry; pooling arrivals across sessions would let a second concurrent
+ * session's turn pay for this one's ping, which manufactures hits. A refresh
+ * recorded without one is kept in the ledger and reported as unattributable
+ * rather than guessed at.
  *
- * For each unscored refresh at time T on a tier with TTL `ms`:
- *
- *   - a later event within `ms`            -> HIT, observed
- *   - a later event after `ms`             -> MISS, observed
- *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
- *                                             demonstrably closed unused
- *   - no later event, window still open    -> NOTHING RECORDED
- *
- * That last line is the important one and it is Plan 2's own instruction: "if
- * no signal is available for a tier, record nothing rather than guessing
- * `hit: false`". A refresh whose window has not closed yet is not a miss, and
- * scoring it as one would drive the tripwire negative on the newest and least
- * informative records.
- *
- * DRAINED AT READ TIME, which is the pattern this codebase already uses for
- * staleness: the producer cannot know the outcome at the moment it acts, so the
- * next reader resolves what has become knowable since.
+ * Returns the stored record, whose `id` is what `scoreRefreshes` pairs the
+ * outcome to, so an issuer can hold onto it.
  */
-export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
-  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
-  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
-  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
-
-  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
-  // so everything past the number already scored is outstanding. Pairing by
-  // timestamp instead would double-count two refreshes recorded in the same
-  // millisecond, which is reachable: a tool run twice in a loop.
-  const outstanding = refreshes.slice(scored);
-  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
-
-  let recorded = 0;
-  for (const refresh of outstanding) {
-    const at = Number(refresh.at) || 0;
-    if (!at) continue;
-    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
-    const next = timeline.find((t) => t > at);
-
-    let hit;
-    if (next !== undefined) hit = next - at <= tierSpec.ms;
-    else if (now - at > tierSpec.ms) hit = false;
-    else continue; // window still open: not yet knowable
-
-    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
-    recorded += 1;
-  }
-  return { outstanding: outstanding.length, recorded };
-}
-
-/**
- * The measured hit rate for a tier, or null below the observation floor.
- *
- * Null rather than a small-sample number, because the caller substitutes it for
- * a modelled probability and three observations would swing the decision harder
- * than the model they replace.
- */
-export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
-  const relevant = outcomes.filter(
-    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
-  );
-  if (relevant.length < OBSERVATION_FLOOR) return null;
-  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
+export function recordRefresh(dir, { tier, prefixTokens, expectedValue, sessionId, at }) {
+  return record(dir, {
+    kind: 'keepwarm',
+    action: 'refresh',
+    tier,
+    prefixTokens,
+    expectedValue,
+    sessionId,
+    at,
+  });
 }
 
 /**
  * Records whether the refresh was used.
  *
  * `hit` means a real turn arrived before expiry, so the write bought a read.
+ * `refreshId` names the refresh this scores, so the same one cannot be scored
+ * twice -- once per turn for the rest of the session, which is what an
+ * unpaired outcome would become.
  */
-export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
+export function recordRefreshOutcome(dir, { tier, prefixTokens, hit, refreshId = null }) {
   const tierSpec = TIERS.find((t) => t.name === tier) || TIERS[0];
   // THE SAME LEDGER keepWarmDecision BUYS THE REFRESH WITH. That function is explicit that a
   // refresh is a PING, which READS the prefix -- costOfPing = prefixTokens * READ_MULTIPLIER --
@@ -317,7 +365,125 @@ export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
   const realised = hit
     ? prefixTokens * (tierSpec.writeMultiplier - READ_MULTIPLIER) - prefixTokens * READ_MULTIPLIER
     : -prefixTokens * READ_MULTIPLIER;
-  record(dir, { kind: 'keepwarm', action: 'outcome', tier, prefixTokens, hit: Boolean(hit), realised: Math.round(realised) });
+  record(dir, {
+    kind: 'keepwarm',
+    action: 'outcome',
+    tier,
+    prefixTokens,
+    hit: Boolean(hit),
+    refreshId,
+    realised: Math.round(realised),
+  });
+}
+
+/**
+ * Scores every recorded refresh whose window has closed -- and NOTHING ELSE.
+ *
+ * This is the arm that was missing. `recordRefresh` and `recordRefreshOutcome`
+ * were both correct and both called by nothing, so the decision spent money on
+ * refreshes and could never find out whether one bought a read.
+ *
+ * THE SIGNAL IS REAL, not invented. `gapDistribution` already treats this log's
+ * timestamps as turn arrivals -- that is the distribution the whole decision is
+ * fitted to -- so the same log answers the outcome question directly: a refresh
+ * at tier `5m` was used if a turn of the same session arrived within five
+ * minutes of it. Four cases refuse to answer rather than guess, and every one
+ * of them refuses in the direction that costs this project its own good news:
+ *
+ *   - `pending`: the window has not closed yet. A hit could be scored the
+ *     instant it arrives while a miss must wait out the whole TTL, so scoring
+ *     early would mean the recorded hits are always complete and the recorded
+ *     misses always lagging -- right-censoring, biased upward, invisible in any
+ *     test. So a hit waits exactly as long as a miss.
+ *   - `uncovered`: the arrival log no longer reaches back to the refresh, so
+ *     absence of an arrival is absence of evidence. RECORDING `hit: false` HERE
+ *     WOULD BE THE INVENTION THIS IS FORBIDDEN TO MAKE: an absent signal is not
+ *     a miss, and treating it as one biases every rate downward and would
+ *     eventually switch keep-warm off on no evidence at all.
+ *   - `unattributable`: the refresh names no session, so no arrival can be
+ *     shown to belong to it.
+ *   - already scored: an outcome already names this refresh.
+ *
+ * The firehose is READ LAZILY, and only when there is something to score. On a
+ * machine where nothing issues refreshes -- which is every machine today, since
+ * nothing in this repository issues one -- the whole cost is the outcome-log
+ * read: median 70 ms on a 3.5 MB log, of which readBalance is 49 ms, because
+ * that reader also scans the firehose tail for pre-split records.
+ */
+export function scoreRefreshes(dir, {
+  refreshes = readBalance(dir),
+  arrivals = null,
+  now = Date.now(),
+} = {}) {
+  const summary = { scored: 0, hits: 0, pending: 0, uncovered: 0, unattributable: 0 };
+  const keepwarm = refreshes.filter((event) => event?.kind === 'keepwarm');
+  const alreadyScored = new Set(
+    keepwarm
+      .filter((event) => event.action === 'outcome' && event.refreshId)
+      .map((event) => event.refreshId)
+  );
+  const unscored = keepwarm.filter(
+    (event) =>
+      event.action === 'refresh' &&
+      Number.isFinite(event.at) &&
+      event.id &&
+      !alreadyScored.has(event.id)
+  );
+
+  // A refresh with no id cannot be paired, so scoring it would write a fresh
+  // outcome on every turn forever. Reported, not silently dropped.
+  summary.unattributable += keepwarm.filter(
+    (event) => event.action === 'refresh' && (!event.id || !Number.isFinite(event.at))
+  ).length;
+
+  if (!unscored.length) return summary;
+
+  const events = (arrivals ? arrivals() : readMetrics(dir)).filter((event) =>
+    Number.isFinite(event?.at)
+  );
+  // Coverage is judged over EVERY event, including our own bookkeeping: the
+  // refresh's own copy in the firehose is what proves the window is still
+  // inside the read. Arrivals are judged over everything else, because a record
+  // keep-warm wrote about itself is not a turn -- and counting one would
+  // manufacture a hit out of the act of measuring.
+  const earliest = events.reduce((min, event) => Math.min(min, event.at), Infinity);
+  const turns = events.filter((event) => event.kind !== 'keepwarm');
+
+  for (const refresh of unscored) {
+    const tier = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    if (now - refresh.at < tier.ms) {
+      summary.pending += 1;
+      continue;
+    }
+    const session = refresh.sessionId;
+    if (!session) {
+      summary.unattributable += 1;
+      continue;
+    }
+    if (!(earliest <= refresh.at)) {
+      summary.uncovered += 1;
+      continue;
+    }
+
+    const opens = refresh.at + TURN_GAP_MS;
+    const closes = refresh.at + tier.ms;
+    const hit = turns.some(
+      (event) =>
+        (event.sessionId ?? event.episodeId) === session &&
+        event.at > opens &&
+        event.at <= closes
+    );
+    recordRefreshOutcome(dir, {
+      tier: refresh.tier,
+      prefixTokens: refresh.prefixTokens,
+      hit,
+      refreshId: refresh.id,
+    });
+    summary.scored += 1;
+    if (hit) summary.hits += 1;
+  }
+
+  return summary;
 }
 
 /**
@@ -372,23 +538,15 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
-  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
-  // becomes evidence now, so the decision below and the tripwire above both see
-  // the most that is currently knowable -- the same read-time drain the
-  // staleness path uses, and for the same reason: the producer cannot know the
-  // outcome at the moment it acts.
-  try {
-    scoreOutstandingRefreshes(dir, { events, outcomes });
-    outcomes = readBalance(dir);
-  } catch {
-    /* scoring is evidence, never a reason to refuse a decision */
-  }
-
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
+  // THE SAME ARRAY THE TRIPWIRE JUST READ, so closing the loop costs no extra
+  // I/O -- and so the decision and its backstop cannot be looking at different
+  // evidence about the same refreshes.
+  const observed = observedHitRates(outcomes);
   const gaps = gapDistribution(dir, { events });
-  const best = ttlTier({ prefixTokens, gaps });
+  const best = ttlTier({ prefixTokens, gaps, observed });
   if (!best) {
     // THE TWO MODELS ANSWER DIFFERENT QUESTIONS, so they may legitimately disagree. ttlTier asks
     // whether holding a cache beats not caching at all; keepWarmDecision asks whether ONE ping
@@ -397,11 +555,7 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({
-      prefixTokens,
-      gaps,
-      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
-    });
+    const decision = keepWarmDecision({ prefixTokens, gaps, observed });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/integrations/gemini/hooks/lib/loo.mjs
+++ b/integrations/gemini/hooks/lib/loo.mjs
@@ -1,0 +1,788 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/loo.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 2 -- what one finding is actually worth, measured by withholding it.
+ *
+ * Layer 1 asks whether the model went back and named a finding. This asks the
+ * harder question and answers it causally: WITHHOLD ONE FINDING while serving
+ * every other finding for the same touch, and compare what the session spent
+ * READING that anchor afterwards. Nobody in this space measures per-item value
+ * this way in production; the state of the art is an offline evaluation set.
+ * That is also why this file is more refusal than statistics -- a causal claim
+ * from four observations is worse than no claim, because it is a number and
+ * numbers get quoted.
+ *
+ * THE ESTIMAND IS READ-SUPPRESSION, and it is deliberately DISJOINT from Layer
+ * 1. Layer 1 keys on an explicit `query` naming a finding key. This keys on
+ * `read` events against the injection's anchor. Neither signal appears in the
+ * other's arithmetic: no `query` event is consulted here, and `usage.mjs`
+ * consults no `read` event. Task 8 calibrates one against the other, and if
+ * both derived from the same channel that calibration would report a strong
+ * correlation between two spellings of one quantity and mean nothing.
+ *
+ * IT INVENTS NO JOIN. `recordToolOutcome` already joins each post-tool result
+ * back to the injection that preceded it, recording `injectionId`,
+ * `findingIds` and a `joinMethod` of `tool-call-id` / `episode-anchor` /
+ * `none`. Every observation here is GATED on that join: an injection with no
+ * joined outcome is unattributable and enters neither arm, exactly as Layer 1
+ * treats `joinMethod: 'none'`. An earlier draft of this plan proposed a fresh
+ * `(sessionId, findingKey)` join; it was rejected and is not here.
+ *
+ * WHAT IT COSTS THE USER, because an experiment that degrades a turn owes an
+ * accounting. One withheld finding means the model may re-derive what it was
+ * told last time, and the worst case is one read of that anchor: measured on
+ * this machine, a median read is 3,769 tokens and the 90th percentile is
+ * 14,082. Five guards bound that exposure, and they are the reason the numbers
+ * below are as small as they are:
+ *
+ *   1. only on a FILE touch, because a command injection has no anchor a read
+ *      event can be joined to -- withholding there would cost a user a finding
+ *      and buy no observation at all (see `buildReport`, which excludes command
+ *      injections from the holdout balance for the same reason);
+ *   2. never when fewer than two findings were kept, so "leave one out" always
+ *      leaves something in -- otherwise it degenerates into `inHoldout`, which
+ *      withholds EVERY finding for an anchor and is a different experiment;
+ *   3. never in the same breath as `inHoldout`: if that arm already withheld
+ *      everything, there is nothing to leave out and a Layer 2 arm recorded
+ *      there would be a fabricated observation;
+ *   4. at most ONE finding per touch, or the effect is attributable to neither;
+ *   5. at most ONE withheld finding per SESSION, so the worst case a user can
+ *      experience is a single re-read -- not one per file they open.
+ *
+ * AND IT NEVER OVERRIDES A PERSON. A `pinned` or `origin: 'human'` finding is
+ * an explicit human decision to keep something in front of the model.
+ * Withholding it to run an experiment would overrule that decision for the
+ * convenience of the measurement, so those findings are exempt: they are
+ * always served, they get no causal score, and `looNote` says so rather than
+ * leaving a reader to wonder why they are missing from the table.
+ */
+
+import { createHash } from 'node:crypto';
+import { readEvidence, readMetrics, readTruncation, isFixtureAnchor } from './metrics.mjs';
+import { retrievalPolicy } from './utility.mjs';
+import { ORIGIN_HUMAN } from './curate.mjs';
+import { canonicalPath } from './paths.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Injections of a finding before it may enter the experiment.
+ *
+ * A finding nobody has served yet has no established value to measure the
+ * absence of, and withholding it would be measuring the cold start rather than
+ * the finding. Four is also what makes the ratio below reachable: at a quarter
+ * of (key, session) pairs armed, a key needs roughly a dozen enrolled
+ * injections before it can reach a verdict at all.
+ */
+export const MIN_PRIOR_INJECTIONS = 4;
+
+/** The observation floor. Below this there is no verdict -- and NOT a zero. */
+export const MIN_SERVED = 6;
+export const MIN_WITHHELD = 3;
+
+/** Benjamini-Hochberg false-discovery rate for published verdicts. */
+export const FDR_Q = 0.1;
+
+/**
+ * Exploration rate.
+ *
+ * Without this, utility feeds the ranking, the ranking feeds injection
+ * frequency, injection frequency feeds the observation count, and a low score
+ * becomes self-fulfilling: the finding is never served often enough to earn a
+ * better one. A tenth of touches therefore ignore the utility order and
+ * promote the LEAST-served candidate instead.
+ */
+export const EPSILON = 0.1;
+
+/**
+ * The share of (finding, session) pairs assigned to the withheld arm.
+ *
+ * Chosen against the floors rather than picked: MIN_SERVED / MIN_WITHHELD is
+ * 2:1, so a quarter withheld reaches both floors at about the same time while
+ * leaving three touches in four undamaged.
+ */
+export const WITHHOLD_FRACTION = 0.25;
+
+/**
+ * Withheld findings allowed per session. ONE.
+ *
+ * The per-touch cap alone bounds nothing across a session: a session that
+ * opens twelve files with enrolled findings could have withheld twelve. This
+ * makes the worst case a user can experience one re-read, at the price of a
+ * mild confound that is stated rather than hidden -- when the cap binds, the
+ * other armed findings in that session are served, so the served arm is
+ * slightly enriched by sessions that touch many enrolled findings.
+ */
+export const MAX_WITHHELD_PER_SESSION = 1;
+
+/**
+ * Fallback shrinkage weight when the between-finding variance cannot be
+ * estimated (fewer than two findings with both arms, or no dispersion at all).
+ *
+ * MIN_SERVED + MIN_WITHHELD, deliberately: a finding's own data outweighs the
+ * population prior only once it has reached the publication floor.
+ */
+export const SHRINKAGE_K = MIN_SERVED + MIN_WITHHELD;
+
+/** Bounds on the estimated shrinkage weight, so a degenerate variance ratio cannot run away. */
+const K_MIN = 1;
+const K_MAX = 100;
+
+/**
+ * Bumped BY HAND when the serving code changes in a way that could move a
+ * finding's measured effect. It is the part of the policy version a hash of the
+ * configuration cannot see.
+ */
+export const LOO_POLICY_GENERATION = 1;
+
+/** Permutation budget before the exact null distribution is sampled instead of enumerated. */
+const MAX_EXACT_PERMUTATIONS = 20_000;
+const SAMPLED_PERMUTATIONS = 10_000;
+
+/**
+ * On by default, off by `TOKEN_OPTIMIZER_LOO=off`.
+ *
+ * Read per call rather than at module load, for the reason `holdoutFraction`
+ * gives: a long-lived process started before the setting changed would
+ * otherwise honour the old value forever with no way to tell.
+ */
+export function LOO_ENABLED() {
+  return String(process.env.TOKEN_OPTIMIZER_LOO || '').trim().toLowerCase() !== 'off';
+}
+
+/**
+ * The serving policy an observation was collected under.
+ *
+ * WHY EVERY OBSERVATION CARRIES ONE. An effect is only meaningful against a
+ * fixed policy. Halve the touch budget or move the minimum net utility and the
+ * same finding is served in different company, at a different rank, against a
+ * different counterfactual -- so pooling observations from before and after
+ * that change would average two different experiments and call the result
+ * causal. `effects()` therefore groups by (finding, policy) and never across.
+ *
+ * IT IS DELIBERATELY ABSENT FROM THE ARM HASH. Including it would reassign
+ * arms the moment a setting changed, which is precisely the mid-session flip
+ * the arm hash exists to prevent. Configuration decides which experiment an
+ * observation belongs to; it must never decide which arm.
+ */
+export function servingPolicyVersion() {
+  const policy = retrievalPolicy();
+  const parts = [
+    `g${LOO_POLICY_GENERATION}`,
+    `touch=${Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500}`,
+    `benefit=${policy.baseBenefitTokens}`,
+    `minutility=${policy.minimumNetUtility}`,
+    `cooldown=${policy.cooldownMs}`,
+    `quarantine=${policy.quarantineHarmCount}`,
+    `holdout=${process.env.TOKEN_OPTIMIZER_HOLDOUT ?? 'default'}`,
+    `withhold=${WITHHOLD_FRACTION}`,
+    `prior=${MIN_PRIOR_INJECTIONS}`,
+    `epsilon=${EPSILON}`,
+  ];
+  const digest = createHash('sha256').update(parts.join('|')).digest('hex');
+  return `${LOO_POLICY_GENERATION}-${digest.slice(0, 8)}`;
+}
+
+/**
+ * A stable number in [0, 1) from a string.
+ *
+ * SHA-256 rather than SHA-1 for the same reason `inHoldout` uses it: this is a
+ * bucketing hash and nothing here is secret, but arguing that a CodeQL finding
+ * is benign is a worse habit than paying a cost that rounds to nothing.
+ */
+function bucket(text) {
+  return createHash('sha256').update(String(text)).digest().readUInt32BE(0) / 4_294_967_296;
+}
+
+/**
+ * The arm of one finding in one session.
+ *
+ * Keyed on (findingKey, sessionId) AND NOTHING ELSE, so a finding cannot
+ * change arms partway through a session: not when the candidate set changes,
+ * not when the budget changes, not when the graph grows. The measurement is a
+ * comparison between sessions, and an arm that flips inside one contaminates
+ * both sides of it.
+ */
+function armed(findingKey, sessionId) {
+  return bucket(`loo-arm:${findingKey}:${sessionId}`) < WITHHOLD_FRACTION;
+}
+
+/** Deterministic tiebreak among armed candidates: lowest bucket, then key order. */
+function armRank(findingKey, sessionId) {
+  return bucket(`loo-rank:${findingKey}:${sessionId}`);
+}
+
+/** The graph node for a finding key, or null. Keys are unique per graph. */
+function findingNode(graph, key) {
+  const nodes = graph?.nodes;
+  if (!nodes || typeof nodes.values !== 'function') return null;
+  for (const node of nodes.values()) {
+    if (node?.kind === 'finding' && node.key === key) return node;
+    // A fixture graph may omit `kind`; key identity is what this needs.
+    if (node?.key === key && node.kind === undefined) return node;
+  }
+  return null;
+}
+
+/**
+ * May this finding ever be withheld?
+ *
+ * FAILS CLOSED ON AN UNKNOWN KEY, which is the opposite of how the rest of
+ * this module fails. Everywhere else a missing input costs a measurement; here
+ * it could cost a human their explicit decision, because a key whose node
+ * cannot be read is a key whose `pinned` and `origin` cannot be checked.
+ */
+function withholdable(graph, key) {
+  const node = findingNode(graph, key);
+  if (!node) return false;
+  if (node.pinned) return false;
+  if (node.origin === ORIGIN_HUMAN) return false;
+  if (node.retired) return false;
+  return true;
+}
+
+/** Prior SERVED injections per finding key, and withheld injections per session. */
+function history(dir, { evidence = null } = {}) {
+  const priorServed = new Map();
+  const withheldPerSession = new Map();
+  const events = evidence || readEvidence(dir);
+  for (const event of events) {
+    if (event.kind !== 'inject') continue;
+    if (typeof event.loo === 'string' && event.loo) {
+      const session = typeof event.sessionId === 'string' ? event.sessionId : '';
+      withheldPerSession.set(session, (withheldPerSession.get(session) || 0) + 1);
+    }
+    if (event.holdout) continue;
+    const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+    for (const raw of keys) {
+      const key = String(raw);
+      priorServed.set(key, (priorServed.get(key) || 0) + 1);
+    }
+  }
+  return { priorServed, withheldPerSession };
+}
+
+/**
+ * Which single finding to withhold from this touch, or null.
+ *
+ * Called from `forTouch` AFTER `fit` has decided what would have been served,
+ * which is the only ordering that produces a true leave-one-out. Withholding
+ * BEFORE the budget runs would let a lower-ranked finding take the freed
+ * tokens, so the withheld arm would receive different company as well as one
+ * fewer finding, and the comparison would confound the two.
+ *
+ * @param {string[]} findingKeys keys that would otherwise be delivered
+ * @param {string} sessionId the session, which pins the arm
+ * @param {object} graph the loaded graph, for `pinned` / `origin`
+ * @param {string|null} dir graph directory, for the injection history
+ */
+export function withheldFor(findingKeys, sessionId, graph, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return null;
+
+    // Every guard that needs no I/O runs first: this is the PreToolUse path,
+    // and on a project with one finding per anchor the answer is null before
+    // anything is read.
+    const keys = [...new Set((findingKeys || []).map((k) => String(k)).filter(Boolean))];
+    if (keys.length < 2) return null;
+    if (!sessionId || typeof sessionId !== 'string') return null;
+
+    // FILE SURFACE ONLY. A command injection's anchor is the command text, and
+    // no read event will ever match it -- so both arms would score zero
+    // downstream and the finding would be scored on nothing.
+    const { surface = 'file', anchor = '', holdout = false } = options;
+    if (surface !== 'file' || !anchor) return null;
+    // The all-findings holdout already withheld everything for this anchor.
+    if (holdout) return null;
+
+    const eligible = keys.filter((key) => withholdable(graph, key));
+    if (!eligible.length) return null;
+
+    const { priorServed, withheldPerSession } = history(dir, options);
+    if ((withheldPerSession.get(sessionId) || 0) >= MAX_WITHHELD_PER_SESSION) return null;
+
+    const enrolled = eligible.filter(
+      (key) => (priorServed.get(key) || 0) >= MIN_PRIOR_INJECTIONS
+    );
+    if (!enrolled.length) return null;
+
+    const candidates = enrolled.filter((key) => armed(key, sessionId));
+    if (!candidates.length) return null;
+
+    // AT MOST ONE. Sorted deterministically so the same touch always yields the
+    // same choice; the findings that lose the tiebreak are SERVED, and the
+    // observation records what actually happened rather than what the arm hash
+    // intended.
+    candidates.sort(
+      (a, b) => armRank(a, sessionId) - armRank(b, sessionId) || (a < b ? -1 : a > b ? 1 : 0)
+    );
+    return candidates[0];
+  } catch {
+    // An experiment must never break a tool call. Failing open here means
+    // serving everything, which is the undegraded behaviour.
+    return null;
+  }
+}
+
+/**
+ * Reorders candidates so exploration can break the feedback loop.
+ *
+ * A tenth of touches -- deterministic in (session, anchor), not random, so the
+ * same touch behaves the same way twice -- promote the LEAST-served candidate
+ * ahead of the utility order, giving it a chance to survive `fit` and accrue
+ * the observations it needs to earn a score. The other nine tenths are
+ * untouched.
+ *
+ * @param {Array<{finding:{key:string}}>} items assessed candidates, best first
+ */
+export function exploreOrder(items, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return items;
+    const list = Array.isArray(items) ? items : [];
+    if (list.length < 2) return list;
+    const { sessionId = '', anchor = '' } = options;
+    if (bucket(`loo-explore:${sessionId}:${anchor}`) >= EPSILON) return list;
+
+    const keyOf = (item) => String(item?.finding?.key ?? item?.key ?? '');
+    const { priorServed } = history(dir, options);
+    let promoted = 0;
+    for (let i = 1; i < list.length; i += 1) {
+      const a = priorServed.get(keyOf(list[i])) || 0;
+      const b = priorServed.get(keyOf(list[promoted])) || 0;
+      if (a < b || (a === b && keyOf(list[i]) < keyOf(list[promoted]))) promoted = i;
+    }
+    if (promoted === 0) return list;
+    return [list[promoted], ...list.filter((_, i) => i !== promoted)];
+  } catch {
+    return Array.isArray(items) ? items : [];
+  }
+}
+
+const mean = (values) =>
+  values.length ? values.reduce((sum, v) => sum + v, 0) / values.length : 0;
+
+/** Sample variance (n-1). Zero for a single observation: dispersion is unknown, not large. */
+function variance(values) {
+  if (values.length < 2) return 0;
+  const m = mean(values);
+  return values.reduce((sum, v) => sum + (v - m) * (v - m), 0) / (values.length - 1);
+}
+
+/**
+ * Every attributable Layer 2 observation, one per (injection, finding, arm).
+ *
+ * THREE THINGS ARE REPORTED SEPARATELY RATHER THAN FOLDED IN, because each of
+ * them would otherwise turn an absence into a zero:
+ *
+ *   `unattributable`  the outcome join could not attach a tool call to the
+ *                     injection, so nothing is known about what followed it.
+ *   `excluded`        the injection could never produce a read-join at all
+ *                     (command surface, session-start, fixture anchor) or was
+ *                     already in the all-findings holdout.
+ *   `costObservations` how many observations saw a non-zero read cost. If this
+ *                     is zero, "withholding changed nothing" and "the read
+ *                     channel never fired" are the same picture, and only one
+ *                     of them is a finding about findings.
+ */
+export function observations(dir, { events = null, evidence = null } = {}) {
+  const empty = {
+    rows: [],
+    unattributable: 0,
+    unattributableOutcomes: 0,
+    excluded: { command: 0, holdout: 0, fixture: 0, unanchored: 0 },
+    injections: 0,
+    withheldInjections: 0,
+    costObservations: 0,
+    policies: [],
+    windowed: false,
+  };
+  try {
+    const causal = evidence || readEvidence(dir);
+    const all = events || readMetrics(dir);
+    // OUT OF BAND and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` describes the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
+
+    // THE JOIN THIS MODULE CONSUMES AND DOES NOT REPLACE.
+    const joined = new Set();
+    let unattributableOutcomes = 0;
+    for (const event of causal) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) {
+        unattributableOutcomes += 1;
+        continue;
+      }
+      joined.add(String(event.injectionId));
+    }
+
+    // Read cost, grouped the way `buildReport` groups it: (session, anchor),
+    // canonicalised on both sides so two spellings of one file are one anchor.
+    // A mismatch here would make every read invisible and report a clean zero
+    // effect in both arms -- correct code, absent measurement.
+    const reads = new Map();
+    for (const event of all) {
+      if (event.kind !== 'read' || !event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      if (!reads.has(key)) reads.set(key, []);
+      reads.get(key).push(event);
+    }
+
+    const injects = causal
+      .filter((event) => event.kind === 'inject')
+      .map((event, index) => ({ event, index }))
+      .sort((a, b) => (a.event.at || 0) - (b.event.at || 0) || a.index - b.index)
+      .map((row) => row.event);
+
+    // How many injections share each (session, anchor), so a key's read total
+    // is SPLIT between them rather than charged in full to each -- the same
+    // correction `buildReport` applies, and for the same reason: without it the
+    // arm means scale with injections-per-anchor instead of per-touch cost.
+    const perKey = new Map();
+    for (const event of injects) {
+      if (!event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      perKey.set(key, (perKey.get(key) || 0) + 1);
+    }
+
+    const rows = [];
+    const excluded = { command: 0, holdout: 0, fixture: 0, unanchored: 0 };
+    const priorServed = new Map();
+    const policies = new Set();
+    let unattributable = 0;
+    let considered = 0;
+    let withheldInjections = 0;
+
+    for (const event of injects) {
+      const served = (Array.isArray(event.findingIds) ? event.findingIds : []).map(String);
+      const withheldKey = typeof event.loo === 'string' && event.loo ? event.loo : null;
+      const bump = () => {
+        for (const key of served) priorServed.set(key, (priorServed.get(key) || 0) + 1);
+      };
+
+      const isCommand =
+        event.surface === 'command' ||
+        event.trigger === 'command' ||
+        event.surface === 'session-start';
+      if (isCommand) {
+        excluded.command += 1;
+        bump();
+        continue;
+      }
+      if (!event.anchor) {
+        excluded.unanchored += 1;
+        bump();
+        continue;
+      }
+      if (isFixtureAnchor(event.anchor)) {
+        excluded.fixture += 1;
+        bump();
+        continue;
+      }
+      if (event.holdout) {
+        excluded.holdout += 1;
+        bump();
+        continue;
+      }
+
+      considered += 1;
+      if (withheldKey) withheldInjections += 1;
+      const policy = typeof event.looPolicy === 'string' && event.looPolicy
+        ? event.looPolicy
+        : 'unversioned';
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const attributable = Boolean(injectionId && joined.has(injectionId));
+
+      // DOWNSTREAM MEANS AFTER, STRICTLY. The read that triggered the touch is
+      // not caused by the advice; it happened before the advice existed.
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      const at = event.at || 0;
+      const total = (reads.get(key) || []).reduce(
+        (sum, read) => sum + ((read.at || 0) > at ? read.tokens || 0 : 0),
+        0
+      );
+      const cost = total / Math.max(1, perKey.get(key) || 1);
+
+      const observe = (findingKey, arm) => {
+        // ENROLMENT IS RE-DERIVED FROM THE LOG rather than trusted from the
+        // serving decision. It is the one field an old or hand-written record
+        // could contradict, and a served observation from before a finding was
+        // enrolled would compare an established finding against its own cold
+        // start.
+        //
+        // CHECKED BEFORE ATTRIBUTABILITY, so `unattributable` counts only
+        // observations the experiment actually wanted. Counting the rest there
+        // would report a join failure for every finding that was never in the
+        // experiment to begin with -- the same shape as the 2,559-row
+        // measurement-bias defect Layer 1 found in its own first draft.
+        if ((priorServed.get(findingKey) || 0) < MIN_PRIOR_INJECTIONS) return;
+        if (!attributable) {
+          unattributable += 1;
+          return;
+        }
+        policies.add(policy);
+        rows.push({ findingKey, arm, cost, policy, injectionId, anchor: event.anchor });
+      };
+
+      if (withheldKey) observe(withheldKey, 'withheld');
+      for (const findingKey of served) observe(findingKey, 'served');
+      bump();
+    }
+
+    return {
+      rows,
+      unattributable,
+      unattributableOutcomes,
+      excluded,
+      injections: considered,
+      withheldInjections,
+      costObservations: rows.filter((row) => row.cost > 0).length,
+      policies: [...policies].sort(),
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
+function permutationP(servedCosts, withheldCosts) {
+  const pooled = [...servedCosts, ...withheldCosts];
+  const n = pooled.length;
+  const k = withheldCosts.length;
+  if (!k || k === n) return null;
+  const observed = Math.abs(mean(withheldCosts) - mean(servedCosts));
+  const total = pooled.reduce((sum, v) => sum + v, 0);
+  // Mean difference from the withheld-arm sum alone: the served sum is the
+  // complement, so one number decides the statistic.
+  const diffFrom = (withheldSum) =>
+    Math.abs(withheldSum / k - (total - withheldSum) / (n - k));
+
+  const choose = (a, b) => {
+    let out = 1;
+    for (let i = 1; i <= b; i += 1) out = (out * (a - b + i)) / i;
+    return out;
+  };
+
+  const tolerance = 1e-9;
+  if (choose(n, k) <= MAX_EXACT_PERMUTATIONS) {
+    let extreme = 0;
+    let count = 0;
+    const walk = (start, chosen, sum) => {
+      if (chosen === k) {
+        count += 1;
+        if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+        return;
+      }
+      for (let i = start; i <= n - (k - chosen); i += 1) walk(i + 1, chosen + 1, sum + pooled[i]);
+    };
+    walk(0, 0, 0);
+    return count ? extreme / count : null;
+  }
+
+  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
+  // the same p-value and a verdict cannot flicker between two audit runs.
+  let state = 0x9e3779b9;
+  const random = () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4_294_967_296;
+  };
+  let extreme = 0;
+  const order = [...pooled];
+  for (let round = 0; round < SAMPLED_PERMUTATIONS; round += 1) {
+    for (let i = order.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(random() * (i + 1));
+      [order[i], order[j]] = [order[j], order[i]];
+    }
+    let sum = 0;
+    for (let i = 0; i < k; i += 1) sum += order[i];
+    if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+  }
+  return (extreme + 1) / (SAMPLED_PERMUTATIONS + 1);
+}
+
+/**
+ * The per-finding causal effect, shrunk, and whether it may be published.
+ *
+ * `raw` is `mean(withheld) - mean(served)`: POSITIVE means the session read the
+ * anchor more when the finding was withheld, which is the finding earning its
+ * place. `shrunk` is the number a reader should use.
+ *
+ * EMPIRICAL BAYES, and both halves of it come from the data. The prior mean is
+ * the population effect across findings; the weight `k` is the ratio of
+ * within-finding noise to between-finding spread, so a population where every
+ * finding behaves alike shrinks hard and one where they genuinely differ
+ * shrinks little. `SHRINKAGE_K` is the fallback when that spread cannot be
+ * estimated at all. Two observations therefore cannot post a wild score.
+ *
+ * PUBLICATION IS NOT THE SAME QUESTION as having an estimate. A row is
+ * published only if it clears the observation floor AND its permutation
+ * p-value survives Benjamini-Hochberg at q = 0.10 across every candidate row.
+ * Everything else gets `published: false` -- which is not a zero effect, and
+ * `looNote` says which of the two it is. An all-zero-cost population needs no
+ * separate guard: p is exactly 1 there, so nothing can publish anyway.
+ *
+ * NEVER POOLED ACROSS POLICY VERSIONS: rows are keyed on (findingKey, policy).
+ */
+export function effects(dir, options = {}) {
+  try {
+    // `obs` is accepted so `looNote` can read the logs once for both.
+    const obs = options.obs || observations(dir, options);
+    const groups = new Map();
+    for (const row of obs.rows) {
+      const id = JSON.stringify([row.findingKey, row.policy]);
+      if (!groups.has(id))
+        groups.set(id, { findingKey: row.findingKey, policy: row.policy, served: [], withheld: [] });
+      groups.get(id)[row.arm === 'withheld' ? 'withheld' : 'served'].push(row.cost);
+    }
+
+    const raws = [];
+    const withinVars = [];
+    for (const group of groups.values()) {
+      if (!group.served.length || !group.withheld.length) continue;
+      raws.push(mean(group.withheld) - mean(group.served));
+      withinVars.push(
+        variance(group.withheld) / group.withheld.length +
+          variance(group.served) / group.served.length
+      );
+    }
+    const prior = raws.length ? mean(raws) : 0;
+    const within = withinVars.length ? mean(withinVars) : 0;
+    const between = raws.length > 1 ? Math.max(0, variance(raws) - within) : 0;
+    const weight =
+      between > 0 && within > 0
+        ? Math.min(K_MAX, Math.max(K_MIN, within / between))
+        : SHRINKAGE_K;
+
+    const rows = [...groups.values()]
+      .map((group) => {
+        const served = group.served.length;
+        const withheld = group.withheld.length;
+        const both = served > 0 && withheld > 0;
+        const raw = both ? mean(group.withheld) - mean(group.served) : null;
+        const n = served + withheld;
+        const shrunk = raw === null ? null : (n * raw + weight * prior) / (n + weight);
+        const eligible = served >= MIN_SERVED && withheld >= MIN_WITHHELD;
+        return {
+          findingKey: group.findingKey,
+          policy: group.policy,
+          served,
+          withheld,
+          servedMean: mean(group.served),
+          withheldMean: mean(group.withheld),
+          raw,
+          shrunk,
+          p: eligible ? permutationP(group.served, group.withheld) : null,
+          published: false,
+        };
+      })
+      .sort((a, b) =>
+        a.findingKey < b.findingKey ? -1 : a.findingKey > b.findingKey ? 1 : a.policy < b.policy ? -1 : 1
+      );
+
+    // BENJAMINI-HOCHBERG at q = 0.10 over every row that cleared the floor.
+    // One finding tested in isolation would publish at p < 0.10; a hundred
+    // would publish ten false ones, and this module's whole claim is that its
+    // numbers can be quoted.
+    //
+    // THERE IS NO SEPARATE "WAS ANY READ COST OBSERVED" GATE HERE, and its
+    // absence is deliberate rather than an omission. One was written, and
+    // mutation testing showed it could not change a single verdict: if every
+    // observation has zero cost then both arm means are zero, the permutation
+    // statistic is zero for every relabelling, and p is exactly 1 -- which no
+    // BH threshold can pass. The guard was unfalsifiable, and an unfalsifiable
+    // guard is worse than none because it reads as protection nobody can test.
+    // `costObservations` survives as what it can honestly be: a DISCLOSURE, so
+    // `looNote` can say the read channel never fired instead of letting a
+    // reader take an arithmetic zero for a measured one.
+    const candidates = rows
+      .filter((row) => row.p !== null)
+      .sort((a, b) => a.p - b.p);
+    const m = candidates.length;
+    let cutoff = 0;
+    for (let i = 0; i < m; i += 1) {
+      if (candidates[i].p <= ((i + 1) / m) * FDR_Q) cutoff = i + 1;
+    }
+    for (let i = 0; i < cutoff; i += 1) candidates[i].published = true;
+
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * One or two lines for the audit, or nothing at all.
+ *
+ * THE REFUSAL IS THE PRODUCT HERE. On a machine with two injections in sixteen
+ * thousand events, the only honest output is that nothing is measurable yet,
+ * and this says so with the counts that make it checkable rather than printing
+ * a mean of nothing. It returns `null` when Layer 2 has not collected a single
+ * observation, so an idle experiment costs the reader no line at all -- the
+ * same standard `referenceNote` holds itself to.
+ */
+export function looNote(dir, options = {}) {
+  try {
+    const obs = options.obs || observations(dir, options);
+    const rows = effects(dir, { ...options, obs });
+    if (!obs.rows.length && !obs.withheldInjections) return null;
+
+    let graph = options.graph;
+    if (graph === undefined) {
+      try {
+        graph = load(dir);
+      } catch {
+        graph = null;
+      }
+    }
+    let exempt = 0;
+    if (graph?.nodes?.values) {
+      for (const node of graph.nodes.values()) {
+        if (node?.kind !== 'finding' || node.retired) continue;
+        if (node.pinned || node.origin === ORIGIN_HUMAN) exempt += 1;
+      }
+    }
+
+    const published = rows.filter((row) => row.published);
+    const head = published.length
+      ? `Per-finding causal value (leave-one-out): ${published.length} of ${rows.length} ` +
+        `findings show a verdict at q=${FDR_Q}` +
+        published
+          .slice(0, 3)
+          .map(
+            (row) =>
+              `; ${row.findingKey} saves ~${Math.round(row.shrunk)} tokens/touch ` +
+              `(${row.served} served, ${row.withheld} withheld, p=${row.p.toFixed(3)})`
+          )
+          .join('') +
+        '.'
+      : `Per-finding causal value (leave-one-out): NOT MEASURABLE YET -- ` +
+        `${obs.rows.length} attributable observations across ${rows.length} findings, ` +
+        `${obs.withheldInjections} withheld touches; the floor is ${MIN_SERVED} served ` +
+        `and ${MIN_WITHHELD} withheld per finding` +
+        (obs.costObservations ? '' : ', and no read cost has been observed in either arm') +
+        '. No effect is reported, which is not the same as an effect of zero.';
+
+    const caveats = [];
+    if (obs.unattributable)
+      caveats.push(
+        `${obs.unattributable} observations were unattributable (no joined tool outcome) and are in neither arm`
+      );
+    if (exempt)
+      caveats.push(
+        `${exempt} pinned or human-origin findings are exempt from withholding and get no causal score`
+      );
+    if (obs.policies.length > 1)
+      caveats.push(
+        `observations span ${obs.policies.length} serving-policy versions and are never pooled across them`
+      );
+    if (obs.windowed)
+      caveats.push('the read log was truncated, so downstream cost can understate');
+    return caveats.length ? `${head} ${caveats.join('; ')}.` : head;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/gemini/hooks/lib/loo.mjs
+++ b/integrations/gemini/hooks/lib/loo.mjs
@@ -545,8 +545,22 @@ export function observations(dir, { events = null, evidence = null } = {}) {
   }
 }
 
-/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
-function permutationP(servedCosts, withheldCosts) {
+/**
+ * Enumerates or samples arm relabellings and returns a two-sided p-value.
+ *
+ * EXPORTED so the cross-layer headline can be held to the same standard as the
+ * per-finding rows it summarises. `crosslayer.mjs` runs this over the two ARMS
+ * of shrunk effect estimates; the statistic, the enumerate-or-sample switch and the
+ * tolerance are therefore shared rather than reimplemented, and there is one
+ * place where "two-sided" is decided.
+ *
+ * `seed` exists for that caller. The default reproduces the fixed seed this
+ * function has always used, so Layer 2's own p-values are byte-identical; the
+ * cross-layer caller passes a seed DERIVED FROM ITS DATA, because a verdict
+ * printed to a human must not depend on `Math.random()` or on which module
+ * happened to call first.
+ */
+export function permutationP(servedCosts, withheldCosts, { seed = 0x9e3779b9 } = {}) {
   const pooled = [...servedCosts, ...withheldCosts];
   const n = pooled.length;
   const k = withheldCosts.length;
@@ -580,9 +594,10 @@ function permutationP(servedCosts, withheldCosts) {
     return count ? extreme / count : null;
   }
 
-  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
-  // the same p-value and a verdict cannot flicker between two audit runs.
-  let state = 0x9e3779b9;
+  // Mulberry32 off the caller's seed: reproducible, so the same data always
+  // yields the same p-value and a verdict cannot flicker between two audit
+  // runs.
+  let state = seed | 0;
   const random = () => {
     state = (state + 0x6d2b79f5) | 0;
     let t = state;

--- a/integrations/gemini/hooks/lib/metrics.mjs
+++ b/integrations/gemini/hooks/lib/metrics.mjs
@@ -31,6 +31,7 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { createHash, randomBytes } from 'node:crypto';
+import { redact } from './redact.mjs';
 
 /**
  * Read per call, not once at module load.
@@ -517,6 +518,15 @@ export function readEvidence(dir) {
 }
 
 /**
+ * The captured-output budget, in characters.
+ *
+ * Small enough that a 3 MB test log cannot bloat the evidence log or a single
+ * injected claim, large enough to hold the stack trace or compiler diagnostic
+ * that makes a failure finding worth anything.
+ */
+const OUTPUT_MAX_BYTES = 4096;
+
+/**
  * Joins a post-tool result to the most recent matching injection.  The exact
  * tool-call id wins; clients that omit it fall back to episode + surface +
  * anchor, in timestamp order, and the report states the weaker join method.
@@ -545,10 +555,31 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
+  // text is INJECTED into model context and EXPORTED to markdown, so the
+  // boundary is the only place that can guarantee it: a second caller added
+  // later would otherwise have to remember, and the one that forgot would leak
+  // a secret into two more places than the terminal it came from. `undefined`
+  // rather than `''` when nothing was captured, so JSON.stringify omits the
+  // key entirely and an absent capture is distinguishable from an empty one.
+  const output =
+    outcome.output === undefined || outcome.output === null
+      ? undefined
+      : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
+  // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric
+  // code at all, and 0 is the success value -- defaulting to it would claim
+  // every unreported call exited cleanly, which is a fabricated observation
+  // rather than a missing one.
+  const exit = Number.isInteger(outcome.exit) ? outcome.exit : null;
+
   return record(dir, {
     kind: 'tool-outcome',
     ...outcome,
     anchor,
+    // AFTER the spread, so a caller cannot smuggle raw text past the boundary
+    // by setting the field itself.
+    output,
+    exit,
     injectionId: injection?.injectionId || null,
     findingIds: injection?.findingIds || [],
     joinMethod,

--- a/integrations/gemini/hooks/lib/metrics.mjs
+++ b/integrations/gemini/hooks/lib/metrics.mjs
@@ -555,6 +555,22 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // FAILURES ONLY, and that is a deliberate override of the original plan.
+  // The plan predates MCP tool names reaching this path, so it never
+  // considered that a SUCCESSFUL `smart_read` would deposit 4 KB of file
+  // content into the evidence log on every call -- the log would grow with
+  // file text and the privacy surface would be every file the session opened.
+  //
+  // Nothing downstream loses anything. A failure claim quotes the error text;
+  // a "this command works" claim needs only the fact that it worked, which
+  // `success` and `exit` already carry. So the stored text narrows to text
+  // that is already an error message.
+  //
+  // GATED ON `success === true`, not on `!== false`: an outcome that never
+  // said whether it worked is unclassified, not successful, and dropping its
+  // text would lose exactly the failures a client too terse to report status
+  // produces.
+  const captureOutput = outcome.success !== true;
   // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
   // text is INJECTED into model context and EXPORTED to markdown, so the
   // boundary is the only place that can guarantee it: a second caller added
@@ -563,7 +579,7 @@ export function recordToolOutcome(dir, outcome) {
   // rather than `''` when nothing was captured, so JSON.stringify omits the
   // key entirely and an absent capture is distinguishable from an empty one.
   const output =
-    outcome.output === undefined || outcome.output === null
+    !captureOutput || outcome.output === undefined || outcome.output === null
       ? undefined
       : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
   // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric

--- a/integrations/gemini/hooks/lib/metrics.mjs
+++ b/integrations/gemini/hooks/lib/metrics.mjs
@@ -663,6 +663,89 @@ export function isFixtureAnchor(anchor) {
  * Fixture anchors are excluded from both.
  */
 /**
+ * Re-reads grouped by anchor -- the one place that decides what "wasteful" means.
+ *
+ * `rereadWaste` needed only the totals, so the grouping lived inside it and the
+ * per-anchor rows were thrown away. `derive.mjs`'s churn detector needs the
+ * rows, and re-deriving them there would put TWO definitions of "a repeat read
+ * of an unchanged file is waste" in the codebase, free to drift apart -- the
+ * exact divergence `npm run sync:hooks` exists to prevent between hooks-core and
+ * its generated copies. So the grouping lives here and both consumers read it.
+ *
+ * A re-read is only a re-read INSIDE ONE SESSION: grouping is keyed on
+ * session + canonical anchor, and rows are then merged per anchor so a file
+ * re-read across three sessions reports as one anchor with the sum of its
+ * repeats rather than three rows the caller has to add up. Merging cannot move
+ * the totals -- a sum of sums -- which is what makes it safe for `rereadWaste`.
+ *
+ * `tokens` is the WASTEFUL token count, not the total: it is the only one of the
+ * three that names something recoverable, and a row whose headline number
+ * included legitimate re-reads would overstate exactly the way the first
+ * version of this measurement did.
+ *
+ * @returns {Array<{anchor: string, repeats: number, wasteful: number,
+ *   tokens: number, legitimate: number, legitimateTokens: number,
+ *   undecidable: number, undecidableTokens: number}>} descending by `wasteful`,
+ *   then by `repeats`.
+ */
+export function rereadsByAnchor(events = [], { includeFixtures = false } = {}) {
+  const groups = new Map();
+  for (const e of events) {
+    if (!e || e.kind !== 'read' || !e.anchor) continue;
+    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
+    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(e);
+  }
+
+  const rows = new Map();
+  for (const list of groups.values()) {
+    if (list.length < 2) continue;
+    list.sort((a, b) => (a.at || 0) - (b.at || 0));
+
+    const anchorKey = canonicalKeyish(list[0].anchor);
+    let row = rows.get(anchorKey);
+    if (!row) {
+      row = {
+        anchor: list[0].anchor,
+        repeats: 0,
+        wasteful: 0,
+        tokens: 0,
+        legitimate: 0,
+        legitimateTokens: 0,
+        undecidable: 0,
+        undecidableTokens: 0,
+      };
+      rows.set(anchorKey, row);
+    }
+
+    for (let i = 1; i < list.length; i++) {
+      const prev = list[i - 1];
+      const cur = list[i];
+      const tokens = cur.tokens || 0;
+      row.repeats += 1;
+      // THE JUDGEMENT, in one place. A repeat read of a file that CHANGED is
+      // correct behaviour, not waste; a read written before fingerprints
+      // existed cannot be judged at all and says so.
+      if (!prev.fp || !cur.fp) {
+        row.undecidable += 1;
+        row.undecidableTokens += tokens;
+      } else if (prev.fp === cur.fp) {
+        row.wasteful += 1;
+        row.tokens += tokens;
+      } else {
+        row.legitimate += 1;
+        row.legitimateTokens += tokens;
+      }
+    }
+  }
+
+  return [...rows.values()].sort(
+    (a, b) => b.wasteful - a.wasteful || b.repeats - a.repeats
+  );
+}
+
+/**
  * Re-read waste, split into what is KNOWN and what is not.
  *
  * The question is narrow on purpose: how often does one session read the same
@@ -677,6 +760,9 @@ export function isFixtureAnchor(anchor) {
  * `undecidable` is reported rather than hidden. Reads written before the
  * fingerprint existed cannot be classified, and a measurement that quietly
  * counted them either way would be inventing its own answer.
+ *
+ * The aggregate fields are UNCHANGED -- `balanceSheet` reads them -- and are now
+ * a fold over `rereadsByAnchor`'s rows. `worst` is purely additive.
  */
 export function rereadWaste(
   dir,
@@ -685,14 +771,7 @@ export function rereadWaste(
   // excludes by design, making the real path untestable.
   { events = readMetrics(dir), includeFixtures = false } = {}
 ) {
-  const groups = new Map();
-  for (const e of events) {
-    if (e.kind !== 'read' || !e.anchor) continue;
-    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
-    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key).push(e);
-  }
+  const rows = rereadsByAnchor(events, { includeFixtures });
 
   const out = {
     repeats: 0,
@@ -704,29 +783,21 @@ export function rereadWaste(
     undecidableTokens: 0,
   };
 
-  for (const list of groups.values()) {
-    if (list.length < 2) continue;
-    list.sort((a, b) => (a.at || 0) - (b.at || 0));
-    for (let i = 1; i < list.length; i++) {
-      const prev = list[i - 1];
-      const cur = list[i];
-      const tokens = cur.tokens || 0;
-      out.repeats += 1;
-      if (!prev.fp || !cur.fp) {
-        out.undecidable += 1;
-        out.undecidableTokens += tokens;
-      } else if (prev.fp === cur.fp) {
-        out.wasteful += 1;
-        out.wastefulTokens += tokens;
-      } else {
-        out.legitimate += 1;
-        out.legitimateTokens += tokens;
-      }
-    }
+  for (const row of rows) {
+    out.repeats += row.repeats;
+    out.wasteful += row.wasteful;
+    out.wastefulTokens += row.tokens;
+    out.legitimate += row.legitimate;
+    out.legitimateTokens += row.legitimateTokens;
+    out.undecidable += row.undecidable;
+    out.undecidableTokens += row.undecidableTokens;
   }
 
   const decided = out.wasteful + out.legitimate;
   out.coverage = out.repeats ? decided / out.repeats : null;
+  // The offenders behind the totals, bounded: a report needs the handful worth
+  // acting on, not one row per file the session touched twice.
+  out.worst = rows.slice(0, 10);
   return out;
 }
 

--- a/integrations/gemini/hooks/lib/recall.mjs
+++ b/integrations/gemini/hooks/lib/recall.mjs
@@ -1,0 +1,390 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/recall.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Does retrieval FIND a finding, or does it only find what it was told where
+ * to look?
+ *
+ * `docs/WIKI_GRAPH.md` says embeddings get added "if measurement shows real
+ * recall loss". Nothing measured recall, so the no-embeddings stance was
+ * unfalsifiable -- a claim with no observation that could contradict it. This
+ * module is the observation.
+ *
+ * ---------------------------------------------------------------------------
+ * THE TAUTOLOGY THIS DELIBERATELY DOES NOT SHIP, AND WHY IT IS RECORDED HERE
+ * ---------------------------------------------------------------------------
+ * The obvious probe -- for each finding, take its anchors and ask whether
+ * `findingsFor` returns it from each -- CANNOT FAIL. `findingsFor(graph, A)`
+ * walks `derived_from` edges backwards into A, and the edge F -> A is the very
+ * thing that makes A an anchor of F. So F is in the result by CONSTRUCTION, not
+ * by retrieval quality, for every graph, forever. Its rate is 1.0 always, and a
+ * permanent 1.0 published as a recall rate reads to a human as "retrieval is
+ * perfect, embeddings unnecessary" -- one unfalsifiable claim swapped for
+ * another, leaning the one direction a measurement of this project by this
+ * project must never lean.
+ *
+ * That check is still worth running -- if it ever fails, traversal is broken
+ * rather than merely lossy -- so it is kept, and reported as `integrity` with
+ * its own `what` string saying it is not a recall rate. It is NEVER `rate`.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT IS MEASURED INSTEAD: LEAVE-ONE-EDGE-OUT
+ * ---------------------------------------------------------------------------
+ * For each active finding F and each anchor A of F, delete the edge F -> A and
+ * ask whether touching A would STILL surface F. Two independent arms, both of
+ * which can genuinely miss, which is what makes this a measurement:
+ *
+ *   Arm A -- TRAVERSAL FROM THE NEIGHBOURHOOD. Run the real `findingsFor` over
+ *   the edge-deleted graph from A itself and from A's `contains` parents. This
+ *   hits only when F has some OTHER structural route in: a second anchor on the
+ *   same file, or an anchor on a sibling symbol under the same parent. A's
+ *   `contains` children need no separate call because `findingsFor` expands
+ *   them itself -- calling the parent therefore covers every sibling, which is
+ *   why the neighbour list is `[A, ...parents(A)]` and not a hop-counted
+ *   frontier. The REAL primitive is used rather than an equivalent inlined
+ *   here, because a probe that reimplements the thing it measures drifts from
+ *   it and then measures itself.
+ *
+ *   Arm B -- BM25 FROM THE ANCHOR'S OWN KEY. Rank the whole active corpus with
+ *   `lexical.rank`, querying with A's key -- the file path or symbol name the
+ *   user actually touched -- and hit if F comes back inside `limit`.
+ *
+ * WHY ARM B IS NOT QUERIED WITH THE FINDING'S OWN CLAIM. The plan's literal
+ * form was "the finding's claim terms against the rest of the corpus", and both
+ * readings of it are degenerate. Querying F's claim against a corpus that
+ * INCLUDES F is the tautology again: BM25 scores a document against its own
+ * text, so F wins its own query every time. Querying F's claim against a corpus
+ * that EXCLUDES F cannot return F at all, so a "hit" would mean some DIFFERENT
+ * finding matched -- that is redundancy of storage, not recall of F, and it
+ * would score a graph better for holding duplicates. The anchor's key is the
+ * one query text that is available offline, is not derived from F, and matches
+ * the production question: a session touches a file, and the only lexical
+ * handle on it is its own path. It misses exactly when a finding's claim never
+ * names the code it is about, which is the recall gap embeddings are supposed
+ * to close.
+ *
+ * ---------------------------------------------------------------------------
+ * REFUSALS -- four, and each costs this project its own good news
+ * ---------------------------------------------------------------------------
+ *  1. TOO FEW OBSERVATIONS -> `rate: null` with a reason. See `MIN_PROBED`.
+ *  2. A CORPUS NO LARGER THAN THE RETRIEVAL LIMIT -> `rate: null`. Arm B is
+ *     recall@`limit`, and below the limit NO FINDING IS EVER CUT FOR BUDGET:
+ *     every document scoring above zero is returned, so the arm measures
+ *     whether a token matched, which is a strictly weaker bar than the one
+ *     production applies when `forTouch` fills a token budget from a ranked
+ *     list. A probe more permissive than the system it measures can only
+ *     overstate recall, so the rate is withheld in that band and the counts are
+ *     published instead. It bites between `MIN_PROBED` and `limit` findings --
+ *     on this machine's project graph, whose one finding had both anchor edges
+ *     "recovered" that way, the observation-count refusal fires first.
+ *  3. NO ANCHOR NODE -> the pair is UNPROBEABLE, not a miss. Reported and
+ *     excluded from the denominator; see `probeEdge`.
+ *  4. STRICT AGGREGATION -> a finding counts as retrieved only if EVERY one of
+ *     its probeable anchor edges is recoverable. A finding reachable from one
+ *     anchor and lost from another is a miss, with the losing anchor named.
+ *     This biases the rate DOWN, which is the safe direction here.
+ *
+ * FAILS OPEN. It runs on a report path; a graph it cannot read must cost a
+ * section, not the report.
+ */
+
+import { load, findingsFor } from './wiki.mjs';
+import { rank } from './lexical.mjs';
+
+/**
+ * Distinct findings that must be probeable before a RATE is published at all.
+ *
+ * NOT AN EFFECT-SIZE CONVENTION -- it is a resolution argument. A proportion
+ * over n observations has a resolution of 1/n, so below ten findings the
+ * published figure moves in steps coarser than ten percentage points, and the
+ * two extremes a small graph actually produces (`1.0` and `0.0`) are the two a
+ * reader is most likely to mistake for a finding about retrieval. At n = 10 and
+ * zero misses the exact binomial 95% upper bound on the true miss rate is still
+ * 1 - 0.05^(1/10) = 0.26, so even a clean sweep here bounds recall loss only
+ * below about a quarter -- which is why the refusal reason says what the number
+ * would and would not have supported rather than just naming the floor.
+ *
+ * THE FLOOR IS ON DISTINCT FINDINGS, NOT ANCHOR EDGES. Two anchors of one
+ * finding are two edges of the same claim, not two independent observations;
+ * counting them would let a single multi-anchored finding unlock a rate.
+ */
+export const MIN_PROBED = 10;
+
+/**
+ * The most findings probed in one call.
+ *
+ * Each probed anchor edge costs a graph-sized edge filter plus one or two real
+ * `findingsFor` walks plus one BM25 pass over the corpus, and this runs on the
+ * on-demand report path. The cap is deterministic (findings sorted by key) and
+ * `truncated` says when it bit, so a large graph gets a smaller, honestly
+ * labelled sample rather than a slow report.
+ */
+export const MAX_FINDINGS = 200;
+
+/** Active findings only. A retired claim is withdrawn; recalling it is not a win. */
+function activeFindings(graph) {
+  return [...graph.nodes.values()]
+    .filter((node) => node && node.kind === 'finding' && !node.retired)
+    .sort((a, b) => String(a.key || '').localeCompare(String(b.key || '')));
+}
+
+/** The `contains` parents of every node, indexed once for the whole probe. */
+function parentIndex(graph) {
+  const parents = new Map();
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contains') continue;
+    const list = parents.get(edge.to);
+    if (list) list.push(edge.from);
+    else parents.set(edge.to, [edge.from]);
+  }
+  return parents;
+}
+
+/** The anchors of one finding: the targets of its own `derived_from` edges. */
+function anchorsOf(graph, findingId) {
+  const out = new Set();
+  for (const edge of graph.edges) {
+    if (edge.edge === 'derived_from' && edge.from === findingId) out.add(edge.to);
+  }
+  return [...out];
+}
+
+/**
+ * The graph minus exactly one anchor edge.
+ *
+ * `nodes` is shared rather than copied: nothing here mutates it, and a
+ * 2,600-node Map copied once per anchor edge is the difference between a probe
+ * and a stall.
+ */
+function withoutAnchorEdge(graph, findingId, anchorId) {
+  return {
+    nodes: graph.nodes,
+    edges: graph.edges.filter(
+      (edge) =>
+        !(
+          edge.edge === 'derived_from' &&
+          edge.from === findingId &&
+          edge.to === anchorId
+        )
+    ),
+  };
+}
+
+/**
+ * One anchor edge, hidden, then asked after. Returns `recovered` with the arm
+ * that found it, or a reason -- and `probeable: false` when the question could
+ * not be put at all.
+ */
+function probeEdge(graph, parents, finding, anchorId, corpus, limit) {
+  const hidden = withoutAnchorEdge(graph, finding.id, anchorId);
+
+  // Arm A. `findingsFor` expands `contains` children itself, so the parent call
+  // covers every sibling of the anchor.
+  const neighbours = [anchorId, ...(parents.get(anchorId) || [])];
+  for (const neighbour of neighbours) {
+    const got = findingsFor(hidden, neighbour, { limit });
+    if (got.some((node) => node.id === finding.id)) {
+      return { recovered: true, arm: 'traversal', anchorId };
+    }
+  }
+
+  // Arm B needs a query, and the query is the anchor's own key. A dangling
+  // anchor edge -- an edge whose target node was never indexed, which
+  // `expand.promote` produces -- leaves nothing to query with. That is a
+  // question that could not be asked, NOT an observed miss: scoring it a miss
+  // would manufacture a recall loss out of a graph-integrity defect.
+  const anchor = graph.nodes.get(anchorId);
+  const key = anchor && typeof anchor.key === 'string' ? anchor.key : '';
+  if (!key) {
+    return {
+      recovered: false,
+      probeable: false,
+      anchorId,
+      reason: `anchor ${anchorId} has no node in the graph, so there is no anchor key to query BM25 with`,
+    };
+  }
+
+  const hits = rank(key, corpus, { limit });
+  if (hits.some((hit) => hit.finding && hit.finding.id === finding.id)) {
+    return { recovered: true, arm: 'lexical', anchorId };
+  }
+
+  return {
+    recovered: false,
+    probeable: true,
+    anchorId,
+    reason: `no neighbouring anchor reaches it and BM25 over ${key} does not rank it in the top ${limit}`,
+  };
+}
+
+/**
+ * The probe. An OFFLINE measurement over the graph as it stands -- it reads,
+ * ranks and traverses, and writes nothing.
+ */
+export function recallProbe(
+  dir,
+  {
+    limit = 20,
+    graph = null,
+    minProbed = MIN_PROBED,
+    maxFindings = MAX_FINDINGS,
+  } = {}
+) {
+  const refuse = (reason) => ({
+    basis: 'offline probe over the current graph',
+    probed: 0,
+    retrieved: 0,
+    rate: null,
+    reason,
+    misses: [],
+    unprobeable: [],
+  });
+
+  let g;
+  try {
+    g = graph || load(dir);
+  } catch {
+    return refuse('the graph could not be read, so recall was not measured.');
+  }
+
+  try {
+    const all = activeFindings(g);
+    const truncated = all.length > maxFindings;
+    const findings = truncated ? all.slice(0, maxFindings) : all;
+    const parents = parentIndex(g);
+    // The corpus BM25 ranks over is the ACTIVE graph, uncapped: the sample is
+    // which findings are probed, not what they compete against. Every reported
+    // figure below reads `corpus.length` rather than `all.length`, so the
+    // published size IS the ranking corpus rather than a parallel claim about
+    // it. The distinction is not pedantry: a mutation that shrank the ranking
+    // corpus to the probed sample -- making retrieval easier, in this project's
+    // favour -- SURVIVED the first mutation run precisely because the reported
+    // number came from the other variable and could not move.
+    const corpus = all;
+
+    const misses = [];
+    const unprobeable = [];
+    const integrityFailures = [];
+    let probed = 0;
+    let retrieved = 0;
+    let integrityOk = 0;
+    let probedEdges = 0;
+    let recoveredEdges = 0;
+    const byArm = { traversal: 0, lexical: 0 };
+
+    for (const finding of findings) {
+      const anchors = anchorsOf(g, finding.id);
+
+      // INTEGRITY, run on the UNTOUCHED graph: the by-construction check. Its
+      // only honest use is as a smoke test, and it is reported as one.
+      if (!anchors.length) {
+        integrityFailures.push({
+          key: finding.key,
+          reason:
+            'active finding with no anchor -- writeHarvested refuses to create one',
+        });
+      } else if (
+        anchors.every((anchorId) =>
+          findingsFor(g, anchorId, { limit }).some((node) => node.id === finding.id)
+        )
+      ) {
+        integrityOk += 1;
+      } else {
+        integrityFailures.push({
+          key: finding.key,
+          reason: `not returned by findingsFor from one of its own anchors at limit ${limit}`,
+        });
+      }
+
+      // An unanchored finding is a definite miss, not an unaskable question:
+      // nothing traverses to it and there is no anchor key to query from, so
+      // the anchor-driven path that serves findings on a file touch can never
+      // surface it. Only an explicit wiki_query naming its own terms would.
+      if (!anchors.length) {
+        probed += 1;
+        misses.push({
+          key: finding.key,
+          reason:
+            'no anchor: nothing traverses to it and there is no anchor key to query with, so only an explicit wiki_query of its own terms would surface it',
+        });
+        continue;
+      }
+
+      const results = anchors.map((anchorId) =>
+        probeEdge(g, parents, finding, anchorId, corpus, limit)
+      );
+      const askable = results.filter((result) => result.probeable !== false);
+      probedEdges += askable.length;
+      recoveredEdges += askable.filter((result) => result.recovered).length;
+      for (const result of askable) {
+        if (result.recovered) byArm[result.arm] += 1;
+      }
+
+      if (!askable.length) {
+        unprobeable.push({ key: finding.key, reason: results[0].reason });
+        continue;
+      }
+
+      probed += 1;
+      const lost = askable.filter((result) => !result.recovered);
+      if (!lost.length) retrieved += 1;
+      else misses.push({ key: finding.key, reason: lost[0].reason });
+    }
+
+    const integrity = {
+      what:
+        'BY CONSTRUCTION: a finding is returned by findingsFor from its own anchor because that edge is what makes it an anchor. Expected 1 for every graph. NOT a recall rate.',
+      probed: findings.length,
+      retrieved: integrityOk,
+      rate: findings.length ? integrityOk / findings.length : null,
+      ok: integrityFailures.length === 0,
+      failures: integrityFailures,
+    };
+
+    // Arm B is recall@`limit`. Over a corpus of at most `limit` findings nothing
+    // is ever cut for budget, so the arm asks only whether a token matched --
+    // weaker than the bar production applies under a token budget, and a probe
+    // more permissive than the system it measures can only overstate recall.
+    const discriminating = corpus.length > limit;
+
+    const common = {
+      basis: 'offline probe over the current graph',
+      probed,
+      retrieved,
+      misses,
+      unprobeable,
+      probedEdges,
+      recoveredEdges,
+      byArm,
+      corpus: corpus.length,
+      discriminating,
+      truncated,
+      minProbed,
+      integrity,
+    };
+
+    if (probed < minProbed) {
+      return {
+        ...common,
+        rate: null,
+        reason:
+          probed === 0
+            ? `no probeable finding: ${unprobeable.length} of ${findings.length} active finding(s) have no anchor node to query from, so recall was not measured. No rate is reported, which is not the same as a rate of zero.`
+            : `${probed} probeable finding(s), below the floor of ${minProbed}: a proportion over ${probed} has a resolution of ${Math.round(
+                100 / probed
+              )} percentage points, so no rate is published. ${retrieved} of ${probed} were recovered without their own anchor edge, which is a count and not a rate.`,
+      };
+    }
+
+    if (!discriminating) {
+      return {
+        ...common,
+        rate: null,
+        reason: `the active corpus holds ${corpus.length} finding(s) and the retrieval limit is ${limit}, so nothing is ever cut for budget and the lexical arm asks only whether a token matched -- a weaker bar than production applies. No rate is published off a probe more permissive than the system it measures; ${retrieved} of ${probed} were recovered, which is a count and not a rate.`,
+      };
+    }
+
+    return { ...common, rate: retrieved / probed, reason: null };
+  } catch {
+    return refuse('the probe failed, so recall was not measured.');
+  }
+}

--- a/integrations/gemini/hooks/lib/redact.mjs
+++ b/integrations/gemini/hooks/lib/redact.mjs
@@ -1,0 +1,30 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/redact.mjs. Regenerate with `npm run sync:hooks`.
+// hooks-core/redact.mjs
+/**
+ * Redaction for anything derived from captured output.
+ *
+ * WHY THIS IS MANDATORY RATHER THAN PRUDENT. derive.mjs builds claims out of
+ * command stderr. A claim is INJECTED into model context and EXPORTED to
+ * markdown, so a secret that reaches a claim reaches two more places than the
+ * terminal it came from. Pattern matching is imperfect and that is stated in the
+ * spec, but "imperfect" beats "absent" by a wide margin here.
+ */
+
+const PATTERNS = [
+  // Bearer / API-key shaped tokens.
+  [/\b(bearer\s+)[A-Za-z0-9._~+/-]{12,}/gi, '$1[redacted]'],
+  [/\b(sk|pk|ghp|gho|github_pat|xox[baprs])[-_][A-Za-z0-9._-]{10,}/gi, '[redacted]'],
+  // KEY=value where the key name suggests a secret.
+  [/\b([A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|APIKEY|API_KEY|PRIVATE_KEY|CREDENTIAL)[A-Z0-9_]*)\s*[=:]\s*\S+/g, '$1=[redacted]'],
+  // Credentials inside a URL.
+  [/\b([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+):[^\s@]+@/gi, '$1:[redacted]@'],
+  // PEM blocks.
+  [/-----BEGIN[^-]*PRIVATE KEY-----[\s\S]*?-----END[^-]*PRIVATE KEY-----/g, '[redacted key]'],
+];
+
+export function redact(text, { max = 400 } = {}) {
+  let out = String(text ?? '');
+  for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
+}

--- a/integrations/gemini/hooks/lib/redact.mjs
+++ b/integrations/gemini/hooks/lib/redact.mjs
@@ -24,7 +24,21 @@ const PATTERNS = [
 ];
 
 export function redact(text, { max = 400 } = {}) {
+  // `?? ''` matters even though String(null)/String(undefined) never throw:
+  // without it a missing value becomes the literal 4-11 character string
+  // "null"/"undefined" -- a garbage claim that silently reaches the graph
+  // and model context instead of surfacing as an error.
   let out = String(text ?? '');
   for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  // Redact BEFORE truncating, never the reverse. Several patterns above rely
+  // on a minimum-length quantifier (e.g. `{10,}`, `{12,}`) plus a prefix.
+  // Truncating first can cut a match down to fewer characters than that
+  // quantifier requires, so the shortened fragment no longer satisfies the
+  // pattern and a live partial secret would pass through in cleartext. By
+  // redacting the full, untruncated string first, every pattern always sees
+  // the complete secret and removes it before any character budget is
+  // spent; the cap below can then only ever cut into already-redacted text
+  // (a label, or the "[redacted]" placeholder itself), never into raw
+  // secret bytes.
   return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
 }

--- a/integrations/gemini/hooks/lib/transcript.mjs
+++ b/integrations/gemini/hooks/lib/transcript.mjs
@@ -19,9 +19,11 @@
  */
 
 import {
-  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, unlinkSync,
+  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync,
+  unlinkSync, openSync, readSync, closeSync,
 } from 'node:fs';
 import { join } from 'node:path';
+import { redact } from './redact.mjs';
 
 /** Where a project's transcripts live, under the graph it belongs to. */
 export const transcriptDir = (dir) => join(dir, 'transcripts');
@@ -210,4 +212,204 @@ export function readArchive(dir, sessionId) {
   } catch {
     return [];
   }
+}
+
+/**
+ * How much of a transcript's TAIL is scanned for failed tool results.
+ *
+ * A transcript is the largest file this project reads: the three real ones on
+ * the measuring machine are 5.8 MB, 22 MB and 45 MB. `archive()` above already
+ * reads the whole thing once at Stop, so an unbounded second pass doubles the
+ * most expensive read on the session-end path for evidence that is, by
+ * construction, mostly old. The tail is the right half to keep for the same
+ * reason `buildFeedbackDigest` keeps the end: what a session learned is
+ * concentrated where the work went wrong, which is later rather than sooner.
+ */
+const FAILED_SCAN_BYTES = () =>
+  Number(process.env.TOKEN_OPTIMIZER_TRANSCRIPT_SCAN_BYTES) || 8 * 1024 * 1024;
+
+/** Failed results kept, most recent first. The pairing detector needs a handful. */
+const FAILED_MAX = 50;
+
+/** Same 4 KB cap `recordToolOutcome` applies to `output`, for the same reason. */
+const FAILED_OUTPUT_MAX = 4096;
+
+/**
+ * The same 120-character truncation `recordToolOutcome` applies to `anchor`.
+ *
+ * ONE COMMAND MUST PRODUCE ONE KEY FROM EITHER SOURCE. A `tool-outcome` stores
+ * the command as `String(tool_input.command).slice(0, 120)`, and `attemptKey`
+ * reads up to three non-flag tokens off whatever it is handed. A long first
+ * token -- a quoted grep pattern, an absolute Windows path, a heredoc -- is cut
+ * by that cap INSIDE those three tokens, so the untruncated transcript copy of
+ * the same command lands in a DIFFERENT group. Measured against one real
+ * session's own evidence: 266 commands present in both sources, and truncating
+ * here made 266 of 266 keys agree where the untruncated text agreed on only
+ * 240.
+ *
+ * WHAT THAT ACTUALLY BUYS, stated precisely rather than generously. `derive`
+ * refuses to build a claim out of a command at or over the cap at all (see
+ * `quotable` there), so agreement on a TRUNCATED key never produces a finding
+ * on its own. It buys two things that still matter: a transcript failure lands
+ * in the same run as the event outcomes of the same command, so the
+ * nearest-preceding-failure rule sees the real sequence rather than a sparse
+ * one; and the no-call-id fallback in `derive`'s deduplication compares command
+ * TEXT against an already-truncated anchor, which cannot match unless this side
+ * is truncated identically.
+ */
+const ANCHOR_MAX = 120;
+
+/**
+ * A tool result that reports a command that RAN and exited non-zero.
+ *
+ * A POSITIVE ALLOWLIST, and the measurement is why. Claude Code sets
+ * `is_error: true` on every kind of unhappy tool result, and across three real
+ * transcripts 214 of them fell into four shapes:
+ *
+ *   83  `Exit code N` + stderr    -- a command ran and failed. THIS ONE.
+ *   109 hook and policy denials   -- overwhelmingly THIS optimizer's own
+ *                                    PreToolUse text ("Recursive shell searches
+ *                                    return unbounded output. Call the
+ *                                    token-optimizer MCP tool smart_grep
+ *                                    instead"), plus `Remove-Item on system
+ *                                    path` blocks.
+ *   18  `<tool_use_error>...`     -- protocol errors: `String to replace not
+ *                                    found`, `File has not been read yet`,
+ *                                    `Blocked: ...`.
+ *   4   a person declined the call.
+ *
+ * Only the first shape is a command failing. In every other shape THE COMMAND
+ * NEVER RAN, so "`X` failed with: ..." would be a false claim about X, and a
+ * later success would pair with a failure that never happened. The 109 are the
+ * dangerous ones: ingesting them would have this tool derive findings from its
+ * own advice, at 0.9 confidence, and serve them back as observations about the
+ * project -- a self-referential loop that also inflates its own finding count.
+ * That is the measurement-bias class this plan tracks, and a denylist would
+ * have let every future denial string through by default.
+ */
+const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
+
+/** Reads at most `bytes` from the END of a file, without loading the rest. */
+function readTail(path, bytes) {
+  let fd;
+  try {
+    const size = statSync(path).size;
+    const length = Math.min(size, bytes);
+    if (!length) return '';
+    fd = openSync(path, 'r');
+    const buffer = Buffer.allocUnsafe(length);
+    readSync(fd, buffer, 0, length, size - length);
+    const text = buffer.toString('utf8');
+    // A tail almost never starts on a line boundary, and half a JSON object is
+    // not a parse failure worth reporting -- it is a partial record. Drop it.
+    return length < size ? text.slice(text.indexOf('\n') + 1) : text;
+  } catch {
+    return '';
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+}
+
+/**
+ * The failed COMMAND results a transcript holds, which no hook event carries.
+ *
+ * WHY THIS READER EXISTS. Claude Code never fires PostToolUse for a failed tool
+ * call: a deliberately failing command produced no event at all, and 2,238 of
+ * 2,238 live `tool-outcome` events on the measuring machine carry
+ * `success: true`. So `derive.mjs`'s two strongest detectors -- command
+ * failed-then-succeeded at 0.90 and test/build red-to-green at 0.85 -- have no
+ * input whatsoever on the primary client, while working normally on the ten
+ * adapter clients. The failures exist; they exist only here.
+ *
+ * WHY NOT THE ARCHIVE, which the plan for this reader assumed. `readTurns`
+ * DROPS tool results by design -- that is where whole file contents would enter
+ * the record -- so `readArchive` returns no failure, ever, and an extractor over
+ * archived turns would find nothing however well it was written. Making the
+ * archive carry them would also push command stderr into `buildFeedbackDigest`,
+ * which is the one code path in this project that sends anything to a model
+ * endpoint. So this reads the transcript and STORES NOTHING NEW: read-only, no
+ * capture path, no new event kind, and no widening of what leaves the machine.
+ *
+ * REDACTED HERE, at this boundary, exactly as `recordToolOutcome` redacts
+ * `output`. Transcript text has never passed a redaction boundary -- that one
+ * never saw it -- and everything returned from here is destined for a claim that
+ * is injected into model context and exported to markdown.
+ *
+ * @returns {Array<{command: string, output: string, exit: number|null,
+ *   at: number, toolCallId: string|null}>} in transcript order, so a caller can
+ *   sort it beside `tool-outcome` events without re-ordering.
+ */
+export function failedResultsFromTranscript(transcriptPath, options = {}) {
+  const { max = FAILED_MAX, scanBytes = FAILED_SCAN_BYTES() } = options || {};
+  if (!transcriptPath) return [];
+  const text = readTail(transcriptPath, scanBytes);
+  if (!text) return [];
+
+  // tool_use_id -> the command that was attempted. The join is EXACT and it is
+  // the only one available: the result block carries no command of its own, and
+  // the id is the same string `episodeMeta` reads into `toolCallId`, so the same
+  // key also deduplicates against events on clients that do report failures.
+  const commands = new Map();
+  const failures = [];
+
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const message = entry.message || entry;
+    const role = message.role || entry.type;
+    const content = message.content;
+    if (!Array.isArray(content)) continue;
+
+    if (role === 'assistant') {
+      for (const block of content) {
+        if (!block || block.type !== 'tool_use' || !block.id) continue;
+        const command = block.input?.command;
+        if (typeof command !== 'string' || !command.trim()) continue;
+        commands.set(String(block.id), command.slice(0, ANCHOR_MAX));
+      }
+      continue;
+    }
+
+    if (role !== 'user') continue;
+    for (const block of content) {
+      if (!block || block.type !== 'tool_result' || block.is_error !== true) continue;
+      // Only a STRING result can be an exit-code report; every failed Claude
+      // Code result observed was one, and a structured body is a shape this
+      // classifier has not measured, so it is refused rather than guessed at.
+      if (typeof block.content !== 'string') continue;
+      const match = EXIT_CODE_RESULT.exec(block.content);
+      if (!match) continue;
+      const command = commands.get(String(block.tool_use_id || ''));
+      // No command means no claim. The result says something failed; without
+      // the text of what failed there is nothing to say about it, and nothing
+      // to group it with.
+      if (!command) continue;
+      failures.push({
+        command,
+        // The exit line itself is stripped: `exit` carries it structurally, and
+        // leaving it in makes every failure claim read "failed with: Exit code 1".
+        output: redact(block.content.slice(match[0].length).trim(), {
+          max: FAILED_OUTPUT_MAX,
+        }),
+        exit: Number(match[1]),
+        at: Date.parse(entry.timestamp || '') || 0,
+        toolCallId: block.tool_use_id ? String(block.tool_use_id) : null,
+      });
+    }
+  }
+
+  // The MOST RECENT `max`, keeping chronological order. A session that failed
+  // two hundred times teaches its last lessons, not its first.
+  return failures.slice(-max);
 }

--- a/integrations/gemini/hooks/lib/usage.mjs
+++ b/integrations/gemini/hooks/lib/usage.mjs
@@ -42,7 +42,7 @@
  * was referenced" and "nothing could be measured" are different answers and
  * this module gives different answers for them.
  */
-import { readMetrics } from './metrics.mjs';
+import { readMetrics, readTruncation } from './metrics.mjs';
 
 /**
  * The events that name a finding, and it is ONE kind, not the two the plan
@@ -129,17 +129,30 @@ export function classify(dir, { events = null } = {}) {
   try {
     const all = inTimeOrder(events || readMetrics(dir));
 
-    // Every reference, keyed on the finding it names. Only references carrying
-    // a session id are usable -- see `unscopedReferences` in `referenceRate`
-    // for the ones this drops and why they are counted rather than credited.
+    // Every reference, keyed on the finding it names and on nothing else.
+    //
+    // NOT SCOPED BY SESSION, and that is a deliberate reversal. Scoping needs
+    // the query's `sessionId`, which `wiki_query` takes as an OPTIONAL input
+    // the model has to volunteer (`options.sessionId ?? null`) -- so the
+    // numerator depended on the model choosing to identify itself, and an
+    // unverifiable model-supplied id is not evidence. Plan 1 settled that for
+    // the `answers` edge and it settles it here: stop depending on the field
+    // rather than hope for cooperation. The finding key is the specific part
+    // anyway; a key is a graph identity, not a guess.
+    //
+    // THE COST, disclosed here and in `referenceNote` because a reader of the
+    // number has to see it: TWO CONCURRENT SESSIONS ON ONE REPOSITORY CAN
+    // CROSS-ATTRIBUTE. Session A's injection of K plus session B's later query
+    // for K reads as a reference. Nothing in the log can separate them once the
+    // session id is gone, so the exposure is real and is stated rather than
+    // priced.
     const references = new Map();
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       const key = referencedKey(event);
-      const session = sessionOf(event);
-      if (!key || !session) continue;
+      if (!key) continue;
       if (!references.has(key)) references.set(key, []);
-      references.get(key).push({ at: event.at || 0, session });
+      references.get(key).push(event.at || 0);
     }
 
     // Which injections the existing outcome join could attribute. An outcome
@@ -170,9 +183,8 @@ export function classify(dir, { events = null } = {}) {
       const injectionId = event.injectionId ? String(event.injectionId) : null;
       const at = event.at || 0;
       const session = sessionOf(event);
-      // STRICTLY AFTER. A query that PRECEDED the injection is the model
-      // asking on its own initiative; crediting it would let the metric take
-      // the credit for a lookup it had nothing to do with.
+      // STRICTLY AFTER here too: activity that predates the injection is not
+      // an opportunity to have used it.
       const followed = (times) => times.some((t) => t > at);
       const continued =
         (injectionId && attributed.has(injectionId)) ||
@@ -181,9 +193,11 @@ export function classify(dir, { events = null } = {}) {
       for (const raw of keys) {
         const findingKey = String(raw);
         const hits = references.get(findingKey) || [];
-        const referenced = session
-          ? hits.some((hit) => hit.session === session && hit.at > at)
-          : false;
+        // TIME ORDER IS THE ONLY REMAINING GUARD, so it carries the whole
+        // weight of the attribution: a query that PRECEDED the injection is
+        // the model asking on its own initiative, and crediting it would let
+        // the metric take the credit for a lookup it had nothing to do with.
+        const referenced = hits.some((hitAt) => hitAt > at);
         rows.push({
           findingKey,
           injectionId,
@@ -204,9 +218,27 @@ export function classify(dir, { events = null } = {}) {
 /**
  * The rate, with everything needed to tell a real 0 from an absent one.
  *
- * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
- * `unattributable` and `unscopedReferences` are reported beside it, never
- * inside it.
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown` and
+ * `unattributable` are reported beside it, never inside it.
+ *
+ * `windowed` SAYS WHETHER THE DENOMINATOR CAN UNDERSTATE, and it is not
+ * decoration. `readMetrics` reads a 2 MB / 5,000-event TAIL of the firehose,
+ * and injections are rare enough on a real project to age out of it: measured
+ * on this repository, both `inject` events sit at lines 502 and 883 of 6,871
+ * and have scrolled away behind ~6,000 later `read` and `tool-outcome` rows,
+ * so the windowed denominator is 0 where the whole-file truth is 1.
+ *
+ * IT IS REPORTED RATHER THAN FIXED, deliberately. `inject` already gets
+ * unwindowed access through `BALANCE_KINDS` / `EVIDENCE_KINDS`, but `query`
+ * does not -- and reading only the INJECTION arm unwindowed would be worse
+ * than the windowing: every old injection would enter the denominator with no
+ * chance of a matching query in the window and score `not-referenced`,
+ * manufacturing a pessimistic rate out of the asymmetry. Making the query arm
+ * unwindowed means adding `query` to `EVIDENCE_KINDS`, which two other
+ * consumers read, and this project's own standard says a shared-classifier
+ * change needs a per-consumer verdict comparison. So the honest move is to
+ * publish the flag: a caller that needs the unwindowed truth passes its own
+ * `events`, which is exactly what the live measurement in the task report did.
  */
 export function referenceRate(dir, { events = null } = {}) {
   const empty = {
@@ -218,10 +250,15 @@ export function referenceRate(dir, { events = null } = {}) {
     unattributable: 0,
     unattributableWithInjectedToolCall: 0,
     referenceEvents: 0,
-    unscopedReferences: 0,
+    windowed: false,
   };
   try {
     const all = events || readMetrics(dir);
+    // OUT OF BAND, and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` reports on the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
     const rows = classify(dir, { events: all });
     const count = (label) => rows.filter((row) => row.label === label).length;
     const referenced = count('referenced');
@@ -231,17 +268,17 @@ export function referenceRate(dir, { events = null } = {}) {
     // Usable reference events in the window: the numerator's producer. If this
     // is zero the channel never fired, and a 0% rate would be measuring the
     // absence of a producer rather than the uselessness of findings.
+    //
+    // NO SESSION REQUIREMENT, matching the attribution above. The former
+    // `unscopedReferences` counted queries dropped for want of a session id;
+    // nothing is dropped for that reason any more, so the field is GONE rather
+    // than kept at a permanent zero that a later reader would misread as
+    // evidence the loss had been fixed.
     let referenceEvents = 0;
-    let unscopedReferences = 0;
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       if (!referencedKey(event)) continue;
-      if (sessionOf(event)) referenceEvents += 1;
-      // Names a finding but cannot be scoped to one injection. `sessionId` is
-      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
-      // is the expected loss rather than an edge case -- counted here so it is
-      // visible instead of silently deflating the numerator.
-      else unscopedReferences += 1;
+      referenceEvents += 1;
     }
 
     // The tool calls that DID receive findings, keyed the way
@@ -292,7 +329,7 @@ export function referenceRate(dir, { events = null } = {}) {
       unattributable,
       unattributableWithInjectedToolCall,
       referenceEvents,
-      unscopedReferences,
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
     };
   } catch {
     return empty;
@@ -300,11 +337,18 @@ export function referenceRate(dir, { events = null } = {}) {
 }
 
 /**
- * One line for the audit, or nothing at all.
+ * One or two lines for the audit, or nothing at all.
  *
  * Says which of the three things is true -- a measured rate, a live channel
  * with no opportunities yet, or no channel at all -- rather than printing a
  * figure and letting the reader assume the first.
+ *
+ * AND IT CARRIES THE CAVEATS, because this is the only place a human meets the
+ * number. A rate attributed on (finding key, time order) can cross-attribute
+ * between two concurrent sessions on one repository, and a windowed read can
+ * understate the denominator. Both are stated beside the figure they qualify.
+ * Putting them only in a task report would be publishing a clean number and
+ * filing the asterisk somewhere nobody quoting it will look.
  */
 export function referenceNote(dir, { events = null } = {}) {
   const r = referenceRate(dir, { events });
@@ -317,6 +361,11 @@ export function referenceNote(dir, { events = null } = {}) {
   }
   return (
     `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
-    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded. ` +
+    'Matched on finding key and time order, so concurrent sessions on this ' +
+    'repository can cross-attribute' +
+    (r.windowed
+      ? '; and the event log was truncated, so the denominator can understate.'
+      : '.')
   );
 }

--- a/integrations/gemini/hooks/lib/usage.mjs
+++ b/integrations/gemini/hooks/lib/usage.mjs
@@ -1,0 +1,322 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/usage.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 1 -- did the model actually go back and use what we injected?
+ *
+ * The cheap behavioural label. One question, answered from the event log alone:
+ * after we put a finding in front of the model, did the model later ASK FOR
+ * THAT FINDING BY NAME?
+ *
+ * WHY EXPLICIT REFERENCE, AND NOT READ-SUPPRESSION. Read-suppression -- "the
+ * file was not re-read, so the finding must have helped" -- is Layer 2's
+ * estimand, measured causally by withholding a finding and comparing. Layer 1
+ * exists to be calibrated AGAINST that. If both layers derived from
+ * suppression, the calibration would compare two spellings of one quantity,
+ * report a strong correlation, and mean nothing. So Layer 1 is deliberately
+ * built on a signal Layer 2 does not touch: an explicit `query` naming the
+ * finding key.
+ *
+ * WHAT THIS DOES NOT DO. It does not invent a join. `recordToolOutcome`
+ * already joins each post-tool result back to the injection that preceded it,
+ * recording `injectionId`, `findingIds` and a `joinMethod` of `tool-call-id`,
+ * `episode-anchor` or `none` -- preferring an exact tool-call id, which is
+ * strictly better evidence than the `(sessionId, findingKey)` approximation an
+ * earlier draft of this plan proposed. This module consumes that join and adds
+ * none of its own. `inject.mjs` needed no change: it has written `findingIds`
+ * at every call site all along.
+ *
+ * WHAT `unknown` IS FOR, and it is the whole reason this file is careful. An
+ * injection whose session simply stopped afterwards is not a miss. Nothing
+ * happened, so nothing can be concluded, and counting it against the finding
+ * would make the metric read worse the more often sessions end -- a number
+ * that moves with session length rather than with usefulness. `unknown` is
+ * therefore EXCLUDED from the denominator rather than scored zero, and
+ * outcomes the join could not attribute at all are reported as
+ * `unattributable` rather than folded into either arm.
+ *
+ * AND WHY THE RATE CAN BE `null`. This project has already shipped two metrics
+ * whose only producer was their own test suite. A rate of 0% that actually
+ * means "no data" is worse than a refusal, because it is a number and numbers
+ * get quoted. So `rate` is null unless there is a denominator AND the
+ * reference channel produced at least one usable event in the window. "Nothing
+ * was referenced" and "nothing could be measured" are different answers and
+ * this module gives different answers for them.
+ */
+import { readMetrics } from './metrics.mjs';
+
+/**
+ * The events that name a finding, and it is ONE kind, not the two the plan
+ * assumed.
+ *
+ * The brief said "a later `query` or `expand` event". Checked against the code
+ * and against every metrics log on this machine, `expand` does not qualify and
+ * cannot be made to:
+ *
+ *   - `recordExpansion` writes `{ ref, tool, shape, asked, sessionId }`. `ref`
+ *     is a TRUNCATION CAPTURE id (a 16-hex digest of captured tool output),
+ *     not a finding key, and `asked` is free text naming a section of that
+ *     output. Neither is a graph key, and no code path ever puts one there.
+ *   - measured: 64 live `expand` events exist on this machine and all 64 carry
+ *     `sessionId: null`, so they could not be scoped to an injection even if
+ *     they did name one.
+ *
+ * Keying the classifier on `expand` would therefore have added a branch that
+ * can never fire -- a metric with no producer, which is the exact defect this
+ * whole effort exists to close. So it is excluded, deliberately and with the
+ * measurement recorded, rather than included for symmetry with the brief.
+ */
+const REFERENCE_KINDS = new Set(['query']);
+
+/**
+ * What counts as the session having CONTINUED past the injection.
+ *
+ * The distinction between `not-referenced` and `unknown` rests entirely on
+ * this, so the set is explicit rather than "any later event". These are the
+ * kinds a tool call produces: if one of them follows the injection in the same
+ * session, the model had the opportunity to ask and did not. If none does, the
+ * session ended and there was no opportunity.
+ *
+ * `inject` is in the set because a later injection means a later tool call
+ * happened. `forecast`, `mcp-client` and `mcp-tool` are NOT: they are written
+ * by session bookkeeping rather than by the model doing something, and
+ * treating them as opportunity would convert `unknown` rows into misses on
+ * bookkeeping alone.
+ */
+const ACTIVITY_KINDS = new Set([
+  'tool-outcome',
+  'read',
+  'query',
+  'expand',
+  'substitute',
+  'inject',
+]);
+
+/** A usable session id: a non-empty string. `null == null` is not a match. */
+const sessionOf = (event) => {
+  const id = event?.sessionId;
+  return typeof id === 'string' && id ? id : null;
+};
+
+/** The finding key a reference event names, or null if it names none. */
+const referencedKey = (event) => {
+  const key = event?.key;
+  return typeof key === 'string' && key ? key : null;
+};
+
+/** Ordering by the caller's timestamp, with log order breaking ties. */
+function inTimeOrder(events) {
+  return events
+    .map((event, index) => ({ event, index }))
+    .sort(
+      (a, b) =>
+        (a.event.at || 0) - (b.event.at || 0) || a.index - b.index
+    )
+    .map((row) => row.event);
+}
+
+/**
+ * One row per (injection, finding) pair, labelled.
+ *
+ * Per injection rather than per finding: the same finding injected twice is two
+ * separate opportunities, and collapsing them would let one reference excuse
+ * every later injection of that key.
+ *
+ * FAILS OPEN. A malformed log yields an empty classification, never a throw:
+ * this runs on report paths that must not break a tool call.
+ */
+export function classify(dir, { events = null } = {}) {
+  let rows = [];
+  try {
+    const all = inTimeOrder(events || readMetrics(dir));
+
+    // Every reference, keyed on the finding it names. Only references carrying
+    // a session id are usable -- see `unscopedReferences` in `referenceRate`
+    // for the ones this drops and why they are counted rather than credited.
+    const references = new Map();
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      const key = referencedKey(event);
+      const session = sessionOf(event);
+      if (!key || !session) continue;
+      if (!references.has(key)) references.set(key, []);
+      references.get(key).push({ at: event.at || 0, session });
+    }
+
+    // Which injections the existing outcome join could attribute. An outcome
+    // carrying our injectionId is proof the tool call completed, which is
+    // opportunity even when the session id is missing from the log.
+    const attributed = new Set();
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) continue;
+      attributed.add(String(event.injectionId));
+    }
+
+    // Activity per session, so "did anything follow?" is one lookup rather
+    // than a scan per injection.
+    const activity = new Map();
+    for (const event of all) {
+      if (!ACTIVITY_KINDS.has(event.kind)) continue;
+      const session = sessionOf(event);
+      if (!session) continue;
+      if (!activity.has(session)) activity.set(session, []);
+      activity.get(session).push(event.at || 0);
+    }
+
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+      if (!keys.length) continue;
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const at = event.at || 0;
+      const session = sessionOf(event);
+      // STRICTLY AFTER. A query that PRECEDED the injection is the model
+      // asking on its own initiative; crediting it would let the metric take
+      // the credit for a lookup it had nothing to do with.
+      const followed = (times) => times.some((t) => t > at);
+      const continued =
+        (injectionId && attributed.has(injectionId)) ||
+        (session ? followed(activity.get(session) || []) : false);
+
+      for (const raw of keys) {
+        const findingKey = String(raw);
+        const hits = references.get(findingKey) || [];
+        const referenced = session
+          ? hits.some((hit) => hit.session === session && hit.at > at)
+          : false;
+        rows.push({
+          findingKey,
+          injectionId,
+          label: referenced
+            ? 'referenced'
+            : continued
+              ? 'not-referenced'
+              : 'unknown',
+        });
+      }
+    }
+  } catch {
+    rows = [];
+  }
+  return rows;
+}
+
+/**
+ * The rate, with everything needed to tell a real 0 from an absent one.
+ *
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
+ * `unattributable` and `unscopedReferences` are reported beside it, never
+ * inside it.
+ */
+export function referenceRate(dir, { events = null } = {}) {
+  const empty = {
+    referenced: 0,
+    notReferenced: 0,
+    unknown: 0,
+    denominator: 0,
+    rate: null,
+    unattributable: 0,
+    unattributableWithInjectedToolCall: 0,
+    referenceEvents: 0,
+    unscopedReferences: 0,
+  };
+  try {
+    const all = events || readMetrics(dir);
+    const rows = classify(dir, { events: all });
+    const count = (label) => rows.filter((row) => row.label === label).length;
+    const referenced = count('referenced');
+    const notReferenced = count('not-referenced');
+    const denominator = referenced + notReferenced;
+
+    // Usable reference events in the window: the numerator's producer. If this
+    // is zero the channel never fired, and a 0% rate would be measuring the
+    // absence of a producer rather than the uselessness of findings.
+    let referenceEvents = 0;
+    let unscopedReferences = 0;
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      if (!referencedKey(event)) continue;
+      if (sessionOf(event)) referenceEvents += 1;
+      // Names a finding but cannot be scoped to one injection. `sessionId` is
+      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
+      // is the expected loss rather than an edge case -- counted here so it is
+      // visible instead of silently deflating the numerator.
+      else unscopedReferences += 1;
+    }
+
+    // The tool calls that DID receive findings, keyed the way
+    // `recordToolOutcome` keys its own primary join: the tool-call id. An
+    // unattributable outcome for one of these is a join that FAILED. An
+    // unattributable outcome for any other tool call had nothing to join to.
+    //
+    // KEYED ON THE TOOL CALL, NOT THE EPISODE, and the first draft of this
+    // got it wrong in a way worth recording because it is the exact
+    // measurement-bias class this plan hunts. `episodeId` equals the SESSION
+    // id, so "unattributable outcomes in an episode that had an injection"
+    // scored all 2,559 tool calls of a session in which ONE injection
+    // happened. It would have published 2,559 join failures where the true
+    // number is zero -- correct code, lying number, and biased pessimistic
+    // rather than flattering, which is no better.
+    const injectedToolCalls = new Set();
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      if (!Array.isArray(event.findingIds) || !event.findingIds.length)
+        continue;
+      if (event.toolCallId) injectedToolCalls.add(String(event.toolCallId));
+    }
+    let unattributable = 0;
+    let unattributableWithInjectedToolCall = 0;
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome' || event.joinMethod !== 'none')
+        continue;
+      unattributable += 1;
+      // BOTH FIGURES, because the raw one alone lies in the pessimistic
+      // direction. Measured on this machine: 2,991 of 2,992 live outcomes
+      // report `joinMethod: 'none'`, and every one of them because NO
+      // INJECTION EXISTED for that tool call -- the graph holds one finding.
+      // Quoting only the raw count would read as a join that fails 99.97% of
+      // the time, which is a different and false claim.
+      if (event.toolCallId && injectedToolCalls.has(String(event.toolCallId)))
+        unattributableWithInjectedToolCall += 1;
+    }
+
+    return {
+      referenced,
+      notReferenced,
+      unknown: count('unknown'),
+      denominator,
+      rate:
+        denominator > 0 && referenceEvents > 0
+          ? referenced / denominator
+          : null,
+      unattributable,
+      unattributableWithInjectedToolCall,
+      referenceEvents,
+      unscopedReferences,
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/**
+ * One line for the audit, or nothing at all.
+ *
+ * Says which of the three things is true -- a measured rate, a live channel
+ * with no opportunities yet, or no channel at all -- rather than printing a
+ * figure and letting the reader assume the first.
+ */
+export function referenceNote(dir, { events = null } = {}) {
+  const r = referenceRate(dir, { events });
+  if (!r.denominator && !r.unknown && !r.referenceEvents) return null;
+  if (r.rate == null) {
+    const why = !r.referenceEvents
+      ? 'no finding was ever queried by key in this window'
+      : `no injection had a chance to be referenced yet (${r.unknown} unknown)`;
+    return `Injected findings referenced later: not measurable -- ${why}.`;
+  }
+  return (
+    `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+  );
+}

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -103,6 +103,44 @@ const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
 
 /**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because FOUR readers depend on it -- mutation accounting,
+ * success classification, output capture and exit-code capture -- and clients
+ * disagree on the envelope name and on nothing else. Letting each reader name
+ * its own subset is exactly how both classifiers came to miss MCP's failure
+ * flag: `toolSucceeded` listed four envelopes and `mutationSucceeded` listed
+ * three, and neither list mentioned `isError` at all.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/**
+ * Did an MCP result declare itself an error?
+ *
+ * `isError` is the ONLY failure signal an MCP result carries -- there is no
+ * `error` field and no `status` -- and `src/server/index.ts` sets it in seven
+ * places. Shared by both classifiers so they cannot disagree about what a
+ * failed call from this project's own tools looks like.
+ *
+ * `=== true` EXACTLY. A client using the key for anything else must not have
+ * its successful calls silently reclassified, and `isError: false` is a
+ * successful MCP call, not a missing verdict.
+ */
+function reportedMcpError(raw) {
+  return [...responseEnvelopes(raw), raw].some(
+    (envelope) => envelope?.isError === true
+  );
+}
+
+/**
  * A post-tool event is not universally proof of success. Some clients split
  * success and failure into distinct events; others expose a result status.
  * Keep mutation accounting conservative so a failed edit cannot arm Stop.
@@ -112,6 +150,19 @@ export function mutationSucceeded(clientName, raw) {
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
     return false;
+  // BEFORE the status read, the explicit-success read AND the client
+  // allowlist, because all three would otherwise pass a failed MCP write. The
+  // allowlist is the one that actually bit: it returns true for claude-code,
+  // codex, qwen, opencode, kilo and windsurf on any post-tool event with no
+  // error and no status, which is precisely the shape of a failed smart_write.
+  //
+  // WHY THIS IS THE SAME BUG AS THE ONE IN `toolSucceeded` AND NOT A COSMETIC
+  // ECHO OF IT: this function gates edit counting and harvest pressure, so
+  // counting a failed write to THE OPTIMIZER'S OWN TOOLS as a mutation
+  // inflates "the optimizer successfully edited a file". Different consumers
+  // from the effectiveness figures, same direction of bias -- toward
+  // flattering the thing being measured.
+  if (reportedMcpError(raw)) return false;
 
   const status =
     raw?.tool_response?.status ??
@@ -145,24 +196,6 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * Spelled out ONCE because three readers depend on it -- success
- * classification, output capture and exit-code capture -- and clients disagree
- * on the envelope name and on nothing else. Letting each reader name its own
- * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
-}
-
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
@@ -181,8 +214,7 @@ export function toolSucceeded(raw) {
   // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
   // optimizer's favour. A measurement that flatters the thing being measured
   // is worse than no measurement.
-  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
-    return false;
+  if (reportedMcpError(raw)) return false;
   const status =
     raw?.tool_response?.status ??
     raw?.toolResponse?.status ??

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -957,10 +957,12 @@ async function runHook(clientName, event, invocation) {
       // accumulates structure and no verdicts at all. These detectors read only
       // what is already on disk and send nothing anywhere.
       //
-      // The COUNT is recorded rather than the candidates: how many findings a
-      // session's own evidence supports is the number that says whether this is
-      // working, and it is measurable before anything is stored. Storage is the
-      // caller's next step, under a budget.
+      // COUNTS are recorded rather than the candidates, and BOTH counts: how
+      // many findings a session's own evidence supports, and how many of them
+      // survived the storage budget and the anchor discipline. The gap between
+      // the two is the number that says whether the bound is doing anything --
+      // one figure alone cannot distinguish "nothing to derive" from "derived
+      // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
       const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
       const dir = wikiDir(projectRoot);
@@ -976,6 +978,7 @@ async function runHook(clientName, event, invocation) {
         sessionId,
         candidates: derived.candidates.length,
         observations: derived.observations.length,
+        written: derived.written.length,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -172,6 +172,136 @@ export function toolSucceeded(raw) {
   return true;
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * The same family `toolSucceeded` reads above, hoisted so the three readers
+ * cannot drift apart. Clients disagree on the envelope name and on nothing
+ * else, so this is the one place that disagreement is spelled out.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/** A non-empty string, or null.  Blank output is the same as none. */
+function nonEmpty(value) {
+  const text = String(value ?? '');
+  return text.trim() ? text : null;
+}
+
+/**
+ * The human-readable result text inside one envelope, or null.
+ *
+ * RETURNS NULL RATHER THAN GUESSING. An envelope shape nobody here has seen
+ * produces no capture at all, which costs one finding. Stringifying it instead
+ * would put `[object Object]` or a wall of JSON metadata into a claim that gets
+ * injected into model context -- a wrong observation, which is strictly worse
+ * than a missing one.
+ */
+function resultText(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'string') return nonEmpty(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return null;
+
+  // MCP content blocks, which is how THIS PROJECT'S OWN tools now arrive:
+  // `normalizeTool` resolves `mcp__<server>__smart_edit`, so smart_edit and
+  // smart_write reach the post-tool path for the first time and their results
+  // are `{ content: [{ type: 'text', text }], isError }` rather than a shell
+  // result. Both the bare array and the wrapping object are accepted because
+  // hosts differ on whether they hand the hook the result or its content.
+  if (Array.isArray(value)) {
+    const blocks = value
+      .map((block) =>
+        typeof block === 'string' ? block : nonEmpty(block?.text)
+      )
+      .filter(Boolean);
+    return blocks.length ? nonEmpty(blocks.join('\n')) : null;
+  }
+  if (typeof value !== 'object') return null;
+
+  // STDERR FIRST, and not because that is the order it was produced in. The
+  // cap can only ever cut the tail, and the diagnostic that explains a failure
+  // is almost always on stderr while the volume is almost always on stdout --
+  // so appending stderr would let a 3 MB build log push the one line worth
+  // capturing out of the window.
+  const streams = [nonEmpty(value.stderr), nonEmpty(value.stdout)].filter(
+    Boolean
+  );
+  if (streams.length) return streams.join('\n');
+
+  if (Array.isArray(value.content)) {
+    const inner = resultText(value.content);
+    if (inner) return inner;
+  }
+
+  const error = value.error;
+  if (error) {
+    const message =
+      typeof error === 'string' ? error : nonEmpty(error.message ?? error.msg);
+    if (message) return message;
+  }
+
+  return (
+    nonEmpty(value.output) ??
+    nonEmpty(value.text) ??
+    nonEmpty(value.message) ??
+    (typeof value.result === 'string' ? nonEmpty(value.result) : null)
+  );
+}
+
+/**
+ * The result text of a completed tool call, or null when the client reports
+ * none.  Redaction and the size cap are NOT applied here -- they belong at the
+ * `recordToolOutcome` boundary, which is the only place every caller passes.
+ */
+export function outputFrom(raw) {
+  for (const envelope of responseEnvelopes(raw)) {
+    const text = resultText(envelope);
+    if (text) return text;
+  }
+  return resultText(raw?.output) ?? resultText(raw?.stdout) ?? null;
+}
+
+/**
+ * Key names that mean "process exit code" and nothing else.
+ *
+ * `code` is deliberately ABSENT. JSON-RPC errors (`code: -32602`), Node errno
+ * objects (`code: 'ENOENT'`) and HTTP wrappers all reuse that name, so reading
+ * it would record a confident exit code for calls that never had one. A null
+ * here is honest; a -32602 claiming to be an exit status is not.
+ */
+const EXIT_KEYS = [
+  'exit_code',
+  'exitCode',
+  'exit',
+  'exit_status',
+  'exitStatus',
+  'return_code',
+  'returncode',
+];
+
+/** The numeric exit code a client reported, or null when it reported none. */
+export function exitFrom(raw) {
+  for (const envelope of [...responseEnvelopes(raw), raw]) {
+    if (!envelope || typeof envelope !== 'object') continue;
+    for (const key of EXIT_KEYS) {
+      const value = envelope[key];
+      if (Number.isInteger(value)) return value;
+      // A client that serializes the code as a digit string still reported it.
+      // Bounded so a hash or an id cannot be mistaken for a status.
+      if (typeof value === 'string' && /^-?\d{1,5}$/.test(value.trim()))
+        return Number(value.trim());
+    }
+  }
+  return null;
+}
+
 function contextOutput(client, eventName, additionalContext) {
   if (client.contextStyle === 'top-level') return { additionalContext };
   if (client.contextStyle === 'cline') {
@@ -890,6 +1020,11 @@ async function runHook(clientName, event, invocation) {
         anchor,
         toolName: payload.tool_name,
         success: toolSucceeded(raw),
+        // The two fields a boolean cannot carry: which KIND of failure this
+        // was. Read through the same normalisers as `success`, never off `raw`
+        // at this call site.
+        output: outputFrom(raw),
+        exit: exitFrom(raw),
         durationMs:
           Number(
             raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -145,11 +145,43 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because three readers depend on it -- success
+ * classification, output capture and exit-code capture -- and clients disagree
+ * on the envelope name and on nothing else. Letting each reader name its own
+ * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
+    return false;
+  // MCP'S OWN FAILURE FLAG, which this function did not read for as long as it
+  // existed. It did not matter while `normalizeTool` dropped MCP names before
+  // any accounting ran; it matters now that `mcp__<server>__smart_edit` and
+  // `smart_write` reach the post-tool path, because an MCP result carries no
+  // `error` field and no `status` -- only `isError` -- so a failed smart_edit
+  // fell through to the optimistic `return true` below.
+  //
+  // WHY THIS IS A MEASUREMENT BUG AND NOT A COSMETIC ONE: this boolean feeds
+  // episode outcomes and effectiveness accounting, so recording every failed
+  // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
+  // optimizer's favour. A measurement that flatters the thing being measured
+  // is worse than no measurement.
+  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
     return false;
   const status =
     raw?.tool_response?.status ??
@@ -170,23 +202,6 @@ export function toolSucceeded(raw) {
   // that its output proved the task.  `success` here is deliberately scoped to
   // the tool call; task correctness comes only from an eval grader.
   return true;
-}
-
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * The same family `toolSucceeded` reads above, hoisted so the three readers
- * cannot drift apart. Clients disagree on the envelope name and on nothing
- * else, so this is the one place that disagreement is spelled out.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
 }
 
 /** A non-empty string, or null.  Blank output is the same as none. */

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -58,6 +58,7 @@ import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { briefing } from './remedy.mjs';
 import { stableText, transcriptFor } from './cache.mjs';
+import { scoreRefreshes } from './keepwarm.mjs';
 import { cachedRoutingBriefing } from './routing.mjs';
 import {
   forCommand,
@@ -1010,6 +1011,26 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE KEEP-WARM FEEDBACK ARM, at the boundary where a turn has just
+      // ended -- which is the only place the arrival question can be answered.
+      // Every refresh whose TTL has since elapsed is scored here as used or
+      // unused; anything the log cannot settle is left unscored rather than
+      // recorded as a miss, because an absent signal is not a miss.
+      //
+      // Nothing in this repository issues a refresh today -- cache_audit only
+      // recommends one -- so this scores nothing, and what it costs while
+      // dormant is one readBalance: median 70 ms on this machine's 3.5 MB log,
+      // against derive's 71-111 ms a few lines below on the same path. The
+      // firehose is read for ARRIVALS only if an unscored refresh exists, so
+      // the dormant case never pays for that. The moment an issuer exists, the
+      // decision starts learning with no second wiring change.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      scoreRefreshes(dir);
+    } catch {
+      // A refresh that cannot be scored costs a measurement, not a session.
     }
     try {
       // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -40,11 +40,13 @@ import {
   touchedFiles,
 } from './decide.mjs';
 import {
+  record,
   recordRead,
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
 } from './metrics.mjs';
+import { derive } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -948,6 +950,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // ZERO-COST DERIVATION, on every client, with no credential. The semantic
+      // harvest below needs an API key, so on a machine without one the graph
+      // accumulates structure and no verdicts at all. These detectors read only
+      // what is already on disk and send nothing anywhere.
+      //
+      // The COUNT is recorded rather than the candidates: how many findings a
+      // session's own evidence supports is the number that says whether this is
+      // working, and it is measurable before anything is stored. Storage is the
+      // caller's next step, under a budget.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      const dir = wikiDir(projectRoot);
+      const derived = derive(dir, {
+        sessionId,
+        projectRoot,
+        transcriptPath: agentScope,
+        // The hook payload's own identity, not a value a model typed.
+        authoritativeSessionId: sessionId,
+      });
+      record(dir, {
+        kind: 'derive',
+        sessionId,
+        candidates: derived.candidates.length,
+        observations: derived.observations.length,
+      });
+    } catch {
+      // A detector failing must never cost a user the end of their session.
     }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -72,7 +72,8 @@ import {
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
-import { isArchived } from './transcript.mjs';
+import { archive, isArchived } from './transcript.mjs';
+import { harvestMode } from './harvest.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
@@ -577,6 +578,65 @@ function emit(object) {
   process.stdout.write(serialized);
 }
 
+/**
+ * What will and will not extract findings after this session, in one sentence.
+ *
+ * THE STATE WAS ONLY EVER LEGIBLE FROM THE DOCTOR, and the doctor is a place
+ * someone visits after they already suspect something is wrong. A user watching
+ * a graph fill with structural nodes and no verdicts has no reason to suspect
+ * anything, which is the failure this project has now measured twice.
+ *
+ * IT IS ADDRESSED TO THE MODEL, NOT ONLY TO THE READER, which is why it earns a
+ * place in the prefix rather than a systemMessage. "Nothing else will write this
+ * down in words" changes what the model does with a conclusion it is holding;
+ * "here is a configuration variable" would not.
+ *
+ * CACHE-SAFE: derived from configuration, so it differs between sessions only
+ * when the configuration does -- the same standard the rest of this block is
+ * held to, and it carries no digits for `stableText` to reject.
+ *
+ * A local endpoint is named FIRST in the off case on purpose. It is the option
+ * that costs nothing and sends nothing, and it was the one buried deepest.
+ */
+function extractionNotice() {
+  switch (harvestMode()) {
+    case 'local':
+      return (
+        '\n\nA local model endpoint is configured, so semantic extraction also runs after this ' +
+        'session -- free and private, with nothing leaving this machine.'
+      );
+    case 'remote':
+      return (
+        '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
+        'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
+    case 'off:mode':
+      // The whole optimizer is off and this text is not emitted anyway. Saying
+      // anything here would be noise stacked on an explicit choice.
+      return '';
+    case 'off:opted-out':
+      // A DELIBERATE CHOICE, SO NO PITCH. The consequence is stated because the
+      // model needs it; the setting that would reverse it is not, because
+      // arguing with a configured decision on every session is how a notice
+      // stops being read. doctor.mjs draws the same line for the same reason.
+      return (
+        '\n\nFallback extraction is off by configuration, so a conclusion you do not record is ' +
+        'not written down in words anywhere. Findings are still derived locally from exit codes, ' +
+        'red-to-green transitions and corrections.'
+      );
+    default:
+      // off:no-key, and any mode a future harvest adds: no extractor is running
+      // and nobody chose that, so the free option is worth naming.
+      return (
+        '\n\nNo separate extractor will run after this session, so a conclusion you do not record ' +
+        'is not written down in words anywhere. Findings are still derived locally from exit ' +
+        'codes, red-to-green transitions and corrections. Pointing ' +
+        'TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model adds semantic extraction, free and ' +
+        'private.'
+      );
+  }
+}
+
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
 export function policyText(
   canDeny,
@@ -635,7 +695,7 @@ export function policyText(
     .filter(Boolean)
     .join(' ');
   const recording = tools.has('wiki_write')
-    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.`
+    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.${extractionNotice()}`
     : '\n\nStructural graph capture remains active through lifecycle hooks. Durable semantic MCP writes are not requested because the writer schema is not proven available.';
 
   return `# Token optimization is active\n\nLive graph capture is active through the lifecycle adapter.\n\n${connection}${routing}${enforcement}${utilities ? `\n\n${utilities}` : ''}${recording}${projectBriefing()}`;
@@ -950,6 +1010,27 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.
+      //
+      // This was lost rather than retired. `plugin/hooks/stop-harvest.mjs` called
+      // `archive()` at Stop, and #300 replaced that entry in `hooks.json` with the
+      // generated `stop.mjs`, which routes here -- so on Claude Code no session has
+      // been archived since. Nothing failed loudly: `readArchive` simply returns an
+      // empty list, so `derive`'s correction detector fell through to the live
+      // transcript (present only for a client that reports one) and `lessons.mjs`
+      // lost the only corpus it can verify a verbatim quote against, which is the
+      // single test that grants a feedback finding human origin.
+      //
+      // BEFORE `derive`, deliberately: the correction detector reads the archive
+      // first and treats the live transcript as the fallback, and the archive is
+      // the copy that survives into later sessions.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      if (agentScope) archive(dir, agentScope, { sessionId });
+    } catch {
+      // The archive is a record, not a result. A session still ends.
     }
     try {
       // ZERO-COST DERIVATION, on every client, with no credential. The semantic

--- a/integrations/kilo/hooks/lib/audit.mjs
+++ b/integrations/kilo/hooks/lib/audit.mjs
@@ -32,6 +32,7 @@
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
+import { looNote } from './loo.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -401,6 +402,16 @@ export function renderAudit(
   // project with no injections and no queries gains no line at all.
   const reference = referenceNote(dir);
   if (reference) body.push('', reference);
+
+  // WHAT ONE FINDING IS CAUSALLY WORTH (Layer 2).
+  //
+  // The same reasoning as above, and the same refusal: `looNote` returns null
+  // until the leave-one-out experiment has collected an observation, and says
+  // NOT MEASURABLE YET rather than printing a mean until it clears the floor.
+  // A causal number is the most quotable thing this project can produce, so it
+  // is the one that most needs to be absent when it is not earned.
+  const causal = looNote(dir);
+  if (causal) body.push('', causal);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/kilo/hooks/lib/audit.mjs
+++ b/integrations/kilo/hooks/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
 import { looNote } from './loo.mjs';
+import { calibrationNote } from './crosslayer.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -244,9 +245,15 @@ export function renderAudit(
     lines.push(text);
   }
 
+  // SCOPED TO THE QUEUE, because that is all it ever described. The bare
+  // sentence "Nothing addressable found." was printed directly above a Layer 1
+  // reference note and a published Layer 2 causal verdict -- so a reader was
+  // told nothing had been found immediately before being shown a finding. The
+  // headline is about the remediation queue and nothing else, and saying so
+  // costs four words and removes a false negative shown to a human.
   const head = shown.length
     ? ['What to do next, most expensive first:', ...lines]
-    : ['Nothing addressable found.'];
+    : ['Nothing addressable found in the remediation queue.'];
 
   const body = [...head];
 
@@ -412,6 +419,16 @@ export function renderAudit(
   // is the one that most needs to be absent when it is not earned.
   const causal = looNote(dir);
   if (causal) body.push('', causal);
+
+  // WHETHER LAYER 1'S CHEAP LABEL PREDICTS LAYER 2'S EXPENSIVE EFFECT.
+  //
+  // The reason this is printed rather than kept for a dashboard: the reference
+  // rate is the number a reader is most likely to quote as a saving, and it is
+  // not one until this comparison says so. `calibrationNote` returns null while
+  // both layers are silent, and otherwise prints the refusal -- naming which
+  // input was insufficient -- rather than a gap of zero.
+  const calibrated = calibrationNote(dir);
+  if (calibrated) body.push('', calibrated);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/kilo/hooks/lib/audit.mjs
+++ b/integrations/kilo/hooks/lib/audit.mjs
@@ -61,6 +61,28 @@ export function declines(dir, { events = readMetrics(dir) } = {}) {
   return counts;
 }
 
+/**
+ * What the local Stop-time derivation path produced in the visible event log.
+ *
+ * The producer records all three counts because any one of them alone is
+ * ambiguous: zero stored can mean no evidence, no candidates, or a binding
+ * storage/anchor filter. This reader keeps those states distinct and prevents
+ * the telemetry itself from becoming an unobserved cost.
+ */
+export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
+  const runs = events.filter((event) => event.kind === 'derive');
+  if (!runs.length) return null;
+
+  const sum = (field) =>
+    runs.reduce((total, event) => total + Math.max(0, Number(event[field]) || 0), 0);
+  const candidates = sum('candidates');
+  const observations = sum('observations');
+  const written = sum('written');
+  return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
+    `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
+    `across ${runs.length.toLocaleString()} Stop run(s).`;
+}
+
 const idOf = (finding) =>
   finding.remedy
     ? `${finding.remedy.type}:${finding.remedy.anchor || finding.remedy.file || (finding.remedy.anchors || []).join(',')}`
@@ -399,6 +421,15 @@ export function renderAudit(
       );
     }
   }
+
+  // WHAT THE DEFAULT, LOCAL DERIVATION PATH ACTUALLY PRODUCED.
+  //
+  // This event used to have a producer and no reader. Keep its three states
+  // together: evidence seen, candidates derived, and findings that survived
+  // selection/storage. A lone stored count would turn every earlier refusal
+  // into an apparent "nothing found" result.
+  const derived = derivationNote(dir);
+  if (derived) body.push('', derived);
 
   // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
   //

--- a/integrations/kilo/hooks/lib/audit.mjs
+++ b/integrations/kilo/hooks/lib/audit.mjs
@@ -31,6 +31,7 @@
  */
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
+import { referenceNote } from './usage.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -390,6 +391,16 @@ export function renderAudit(
       );
     }
   }
+
+  // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
+  //
+  // Printed here because this is the report that already asks "did the advice
+  // change anything", and because a measurement with no reader is how this
+  // project shipped two metrics whose only consumer was their own test suite.
+  // `referenceNote` returns null when it has nothing honest to say, so a
+  // project with no injections and no queries gains no line at all.
+  const reference = referenceNote(dir);
+  if (reference) body.push('', reference);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/kilo/hooks/lib/consolidate.mjs
+++ b/integrations/kilo/hooks/lib/consolidate.mjs
@@ -142,7 +142,8 @@ const ALWAYS_KEEP = new Set(['failure', 'decision']);
  * Chooses what to promote into the graph, under a token budget.
  *
  * @param {object} graph      Loaded wiki graph, for reuse probability.
- * @param {Array}  candidates Extracted conclusions, each { type, summary, anchors, evidence, at }.
+ * @param {Array}  candidates Extracted conclusions, each { type, claim (or summary),
+ *                              anchors, evidence, at }.
  * @param {object} options    budget: tokens available for promoted findings.
  */
 export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}) {
@@ -221,4 +222,3 @@ export function aggregateConsolidation(findings) {
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
-

--- a/integrations/kilo/hooks/lib/crosslayer.mjs
+++ b/integrations/kilo/hooks/lib/crosslayer.mjs
@@ -1,0 +1,351 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/crosslayer.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The calibration loop: does Layer 1's LABEL predict Layer 2's EFFECT?
+ *
+ * Layer 1 (`usage.mjs`) classifies an injected finding by whether the model
+ * later NAMED it. Layer 2 (`loo.mjs`) measures, by leave-one-out, how many
+ * tokens of reading a finding actually SUPPRESSED. Those are two different
+ * quantities, and the whole point of putting them side by side is that the
+ * cheap one (a label, available on every injection) might stand in for the
+ * expensive one (a causal effect, costing three withheld sessions per finding).
+ *
+ * WHY THIS IS A REAL QUESTION AND NOT A TAUTOLOGY. Task 7 established the
+ * independence three ways -- statically (`loo.mjs` contains no `query` or
+ * `reference`; `usage.mjs` contains no `tokens`, `cost` or `bytes`),
+ * behaviourally in both directions, and by naming the one overlap that does
+ * exist (`recordToolOutcome`'s join, which supplies ATTRIBUTABILITY to both and
+ * the measured quantity to neither). This module is built to preserve that:
+ *
+ *   - from Layer 1 it takes ONLY the categorical label per finding key. No
+ *     rate, no count, no magnitude -- Layer 1 has no magnitude to give.
+ *   - from Layer 2 it takes ONLY the effect magnitude per finding key.
+ *   - the join is the finding key, which is a graph identity and not a
+ *     measurement.
+ *
+ * If a magnitude common to both ever entered, this would correlate a quantity
+ * with itself and report a strong result that means nothing. Two tests pin the
+ * separation from opposite sides: flipping the labels while holding the effects
+ * fixed must move the gap, and changing Layer 1's rate WITHOUT changing any
+ * label must leave the gap byte-identical.
+ *
+ * MEASURED UTILITY RANKS A FINDING. IT MUST NEVER RAISE ITS CONFIDENCE.
+ * A confidently WRONG finding suppresses reads better than a hedged true one,
+ * so utility alone optimises directly against "wrong findings are worse than
+ * none". The plan called for a `mayPromote` gate over
+ * `hasOutstandingContradiction` here. There is nothing to gate: every write of
+ * `confidence` in `hooks-core` happens at CREATION (a per-producer constant in
+ * `derive.mjs` / `lessons.mjs` / `harvest.mjs`, or a human's own number in
+ * `curate.mjs`), and no code path updates a stored finding's confidence
+ * afterwards. `assessFindings` in `utility.mjs` READS confidence into an
+ * ephemeral `netUtility` used for ordering and writes nothing back. So a gate
+ * here would be unreachable, and an unreachable gate is the exact defect class
+ * this work exists to close. `hasOutstandingContradiction` already has its
+ * real consumer -- `staleness.mjs` calls it as the dispute gate on serve.
+ * What is enforceable is the invariant itself, and it is: this module never
+ * writes to the graph, and `tests/hooks/calibration-loop.test.mjs` asserts that
+ * neither it nor either layer under it can move a stored confidence.
+ *
+ * NOTHING HERE IS PRICED. A calibration verdict, a holdout estimate and a
+ * consolidation ratio are all estimates; currency belongs only on a measured
+ * counterfactual, and `balanceSheet`'s `measuredCounterfactual` is the one
+ * section in the sheet below that qualifies.
+ */
+
+import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
+import { classify, referenceRate } from './usage.mjs';
+import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Distinct findings needed in EACH arm before a gap is reported at all.
+ *
+ * Two findings per arm is a difference of two numbers; the comparison would be
+ * dominated by whichever finding happened to sit on a big file. Three is still
+ * small, and the refusal says so rather than implying the gap is solid.
+ */
+export const MIN_FINDINGS_PER_ARM = 3;
+
+/**
+ * The smallest gap that may be PUBLISHED, in tokens per touch.
+ *
+ * Not an effect-size convention: it is tied to the unit the verdict prints. The
+ * published sentence rounds the gap to whole tokens, so a gap of 1e-13 -- which
+ * is what two arms of equal means produce once floating point has had its say --
+ * would publish as "referenced findings suppress 0 more tokens/touch". That is a
+ * calibration claim resting on arithmetic noise, and it leans the only direction
+ * a measurement of this project by this project must never lean.
+ */
+export const MIN_GAP_TOKENS = 1;
+
+/**
+ * The per-finding Layer 1 label, folded from per-injection rows.
+ *
+ * ANY reference wins. `classify` emits one row per (injection, finding) because
+ * one reference must not excuse every later injection -- that is the right unit
+ * for a RATE. For a label the question is different: did the model ever name
+ * this finding? A finding referenced once and ignored nine times is a finding
+ * the model reads, and averaging it into `not-referenced` would put it in the
+ * arm whose mean effect it is meant to predict.
+ *
+ * `unknown` rows are dropped rather than defaulted, exactly as Layer 1 drops
+ * them from its own denominator.
+ */
+export function labelsByFinding(rows) {
+  const labels = new Map();
+  for (const row of rows || []) {
+    const key = row?.findingKey;
+    if (typeof key !== 'string' || !key) continue;
+    if (row.label === 'referenced') labels.set(key, 'referenced');
+    else if (row.label === 'not-referenced' && !labels.has(key))
+      labels.set(key, 'not-referenced');
+  }
+  return labels;
+}
+
+const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * Does Layer 1's label predict Layer 2's effect?
+ *
+ * Returns `publishable`, a `verdict` in English, and `gap` ONLY when a gap was
+ * actually computed. There is no `gap: 0` for the unmeasured case, and that is
+ * deliberate: a permanent zero reads as "measured, and the two agree", which is
+ * the opposite of "nothing was measured". Task 7 deleted a field rather than
+ * zero it for the same reason.
+ *
+ * FAILS OPEN. This runs on report paths that must not break a tool call.
+ */
+export function calibration(dir, options = {}) {
+  const refuse = (verdict, extra = {}) => ({
+    publishable: false,
+    verdict,
+    ...extra,
+  });
+
+  try {
+    // ONE READ for both layers, so the two arms of the comparison cannot cover
+    // different spans of the log. `referenceRate` reports `windowed: false`
+    // when the caller supplies events -- correctly, since the bounds are then
+    // the caller's -- so the truncation flag is taken here, from the read that
+    // actually set it, and republished.
+    const supplied = options.events || null;
+    const events = supplied || readMetrics(dir);
+    const truncation = supplied ? null : readTruncation();
+    const truncated = Boolean(
+      truncation && (truncation.byBytes || truncation.byEvents)
+    );
+
+    const layer1 = referenceRate(dir, { events });
+    const labels = labelsByFinding(classify(dir, { events }));
+
+    const obs = observations(dir, { ...options, events });
+    const rows = effects(dir, { ...options, events, obs });
+
+    // ONE POLICY VERSION. Layer 2 refuses to pool arms across serving
+    // policies; a calibration that pooled them would undo that guard one level
+    // up. Rows from any other policy are excluded and counted.
+    const policy = servingPolicyVersion();
+    const inPolicy = rows.filter((row) => row.policy === policy);
+
+    const layer2 = {
+      rows: rows.length,
+      inPolicy: inPolicy.length,
+      published: rows.filter((row) => row.published).length,
+      observations: obs.rows.length,
+      policy,
+    };
+    const l1 = {
+      referenced: layer1.referenced,
+      notReferenced: layer1.notReferenced,
+      unknown: layer1.unknown,
+      denominator: layer1.denominator,
+      rate: layer1.rate,
+      referenceEvents: layer1.referenceEvents,
+    };
+
+    const excluded = { layer1Unknown: layer1.unknown, unlabelled: 0, noEffect: 0 };
+    const arms = { referenced: [], notReferenced: [] };
+    for (const row of inPolicy) {
+      // THE SHRUNK ESTIMATE, not the raw one. Shrinkage pulls every finding
+      // toward the population mean, so it pulls the GAP toward zero -- the
+      // bias runs against publishing, which is the only direction a
+      // measurement of this project by this project may lean.
+      if (row.shrunk === null || !Number.isFinite(row.shrunk)) {
+        excluded.noEffect += 1;
+        continue;
+      }
+      const label = labels.get(row.findingKey);
+      if (label === 'referenced') arms.referenced.push(row.shrunk);
+      else if (label === 'not-referenced') arms.notReferenced.push(row.shrunk);
+      else excluded.unlabelled += 1;
+    }
+
+    const context = { layer1: l1, layer2, arms: { referenced: arms.referenced.length, notReferenced: arms.notReferenced.length }, excluded, windowed: truncated };
+    const caveat = truncated
+      ? ' The event log was truncated, so both sides can understate.'
+      : '';
+
+    // WHICH INPUT WAS INSUFFICIENT, named. "Not enough data" tells a reader
+    // nothing about which half of the loop to go and fix.
+    const l1Silent = layer1.rate === null;
+    const l2Silent = layer2.observations === 0;
+    if (l1Silent || l2Silent) {
+      const why = [];
+      if (l1Silent)
+        why.push(
+          `Layer 1 has ${layer1.denominator} classifiable observation(s) and ` +
+            `${layer1.referenceEvents} reference event(s), so it publishes no rate`
+        );
+      if (l2Silent)
+        why.push(
+          `Layer 2 has ${layer2.observations} observation(s), so it publishes no effect`
+        );
+      return refuse(
+        `not calibrated: ${why.join('; and ')}. No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+    }
+
+    // A POLICY CHANGE RESETS THE CALIBRATION, and says so rather than reporting
+    // an empty arm. Layer 2 refuses to pool arms across serving policies, so
+    // rows generated under an older one cannot answer a question about how the
+    // graph serves findings today -- but "0 findings per arm" would send a
+    // reader hunting for missing observations that are right there in the log.
+    if (rows.length > 0 && inPolicy.length === 0)
+      return refuse(
+        `not calibrated: all ${rows.length} Layer 2 effect row(s) were measured under a different serving ` +
+          `policy than the current ${policy}, and arms are never pooled across policies. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (layer2.published === 0)
+      return refuse(
+        `not calibrated: Layer 2 has ${layer2.observations} observation(s) but no published effect at q=0.1, ` +
+          'so its per-finding numbers are noise and a difference between two means of them would be too. ' +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (
+      arms.referenced.length < MIN_FINDINGS_PER_ARM ||
+      arms.notReferenced.length < MIN_FINDINGS_PER_ARM
+    )
+      return refuse(
+        `not calibrated: ${arms.referenced.length} referenced and ${arms.notReferenced.length} not-referenced ` +
+          `finding(s) carry a Layer 2 effect, below the floor of ${MIN_FINDINGS_PER_ARM} per arm. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    const referencedMean = mean(arms.referenced);
+    const notReferencedMean = mean(arms.notReferenced);
+    const gap = referencedMean - notReferencedMean;
+    const measured = { ...context, gap, referencedMean, notReferencedMean };
+
+    if (!(gap >= MIN_GAP_TOKENS))
+      return refuse(
+        `uncalibrated: Layer 1's "referenced" label does not predict a larger Layer 2 effect ` +
+          `(referenced ${Math.round(referencedMean).toLocaleString()} vs not-referenced ` +
+          `${Math.round(notReferencedMean).toLocaleString()} tokens/touch, gap ${Math.round(gap).toLocaleString()}). ` +
+          `Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
+    return {
+      publishable: true,
+      verdict:
+        `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
+      ...measured,
+    };
+  } catch {
+    return refuse(
+      'not calibrated: the calibration inputs could not be read. No gap is reported, which is not the same as a gap of zero.'
+    );
+  }
+}
+
+/**
+ * What the graph cost to build against what it carries -- AN ESTIMATE, and
+ * never priced.
+ *
+ * `consolidationRatio` is the per-finding form and the aggregate is the fold.
+ * Both need `derivedCost`, which `expand.promote` persists onto the finding
+ * node it creates (`src/server/disclosure.ts` is its caller) and which
+ * `harvest-write.mjs` does not yet carry through -- so a graph built only by
+ * the harvest reports nothing here rather than a ratio of one.
+ */
+export function consolidation(dir, { graph = null } = {}) {
+  try {
+    const g = graph || load(dir);
+    const findings = [...g.nodes.values()].filter(
+      (node) => node.kind === 'finding' && !node.retired
+    );
+    const rated = [];
+    for (const finding of findings) {
+      const ratio = consolidationRatio(finding);
+      if (ratio === null) continue;
+      rated.push({ key: finding.key, ratio, derivedCost: finding.derivedCost });
+    }
+    const aggregate = aggregateConsolidation(findings);
+    return {
+      what: 'cost to derive against cost to carry',
+      // SAID IN THE DATA, not only in the prose above it, because this is the
+      // field a dashboard will read and a dashboard will not read a comment.
+      basis: 'estimate',
+      priced: false,
+      findings: findings.length,
+      withDerivedCost: rated.length,
+      aggregate,
+      best: rated.sort((a, b) => b.ratio - a.ratio).slice(0, 5),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The balance sheet with the graph's own three measurements attached.
+ *
+ * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
+ * imports, so it cannot import them back. This is where the two meet, and it
+ * is the shape `get_optimization_report` serves.
+ */
+export function graphBalanceSheet(dir, options = {}) {
+  const sheet = balanceSheet(dir);
+  const cal = calibration(dir, options);
+  const { layer1 = null, layer2 = null } = cal;
+  return {
+    ...sheet,
+    layer1,
+    layer2,
+    calibration: cal,
+    consolidation: consolidation(dir, options),
+  };
+}
+
+/**
+ * One audit line, or null when there is nothing honest to say.
+ *
+ * Silent when NEITHER layer has produced anything: a reader of a graph that has
+ * never injected a finding is owed no paragraph about a loop that has not
+ * started. The moment either side speaks, the refusal is worth printing --
+ * because at that point a reader could otherwise take Layer 1's rate for a
+ * saving, which is precisely what this loop exists to stop.
+ */
+export function calibrationNote(dir, options = {}) {
+  try {
+    const result = calibration(dir, options);
+    const l1 = result.layer1;
+    const l2 = result.layer2;
+    if (!l1 || !l2) return null;
+    if (l1.denominator === 0 && l2.observations === 0) return null;
+    return `Layer 1 against Layer 2: ${result.verdict}`;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/kilo/hooks/lib/crosslayer.mjs
+++ b/integrations/kilo/hooks/lib/crosslayer.mjs
@@ -54,7 +54,13 @@
 
 import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
-import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import {
+  effects,
+  observations,
+  servingPolicyVersion,
+  permutationP,
+  FDR_Q,
+} from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
 import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
@@ -106,6 +112,32 @@ export function labelsByFinding(rows) {
 }
 
 const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * A deterministic, label-symmetric permutation test for the headline gap.
+ *
+ * Layer 2 only publishes a per-finding row after a two-sided permutation test.
+ * The calibration headline summarises those rows, so a positive difference of
+ * arm means must clear the same evidential bar rather than being promoted just
+ * because it points in this project's favour.
+ *
+ * Sorting within each arm and then sorting the two arms makes the sampled path
+ * invariant to event order and to swapping the labels. The seed is derived
+ * from that canonical data instead of shared globally, so two different
+ * datasets do not reuse one arbitrary sequence of sampled relabellings.
+ */
+export function calibrationP(referenced, notReferenced) {
+  const arms = [referenced, notReferenced]
+    .map((values) => [...values].sort((a, b) => a - b))
+    .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  const encoded = JSON.stringify(arms);
+  let seed = 2166136261;
+  for (const char of encoded) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return permutationP(arms[0], arms[1], { seed: seed >>> 0 });
+}
 
 /**
  * Does Layer 1's label predict Layer 2's effect?
@@ -244,7 +276,16 @@ export function calibration(dir, options = {}) {
     const referencedMean = mean(arms.referenced);
     const notReferencedMean = mean(arms.notReferenced);
     const gap = referencedMean - notReferencedMean;
-    const measured = { ...context, gap, referencedMean, notReferencedMean };
+    const p = calibrationP(arms.referenced, arms.notReferenced);
+    const measured = {
+      ...context,
+      gap,
+      referencedMean,
+      notReferencedMean,
+      p,
+      alpha: FDR_Q,
+      test: 'two-sided permutation',
+    };
 
     if (!(gap >= MIN_GAP_TOKENS))
       return refuse(
@@ -255,11 +296,20 @@ export function calibration(dir, options = {}) {
         measured
       );
 
+    if (p === null || p > FDR_Q)
+      return refuse(
+        `not calibrated: the positive Layer 1/Layer 2 gap is not statistically resolved by the ` +
+          `two-sided permutation test (p=${p === null ? 'unavailable' : p.toFixed(3)}, ` +
+          `alpha=${FDR_Q.toFixed(3)}). Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
     return {
       publishable: true,
       verdict:
         `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
-        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, ` +
+        `shrunk estimates, two-sided permutation p=${p.toFixed(3)}). ` +
         `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
       ...measured,
     };

--- a/integrations/kilo/hooks/lib/crosslayer.mjs
+++ b/integrations/kilo/hooks/lib/crosslayer.mjs
@@ -56,6 +56,7 @@ import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
 import { effects, observations, servingPolicyVersion } from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
 
 /**
@@ -309,11 +310,19 @@ export function consolidation(dir, { graph = null } = {}) {
 }
 
 /**
- * The balance sheet with the graph's own three measurements attached.
+ * The balance sheet with the graph's own measurements attached.
  *
  * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
  * imports, so it cannot import them back. This is where the two meet, and it
  * is the shape `get_optimization_report` serves.
+ *
+ * `recall` joins them as an OFFLINE PROBE, and that label travels in the data
+ * (`recall.basis`) as well as in the rendered line. It is not an observation of
+ * anything a session did: it deletes an anchor edge in memory and re-runs the
+ * real retrieval primitives over the graph as it stands right now. `recall.mjs`
+ * imports only `wiki.mjs` and `lexical.mjs`, neither of which imports anything
+ * in this direction, so no cycle -- the same reason `calibration` had to live
+ * here rather than in `metrics.mjs`.
  */
 export function graphBalanceSheet(dir, options = {}) {
   const sheet = balanceSheet(dir);
@@ -325,6 +334,7 @@ export function graphBalanceSheet(dir, options = {}) {
     layer2,
     calibration: cal,
     consolidation: consolidation(dir, options),
+    recall: recallProbe(dir, options),
   };
 }
 

--- a/integrations/kilo/hooks/lib/derive.mjs
+++ b/integrations/kilo/hooks/lib/derive.mjs
@@ -23,13 +23,21 @@
  * the observation supports no claim at all are refused rather than downgraded
  * (see `attemptKey` and the identical-text guard below).
  *
- * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
- * budget, belongs to the caller.
+ * WHAT IS STORED IS BOUNDED. Candidates go through `selectForConsolidation`
+ * before `writeHarvested`, so a long session cannot spend the whole retrieval
+ * budget of every later session on one afternoon's exit codes. Nothing enters
+ * the graph unbudgeted, and nothing enters it wearing a human origin.
  */
 
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
 import { readArchive, readTurns } from './transcript.mjs';
 import { redact } from './redact.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { load } from './wiki.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -106,6 +114,92 @@ const triggerFor = (command) =>
   attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
 
 /**
+ * Literal root-level files that define how a project is BUILT, RUN and TESTED,
+ * best first. A `command` claim is a claim about this project's commands, and
+ * this is the file those commands are declared in.
+ */
+const PROJECT_MARKERS = [
+  'package.json', 'pyproject.toml', 'Cargo.toml', 'go.mod', 'pom.xml',
+  'build.gradle.kts', 'build.gradle', 'build.sbt', 'mix.exs', 'composer.json',
+  'Gemfile', 'Package.swift', 'CMakeLists.txt', 'Makefile', 'Taskfile.yml',
+  'requirements.txt', 'setup.py', 'deno.json', 'bun.lockb',
+];
+
+/** .NET has no single literal marker; the solution or project file is one. */
+const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
+
+/**
+ * A REAL FILE to anchor a derived claim to, inside the project root.
+ *
+ * WHY NOT THE PROJECT ROOT ITSELF, which is what the extraction step reaches
+ * for and what `promoteToShared` uses in the shared tier. Because
+ * `writeHarvested` resolves every anchor through `indexFile`, `indexFile` reads
+ * the path, and reading a DIRECTORY returns null -- so a candidate anchored to
+ * `projectRoot` resolves to nothing, is refused as unanchorable, and the whole
+ * pipeline stores zero findings while reporting a healthy candidate count.
+ * Verified directly: `indexFile(dir, dir)` returns null. That refusal is
+ * correct and must not be weakened -- an anchor that cannot be indexed is an
+ * anchor that can never be invalidated -- so the anchor has to be a file.
+ *
+ * STALENESS DOES NOT MISFIRE ON THIS. `command`, `failure` and `feedback` are
+ * all outside `CONTENT_DEPENDENT` (staleness.mjs), so the anchor is a RETRIEVAL
+ * AND EXISTENCE hook rather than a contents claim: editing the manifest does
+ * not mark these findings stale. staleness.mjs names this exact case in its own
+ * comment -- "a claim about `npm test` anchored to package.json" -- and calls
+ * missing that invalidation the better error.
+ *
+ * A project with no recognisable marker gets the root back, which will not
+ * resolve, so its candidates are derived and then refused rather than stored
+ * against a fabricated anchor. That is the fail-open direction: no finding
+ * beats a finding anchored to something that is not what the claim is about.
+ */
+export function projectAnchor(projectRoot) {
+  if (!projectRoot) return null;
+  let entries;
+  try {
+    entries = readdirSync(projectRoot);
+  } catch {
+    return projectRoot;
+  }
+  const present = new Set(entries);
+  for (const marker of PROJECT_MARKERS) {
+    if (!present.has(marker)) continue;
+    const path = join(projectRoot, marker);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // A marker that cannot be stat'ed is not a marker.
+    }
+  }
+  // Sorted so two sessions in the same repository pick the SAME solution file:
+  // readdir order is not guaranteed stable across hosts, and an anchor that
+  // varies by host splits one finding into two nodes.
+  for (const entry of [...entries].sort()) {
+    if (!DOTNET_MARKER.test(entry)) continue;
+    const path = join(projectRoot, entry);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // Same.
+    }
+  }
+  return projectRoot;
+}
+
+/**
+ * Tokens of claim text one session may add to the graph.
+ *
+ * SCALED TO THE RETRIEVAL BUDGET IT COMPETES FOR, not picked round. A single
+ * command's injection budget is 500 tokens (`TOKEN_OPTIMIZER_TOUCH_BUDGET`),
+ * and everything stored here is competing for that budget on every later
+ * command, forever. Two touch-budgets per session is the bound: enough for a
+ * few dozen real claims, and short of one session's exit codes crowding out
+ * every finding a human or a model ever wrote.
+ */
+const storageBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_DERIVE_BUDGET) || 1000;
+
+/**
  * Derives finding candidates from one project's local evidence.
  *
  * @param {string} dir wiki directory.
@@ -118,11 +212,18 @@ const triggerFor = (command) =>
  *   and is refused by `writeHarvested` anyway, so emitting one would only spend
  *   the caller's budget on junk.
  * @param {string|null} options.authoritativeSessionId the session id as the HOOK
- *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
- *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
- *   edge -- `taskForAnchors` returns null without one, so an unverified string
- *   would silently produce no edge. Threaded rather than defaulted from
- *   `sessionId`: defaulting would promote any caller's string to trusted.
+ *   PAYLOAD reported it, never a value a model typed. Passed straight to
+ *   `writeHarvested`, which needs it to resolve the `answers` edge --
+ *   `taskForAnchors` returns null without one, so an unverified string would
+ *   silently produce no edge. Threaded rather than defaulted from `sessionId`:
+ *   defaulting would promote any caller's string to trusted. Also returned, so a
+ *   caller can see what it handed over.
+ * @returns {object} `{ candidates, observations, written, selected, dropped,
+ *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
+ *   everything derived; `written` is the subset of keys the graph actually
+ *   holds, which is smaller for three independent reasons -- the budget, the
+ *   anchor discipline, and the duplicate collapse that returns an EXISTING key
+ *   when a later session derives the same claim again.
  */
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
@@ -152,6 +253,11 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // ONE anchor for the whole run, so every candidate from this session points at
+  // the same node and the duplicate collapse in `writeHarvested` can recognise
+  // the same lesson across sessions.
+  const anchorPath = projectAnchor(projectRoot);
 
   const seen = new Set();
   const add = (candidate) => {
@@ -246,7 +352,7 @@ export function derive(dir, options = {}) {
               `observed in one session: \`${failed.command}\` failed` +
                 `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
                 `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
-                'an intervening edit or a flaky run explains the same pair.',
+                'an intervening edit or an unrelated environment change explains the same pair.',
               { max: EVIDENCE_MAX }
             ),
             applicability: 'when about to run this command in this project',
@@ -255,7 +361,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the failing form later succeeds unchanged'],
             trigger: triggerFor(outcome.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: outcome.at || Date.now(),
@@ -280,7 +386,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the same command later succeeds unchanged'],
             trigger: triggerFor(failed.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: failed.at || Date.now(),
@@ -330,7 +436,7 @@ export function derive(dir, options = {}) {
           confidenceLabel: labelFor(CONFIDENCE.correction),
           scope: 'project',
           invalidators: ['the user later asks for the corrected behaviour'],
-          anchors: [projectRoot],
+          anchors: [anchorPath],
           derivedBy: 'correction',
           sessionId,
           at: Date.parse(turn.at || '') || Date.now(),
@@ -379,6 +485,48 @@ export function derive(dir, options = {}) {
     }
   } catch {
     // One detector, never the session.
+  }
+
+  // ---- storage, under a budget -------------------------------------------
+  //
+  // NOTHING ENTERS THE GRAPH UNBUDGETED. `selectForConsolidation` existed for
+  // exactly this and had no caller, which meant that until now nothing bounded
+  // what a session could add. It admits `failure` and `decision` on a FLOOR
+  // before ranking -- a dead end exists nowhere else and is small, and cheap to
+  // find is not cheap to find again -- then fills the remainder by
+  // cost x irrecoverability x reuse-probability.
+  //
+  // ORIGIN_HARVESTED, EXPLICITLY, never ORIGIN_HUMAN. These are machine
+  // derivations; `curate.mjs` states the reason in its own header -- "a
+  // hand-written assertion and a machine guess look identical three months
+  // later, which quietly destroys the reader's ability to calibrate trust".
+  // `writeHarvested` would refuse a batch-wide human origin anyway, and a
+  // candidate here carries neither `origin` nor `quote`, so it cannot earn one
+  // per finding either. That is deliberate: whether a turn was a correction at
+  // all is a lexical guess, and the standing-rules layer selects on human
+  // origin to inject on EVERY turn.
+  try {
+    if (result.candidates.length) {
+      const selected = selectForConsolidation(load(dir), result.candidates, {
+        budget: storageBudget(),
+      });
+      result.selected = selected.kept.length;
+      result.dropped = selected.dropped;
+      result.selectedTokens = selected.tokens;
+      result.written = writeHarvested(dir, selected.kept, {
+        sessionId,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        // The hook payload's own identity, passed through untouched. Without it
+        // `taskForAnchors` returns null and the `answers` edge never fires --
+        // which is the state a default install has been in, because its only
+        // other producer is credential-gated.
+        authoritativeSessionId,
+      });
+    }
+  } catch {
+    // Storage is the last step and the session is already over. A graph write
+    // that fails must not turn a completed session into a hook error.
   }
 
   return result;

--- a/integrations/kilo/hooks/lib/derive.mjs
+++ b/integrations/kilo/hooks/lib/derive.mjs
@@ -139,17 +139,19 @@ const quotable = (command) => {
  * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
  * found across 163 transcripts on this machine it refuses 2 and keeps 6.
  *
- * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
- * building the key, so the claim is about `npm test` rather than about the `cd`.
- * That changes `attemptKey` for every client and every finding already derived
- * from it, so it belongs in its own change with its own comparison.
+ * `commandBody` below now skips a leading `cd <path> &&`, so those two are
+ * recovered and this guard is left holding only the keys that reached a
+ * separator which is NOT a directory change -- `git fetch && <anything>`, a
+ * pipeline, a `;`-joined pair. Those still name no single attempt.
  */
 const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
 
 /**
  * Did `attemptKey` actually capture a command, or only how one was chained?
  *
- * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart --
+ * which now means AFTER `commandBody` has removed any leading `cd`, so this no
+ * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
 const hasAttemptIdentity = (command) =>
@@ -177,6 +179,81 @@ const CORRECTION_OPENER =
   /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
 
 /**
+ * A leading directory change, stripped before the key is built.
+ *
+ * THE MEASURED CASE, AND ONLY THE MEASURED CASE. `attemptKey` spends up to
+ * three non-flag tokens on identity and the habit on this machine is
+ * `cd <absolute path> && <the real command>`, which spends all three on `cd`,
+ * the path and the separator. This repository's own corpus: 1,400 of 2,243
+ * command outcomes open with a `cd`, and the single key
+ * `cd c:/users/.../token-optimizer-mcp &&` covered 547 distinct command lines.
+ * A `cd` says WHERE a command ran; it says nothing about WHAT ran, so it cannot
+ * be part of the identity of an attempt.
+ *
+ * THE SEPARATOR SET IS THE ONE THAT WAS OBSERVED: `&&` (1,147), a newline (204)
+ * and `;` (38) after a leading `cd`. All three mean "then run this". `||` is
+ * DELIBERATELY EXCLUDED even though it costs one line to add: `cd x || echo
+ * failed` puts an error branch after the separator, not the next step, so
+ * stripping there would key the attempt on a failure handler. It occurred zero
+ * times.
+ *
+ * AND NOTHING WIDER, each refusal for a reason from the same corpus:
+ *
+ *   Environment assignments (`FOO=bar cmd`) DO carry information about what
+ *   ran. The one true instance here is
+ *   `TOKEN_OPTIMIZER_HOLDOUT=1 node ... jest.js ...`, and the holdout arm is a
+ *   genuinely different attempt from the same command without it. The other 20
+ *   are shell variable assignments joined by `;` -- statements, not prefixes --
+ *   whose value is usually a 120-character path that would be stripped down to
+ *   nothing useful.
+ *
+ *   `time`, `env`, `nice`, `sudo`, `bash -c`, `pushd`, `Set-Location`: ZERO
+ *   occurrences in 2,243 commands. Code for an unmeasured prefix is a way to
+ *   over-strip that no evidence asked for, and over-stripping merges commands
+ *   that genuinely differ -- the same bug in the other direction. `bash -c` is
+ *   worse than unmeasured: the command sits inside a quoted string, so stripping
+ *   the wrapper leaves a key beginning with a quote character.
+ *
+ *   `cd /d C:\path &&` and `cd "C:/a b" &&` need no extra rule -- the match runs
+ *   to the separator rather than counting tokens, so flags and quoted paths
+ *   containing spaces are consumed for free. Neither appears here, so neither is
+ *   claimed as tested behaviour beyond its unit test.
+ *
+ * A `cd` with NO separator is left alone: `cd <path>` on its own ran no command,
+ * and its key is as meaningless afterwards as before -- there is nothing to
+ * recover. Stripping is repeated up to `MAX_DIR_PREFIXES` times so
+ * `cd a && cd b && cmd` reaches `cmd`; the bound exists only so a pathological
+ * line cannot loop, since each pass must consume a whole `cd ... <sep>`.
+ *
+ * APPLIED IDENTICALLY TO BOTH SOURCES because it is applied INSIDE `attemptKey`,
+ * which is the single function both the event path and the transcript reader's
+ * output pass through. The 120-character anchor cap that makes the two agree on
+ * 266 of 266 keys is untouched and still applied on both sides before this runs.
+ */
+const DIR_PREFIX = /^\s*cd\s[^\r\n;&|]*?(?:&&|;|\r?\n)\s*/i;
+const MAX_DIR_PREFIXES = 4;
+
+/**
+ * The command text with any leading directory change removed.
+ *
+ * Used for the key AND for the identical-text refusal, which is the half that
+ * keeps this from becoming a licence to pair more loosely: without it,
+ * `cd repo && npm test` failing and `npm test` succeeding would emit
+ * "`npm test` succeeded where `cd repo && npm test` failed" at 0.90 -- two
+ * spellings of one attempt, dressed up as a difference that mattered. The
+ * claim itself still quotes the RAW command, because that is what ran.
+ */
+export function commandBody(command) {
+  let text = String(command || '');
+  for (let i = 0; i < MAX_DIR_PREFIXES; i++) {
+    const stripped = text.replace(DIR_PREFIX, '');
+    if (stripped === text) break;
+    text = stripped;
+  }
+  return text;
+}
+
+/**
  * The prefix that makes two invocations "the same attempt".
  *
  * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
@@ -194,7 +271,7 @@ const CORRECTION_OPENER =
  * ships a false claim into model context.
  */
 export function attemptKey(command) {
-  return String(command || '')
+  return commandBody(command)
     .trim()
     .split(/\s+/)
     .filter((token) => token && !token.startsWith('-'))
@@ -494,7 +571,14 @@ export function derive(dir, options = {}) {
           // is real and supports NEITHER claim, so nothing is emitted. This is
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
-          if (failed.command === outcome.command) continue;
+          // COMPARED WITH THE DIRECTORY CHANGE REMOVED, for the same reason
+          // the key is. `cd repo && npm test` and `npm test` are one attempt
+          // spelled two ways; before `commandBody` they landed in different
+          // groups and never met, and letting them meet without widening this
+          // guard would emit "`npm test` succeeded where `cd repo && npm test`
+          // failed" at 0.90 -- a difference in the claim that is not a
+          // difference in what ran. Same for two `cd`s to different paths.
+          if (commandBody(failed.command) === commandBody(outcome.command)) continue;
 
           // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
           // client both sides of almost every pair are truncated multi-line
@@ -502,10 +586,12 @@ export function derive(dir, options = {}) {
           // spending the retrieval budget of every later session.
           if (!quotable(failed.command) || !quotable(outcome.command)) continue;
 
-          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
-          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
-          // command lines in this repository alone, and any pair drawn from that
-          // group is a false claim about both halves.
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`. The
+          // `cd <path> &&` case that grouped 547 unrelated command lines in this
+          // repository is now handled earlier by `commandBody`; what is left
+          // here is every OTHER separator -- `git fetch && <anything>`, a
+          // pipeline, a `;`-joined pair -- where the key still names no single
+          // attempt and any pair drawn from it is false about both halves.
           if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =

--- a/integrations/kilo/hooks/lib/derive.mjs
+++ b/integrations/kilo/hooks/lib/derive.mjs
@@ -1,0 +1,385 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/derive.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Findings from data we already hold, with no model call.
+ *
+ * WHY THIS EXISTS. The semantic harvest is on by default but its real gate is a
+ * credential: `harvestMode()` returns `off:no-key` on any machine without one,
+ * which is CI, corporate laptops, and every subscription-only login. This
+ * repository's own graph is the evidence -- 2,965 symbol nodes, 904 file nodes,
+ * 128 task nodes and ONE finding -- because the structural layer accumulates
+ * from ordinary tool traffic while every verdict needed an API key this machine
+ * does not have.
+ *
+ * Everything here is derived from outcomes, transitions and corrections that are
+ * ALREADY RECORDED LOCALLY. Nothing is sent anywhere, nothing is billed, so
+ * there is nothing to consent to and this runs by default. It is the only
+ * finding producer on a machine without a key.
+ *
+ * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
+ * second command fixed the first -- an intervening edit, a dependency install or
+ * a flaky test explains it just as well. So each detector carries a confidence
+ * ceiling, the claim text says only what was OBSERVED, and the two shapes where
+ * the observation supports no claim at all are refused rather than downgraded
+ * (see `attemptKey` and the identical-text guard below).
+ *
+ * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
+ * budget, belongs to the caller.
+ */
+
+import { readMetrics, rereadsByAnchor } from './metrics.mjs';
+import { readArchive, readTurns } from './transcript.mjs';
+import { redact } from './redact.mjs';
+
+/**
+ * Ceilings, ordered by how much the evidence actually supports.
+ *
+ * A command that succeeded where a DIFFERENT command failed is close to a direct
+ * observation. A test or build going red-to-green is weaker, because the usual
+ * cause is the code changing between the two runs rather than anything about the
+ * command. A correction is a lexical guess about what a human meant. Churn
+ * describes our own reading behaviour and says nothing about the code at all.
+ */
+export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+
+/** Claim text cap. A finding is one sentence; a paragraph is evidence. */
+const CLAIM_MAX = 300;
+const EVIDENCE_MAX = 400;
+
+/** Bounded so a pathological log cannot turn session end into real work. */
+const MAX_CANDIDATES = 200;
+
+/**
+ * Commands whose red-to-green transition is usually explained by the CODE
+ * changing rather than by the command. They get the lower ceiling.
+ */
+const CODE_SENSITIVE = /\b(test|tests|jest|vitest|pytest|mocha|build|compile|tsc|lint|typecheck)\b/i;
+
+/**
+ * Openers that mark a user turn as a correction rather than an instruction.
+ *
+ * DELIBERATELY NARROW, and anchored to the START of the turn. The model-based
+ * extractor in `lessons.mjs` can read intent; this cannot, so it only claims the
+ * shapes where the first few words carry the whole signal. Recall is poor by
+ * design: a missed correction costs one finding, a false one puts words in the
+ * user's mouth at 0.6 confidence.
+ */
+const CORRECTION_OPENER =
+  /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
+
+/**
+ * The prefix that makes two invocations "the same attempt".
+ *
+ * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
+ * through what the alternatives do to real command lines:
+ *
+ *   Two tokens conflates `npm run build` with `npm run test`, and the pair then
+ *   produces "`npm run test` works where `npm run build` failed" -- a claim that
+ *   is simply false.
+ *
+ *   Counting flags splits `deploy` from `deploy --retry`, which is the single
+ *   most useful pair this detector can find, into two groups that never meet.
+ *
+ * Conservative in the remaining direction: `npm run build:prod` and
+ * `npm run build` do not pair. A missed pair costs one finding; a wrong pair
+ * ships a false claim into model context.
+ */
+export function attemptKey(command) {
+  return String(command || '')
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'))
+    .slice(0, 3)
+    .join(' ')
+    .toLowerCase();
+}
+
+/** Normalised claim text, so the same lesson derived twice is one candidate. */
+const claimKey = (type, claim) =>
+  `${type}|${String(claim).toLowerCase().replace(/\s+/g, ' ').trim()}`;
+
+/** 0.95 is reserved for verified; everything here is inference. */
+const labelFor = (confidence) => (confidence >= 0.75 ? 'probable' : 'speculative');
+
+/** A literal command prefix, safe to hand to `safeTrigger`. */
+const triggerFor = (command) =>
+  attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
+
+/**
+ * Derives finding candidates from one project's local evidence.
+ *
+ * @param {string} dir wiki directory.
+ * @param {object} options
+ * @param {string|null} options.sessionId session this ran for, for provenance.
+ * @param {string|null} options.transcriptPath live transcript, read only when the
+ *   archive holds nothing for this session yet.
+ * @param {string|null} options.projectRoot the anchor every derived claim gets.
+ *   Without it nothing is derived: an unanchored finding cannot be invalidated
+ *   and is refused by `writeHarvested` anyway, so emitting one would only spend
+ *   the caller's budget on junk.
+ * @param {string|null} options.authoritativeSessionId the session id as the HOOK
+ *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
+ *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
+ *   edge -- `taskForAnchors` returns null without one, so an unverified string
+ *   would silently produce no edge. Threaded rather than defaulted from
+ *   `sessionId`: defaulting would promote any caller's string to trusted.
+ */
+export function derive(dir, options = {}) {
+  // `options || {}` rather than a destructuring default. A default only fires on
+  // `undefined`, so a caller passing an explicitly null options object -- which
+  // is what a hook does when it has nothing to say -- threw a TypeError out of
+  // the parameter list itself, before any of the try/catch below could fail open.
+  const {
+    sessionId = null,
+    transcriptPath = null,
+    projectRoot = null,
+    authoritativeSessionId = null,
+  } = options || {};
+
+  const result = {
+    candidates: [],
+    observations: [],
+    written: [],
+    sessionId,
+    authoritativeSessionId,
+  };
+
+  let events;
+  try {
+    events = readMetrics(dir);
+  } catch {
+    // Session end must cost nothing. No evidence is not an error.
+    return result;
+  }
+  if (!Array.isArray(events)) return result;
+
+  const seen = new Set();
+  const add = (candidate) => {
+    if (result.candidates.length >= MAX_CANDIDATES) return;
+    const key = claimKey(candidate.type, candidate.claim);
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.candidates.push(candidate);
+  };
+
+  // ---- 1 & 2: a failed attempt followed by a succeeding one ---------------
+  //
+  // The event is `tool-outcome` and THE COMMAND TEXT IS IN `anchor`: there is no
+  // separate command field, because the anchor of a command surface IS the
+  // command. It is capped at 120 characters at the boundary, so a very long
+  // command line is compared and quoted truncated.
+  try {
+    if (projectRoot) {
+      const outcomes = events
+        .filter(
+          (e) =>
+            e &&
+            e.kind === 'tool-outcome' &&
+            e.surface === 'command' &&
+            typeof e.anchor === 'string' &&
+            e.anchor.trim()
+        )
+        .map((e) => ({
+          command: e.anchor.trim(),
+          output: typeof e.output === 'string' ? e.output : '',
+          exit: Number.isInteger(e.exit) ? e.exit : null,
+          at: e.at ?? 0,
+          // `success` FIRST, `exit` only as a refinement. MCP tools report no
+          // numeric code at all, so a classifier keyed on `exit !== 0` would be
+          // inert for most clients -- and `exit` is null rather than 0 precisely
+          // so that absence is not read as a clean exit.
+          failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
+        }))
+        .sort((a, b) => a.at - b.at);
+
+      const byAttempt = new Map();
+      for (const outcome of outcomes) {
+        const key = attemptKey(outcome.command);
+        if (!key) continue;
+        if (!byAttempt.has(key)) byAttempt.set(key, []);
+        byAttempt.get(key).push(outcome);
+      }
+
+      for (const run of byAttempt.values()) {
+        // The NEAREST preceding failure, not the first one in the session. With
+        // `find` over the whole run, a command that failed at 09:00 and
+        // succeeded at 17:00 after nine unrelated attempts is reported as one
+        // story.
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          // One pair per failure: a command that succeeds twice afterwards has
+          // not taught two lessons.
+          lastFailure = null;
+
+          // THE GUARD THAT REMOVES THE LARGEST JUNK CLASS. The commonest shape
+          // in a coding session is `npm run build` failing, the code being
+          // fixed, and `npm run build` succeeding -- identical text. From that
+          // pair the two available claims are "`npm run build` works where
+          // `npm run build` failed", which is incoherent, and "`npm run build`
+          // fails", which the same evidence has just disproved. The observation
+          // is real and supports NEITHER claim, so nothing is emitted. This is
+          // not a confidence question; a ceiling cannot rescue a claim whose
+          // content is wrong.
+          if (failed.command === outcome.command) continue;
+
+          const codeSensitive =
+            CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);
+          const confidence = codeSensitive ? CONFIDENCE.test : CONFIDENCE.command;
+          const derivedBy = codeSensitive ? 'test-transition' : 'command-transition';
+
+          // "SUCCEEDED WHERE", NOT "FIXES". What is observed is two outcomes in
+          // order on the same attempt; that the difference in the command line
+          // CAUSED the difference in outcome is not observed and is not claimed.
+          add({
+            type: 'command',
+            claim: redact(
+              `\`${outcome.command}\` succeeded in this project where \`${failed.command}\` failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
+                'an intervening edit or a flaky run explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: 'when about to run this command in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the failing form later succeeds unchanged'],
+            trigger: triggerFor(outcome.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+
+          // The error text, only when there is error text. Without it the claim
+          // degrades to "`X` failed with:" and nothing after the colon, which
+          // carries no information and still costs budget.
+          const firstLine = failed.output.split('\n').find((line) => line.trim()) || '';
+          if (firstLine.trim().length < 8) continue;
+          add({
+            type: 'failure',
+            claim: redact(`\`${failed.command}\` failed with: ${firstLine.trim()}`, {
+              max: CLAIM_MAX,
+            }),
+            evidence: redact(`captured output of the failing run:\n${failed.output}`, {
+              max: EVIDENCE_MAX,
+            }),
+            applicability: 'when this command is about to be run in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the same command later succeeds unchanged'],
+            trigger: triggerFor(failed.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: failed.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 3: user corrections ------------------------------------------------
+  //
+  // A `feedback` finding -- the one type whose source is a person saying the
+  // agent was wrong. The MODEL-BASED extractor for this lives in `lessons.mjs`
+  // and needs the credential this module exists to do without, so here the
+  // signal is lexical: the opening words of the user's own turn.
+  //
+  // ORIGIN IS NOT PROMOTED. `writeHarvested` grants ORIGIN_HUMAN to a finding
+  // carrying a verified verbatim quote, and the standing-rules layer selects on
+  // that origin to inject a claim on EVERY turn. The quote here would be
+  // verbatim -- it is copied out of the archive -- but whether the turn was a
+  // correction at all is a guess, and a guess must not buy always-on injection.
+  // So no `origin` and no `quote` field: this stays harvested provenance.
+  try {
+    if (projectRoot) {
+      let turns = readArchive(dir, sessionId);
+      // The archive is written by the Stop hook too, and the order of the two is
+      // not this module's to assume, so fall back to the live transcript.
+      if (!turns.length && transcriptPath) turns = readTurns(transcriptPath);
+
+      for (const turn of turns) {
+        if (!turn || turn.role !== 'user') continue;
+        const text = String(turn.text || '').trim();
+        // Long turns are new instructions with a complaint somewhere inside
+        // them; truncating one into a claim would misquote the user.
+        if (text.length < 12 || text.length > 300) continue;
+        if (!CORRECTION_OPENER.test(text)) continue;
+        add({
+          type: 'feedback',
+          claim: redact(text, { max: CLAIM_MAX }),
+          evidence: redact(`the user opened a turn with a correction: "${text}"`, {
+            max: EVIDENCE_MAX,
+          }),
+          applicability: 'when working in this project, before repeating what was corrected',
+          confidence: CONFIDENCE.correction,
+          confidenceLabel: labelFor(CONFIDENCE.correction),
+          scope: 'project',
+          invalidators: ['the user later asks for the corrected behaviour'],
+          anchors: [projectRoot],
+          derivedBy: 'correction',
+          sessionId,
+          at: Date.parse(turn.at || '') || Date.now(),
+        });
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 4: re-read churn ---------------------------------------------------
+  //
+  // NOT A FINDING, AND THAT IS THE DECISION RATHER THAN AN OMISSION.
+  //
+  // Churn is a claim about OUR OWN reading behaviour: "this file was read three
+  // times unchanged". Every finding type available is a claim about the work --
+  // `map` describes how an area of the codebase is laid out, and is
+  // content-dependent, so a churn claim filed as `map` would be checked for
+  // staleness against contents it makes no claim about and flip stale on the
+  // first edit to a file it never described. Worse, the anchors it would take
+  // are by construction the HOTTEST files in the project, which are exactly the
+  // files that already carry real findings, so a 0.4-confidence row saying
+  // nothing actionable would sit in the injection budget beside them and render
+  // on the same reads. Nothing a future agent could DO differently follows from
+  // it: it does not say what the file contains, so it cannot substitute for
+  // reading it.
+  //
+  // The signal is still worth having -- as the measurement it already is.
+  // `rereadWaste` reports it on the balance sheet, `rereadsByAnchor` names the
+  // offenders, and this returns those rows as OBSERVATIONS: computed, carried,
+  // and deliberately not competing for context. Three detectors produce
+  // findings; the fourth produces a number.
+  try {
+    for (const row of rereadsByAnchor(events).slice(0, 3)) {
+      if (!row.anchor || row.wasteful < 2) continue;
+      result.observations.push({
+        kind: 'churn',
+        anchor: row.anchor,
+        repeats: row.repeats,
+        wasteful: row.wasteful,
+        tokens: row.tokens,
+        confidence: CONFIDENCE.churn,
+        derivedBy: 'churn',
+        note: `re-read ${row.repeats} times, ${row.wasteful} of them unchanged`,
+      });
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  return result;
+}

--- a/integrations/kilo/hooks/lib/derive.mjs
+++ b/integrations/kilo/hooks/lib/derive.mjs
@@ -16,6 +16,13 @@
  * there is nothing to consent to and this runs by default. It is the only
  * finding producer on a machine without a key.
  *
+ * THREE SOURCES, NOT TWO. `tool-outcome` events, the transcript archive, and --
+ * since the transition detectors were measured to have no input at all on the
+ * primary client -- the raw transcript's FAILED tool results, which is the only
+ * place a Claude Code failure is recorded (`failedResultsFromTranscript` in
+ * transcript.mjs, and the note above `quotable` for what that measurement
+ * actually yielded).
+ *
  * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
  * second command fixed the first -- an intervening edit, a dependency install or
  * a flaky test explains it just as well. So each detector carries a confidence
@@ -32,7 +39,11 @@
 import { readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
-import { readArchive, readTurns } from './transcript.mjs';
+import {
+  readArchive,
+  readTurns,
+  failedResultsFromTranscript,
+} from './transcript.mjs';
 import { redact } from './redact.mjs';
 import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
@@ -56,6 +67,96 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * The anchor cap a command surface is stored under, restated here as a TEST.
+ *
+ * `recordToolOutcome` truncates `anchor` to 120 characters, so a command at or
+ * over that length reached this module already cut -- and `quotable` below
+ * refuses to build a claim out of the fragment.
+ */
+const COMMAND_ANCHOR_MAX = 120;
+
+/**
+ * Can this command text be QUOTED in a claim a reader could act on?
+ *
+ * THE SECOND REFUSAL OF ITS KIND, and it exists because measurement forced it.
+ * Wiring the transcript reader gave the transition detectors their first real
+ * input on this client and immediately produced four candidates at 0.9
+ * confidence whose claim text read:
+ *
+ *   `cd /c/Users/.../token-optimizer-mcp\ncat >> docs/superpowers/plans/2026-` succeeded
+ *   in this project where `cd /c/Users/.../token-optimizer-mcp\ncat > /tmp/probe3.mjs
+ *   <<'EOF'\nimport { readdirSync, readFileSync, sta` failed
+ *
+ * -- two truncated fragments of throwaway shell scripts, grouped together only
+ * because `attemptKey`'s three tokens were spent on `cd`, the absolute path, and
+ * the verb. Then measured properly across three real transcripts: **0 of 83**
+ * captured command failures are single-line and inside the cap. 65% of this
+ * project's 2,178 successful command outcomes are not either. On this client a
+ * "command" is usually a whole shell script, so the attempt identity the
+ * transition detectors are built on does not fit most of the traffic.
+ *
+ * This is the same judgement as the identical-text guard below rather than a
+ * confidence question: a claim whose subject is a truncated fragment of a
+ * program is not a weaker claim, it is not a claim. A raised cap would not
+ * rescue it -- quoting the whole 500-character heredoc is no more actionable.
+ *
+ * What survives is exactly what the detector was designed for: `npm test`,
+ * `dotnet build X`, `deploy --retry` -- a repeatable command someone could run
+ * again. This machine captured none failing, which is why the honest yield here
+ * is zero and why that is reported rather than dressed up.
+ *
+ * Applied to BOTH sources. Where the evidence arrived from has no bearing on
+ * whether the resulting sentence says anything, and a rule that let events
+ * through would ship the junk on the ten clients that do report failures.
+ */
+const quotable = (command) => {
+  const text = String(command || '');
+  return (
+    text.trim().length > 0 &&
+    !/[\r\n]/.test(text) &&
+    text.length < COMMAND_ANCHOR_MAX
+  );
+};
+
+/**
+ * Tokens that separate one command from the next rather than naming one.
+ *
+ * MEASURED, LIKE EVERY OTHER REFUSAL HERE. `attemptKey` spends up to three
+ * non-flag tokens on identity, and the habit on this machine is
+ * `cd <absolute path> && <the real command>` -- which spends all three on `cd`,
+ * the path and `&&`, so the real command never enters the key. This project's
+ * own evidence: the single key `cd c:/users/.../token-optimizer-mcp &&` covers
+ * **539 distinct command lines**. One quotable failure in that group would pair
+ * with an arbitrary unrelated success and claim "`cd repo && grep -n ...`
+ * succeeded where `cd repo && git merge ...` failed", which is false about both.
+ *
+ * A KEY THAT REACHED A SEPARATOR NEVER REACHED A COMMAND, so there is no attempt
+ * to compare and nothing to claim -- the same judgement as the identical-text
+ * guard rather than a lower ceiling. Narrow on purpose: `2>&1` and `/F` are not
+ * separators and do not trip this, so `cat commitlint.config.mjs 2>&1` and
+ * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
+ * found across 163 transcripts on this machine it refuses 2 and keeps 6.
+ *
+ * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
+ * building the key, so the claim is about `npm test` rather than about the `cd`.
+ * That changes `attemptKey` for every client and every finding already derived
+ * from it, so it belongs in its own change with its own comparison.
+ */
+const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
+
+/**
+ * Did `attemptKey` actually capture a command, or only how one was chained?
+ *
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * One check per pair is enough: both halves share the key by construction.
+ */
+const hasAttemptIdentity = (command) =>
+  attemptKey(command)
+    .split(' ')
+    .filter(Boolean)
+    .every((token) => !COMMAND_SEPARATORS.has(token));
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -274,6 +375,17 @@ export function derive(dir, options = {}) {
   // separate command field, because the anchor of a command surface IS the
   // command. It is capped at 120 characters at the boundary, so a very long
   // command line is compared and quoted truncated.
+  //
+  // TWO SOURCES OF FAILURE, ONE PAIRING LOOP. Claude Code never fires
+  // PostToolUse for a failed tool call -- 2,238 of 2,238 live `tool-outcome`
+  // events on the measuring machine carry `success: true`, and a deliberately
+  // failing command produced no event at all -- so on the primary client these
+  // two detectors had NO INPUT WHATSOEVER while working normally on the ten
+  // adapter clients. `failedResultsFromTranscript` supplies the missing half
+  // from the only place it exists. The successes still come from events only:
+  // a transcript failure that pairs with nothing stays unclaimed, which is also
+  // what keeps a failure from ANOTHER project's directory out of this project's
+  // graph -- a candidate cannot be emitted without a success recorded HERE.
   try {
     if (projectRoot) {
       const outcomes = events
@@ -290,6 +402,9 @@ export function derive(dir, options = {}) {
           output: typeof e.output === 'string' ? e.output : '',
           exit: Number.isInteger(e.exit) ? e.exit : null,
           at: e.at ?? 0,
+          // Carried purely so the transcript merge below can recognise the same
+          // tool call arriving from the other source.
+          toolCallId: e.toolCallId ? String(e.toolCallId) : null,
           // `success` FIRST, `exit` only as a refinement. MCP tools report no
           // numeric code at all, so a classifier keyed on `exit !== 0` would be
           // inert for most clients -- and `exit` is null rather than 0 precisely
@@ -297,6 +412,53 @@ export function derive(dir, options = {}) {
           failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
         }))
         .sort((a, b) => a.at - b.at);
+
+      // DEDUPLICATED ON `toolCallId`, which is the SAME STRING in both sources:
+      // `episodeMeta` reads `raw.tool_use_id` into `toolCallId`, and that is the
+      // transcript's `tool_use_id` verbatim -- verified against live evidence
+      // (`toolu_01L4Nwr...` in metrics.jsonl, the same ids in the transcript).
+      // So on the ten clients that DO report failures, the event copy wins and
+      // the transcript copy is dropped before grouping. Without this the two
+      // copies of one failure would sit in the same run and the second of them
+      // would be paired against the first as a failed-then-succeeded story about
+      // itself.
+      //
+      // The fallback covers a client that reports a failure with no call id:
+      // identical command text within two seconds is one failure recorded twice,
+      // not two failures, because nothing re-runs a command that fast.
+      const eventIds = new Set(
+        outcomes.map((o) => o.toolCallId).filter(Boolean)
+      );
+      const eventFailures = outcomes.filter((o) => o.failed);
+      const alreadyRecorded = (failure) => {
+        if (failure.toolCallId && eventIds.has(failure.toolCallId)) return true;
+        return eventFailures.some(
+          (o) =>
+            o.command === failure.command &&
+            Math.abs((o.at || 0) - (failure.at || 0)) <= 2000
+        );
+      };
+
+      let transcriptFailures = [];
+      try {
+        transcriptFailures = failedResultsFromTranscript(transcriptPath).filter(
+          (failure) => failure.command.trim() && !alreadyRecorded(failure)
+        );
+      } catch {
+        // The reader is an extra source, never a reason the detector stops.
+      }
+      for (const failure of transcriptFailures) {
+        outcomes.push({
+          command: failure.command.trim(),
+          output: failure.output,
+          exit: failure.exit,
+          at: failure.at,
+          toolCallId: failure.toolCallId,
+          // Read from `Exit code N`, which is the only shape the reader admits.
+          failed: true,
+        });
+      }
+      if (transcriptFailures.length) outcomes.sort((a, b) => a.at - b.at);
 
       const byAttempt = new Map();
       for (const outcome of outcomes) {
@@ -333,6 +495,18 @@ export function derive(dir, options = {}) {
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
           if (failed.command === outcome.command) continue;
+
+          // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
+          // client both sides of almost every pair are truncated multi-line
+          // shell scripts, and a claim quoting a fragment of one is noise
+          // spending the retrieval budget of every later session.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
+          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
+          // command lines in this repository alone, and any pair drawn from that
+          // group is a false claim about both halves.
+          if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =
             CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);

--- a/integrations/kilo/hooks/lib/doctor.mjs
+++ b/integrations/kilo/hooks/lib/doctor.mjs
@@ -197,7 +197,8 @@ function hooksDirFor({ hooksDir, install, root }) {
  * identical from outside: a graph that fills with structural nodes either way.
  *
  * Measured on a real 5.4.0 install: 484 symbol, 286 file and 122 task nodes and
- * ZERO findings, because harvestMode() was 'off:not-opted-in'. Fifteen checks
+ * ZERO findings, because harvestMode() then returned an opt-in refusal (the mode has
+ * since been renamed: it is 'off:no-key' now, and opting in is no longer the gate). Fifteen checks
  * passed and none mentioned harvest. stop-harvest.mjs names this exact gap --
  * "nothing in doctor, audit or waste mentions harvest, so a user sees a graph
  * filling with structural nodes and no findings and has no way to learn why" --
@@ -221,9 +222,15 @@ export function probeHarvest() {
   // optimizer is off" is noise, which is why stop-harvest maps it to no notice.
   if (mode === 'off:mode') return [];
 
+  // SAID PLAINLY, because this is the configuration a user would choose if they
+  // knew it existed and the previous wording buried it in machinery. A local
+  // endpoint is the only setting under which the semantic harvest runs with no
+  // credential, no billing and no digest leaving the machine -- so the two facts
+  // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
     return [ok('finding extraction is available',
-      'active-model wiki_write is primary; local endpoint also enables fallback extraction')];
+      'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
+      'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
@@ -233,10 +240,19 @@ export function probeHarvest() {
 
   // No second-model credential is required for the primary path. The Codex/agent session that
   // already paid to derive the conclusion is the extractor and wiki_write is local.
+  // NAME THE TRADE, not just the missing variable. This is the default state on
+  // every machine without a credential, so it is the text most users will read,
+  // and "unavailable" alone tells them neither what they are missing nor that
+  // the free option exists. Local findings still accumulate: derive.mjs reads
+  // exit codes, red-to-green transitions, corrections and churn out of evidence
+  // already on disk and sends nothing anywhere.
   if (mode === 'off:no-key') {
     return [ok('finding extraction is available',
-      'active model records durable conclusions through local wiki_write; no separate-model ' +
-      'credential is configured, so fallback transcript extraction is unavailable')];
+      'active model records durable conclusions through local wiki_write, and derive runs at ' +
+      'session end with no credential. No separate-model credential is configured, so fallback ' +
+      'transcript extraction is unavailable: point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local ' +
+      'model to run it free and private, or set TOKEN_OPTIMIZER_API_KEY to run it from a bounded ' +
+      'digest of paths, commands, prompts and conclusions -- never file contents')];
   }
 
   // off:opted-out -- a deliberate choice, reported as one. Nagging about a setting somebody chose

--- a/integrations/kilo/hooks/lib/inject.mjs
+++ b/integrations/kilo/hooks/lib/inject.mjs
@@ -1134,10 +1134,25 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // injected more than the budget allowed and recorded fewer tokens than it
   // spent -- in a block whose entire justification is that it is tightly
   // bounded and measured against the control arm.
+  // THE LAST LINE IS HOW THE NEXT RULE GETS HERE, and it is one line because
+  // this block is charged on every session forever. A rule reaches this list
+  // only by being pinned or by being a person's verified correction, and both
+  // start as a `wiki_write` -- so a model reading a set of standing rules with
+  // no idea how they were produced has no way to add to it. Stated at the point
+  // of the evidence rather than as a separate always-on block: the reader is
+  // already looking at the output of the mechanism being described.
+  //
+  // THE COLD GRAPH IS COVERED ELSEWHERE, deliberately. Nothing here renders
+  // until at least one rule qualifies, which is the property the always-on
+  // budget depends on, so this line cannot be the first-session nudge --
+  // `policyText`'s "Record what you work out" section is, and it is emitted at
+  // SessionStart whether or not the graph holds anything.
   const HEADING =
     '# Standing rules for this project' +
     '\n\nEstablished in previous sessions and expected to hold. ' +
-    'These are not suggestions.\n\n';
+    'These are not suggestions.\n\n' +
+    'Record what you work out with wiki_write and a real file anchor; ' +
+    'that is how a rule reaches this list.\n\n';
   const noticeFor = (n) =>
     n
       ? `\n(${n} further standing rule${n === 1 ? '' : 's'} did not fit this budget; ` +

--- a/integrations/kilo/hooks/lib/inject.mjs
+++ b/integrations/kilo/hooks/lib/inject.mjs
@@ -35,6 +35,7 @@ import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
 import { cacheOrdered } from './cache.mjs';
+import { withheldFor, exploreOrder, servingPolicyVersion, LOO_ENABLED } from './loo.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -311,8 +312,38 @@ export function forTouch(
     });
     for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
   }
-  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  // LAYER 2 EXPLORATION, BEFORE the budget decides.
+  //
+  // `assessed.eligible` arrives in net-utility order and `fit` keeps that order
+  // until the budget runs out -- so the ranking decides which findings are ever
+  // served, which decides which ever accumulate observations, which decides
+  // their utility. A tenth of touches therefore promote the least-served
+  // candidate first. This is the only place it can go: after `fit` the choice
+  // has already been made.
+  const ordered = exploreOrder(assessed.eligible, dir, { sessionId, anchor: filePath });
+  const { kept, spent } = fit(ordered.map((item) => item.finding), budget);
   if (!kept.length) return null;
+
+  // LAYER 2 WITHHOLDING, AFTER the budget decides, which is the only ordering
+  // that produces a leave-one-out rather than a substitution: withholding first
+  // would let the next-ranked finding take the freed tokens, so the withheld
+  // arm would differ from the served arm by two findings instead of one and the
+  // effect would belong to neither.
+  //
+  // `holdout` is passed so the two experiments cannot compose into "withhold
+  // everything and call it a leave-one-out": that arm already serves nothing.
+  const withheld = withheldFor(kept.map((finding) => finding.key), sessionId, graph, dir, {
+    surface: 'file',
+    anchor: filePath,
+    holdout,
+  });
+  const delivered = withheld ? kept.filter((finding) => finding.key !== withheld) : kept;
+  // RE-PRICED, because `fit` priced what it KEPT and this delivers less. Using
+  // `spent` would bill the injection-cost side of the balance sheet for text
+  // the model never received.
+  const deliveredSpent = withheld
+    ? delivered.reduce((sum, finding) => sum + estimate(render(finding)), 0)
+    : spent;
 
   record(dir, {
     kind: 'inject',
@@ -321,15 +352,20 @@ export function forTouch(
     surface: 'file',
     anchor: filePath,
     holdout,
-    tokens: holdout ? 0 : spent,
-    deliveredTokens: holdout ? 0 : spent,
+    tokens: holdout ? 0 : deliveredSpent,
+    deliveredTokens: holdout ? 0 : deliveredSpent,
     shadowTokens: spent,
-    count: holdout ? 0 : kept.length,
+    count: holdout ? 0 : delivered.length,
     candidateCount: kept.length,
-    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    findingIds: holdout ? [] : delivered.map((finding) => finding.key),
     shadowFindingIds: kept.map((finding) => finding.key),
-    stale: kept.some((f) => f.stale),
+    stale: delivered.some((f) => f.stale),
     sessionId,
+    // ON EVERY RECORD, not only the withheld ones. A served observation needs
+    // the policy version as much as a withheld one does, or `effects` cannot
+    // keep the two arms of one comparison inside one policy.
+    ...(LOO_ENABLED() ? { looPolicy: servingPolicyVersion() } : {}),
+    ...(withheld ? { loo: withheld } : {}),
   });
 
   // MARKED SEEN IN BOTH ARMS, for the same reason as the command path: a file
@@ -339,11 +375,16 @@ export function forTouch(
   // grow faster purely from repetition.
   //
   // This is the identical defect that was fixed in `forCommand` and not here.
+  //
+  // THE WITHHELD KEY IS MARKED TOO, and that is load-bearing rather than tidy:
+  // an unmarked one would be a candidate again on the next touch of this file,
+  // where the one-per-touch tiebreak could serve it -- flipping its arm inside
+  // the very session the arm hash exists to pin it for.
   for (const f of kept) alreadyInjected.add(f.key);
 
-  if (holdout || !kept.length) return null;
+  if (holdout || !delivered.length) return null;
 
-  return `Known about ${filePath} (from previous sessions):\n${kept.map(render).join('\n')}`;
+  return `Known about ${filePath} (from previous sessions):\n${delivered.map(render).join('\n')}`;
 }
 
 /**

--- a/integrations/kilo/hooks/lib/keepwarm.mjs
+++ b/integrations/kilo/hooks/lib/keepwarm.mjs
@@ -30,6 +30,15 @@ import { record, readMetrics, readBalance } from './metrics.mjs';
 import { WRITE_MULTIPLIER, READ_MULTIPLIER } from './cache.mjs';
 
 /**
+ * The shortest gap that counts as a NEW turn rather than a burst inside one.
+ *
+ * Shared by the gap distribution and by the hit test, because they have to
+ * agree about what a turn is. Two copies of this number would let the decision
+ * be fitted to one definition of a turn and scored against another.
+ */
+export const TURN_GAP_MS = 250;
+
+/**
  * TTL tiers, with what a WRITE costs at each.
  *
  * A five-minute entry is written at 1.25x a plain input token; the one-hour
@@ -85,7 +94,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
     for (let i = 1; i < session.length; i++) {
       const gap = session[i] - session[i - 1];
       // A burst of events inside one turn is not a gap between turns.
-      if (gap > 250) gaps.push(gap);
+      if (gap > TURN_GAP_MS) gaps.push(gap);
     }
   }
   if (gaps.length < 6) return null;
@@ -105,10 +114,91 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
 }
 
 /**
+ * Refreshes to observe at a tier before the observation may bound the decision.
+ *
+ * THE SAME NUMBER THE BACKSTOP DEMANDS, deliberately. The decision and the
+ * tripwire read the same ledger, so letting them disagree about when there is
+ * enough evidence would mean one of them acting on a sample the other calls too
+ * small. Below the floor the decision keeps its expected-value answer, so a
+ * single unlucky miss changes nothing at all.
+ *
+ * NOT A CONFIDENCE INTERVAL, and the reason is arithmetic rather than taste. A
+ * Wilson 95% upper bound at ten refreshes and zero hits is 0.28 -- so a policy
+ * that missed ten times out of ten would still be recommended, which is exactly
+ * the case the loop exists to catch. The point estimate is safe here because of
+ * the bound below: an observation may only ever LOWER the modelled probability,
+ * so sampling noise cannot manufacture a refresh, and the tripwire's realised
+ * ledger is a second guard underneath.
+ */
+export const OBSERVATION_FLOOR = TRIPWIRE_MIN;
+
+/**
+ * The measured hit rate per tier, from recorded outcomes.
+ *
+ * Tiers below the floor are ABSENT rather than present with a small n, because
+ * a rate carrying no weight is the thing most likely to be used as though it
+ * did.
+ */
+export function observedHitRates(outcomes = []) {
+  const byTier = new Map();
+  for (const event of outcomes) {
+    if (event?.kind !== 'keepwarm' || event.action !== 'outcome') continue;
+    const name = TIERS.some((t) => t.name === event.tier) ? event.tier : TIERS[0].name;
+    const row = byTier.get(name) || { refreshes: 0, hits: 0 };
+    row.refreshes += 1;
+    if (event.hit) row.hits += 1;
+    byTier.set(name, row);
+  }
+
+  const qualified = new Map();
+  for (const [name, row] of byTier) {
+    if (row.refreshes < OBSERVATION_FLOOR) continue;
+    qualified.set(name, { ...row, rate: row.hits / row.refreshes });
+  }
+  return qualified;
+}
+
+/**
+ * What the refreshes at this tier actually did, if enough of them have.
+ *
+ * Tolerates being handed anything -- null, a plain object, a Map -- because the
+ * callers are two public functions whose options object is assembled by other
+ * people's code.
+ */
+function observationsFor(observed, tierName) {
+  const row = observed instanceof Map ? observed.get(tierName) : null;
+  return row && Number.isFinite(row.rate) ? row : null;
+}
+
+/**
+ * The modelled probability, BOUNDED BY what was observed and never raised by it.
+ *
+ * The asymmetry is the whole point and runs against this project's interest. A
+ * recorded `hit` says only that a turn arrived before the entry expired; it
+ * cannot say the refresh is what kept the entry alive, because a turn arriving
+ * one minute after a five-minute ping would have found the entry warm anyway.
+ * So the observed rate is an UPPER bound on a refresh's value, and substituting
+ * it for the model would flatter keep-warm badly: on the machine this was
+ * written on, the modelled ping probability is 0.2% and the observable
+ * before-expiry rate is 99.5%, so the substitution would recommend refreshing
+ * forever. A low rate, by contrast, is real evidence against: if turns do not
+ * even arrive inside the TTL, the refresh certainly bought nothing.
+ */
+function bounded(modelled, seen) {
+  return seen ? Math.min(modelled, seen.rate) : modelled;
+}
+
+/**
  * Should we refresh this prefix now?
  *
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
+ *
+ * `observed` is passed IN rather than read from disk here: this function is
+ * pure, its purity is what lets the tests build a distribution by hand, and
+ * `shouldKeepWarm` has already read the outcome log for the tripwire -- so
+ * threading the reader in here would be a second read of the same file and a
+ * second place for the window discipline to be got wrong.
  */
 export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
@@ -125,42 +215,30 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
   const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
-
-  // MEASURED BEATS MODELLED, once there is enough of it.
-  //
-  // The module header already commits to this -- "an expected-value decision is
-  // only as good as the distribution it was fitted to, and distributions
-  // shift" -- and the tripwire underneath was the only thing acting on it, as
-  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
-  // entirely" there was nothing, because the observed hit rate was never
-  // computed: both recording halves had no call site, so ten refreshes that
-  // bought nothing would keep recommending refresh right up to the moment the
-  // tripwire cut the whole feature off.
-  //
-  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
-  // handful of samples would swing the decision harder than the distribution
-  // they replace.
-  const probability = observed ? observed.rate : modelled;
+  const seen = observationsFor(observed, tier.name);
+  const probability = bounded(modelled, seen);
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
-  const basis = observed
-    ? `measured over ${observed.observations} refreshes`
-    : 'modelled from the gap distribution';
+  const note = seen && probability < modelled
+    ? `; bounded by ${seen.refreshes} observed refreshes, ` +
+      `${Math.round(seen.rate * 100)}% used before expiry`
+    : '';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
     modelledProbability: modelled,
-    basis,
+    observedHitRate: seen ? seen.rate : null,
+    observedRefreshes: seen ? seen.refreshes : 0,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
-    reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
+    reason: (ev > 0
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
-        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`) + note,
   };
 }
 
@@ -171,7 +249,12 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
  * long enough that the short tier keeps missing. Returns null when neither tier
  * pays, which is a real answer and the one a default-on product never gives.
  */
-export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS }) {
+export function ttlTier({
+  prefixTokens,
+  gaps,
+  turnsPerSession = DEFAULT_TURNS,
+  observed = null,
+}) {
   if (!prefixTokens || !gaps) return null;
 
   // Expected cost of a turn under each tier, as a multiple of what the prefix
@@ -179,7 +262,16 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   // again; and the FIRST write is amortised over the session, which is what
   // stops the expensive tier from looking free whenever gaps are short.
   const costOf = (tier) => {
-    const hit = gaps.probabilityWithin(tier.ms);
+    // THE SAME QUANTITY THE OUTCOMES RECORD, which is what makes the
+    // observation admissible here at all. `hit` is P(a turn arrives before the
+    // entry expires) and `recordRefreshOutcome`'s `hit` is exactly that event,
+    // measured -- unlike keepWarmDecision, whose probability is the narrower
+    // ping window and for which the same observation is only an upper bound.
+    // Bounded rather than replaced even so: a sample drawn only from moments we
+    // CHOSE to refresh is not a sample of gaps, and its bias runs our way.
+    const modelled = gaps.probabilityWithin(tier.ms);
+    const seen = observationsFor(observed, tier.name);
+    const hit = bounded(modelled, seen);
     const perTurn = hit * READ_MULTIPLIER + (1 - hit) * tier.writeMultiplier;
     // THE SUPPLIED VALUE, not only the computed one. Math.max(1, NaN) is NaN -- Math.max
     // propagates it rather than clamping -- so perTurn became NaN, the `perTurn >= 1` guard below
@@ -192,6 +284,8 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     return {
       tier,
       hit,
+      seen,
+      boundedByObservation: Boolean(seen) && hit < modelled,
       perTurn: (tier.writeMultiplier + (turns - 1) * perTurn) / turns,
     };
   };
@@ -208,99 +302,53 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     action: 'refresh',
     tier: best.tier.name,
     hitProbability: best.hit,
+    observedHitRate: best.seen ? best.seen.rate : null,
+    observedRefreshes: best.seen ? best.seen.refreshes : 0,
     expectedCostPerTurn: Number(best.perTurn.toFixed(3)),
     expectedValue: Math.round((1 - best.perTurn) * prefixTokens),
     reason: `${Math.round(best.hit * 100)}% of gaps land inside ${best.tier.name}; ` +
-      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached`,
+      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached` +
+      (best.boundedByObservation
+        ? `, bounded by ${best.seen.refreshes} observed refreshes ` +
+          `(${Math.round(best.seen.rate * 100)}% used before expiry)`
+        : ''),
   };
 }
 
-/** Observations of a tier before its measured hit rate may override the model. */
-export const OBSERVATION_FLOOR = 5;
-
-/** Records a refresh so its outcome can be scored. */
-export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
-  record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
-}
-
 /**
- * Scores every refresh whose window has since resolved.
+ * Records a refresh so its outcome can be scored.
  *
- * THE MISSING HALF, and it was missing because nobody could see where the
- * signal would come from. `recordRefreshOutcome` needs to know whether a real
- * turn arrived before the entry expired -- and that is not a thing anyone has
- * to instrument, because the event log already records when every turn
- * happened. The answer was in the data the whole time.
+ * `sessionId` IS REQUIRED FOR THE REFRESH TO BE SCOREABLE, and is not defaulted
+ * to anything. The hit test asks whether a turn of THIS conversation arrived
+ * before expiry; pooling arrivals across sessions would let a second concurrent
+ * session's turn pay for this one's ping, which manufactures hits. A refresh
+ * recorded without one is kept in the ledger and reported as unattributable
+ * rather than guessed at.
  *
- * For each unscored refresh at time T on a tier with TTL `ms`:
- *
- *   - a later event within `ms`            -> HIT, observed
- *   - a later event after `ms`             -> MISS, observed
- *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
- *                                             demonstrably closed unused
- *   - no later event, window still open    -> NOTHING RECORDED
- *
- * That last line is the important one and it is Plan 2's own instruction: "if
- * no signal is available for a tier, record nothing rather than guessing
- * `hit: false`". A refresh whose window has not closed yet is not a miss, and
- * scoring it as one would drive the tripwire negative on the newest and least
- * informative records.
- *
- * DRAINED AT READ TIME, which is the pattern this codebase already uses for
- * staleness: the producer cannot know the outcome at the moment it acts, so the
- * next reader resolves what has become knowable since.
+ * Returns the stored record, whose `id` is what `scoreRefreshes` pairs the
+ * outcome to, so an issuer can hold onto it.
  */
-export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
-  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
-  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
-  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
-
-  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
-  // so everything past the number already scored is outstanding. Pairing by
-  // timestamp instead would double-count two refreshes recorded in the same
-  // millisecond, which is reachable: a tool run twice in a loop.
-  const outstanding = refreshes.slice(scored);
-  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
-
-  let recorded = 0;
-  for (const refresh of outstanding) {
-    const at = Number(refresh.at) || 0;
-    if (!at) continue;
-    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
-    const next = timeline.find((t) => t > at);
-
-    let hit;
-    if (next !== undefined) hit = next - at <= tierSpec.ms;
-    else if (now - at > tierSpec.ms) hit = false;
-    else continue; // window still open: not yet knowable
-
-    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
-    recorded += 1;
-  }
-  return { outstanding: outstanding.length, recorded };
-}
-
-/**
- * The measured hit rate for a tier, or null below the observation floor.
- *
- * Null rather than a small-sample number, because the caller substitutes it for
- * a modelled probability and three observations would swing the decision harder
- * than the model they replace.
- */
-export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
-  const relevant = outcomes.filter(
-    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
-  );
-  if (relevant.length < OBSERVATION_FLOOR) return null;
-  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
+export function recordRefresh(dir, { tier, prefixTokens, expectedValue, sessionId, at }) {
+  return record(dir, {
+    kind: 'keepwarm',
+    action: 'refresh',
+    tier,
+    prefixTokens,
+    expectedValue,
+    sessionId,
+    at,
+  });
 }
 
 /**
  * Records whether the refresh was used.
  *
  * `hit` means a real turn arrived before expiry, so the write bought a read.
+ * `refreshId` names the refresh this scores, so the same one cannot be scored
+ * twice -- once per turn for the rest of the session, which is what an
+ * unpaired outcome would become.
  */
-export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
+export function recordRefreshOutcome(dir, { tier, prefixTokens, hit, refreshId = null }) {
   const tierSpec = TIERS.find((t) => t.name === tier) || TIERS[0];
   // THE SAME LEDGER keepWarmDecision BUYS THE REFRESH WITH. That function is explicit that a
   // refresh is a PING, which READS the prefix -- costOfPing = prefixTokens * READ_MULTIPLIER --
@@ -317,7 +365,125 @@ export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
   const realised = hit
     ? prefixTokens * (tierSpec.writeMultiplier - READ_MULTIPLIER) - prefixTokens * READ_MULTIPLIER
     : -prefixTokens * READ_MULTIPLIER;
-  record(dir, { kind: 'keepwarm', action: 'outcome', tier, prefixTokens, hit: Boolean(hit), realised: Math.round(realised) });
+  record(dir, {
+    kind: 'keepwarm',
+    action: 'outcome',
+    tier,
+    prefixTokens,
+    hit: Boolean(hit),
+    refreshId,
+    realised: Math.round(realised),
+  });
+}
+
+/**
+ * Scores every recorded refresh whose window has closed -- and NOTHING ELSE.
+ *
+ * This is the arm that was missing. `recordRefresh` and `recordRefreshOutcome`
+ * were both correct and both called by nothing, so the decision spent money on
+ * refreshes and could never find out whether one bought a read.
+ *
+ * THE SIGNAL IS REAL, not invented. `gapDistribution` already treats this log's
+ * timestamps as turn arrivals -- that is the distribution the whole decision is
+ * fitted to -- so the same log answers the outcome question directly: a refresh
+ * at tier `5m` was used if a turn of the same session arrived within five
+ * minutes of it. Four cases refuse to answer rather than guess, and every one
+ * of them refuses in the direction that costs this project its own good news:
+ *
+ *   - `pending`: the window has not closed yet. A hit could be scored the
+ *     instant it arrives while a miss must wait out the whole TTL, so scoring
+ *     early would mean the recorded hits are always complete and the recorded
+ *     misses always lagging -- right-censoring, biased upward, invisible in any
+ *     test. So a hit waits exactly as long as a miss.
+ *   - `uncovered`: the arrival log no longer reaches back to the refresh, so
+ *     absence of an arrival is absence of evidence. RECORDING `hit: false` HERE
+ *     WOULD BE THE INVENTION THIS IS FORBIDDEN TO MAKE: an absent signal is not
+ *     a miss, and treating it as one biases every rate downward and would
+ *     eventually switch keep-warm off on no evidence at all.
+ *   - `unattributable`: the refresh names no session, so no arrival can be
+ *     shown to belong to it.
+ *   - already scored: an outcome already names this refresh.
+ *
+ * The firehose is READ LAZILY, and only when there is something to score. On a
+ * machine where nothing issues refreshes -- which is every machine today, since
+ * nothing in this repository issues one -- the whole cost is the outcome-log
+ * read: median 70 ms on a 3.5 MB log, of which readBalance is 49 ms, because
+ * that reader also scans the firehose tail for pre-split records.
+ */
+export function scoreRefreshes(dir, {
+  refreshes = readBalance(dir),
+  arrivals = null,
+  now = Date.now(),
+} = {}) {
+  const summary = { scored: 0, hits: 0, pending: 0, uncovered: 0, unattributable: 0 };
+  const keepwarm = refreshes.filter((event) => event?.kind === 'keepwarm');
+  const alreadyScored = new Set(
+    keepwarm
+      .filter((event) => event.action === 'outcome' && event.refreshId)
+      .map((event) => event.refreshId)
+  );
+  const unscored = keepwarm.filter(
+    (event) =>
+      event.action === 'refresh' &&
+      Number.isFinite(event.at) &&
+      event.id &&
+      !alreadyScored.has(event.id)
+  );
+
+  // A refresh with no id cannot be paired, so scoring it would write a fresh
+  // outcome on every turn forever. Reported, not silently dropped.
+  summary.unattributable += keepwarm.filter(
+    (event) => event.action === 'refresh' && (!event.id || !Number.isFinite(event.at))
+  ).length;
+
+  if (!unscored.length) return summary;
+
+  const events = (arrivals ? arrivals() : readMetrics(dir)).filter((event) =>
+    Number.isFinite(event?.at)
+  );
+  // Coverage is judged over EVERY event, including our own bookkeeping: the
+  // refresh's own copy in the firehose is what proves the window is still
+  // inside the read. Arrivals are judged over everything else, because a record
+  // keep-warm wrote about itself is not a turn -- and counting one would
+  // manufacture a hit out of the act of measuring.
+  const earliest = events.reduce((min, event) => Math.min(min, event.at), Infinity);
+  const turns = events.filter((event) => event.kind !== 'keepwarm');
+
+  for (const refresh of unscored) {
+    const tier = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    if (now - refresh.at < tier.ms) {
+      summary.pending += 1;
+      continue;
+    }
+    const session = refresh.sessionId;
+    if (!session) {
+      summary.unattributable += 1;
+      continue;
+    }
+    if (!(earliest <= refresh.at)) {
+      summary.uncovered += 1;
+      continue;
+    }
+
+    const opens = refresh.at + TURN_GAP_MS;
+    const closes = refresh.at + tier.ms;
+    const hit = turns.some(
+      (event) =>
+        (event.sessionId ?? event.episodeId) === session &&
+        event.at > opens &&
+        event.at <= closes
+    );
+    recordRefreshOutcome(dir, {
+      tier: refresh.tier,
+      prefixTokens: refresh.prefixTokens,
+      hit,
+      refreshId: refresh.id,
+    });
+    summary.scored += 1;
+    if (hit) summary.hits += 1;
+  }
+
+  return summary;
 }
 
 /**
@@ -372,23 +538,15 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
-  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
-  // becomes evidence now, so the decision below and the tripwire above both see
-  // the most that is currently knowable -- the same read-time drain the
-  // staleness path uses, and for the same reason: the producer cannot know the
-  // outcome at the moment it acts.
-  try {
-    scoreOutstandingRefreshes(dir, { events, outcomes });
-    outcomes = readBalance(dir);
-  } catch {
-    /* scoring is evidence, never a reason to refuse a decision */
-  }
-
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
+  // THE SAME ARRAY THE TRIPWIRE JUST READ, so closing the loop costs no extra
+  // I/O -- and so the decision and its backstop cannot be looking at different
+  // evidence about the same refreshes.
+  const observed = observedHitRates(outcomes);
   const gaps = gapDistribution(dir, { events });
-  const best = ttlTier({ prefixTokens, gaps });
+  const best = ttlTier({ prefixTokens, gaps, observed });
   if (!best) {
     // THE TWO MODELS ANSWER DIFFERENT QUESTIONS, so they may legitimately disagree. ttlTier asks
     // whether holding a cache beats not caching at all; keepWarmDecision asks whether ONE ping
@@ -397,11 +555,7 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({
-      prefixTokens,
-      gaps,
-      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
-    });
+    const decision = keepWarmDecision({ prefixTokens, gaps, observed });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/integrations/kilo/hooks/lib/loo.mjs
+++ b/integrations/kilo/hooks/lib/loo.mjs
@@ -1,0 +1,788 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/loo.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 2 -- what one finding is actually worth, measured by withholding it.
+ *
+ * Layer 1 asks whether the model went back and named a finding. This asks the
+ * harder question and answers it causally: WITHHOLD ONE FINDING while serving
+ * every other finding for the same touch, and compare what the session spent
+ * READING that anchor afterwards. Nobody in this space measures per-item value
+ * this way in production; the state of the art is an offline evaluation set.
+ * That is also why this file is more refusal than statistics -- a causal claim
+ * from four observations is worse than no claim, because it is a number and
+ * numbers get quoted.
+ *
+ * THE ESTIMAND IS READ-SUPPRESSION, and it is deliberately DISJOINT from Layer
+ * 1. Layer 1 keys on an explicit `query` naming a finding key. This keys on
+ * `read` events against the injection's anchor. Neither signal appears in the
+ * other's arithmetic: no `query` event is consulted here, and `usage.mjs`
+ * consults no `read` event. Task 8 calibrates one against the other, and if
+ * both derived from the same channel that calibration would report a strong
+ * correlation between two spellings of one quantity and mean nothing.
+ *
+ * IT INVENTS NO JOIN. `recordToolOutcome` already joins each post-tool result
+ * back to the injection that preceded it, recording `injectionId`,
+ * `findingIds` and a `joinMethod` of `tool-call-id` / `episode-anchor` /
+ * `none`. Every observation here is GATED on that join: an injection with no
+ * joined outcome is unattributable and enters neither arm, exactly as Layer 1
+ * treats `joinMethod: 'none'`. An earlier draft of this plan proposed a fresh
+ * `(sessionId, findingKey)` join; it was rejected and is not here.
+ *
+ * WHAT IT COSTS THE USER, because an experiment that degrades a turn owes an
+ * accounting. One withheld finding means the model may re-derive what it was
+ * told last time, and the worst case is one read of that anchor: measured on
+ * this machine, a median read is 3,769 tokens and the 90th percentile is
+ * 14,082. Five guards bound that exposure, and they are the reason the numbers
+ * below are as small as they are:
+ *
+ *   1. only on a FILE touch, because a command injection has no anchor a read
+ *      event can be joined to -- withholding there would cost a user a finding
+ *      and buy no observation at all (see `buildReport`, which excludes command
+ *      injections from the holdout balance for the same reason);
+ *   2. never when fewer than two findings were kept, so "leave one out" always
+ *      leaves something in -- otherwise it degenerates into `inHoldout`, which
+ *      withholds EVERY finding for an anchor and is a different experiment;
+ *   3. never in the same breath as `inHoldout`: if that arm already withheld
+ *      everything, there is nothing to leave out and a Layer 2 arm recorded
+ *      there would be a fabricated observation;
+ *   4. at most ONE finding per touch, or the effect is attributable to neither;
+ *   5. at most ONE withheld finding per SESSION, so the worst case a user can
+ *      experience is a single re-read -- not one per file they open.
+ *
+ * AND IT NEVER OVERRIDES A PERSON. A `pinned` or `origin: 'human'` finding is
+ * an explicit human decision to keep something in front of the model.
+ * Withholding it to run an experiment would overrule that decision for the
+ * convenience of the measurement, so those findings are exempt: they are
+ * always served, they get no causal score, and `looNote` says so rather than
+ * leaving a reader to wonder why they are missing from the table.
+ */
+
+import { createHash } from 'node:crypto';
+import { readEvidence, readMetrics, readTruncation, isFixtureAnchor } from './metrics.mjs';
+import { retrievalPolicy } from './utility.mjs';
+import { ORIGIN_HUMAN } from './curate.mjs';
+import { canonicalPath } from './paths.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Injections of a finding before it may enter the experiment.
+ *
+ * A finding nobody has served yet has no established value to measure the
+ * absence of, and withholding it would be measuring the cold start rather than
+ * the finding. Four is also what makes the ratio below reachable: at a quarter
+ * of (key, session) pairs armed, a key needs roughly a dozen enrolled
+ * injections before it can reach a verdict at all.
+ */
+export const MIN_PRIOR_INJECTIONS = 4;
+
+/** The observation floor. Below this there is no verdict -- and NOT a zero. */
+export const MIN_SERVED = 6;
+export const MIN_WITHHELD = 3;
+
+/** Benjamini-Hochberg false-discovery rate for published verdicts. */
+export const FDR_Q = 0.1;
+
+/**
+ * Exploration rate.
+ *
+ * Without this, utility feeds the ranking, the ranking feeds injection
+ * frequency, injection frequency feeds the observation count, and a low score
+ * becomes self-fulfilling: the finding is never served often enough to earn a
+ * better one. A tenth of touches therefore ignore the utility order and
+ * promote the LEAST-served candidate instead.
+ */
+export const EPSILON = 0.1;
+
+/**
+ * The share of (finding, session) pairs assigned to the withheld arm.
+ *
+ * Chosen against the floors rather than picked: MIN_SERVED / MIN_WITHHELD is
+ * 2:1, so a quarter withheld reaches both floors at about the same time while
+ * leaving three touches in four undamaged.
+ */
+export const WITHHOLD_FRACTION = 0.25;
+
+/**
+ * Withheld findings allowed per session. ONE.
+ *
+ * The per-touch cap alone bounds nothing across a session: a session that
+ * opens twelve files with enrolled findings could have withheld twelve. This
+ * makes the worst case a user can experience one re-read, at the price of a
+ * mild confound that is stated rather than hidden -- when the cap binds, the
+ * other armed findings in that session are served, so the served arm is
+ * slightly enriched by sessions that touch many enrolled findings.
+ */
+export const MAX_WITHHELD_PER_SESSION = 1;
+
+/**
+ * Fallback shrinkage weight when the between-finding variance cannot be
+ * estimated (fewer than two findings with both arms, or no dispersion at all).
+ *
+ * MIN_SERVED + MIN_WITHHELD, deliberately: a finding's own data outweighs the
+ * population prior only once it has reached the publication floor.
+ */
+export const SHRINKAGE_K = MIN_SERVED + MIN_WITHHELD;
+
+/** Bounds on the estimated shrinkage weight, so a degenerate variance ratio cannot run away. */
+const K_MIN = 1;
+const K_MAX = 100;
+
+/**
+ * Bumped BY HAND when the serving code changes in a way that could move a
+ * finding's measured effect. It is the part of the policy version a hash of the
+ * configuration cannot see.
+ */
+export const LOO_POLICY_GENERATION = 1;
+
+/** Permutation budget before the exact null distribution is sampled instead of enumerated. */
+const MAX_EXACT_PERMUTATIONS = 20_000;
+const SAMPLED_PERMUTATIONS = 10_000;
+
+/**
+ * On by default, off by `TOKEN_OPTIMIZER_LOO=off`.
+ *
+ * Read per call rather than at module load, for the reason `holdoutFraction`
+ * gives: a long-lived process started before the setting changed would
+ * otherwise honour the old value forever with no way to tell.
+ */
+export function LOO_ENABLED() {
+  return String(process.env.TOKEN_OPTIMIZER_LOO || '').trim().toLowerCase() !== 'off';
+}
+
+/**
+ * The serving policy an observation was collected under.
+ *
+ * WHY EVERY OBSERVATION CARRIES ONE. An effect is only meaningful against a
+ * fixed policy. Halve the touch budget or move the minimum net utility and the
+ * same finding is served in different company, at a different rank, against a
+ * different counterfactual -- so pooling observations from before and after
+ * that change would average two different experiments and call the result
+ * causal. `effects()` therefore groups by (finding, policy) and never across.
+ *
+ * IT IS DELIBERATELY ABSENT FROM THE ARM HASH. Including it would reassign
+ * arms the moment a setting changed, which is precisely the mid-session flip
+ * the arm hash exists to prevent. Configuration decides which experiment an
+ * observation belongs to; it must never decide which arm.
+ */
+export function servingPolicyVersion() {
+  const policy = retrievalPolicy();
+  const parts = [
+    `g${LOO_POLICY_GENERATION}`,
+    `touch=${Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500}`,
+    `benefit=${policy.baseBenefitTokens}`,
+    `minutility=${policy.minimumNetUtility}`,
+    `cooldown=${policy.cooldownMs}`,
+    `quarantine=${policy.quarantineHarmCount}`,
+    `holdout=${process.env.TOKEN_OPTIMIZER_HOLDOUT ?? 'default'}`,
+    `withhold=${WITHHOLD_FRACTION}`,
+    `prior=${MIN_PRIOR_INJECTIONS}`,
+    `epsilon=${EPSILON}`,
+  ];
+  const digest = createHash('sha256').update(parts.join('|')).digest('hex');
+  return `${LOO_POLICY_GENERATION}-${digest.slice(0, 8)}`;
+}
+
+/**
+ * A stable number in [0, 1) from a string.
+ *
+ * SHA-256 rather than SHA-1 for the same reason `inHoldout` uses it: this is a
+ * bucketing hash and nothing here is secret, but arguing that a CodeQL finding
+ * is benign is a worse habit than paying a cost that rounds to nothing.
+ */
+function bucket(text) {
+  return createHash('sha256').update(String(text)).digest().readUInt32BE(0) / 4_294_967_296;
+}
+
+/**
+ * The arm of one finding in one session.
+ *
+ * Keyed on (findingKey, sessionId) AND NOTHING ELSE, so a finding cannot
+ * change arms partway through a session: not when the candidate set changes,
+ * not when the budget changes, not when the graph grows. The measurement is a
+ * comparison between sessions, and an arm that flips inside one contaminates
+ * both sides of it.
+ */
+function armed(findingKey, sessionId) {
+  return bucket(`loo-arm:${findingKey}:${sessionId}`) < WITHHOLD_FRACTION;
+}
+
+/** Deterministic tiebreak among armed candidates: lowest bucket, then key order. */
+function armRank(findingKey, sessionId) {
+  return bucket(`loo-rank:${findingKey}:${sessionId}`);
+}
+
+/** The graph node for a finding key, or null. Keys are unique per graph. */
+function findingNode(graph, key) {
+  const nodes = graph?.nodes;
+  if (!nodes || typeof nodes.values !== 'function') return null;
+  for (const node of nodes.values()) {
+    if (node?.kind === 'finding' && node.key === key) return node;
+    // A fixture graph may omit `kind`; key identity is what this needs.
+    if (node?.key === key && node.kind === undefined) return node;
+  }
+  return null;
+}
+
+/**
+ * May this finding ever be withheld?
+ *
+ * FAILS CLOSED ON AN UNKNOWN KEY, which is the opposite of how the rest of
+ * this module fails. Everywhere else a missing input costs a measurement; here
+ * it could cost a human their explicit decision, because a key whose node
+ * cannot be read is a key whose `pinned` and `origin` cannot be checked.
+ */
+function withholdable(graph, key) {
+  const node = findingNode(graph, key);
+  if (!node) return false;
+  if (node.pinned) return false;
+  if (node.origin === ORIGIN_HUMAN) return false;
+  if (node.retired) return false;
+  return true;
+}
+
+/** Prior SERVED injections per finding key, and withheld injections per session. */
+function history(dir, { evidence = null } = {}) {
+  const priorServed = new Map();
+  const withheldPerSession = new Map();
+  const events = evidence || readEvidence(dir);
+  for (const event of events) {
+    if (event.kind !== 'inject') continue;
+    if (typeof event.loo === 'string' && event.loo) {
+      const session = typeof event.sessionId === 'string' ? event.sessionId : '';
+      withheldPerSession.set(session, (withheldPerSession.get(session) || 0) + 1);
+    }
+    if (event.holdout) continue;
+    const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+    for (const raw of keys) {
+      const key = String(raw);
+      priorServed.set(key, (priorServed.get(key) || 0) + 1);
+    }
+  }
+  return { priorServed, withheldPerSession };
+}
+
+/**
+ * Which single finding to withhold from this touch, or null.
+ *
+ * Called from `forTouch` AFTER `fit` has decided what would have been served,
+ * which is the only ordering that produces a true leave-one-out. Withholding
+ * BEFORE the budget runs would let a lower-ranked finding take the freed
+ * tokens, so the withheld arm would receive different company as well as one
+ * fewer finding, and the comparison would confound the two.
+ *
+ * @param {string[]} findingKeys keys that would otherwise be delivered
+ * @param {string} sessionId the session, which pins the arm
+ * @param {object} graph the loaded graph, for `pinned` / `origin`
+ * @param {string|null} dir graph directory, for the injection history
+ */
+export function withheldFor(findingKeys, sessionId, graph, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return null;
+
+    // Every guard that needs no I/O runs first: this is the PreToolUse path,
+    // and on a project with one finding per anchor the answer is null before
+    // anything is read.
+    const keys = [...new Set((findingKeys || []).map((k) => String(k)).filter(Boolean))];
+    if (keys.length < 2) return null;
+    if (!sessionId || typeof sessionId !== 'string') return null;
+
+    // FILE SURFACE ONLY. A command injection's anchor is the command text, and
+    // no read event will ever match it -- so both arms would score zero
+    // downstream and the finding would be scored on nothing.
+    const { surface = 'file', anchor = '', holdout = false } = options;
+    if (surface !== 'file' || !anchor) return null;
+    // The all-findings holdout already withheld everything for this anchor.
+    if (holdout) return null;
+
+    const eligible = keys.filter((key) => withholdable(graph, key));
+    if (!eligible.length) return null;
+
+    const { priorServed, withheldPerSession } = history(dir, options);
+    if ((withheldPerSession.get(sessionId) || 0) >= MAX_WITHHELD_PER_SESSION) return null;
+
+    const enrolled = eligible.filter(
+      (key) => (priorServed.get(key) || 0) >= MIN_PRIOR_INJECTIONS
+    );
+    if (!enrolled.length) return null;
+
+    const candidates = enrolled.filter((key) => armed(key, sessionId));
+    if (!candidates.length) return null;
+
+    // AT MOST ONE. Sorted deterministically so the same touch always yields the
+    // same choice; the findings that lose the tiebreak are SERVED, and the
+    // observation records what actually happened rather than what the arm hash
+    // intended.
+    candidates.sort(
+      (a, b) => armRank(a, sessionId) - armRank(b, sessionId) || (a < b ? -1 : a > b ? 1 : 0)
+    );
+    return candidates[0];
+  } catch {
+    // An experiment must never break a tool call. Failing open here means
+    // serving everything, which is the undegraded behaviour.
+    return null;
+  }
+}
+
+/**
+ * Reorders candidates so exploration can break the feedback loop.
+ *
+ * A tenth of touches -- deterministic in (session, anchor), not random, so the
+ * same touch behaves the same way twice -- promote the LEAST-served candidate
+ * ahead of the utility order, giving it a chance to survive `fit` and accrue
+ * the observations it needs to earn a score. The other nine tenths are
+ * untouched.
+ *
+ * @param {Array<{finding:{key:string}}>} items assessed candidates, best first
+ */
+export function exploreOrder(items, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return items;
+    const list = Array.isArray(items) ? items : [];
+    if (list.length < 2) return list;
+    const { sessionId = '', anchor = '' } = options;
+    if (bucket(`loo-explore:${sessionId}:${anchor}`) >= EPSILON) return list;
+
+    const keyOf = (item) => String(item?.finding?.key ?? item?.key ?? '');
+    const { priorServed } = history(dir, options);
+    let promoted = 0;
+    for (let i = 1; i < list.length; i += 1) {
+      const a = priorServed.get(keyOf(list[i])) || 0;
+      const b = priorServed.get(keyOf(list[promoted])) || 0;
+      if (a < b || (a === b && keyOf(list[i]) < keyOf(list[promoted]))) promoted = i;
+    }
+    if (promoted === 0) return list;
+    return [list[promoted], ...list.filter((_, i) => i !== promoted)];
+  } catch {
+    return Array.isArray(items) ? items : [];
+  }
+}
+
+const mean = (values) =>
+  values.length ? values.reduce((sum, v) => sum + v, 0) / values.length : 0;
+
+/** Sample variance (n-1). Zero for a single observation: dispersion is unknown, not large. */
+function variance(values) {
+  if (values.length < 2) return 0;
+  const m = mean(values);
+  return values.reduce((sum, v) => sum + (v - m) * (v - m), 0) / (values.length - 1);
+}
+
+/**
+ * Every attributable Layer 2 observation, one per (injection, finding, arm).
+ *
+ * THREE THINGS ARE REPORTED SEPARATELY RATHER THAN FOLDED IN, because each of
+ * them would otherwise turn an absence into a zero:
+ *
+ *   `unattributable`  the outcome join could not attach a tool call to the
+ *                     injection, so nothing is known about what followed it.
+ *   `excluded`        the injection could never produce a read-join at all
+ *                     (command surface, session-start, fixture anchor) or was
+ *                     already in the all-findings holdout.
+ *   `costObservations` how many observations saw a non-zero read cost. If this
+ *                     is zero, "withholding changed nothing" and "the read
+ *                     channel never fired" are the same picture, and only one
+ *                     of them is a finding about findings.
+ */
+export function observations(dir, { events = null, evidence = null } = {}) {
+  const empty = {
+    rows: [],
+    unattributable: 0,
+    unattributableOutcomes: 0,
+    excluded: { command: 0, holdout: 0, fixture: 0, unanchored: 0 },
+    injections: 0,
+    withheldInjections: 0,
+    costObservations: 0,
+    policies: [],
+    windowed: false,
+  };
+  try {
+    const causal = evidence || readEvidence(dir);
+    const all = events || readMetrics(dir);
+    // OUT OF BAND and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` describes the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
+
+    // THE JOIN THIS MODULE CONSUMES AND DOES NOT REPLACE.
+    const joined = new Set();
+    let unattributableOutcomes = 0;
+    for (const event of causal) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) {
+        unattributableOutcomes += 1;
+        continue;
+      }
+      joined.add(String(event.injectionId));
+    }
+
+    // Read cost, grouped the way `buildReport` groups it: (session, anchor),
+    // canonicalised on both sides so two spellings of one file are one anchor.
+    // A mismatch here would make every read invisible and report a clean zero
+    // effect in both arms -- correct code, absent measurement.
+    const reads = new Map();
+    for (const event of all) {
+      if (event.kind !== 'read' || !event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      if (!reads.has(key)) reads.set(key, []);
+      reads.get(key).push(event);
+    }
+
+    const injects = causal
+      .filter((event) => event.kind === 'inject')
+      .map((event, index) => ({ event, index }))
+      .sort((a, b) => (a.event.at || 0) - (b.event.at || 0) || a.index - b.index)
+      .map((row) => row.event);
+
+    // How many injections share each (session, anchor), so a key's read total
+    // is SPLIT between them rather than charged in full to each -- the same
+    // correction `buildReport` applies, and for the same reason: without it the
+    // arm means scale with injections-per-anchor instead of per-touch cost.
+    const perKey = new Map();
+    for (const event of injects) {
+      if (!event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      perKey.set(key, (perKey.get(key) || 0) + 1);
+    }
+
+    const rows = [];
+    const excluded = { command: 0, holdout: 0, fixture: 0, unanchored: 0 };
+    const priorServed = new Map();
+    const policies = new Set();
+    let unattributable = 0;
+    let considered = 0;
+    let withheldInjections = 0;
+
+    for (const event of injects) {
+      const served = (Array.isArray(event.findingIds) ? event.findingIds : []).map(String);
+      const withheldKey = typeof event.loo === 'string' && event.loo ? event.loo : null;
+      const bump = () => {
+        for (const key of served) priorServed.set(key, (priorServed.get(key) || 0) + 1);
+      };
+
+      const isCommand =
+        event.surface === 'command' ||
+        event.trigger === 'command' ||
+        event.surface === 'session-start';
+      if (isCommand) {
+        excluded.command += 1;
+        bump();
+        continue;
+      }
+      if (!event.anchor) {
+        excluded.unanchored += 1;
+        bump();
+        continue;
+      }
+      if (isFixtureAnchor(event.anchor)) {
+        excluded.fixture += 1;
+        bump();
+        continue;
+      }
+      if (event.holdout) {
+        excluded.holdout += 1;
+        bump();
+        continue;
+      }
+
+      considered += 1;
+      if (withheldKey) withheldInjections += 1;
+      const policy = typeof event.looPolicy === 'string' && event.looPolicy
+        ? event.looPolicy
+        : 'unversioned';
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const attributable = Boolean(injectionId && joined.has(injectionId));
+
+      // DOWNSTREAM MEANS AFTER, STRICTLY. The read that triggered the touch is
+      // not caused by the advice; it happened before the advice existed.
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      const at = event.at || 0;
+      const total = (reads.get(key) || []).reduce(
+        (sum, read) => sum + ((read.at || 0) > at ? read.tokens || 0 : 0),
+        0
+      );
+      const cost = total / Math.max(1, perKey.get(key) || 1);
+
+      const observe = (findingKey, arm) => {
+        // ENROLMENT IS RE-DERIVED FROM THE LOG rather than trusted from the
+        // serving decision. It is the one field an old or hand-written record
+        // could contradict, and a served observation from before a finding was
+        // enrolled would compare an established finding against its own cold
+        // start.
+        //
+        // CHECKED BEFORE ATTRIBUTABILITY, so `unattributable` counts only
+        // observations the experiment actually wanted. Counting the rest there
+        // would report a join failure for every finding that was never in the
+        // experiment to begin with -- the same shape as the 2,559-row
+        // measurement-bias defect Layer 1 found in its own first draft.
+        if ((priorServed.get(findingKey) || 0) < MIN_PRIOR_INJECTIONS) return;
+        if (!attributable) {
+          unattributable += 1;
+          return;
+        }
+        policies.add(policy);
+        rows.push({ findingKey, arm, cost, policy, injectionId, anchor: event.anchor });
+      };
+
+      if (withheldKey) observe(withheldKey, 'withheld');
+      for (const findingKey of served) observe(findingKey, 'served');
+      bump();
+    }
+
+    return {
+      rows,
+      unattributable,
+      unattributableOutcomes,
+      excluded,
+      injections: considered,
+      withheldInjections,
+      costObservations: rows.filter((row) => row.cost > 0).length,
+      policies: [...policies].sort(),
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
+function permutationP(servedCosts, withheldCosts) {
+  const pooled = [...servedCosts, ...withheldCosts];
+  const n = pooled.length;
+  const k = withheldCosts.length;
+  if (!k || k === n) return null;
+  const observed = Math.abs(mean(withheldCosts) - mean(servedCosts));
+  const total = pooled.reduce((sum, v) => sum + v, 0);
+  // Mean difference from the withheld-arm sum alone: the served sum is the
+  // complement, so one number decides the statistic.
+  const diffFrom = (withheldSum) =>
+    Math.abs(withheldSum / k - (total - withheldSum) / (n - k));
+
+  const choose = (a, b) => {
+    let out = 1;
+    for (let i = 1; i <= b; i += 1) out = (out * (a - b + i)) / i;
+    return out;
+  };
+
+  const tolerance = 1e-9;
+  if (choose(n, k) <= MAX_EXACT_PERMUTATIONS) {
+    let extreme = 0;
+    let count = 0;
+    const walk = (start, chosen, sum) => {
+      if (chosen === k) {
+        count += 1;
+        if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+        return;
+      }
+      for (let i = start; i <= n - (k - chosen); i += 1) walk(i + 1, chosen + 1, sum + pooled[i]);
+    };
+    walk(0, 0, 0);
+    return count ? extreme / count : null;
+  }
+
+  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
+  // the same p-value and a verdict cannot flicker between two audit runs.
+  let state = 0x9e3779b9;
+  const random = () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4_294_967_296;
+  };
+  let extreme = 0;
+  const order = [...pooled];
+  for (let round = 0; round < SAMPLED_PERMUTATIONS; round += 1) {
+    for (let i = order.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(random() * (i + 1));
+      [order[i], order[j]] = [order[j], order[i]];
+    }
+    let sum = 0;
+    for (let i = 0; i < k; i += 1) sum += order[i];
+    if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+  }
+  return (extreme + 1) / (SAMPLED_PERMUTATIONS + 1);
+}
+
+/**
+ * The per-finding causal effect, shrunk, and whether it may be published.
+ *
+ * `raw` is `mean(withheld) - mean(served)`: POSITIVE means the session read the
+ * anchor more when the finding was withheld, which is the finding earning its
+ * place. `shrunk` is the number a reader should use.
+ *
+ * EMPIRICAL BAYES, and both halves of it come from the data. The prior mean is
+ * the population effect across findings; the weight `k` is the ratio of
+ * within-finding noise to between-finding spread, so a population where every
+ * finding behaves alike shrinks hard and one where they genuinely differ
+ * shrinks little. `SHRINKAGE_K` is the fallback when that spread cannot be
+ * estimated at all. Two observations therefore cannot post a wild score.
+ *
+ * PUBLICATION IS NOT THE SAME QUESTION as having an estimate. A row is
+ * published only if it clears the observation floor AND its permutation
+ * p-value survives Benjamini-Hochberg at q = 0.10 across every candidate row.
+ * Everything else gets `published: false` -- which is not a zero effect, and
+ * `looNote` says which of the two it is. An all-zero-cost population needs no
+ * separate guard: p is exactly 1 there, so nothing can publish anyway.
+ *
+ * NEVER POOLED ACROSS POLICY VERSIONS: rows are keyed on (findingKey, policy).
+ */
+export function effects(dir, options = {}) {
+  try {
+    // `obs` is accepted so `looNote` can read the logs once for both.
+    const obs = options.obs || observations(dir, options);
+    const groups = new Map();
+    for (const row of obs.rows) {
+      const id = JSON.stringify([row.findingKey, row.policy]);
+      if (!groups.has(id))
+        groups.set(id, { findingKey: row.findingKey, policy: row.policy, served: [], withheld: [] });
+      groups.get(id)[row.arm === 'withheld' ? 'withheld' : 'served'].push(row.cost);
+    }
+
+    const raws = [];
+    const withinVars = [];
+    for (const group of groups.values()) {
+      if (!group.served.length || !group.withheld.length) continue;
+      raws.push(mean(group.withheld) - mean(group.served));
+      withinVars.push(
+        variance(group.withheld) / group.withheld.length +
+          variance(group.served) / group.served.length
+      );
+    }
+    const prior = raws.length ? mean(raws) : 0;
+    const within = withinVars.length ? mean(withinVars) : 0;
+    const between = raws.length > 1 ? Math.max(0, variance(raws) - within) : 0;
+    const weight =
+      between > 0 && within > 0
+        ? Math.min(K_MAX, Math.max(K_MIN, within / between))
+        : SHRINKAGE_K;
+
+    const rows = [...groups.values()]
+      .map((group) => {
+        const served = group.served.length;
+        const withheld = group.withheld.length;
+        const both = served > 0 && withheld > 0;
+        const raw = both ? mean(group.withheld) - mean(group.served) : null;
+        const n = served + withheld;
+        const shrunk = raw === null ? null : (n * raw + weight * prior) / (n + weight);
+        const eligible = served >= MIN_SERVED && withheld >= MIN_WITHHELD;
+        return {
+          findingKey: group.findingKey,
+          policy: group.policy,
+          served,
+          withheld,
+          servedMean: mean(group.served),
+          withheldMean: mean(group.withheld),
+          raw,
+          shrunk,
+          p: eligible ? permutationP(group.served, group.withheld) : null,
+          published: false,
+        };
+      })
+      .sort((a, b) =>
+        a.findingKey < b.findingKey ? -1 : a.findingKey > b.findingKey ? 1 : a.policy < b.policy ? -1 : 1
+      );
+
+    // BENJAMINI-HOCHBERG at q = 0.10 over every row that cleared the floor.
+    // One finding tested in isolation would publish at p < 0.10; a hundred
+    // would publish ten false ones, and this module's whole claim is that its
+    // numbers can be quoted.
+    //
+    // THERE IS NO SEPARATE "WAS ANY READ COST OBSERVED" GATE HERE, and its
+    // absence is deliberate rather than an omission. One was written, and
+    // mutation testing showed it could not change a single verdict: if every
+    // observation has zero cost then both arm means are zero, the permutation
+    // statistic is zero for every relabelling, and p is exactly 1 -- which no
+    // BH threshold can pass. The guard was unfalsifiable, and an unfalsifiable
+    // guard is worse than none because it reads as protection nobody can test.
+    // `costObservations` survives as what it can honestly be: a DISCLOSURE, so
+    // `looNote` can say the read channel never fired instead of letting a
+    // reader take an arithmetic zero for a measured one.
+    const candidates = rows
+      .filter((row) => row.p !== null)
+      .sort((a, b) => a.p - b.p);
+    const m = candidates.length;
+    let cutoff = 0;
+    for (let i = 0; i < m; i += 1) {
+      if (candidates[i].p <= ((i + 1) / m) * FDR_Q) cutoff = i + 1;
+    }
+    for (let i = 0; i < cutoff; i += 1) candidates[i].published = true;
+
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * One or two lines for the audit, or nothing at all.
+ *
+ * THE REFUSAL IS THE PRODUCT HERE. On a machine with two injections in sixteen
+ * thousand events, the only honest output is that nothing is measurable yet,
+ * and this says so with the counts that make it checkable rather than printing
+ * a mean of nothing. It returns `null` when Layer 2 has not collected a single
+ * observation, so an idle experiment costs the reader no line at all -- the
+ * same standard `referenceNote` holds itself to.
+ */
+export function looNote(dir, options = {}) {
+  try {
+    const obs = options.obs || observations(dir, options);
+    const rows = effects(dir, { ...options, obs });
+    if (!obs.rows.length && !obs.withheldInjections) return null;
+
+    let graph = options.graph;
+    if (graph === undefined) {
+      try {
+        graph = load(dir);
+      } catch {
+        graph = null;
+      }
+    }
+    let exempt = 0;
+    if (graph?.nodes?.values) {
+      for (const node of graph.nodes.values()) {
+        if (node?.kind !== 'finding' || node.retired) continue;
+        if (node.pinned || node.origin === ORIGIN_HUMAN) exempt += 1;
+      }
+    }
+
+    const published = rows.filter((row) => row.published);
+    const head = published.length
+      ? `Per-finding causal value (leave-one-out): ${published.length} of ${rows.length} ` +
+        `findings show a verdict at q=${FDR_Q}` +
+        published
+          .slice(0, 3)
+          .map(
+            (row) =>
+              `; ${row.findingKey} saves ~${Math.round(row.shrunk)} tokens/touch ` +
+              `(${row.served} served, ${row.withheld} withheld, p=${row.p.toFixed(3)})`
+          )
+          .join('') +
+        '.'
+      : `Per-finding causal value (leave-one-out): NOT MEASURABLE YET -- ` +
+        `${obs.rows.length} attributable observations across ${rows.length} findings, ` +
+        `${obs.withheldInjections} withheld touches; the floor is ${MIN_SERVED} served ` +
+        `and ${MIN_WITHHELD} withheld per finding` +
+        (obs.costObservations ? '' : ', and no read cost has been observed in either arm') +
+        '. No effect is reported, which is not the same as an effect of zero.';
+
+    const caveats = [];
+    if (obs.unattributable)
+      caveats.push(
+        `${obs.unattributable} observations were unattributable (no joined tool outcome) and are in neither arm`
+      );
+    if (exempt)
+      caveats.push(
+        `${exempt} pinned or human-origin findings are exempt from withholding and get no causal score`
+      );
+    if (obs.policies.length > 1)
+      caveats.push(
+        `observations span ${obs.policies.length} serving-policy versions and are never pooled across them`
+      );
+    if (obs.windowed)
+      caveats.push('the read log was truncated, so downstream cost can understate');
+    return caveats.length ? `${head} ${caveats.join('; ')}.` : head;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/kilo/hooks/lib/loo.mjs
+++ b/integrations/kilo/hooks/lib/loo.mjs
@@ -545,8 +545,22 @@ export function observations(dir, { events = null, evidence = null } = {}) {
   }
 }
 
-/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
-function permutationP(servedCosts, withheldCosts) {
+/**
+ * Enumerates or samples arm relabellings and returns a two-sided p-value.
+ *
+ * EXPORTED so the cross-layer headline can be held to the same standard as the
+ * per-finding rows it summarises. `crosslayer.mjs` runs this over the two ARMS
+ * of shrunk effect estimates; the statistic, the enumerate-or-sample switch and the
+ * tolerance are therefore shared rather than reimplemented, and there is one
+ * place where "two-sided" is decided.
+ *
+ * `seed` exists for that caller. The default reproduces the fixed seed this
+ * function has always used, so Layer 2's own p-values are byte-identical; the
+ * cross-layer caller passes a seed DERIVED FROM ITS DATA, because a verdict
+ * printed to a human must not depend on `Math.random()` or on which module
+ * happened to call first.
+ */
+export function permutationP(servedCosts, withheldCosts, { seed = 0x9e3779b9 } = {}) {
   const pooled = [...servedCosts, ...withheldCosts];
   const n = pooled.length;
   const k = withheldCosts.length;
@@ -580,9 +594,10 @@ function permutationP(servedCosts, withheldCosts) {
     return count ? extreme / count : null;
   }
 
-  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
-  // the same p-value and a verdict cannot flicker between two audit runs.
-  let state = 0x9e3779b9;
+  // Mulberry32 off the caller's seed: reproducible, so the same data always
+  // yields the same p-value and a verdict cannot flicker between two audit
+  // runs.
+  let state = seed | 0;
   const random = () => {
     state = (state + 0x6d2b79f5) | 0;
     let t = state;

--- a/integrations/kilo/hooks/lib/metrics.mjs
+++ b/integrations/kilo/hooks/lib/metrics.mjs
@@ -31,6 +31,7 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { createHash, randomBytes } from 'node:crypto';
+import { redact } from './redact.mjs';
 
 /**
  * Read per call, not once at module load.
@@ -517,6 +518,15 @@ export function readEvidence(dir) {
 }
 
 /**
+ * The captured-output budget, in characters.
+ *
+ * Small enough that a 3 MB test log cannot bloat the evidence log or a single
+ * injected claim, large enough to hold the stack trace or compiler diagnostic
+ * that makes a failure finding worth anything.
+ */
+const OUTPUT_MAX_BYTES = 4096;
+
+/**
  * Joins a post-tool result to the most recent matching injection.  The exact
  * tool-call id wins; clients that omit it fall back to episode + surface +
  * anchor, in timestamp order, and the report states the weaker join method.
@@ -545,10 +555,31 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
+  // text is INJECTED into model context and EXPORTED to markdown, so the
+  // boundary is the only place that can guarantee it: a second caller added
+  // later would otherwise have to remember, and the one that forgot would leak
+  // a secret into two more places than the terminal it came from. `undefined`
+  // rather than `''` when nothing was captured, so JSON.stringify omits the
+  // key entirely and an absent capture is distinguishable from an empty one.
+  const output =
+    outcome.output === undefined || outcome.output === null
+      ? undefined
+      : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
+  // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric
+  // code at all, and 0 is the success value -- defaulting to it would claim
+  // every unreported call exited cleanly, which is a fabricated observation
+  // rather than a missing one.
+  const exit = Number.isInteger(outcome.exit) ? outcome.exit : null;
+
   return record(dir, {
     kind: 'tool-outcome',
     ...outcome,
     anchor,
+    // AFTER the spread, so a caller cannot smuggle raw text past the boundary
+    // by setting the field itself.
+    output,
+    exit,
     injectionId: injection?.injectionId || null,
     findingIds: injection?.findingIds || [],
     joinMethod,

--- a/integrations/kilo/hooks/lib/metrics.mjs
+++ b/integrations/kilo/hooks/lib/metrics.mjs
@@ -555,6 +555,22 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // FAILURES ONLY, and that is a deliberate override of the original plan.
+  // The plan predates MCP tool names reaching this path, so it never
+  // considered that a SUCCESSFUL `smart_read` would deposit 4 KB of file
+  // content into the evidence log on every call -- the log would grow with
+  // file text and the privacy surface would be every file the session opened.
+  //
+  // Nothing downstream loses anything. A failure claim quotes the error text;
+  // a "this command works" claim needs only the fact that it worked, which
+  // `success` and `exit` already carry. So the stored text narrows to text
+  // that is already an error message.
+  //
+  // GATED ON `success === true`, not on `!== false`: an outcome that never
+  // said whether it worked is unclassified, not successful, and dropping its
+  // text would lose exactly the failures a client too terse to report status
+  // produces.
+  const captureOutput = outcome.success !== true;
   // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
   // text is INJECTED into model context and EXPORTED to markdown, so the
   // boundary is the only place that can guarantee it: a second caller added
@@ -563,7 +579,7 @@ export function recordToolOutcome(dir, outcome) {
   // rather than `''` when nothing was captured, so JSON.stringify omits the
   // key entirely and an absent capture is distinguishable from an empty one.
   const output =
-    outcome.output === undefined || outcome.output === null
+    !captureOutput || outcome.output === undefined || outcome.output === null
       ? undefined
       : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
   // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric

--- a/integrations/kilo/hooks/lib/metrics.mjs
+++ b/integrations/kilo/hooks/lib/metrics.mjs
@@ -663,6 +663,89 @@ export function isFixtureAnchor(anchor) {
  * Fixture anchors are excluded from both.
  */
 /**
+ * Re-reads grouped by anchor -- the one place that decides what "wasteful" means.
+ *
+ * `rereadWaste` needed only the totals, so the grouping lived inside it and the
+ * per-anchor rows were thrown away. `derive.mjs`'s churn detector needs the
+ * rows, and re-deriving them there would put TWO definitions of "a repeat read
+ * of an unchanged file is waste" in the codebase, free to drift apart -- the
+ * exact divergence `npm run sync:hooks` exists to prevent between hooks-core and
+ * its generated copies. So the grouping lives here and both consumers read it.
+ *
+ * A re-read is only a re-read INSIDE ONE SESSION: grouping is keyed on
+ * session + canonical anchor, and rows are then merged per anchor so a file
+ * re-read across three sessions reports as one anchor with the sum of its
+ * repeats rather than three rows the caller has to add up. Merging cannot move
+ * the totals -- a sum of sums -- which is what makes it safe for `rereadWaste`.
+ *
+ * `tokens` is the WASTEFUL token count, not the total: it is the only one of the
+ * three that names something recoverable, and a row whose headline number
+ * included legitimate re-reads would overstate exactly the way the first
+ * version of this measurement did.
+ *
+ * @returns {Array<{anchor: string, repeats: number, wasteful: number,
+ *   tokens: number, legitimate: number, legitimateTokens: number,
+ *   undecidable: number, undecidableTokens: number}>} descending by `wasteful`,
+ *   then by `repeats`.
+ */
+export function rereadsByAnchor(events = [], { includeFixtures = false } = {}) {
+  const groups = new Map();
+  for (const e of events) {
+    if (!e || e.kind !== 'read' || !e.anchor) continue;
+    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
+    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(e);
+  }
+
+  const rows = new Map();
+  for (const list of groups.values()) {
+    if (list.length < 2) continue;
+    list.sort((a, b) => (a.at || 0) - (b.at || 0));
+
+    const anchorKey = canonicalKeyish(list[0].anchor);
+    let row = rows.get(anchorKey);
+    if (!row) {
+      row = {
+        anchor: list[0].anchor,
+        repeats: 0,
+        wasteful: 0,
+        tokens: 0,
+        legitimate: 0,
+        legitimateTokens: 0,
+        undecidable: 0,
+        undecidableTokens: 0,
+      };
+      rows.set(anchorKey, row);
+    }
+
+    for (let i = 1; i < list.length; i++) {
+      const prev = list[i - 1];
+      const cur = list[i];
+      const tokens = cur.tokens || 0;
+      row.repeats += 1;
+      // THE JUDGEMENT, in one place. A repeat read of a file that CHANGED is
+      // correct behaviour, not waste; a read written before fingerprints
+      // existed cannot be judged at all and says so.
+      if (!prev.fp || !cur.fp) {
+        row.undecidable += 1;
+        row.undecidableTokens += tokens;
+      } else if (prev.fp === cur.fp) {
+        row.wasteful += 1;
+        row.tokens += tokens;
+      } else {
+        row.legitimate += 1;
+        row.legitimateTokens += tokens;
+      }
+    }
+  }
+
+  return [...rows.values()].sort(
+    (a, b) => b.wasteful - a.wasteful || b.repeats - a.repeats
+  );
+}
+
+/**
  * Re-read waste, split into what is KNOWN and what is not.
  *
  * The question is narrow on purpose: how often does one session read the same
@@ -677,6 +760,9 @@ export function isFixtureAnchor(anchor) {
  * `undecidable` is reported rather than hidden. Reads written before the
  * fingerprint existed cannot be classified, and a measurement that quietly
  * counted them either way would be inventing its own answer.
+ *
+ * The aggregate fields are UNCHANGED -- `balanceSheet` reads them -- and are now
+ * a fold over `rereadsByAnchor`'s rows. `worst` is purely additive.
  */
 export function rereadWaste(
   dir,
@@ -685,14 +771,7 @@ export function rereadWaste(
   // excludes by design, making the real path untestable.
   { events = readMetrics(dir), includeFixtures = false } = {}
 ) {
-  const groups = new Map();
-  for (const e of events) {
-    if (e.kind !== 'read' || !e.anchor) continue;
-    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
-    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key).push(e);
-  }
+  const rows = rereadsByAnchor(events, { includeFixtures });
 
   const out = {
     repeats: 0,
@@ -704,29 +783,21 @@ export function rereadWaste(
     undecidableTokens: 0,
   };
 
-  for (const list of groups.values()) {
-    if (list.length < 2) continue;
-    list.sort((a, b) => (a.at || 0) - (b.at || 0));
-    for (let i = 1; i < list.length; i++) {
-      const prev = list[i - 1];
-      const cur = list[i];
-      const tokens = cur.tokens || 0;
-      out.repeats += 1;
-      if (!prev.fp || !cur.fp) {
-        out.undecidable += 1;
-        out.undecidableTokens += tokens;
-      } else if (prev.fp === cur.fp) {
-        out.wasteful += 1;
-        out.wastefulTokens += tokens;
-      } else {
-        out.legitimate += 1;
-        out.legitimateTokens += tokens;
-      }
-    }
+  for (const row of rows) {
+    out.repeats += row.repeats;
+    out.wasteful += row.wasteful;
+    out.wastefulTokens += row.tokens;
+    out.legitimate += row.legitimate;
+    out.legitimateTokens += row.legitimateTokens;
+    out.undecidable += row.undecidable;
+    out.undecidableTokens += row.undecidableTokens;
   }
 
   const decided = out.wasteful + out.legitimate;
   out.coverage = out.repeats ? decided / out.repeats : null;
+  // The offenders behind the totals, bounded: a report needs the handful worth
+  // acting on, not one row per file the session touched twice.
+  out.worst = rows.slice(0, 10);
   return out;
 }
 

--- a/integrations/kilo/hooks/lib/recall.mjs
+++ b/integrations/kilo/hooks/lib/recall.mjs
@@ -1,0 +1,390 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/recall.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Does retrieval FIND a finding, or does it only find what it was told where
+ * to look?
+ *
+ * `docs/WIKI_GRAPH.md` says embeddings get added "if measurement shows real
+ * recall loss". Nothing measured recall, so the no-embeddings stance was
+ * unfalsifiable -- a claim with no observation that could contradict it. This
+ * module is the observation.
+ *
+ * ---------------------------------------------------------------------------
+ * THE TAUTOLOGY THIS DELIBERATELY DOES NOT SHIP, AND WHY IT IS RECORDED HERE
+ * ---------------------------------------------------------------------------
+ * The obvious probe -- for each finding, take its anchors and ask whether
+ * `findingsFor` returns it from each -- CANNOT FAIL. `findingsFor(graph, A)`
+ * walks `derived_from` edges backwards into A, and the edge F -> A is the very
+ * thing that makes A an anchor of F. So F is in the result by CONSTRUCTION, not
+ * by retrieval quality, for every graph, forever. Its rate is 1.0 always, and a
+ * permanent 1.0 published as a recall rate reads to a human as "retrieval is
+ * perfect, embeddings unnecessary" -- one unfalsifiable claim swapped for
+ * another, leaning the one direction a measurement of this project by this
+ * project must never lean.
+ *
+ * That check is still worth running -- if it ever fails, traversal is broken
+ * rather than merely lossy -- so it is kept, and reported as `integrity` with
+ * its own `what` string saying it is not a recall rate. It is NEVER `rate`.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT IS MEASURED INSTEAD: LEAVE-ONE-EDGE-OUT
+ * ---------------------------------------------------------------------------
+ * For each active finding F and each anchor A of F, delete the edge F -> A and
+ * ask whether touching A would STILL surface F. Two independent arms, both of
+ * which can genuinely miss, which is what makes this a measurement:
+ *
+ *   Arm A -- TRAVERSAL FROM THE NEIGHBOURHOOD. Run the real `findingsFor` over
+ *   the edge-deleted graph from A itself and from A's `contains` parents. This
+ *   hits only when F has some OTHER structural route in: a second anchor on the
+ *   same file, or an anchor on a sibling symbol under the same parent. A's
+ *   `contains` children need no separate call because `findingsFor` expands
+ *   them itself -- calling the parent therefore covers every sibling, which is
+ *   why the neighbour list is `[A, ...parents(A)]` and not a hop-counted
+ *   frontier. The REAL primitive is used rather than an equivalent inlined
+ *   here, because a probe that reimplements the thing it measures drifts from
+ *   it and then measures itself.
+ *
+ *   Arm B -- BM25 FROM THE ANCHOR'S OWN KEY. Rank the whole active corpus with
+ *   `lexical.rank`, querying with A's key -- the file path or symbol name the
+ *   user actually touched -- and hit if F comes back inside `limit`.
+ *
+ * WHY ARM B IS NOT QUERIED WITH THE FINDING'S OWN CLAIM. The plan's literal
+ * form was "the finding's claim terms against the rest of the corpus", and both
+ * readings of it are degenerate. Querying F's claim against a corpus that
+ * INCLUDES F is the tautology again: BM25 scores a document against its own
+ * text, so F wins its own query every time. Querying F's claim against a corpus
+ * that EXCLUDES F cannot return F at all, so a "hit" would mean some DIFFERENT
+ * finding matched -- that is redundancy of storage, not recall of F, and it
+ * would score a graph better for holding duplicates. The anchor's key is the
+ * one query text that is available offline, is not derived from F, and matches
+ * the production question: a session touches a file, and the only lexical
+ * handle on it is its own path. It misses exactly when a finding's claim never
+ * names the code it is about, which is the recall gap embeddings are supposed
+ * to close.
+ *
+ * ---------------------------------------------------------------------------
+ * REFUSALS -- four, and each costs this project its own good news
+ * ---------------------------------------------------------------------------
+ *  1. TOO FEW OBSERVATIONS -> `rate: null` with a reason. See `MIN_PROBED`.
+ *  2. A CORPUS NO LARGER THAN THE RETRIEVAL LIMIT -> `rate: null`. Arm B is
+ *     recall@`limit`, and below the limit NO FINDING IS EVER CUT FOR BUDGET:
+ *     every document scoring above zero is returned, so the arm measures
+ *     whether a token matched, which is a strictly weaker bar than the one
+ *     production applies when `forTouch` fills a token budget from a ranked
+ *     list. A probe more permissive than the system it measures can only
+ *     overstate recall, so the rate is withheld in that band and the counts are
+ *     published instead. It bites between `MIN_PROBED` and `limit` findings --
+ *     on this machine's project graph, whose one finding had both anchor edges
+ *     "recovered" that way, the observation-count refusal fires first.
+ *  3. NO ANCHOR NODE -> the pair is UNPROBEABLE, not a miss. Reported and
+ *     excluded from the denominator; see `probeEdge`.
+ *  4. STRICT AGGREGATION -> a finding counts as retrieved only if EVERY one of
+ *     its probeable anchor edges is recoverable. A finding reachable from one
+ *     anchor and lost from another is a miss, with the losing anchor named.
+ *     This biases the rate DOWN, which is the safe direction here.
+ *
+ * FAILS OPEN. It runs on a report path; a graph it cannot read must cost a
+ * section, not the report.
+ */
+
+import { load, findingsFor } from './wiki.mjs';
+import { rank } from './lexical.mjs';
+
+/**
+ * Distinct findings that must be probeable before a RATE is published at all.
+ *
+ * NOT AN EFFECT-SIZE CONVENTION -- it is a resolution argument. A proportion
+ * over n observations has a resolution of 1/n, so below ten findings the
+ * published figure moves in steps coarser than ten percentage points, and the
+ * two extremes a small graph actually produces (`1.0` and `0.0`) are the two a
+ * reader is most likely to mistake for a finding about retrieval. At n = 10 and
+ * zero misses the exact binomial 95% upper bound on the true miss rate is still
+ * 1 - 0.05^(1/10) = 0.26, so even a clean sweep here bounds recall loss only
+ * below about a quarter -- which is why the refusal reason says what the number
+ * would and would not have supported rather than just naming the floor.
+ *
+ * THE FLOOR IS ON DISTINCT FINDINGS, NOT ANCHOR EDGES. Two anchors of one
+ * finding are two edges of the same claim, not two independent observations;
+ * counting them would let a single multi-anchored finding unlock a rate.
+ */
+export const MIN_PROBED = 10;
+
+/**
+ * The most findings probed in one call.
+ *
+ * Each probed anchor edge costs a graph-sized edge filter plus one or two real
+ * `findingsFor` walks plus one BM25 pass over the corpus, and this runs on the
+ * on-demand report path. The cap is deterministic (findings sorted by key) and
+ * `truncated` says when it bit, so a large graph gets a smaller, honestly
+ * labelled sample rather than a slow report.
+ */
+export const MAX_FINDINGS = 200;
+
+/** Active findings only. A retired claim is withdrawn; recalling it is not a win. */
+function activeFindings(graph) {
+  return [...graph.nodes.values()]
+    .filter((node) => node && node.kind === 'finding' && !node.retired)
+    .sort((a, b) => String(a.key || '').localeCompare(String(b.key || '')));
+}
+
+/** The `contains` parents of every node, indexed once for the whole probe. */
+function parentIndex(graph) {
+  const parents = new Map();
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contains') continue;
+    const list = parents.get(edge.to);
+    if (list) list.push(edge.from);
+    else parents.set(edge.to, [edge.from]);
+  }
+  return parents;
+}
+
+/** The anchors of one finding: the targets of its own `derived_from` edges. */
+function anchorsOf(graph, findingId) {
+  const out = new Set();
+  for (const edge of graph.edges) {
+    if (edge.edge === 'derived_from' && edge.from === findingId) out.add(edge.to);
+  }
+  return [...out];
+}
+
+/**
+ * The graph minus exactly one anchor edge.
+ *
+ * `nodes` is shared rather than copied: nothing here mutates it, and a
+ * 2,600-node Map copied once per anchor edge is the difference between a probe
+ * and a stall.
+ */
+function withoutAnchorEdge(graph, findingId, anchorId) {
+  return {
+    nodes: graph.nodes,
+    edges: graph.edges.filter(
+      (edge) =>
+        !(
+          edge.edge === 'derived_from' &&
+          edge.from === findingId &&
+          edge.to === anchorId
+        )
+    ),
+  };
+}
+
+/**
+ * One anchor edge, hidden, then asked after. Returns `recovered` with the arm
+ * that found it, or a reason -- and `probeable: false` when the question could
+ * not be put at all.
+ */
+function probeEdge(graph, parents, finding, anchorId, corpus, limit) {
+  const hidden = withoutAnchorEdge(graph, finding.id, anchorId);
+
+  // Arm A. `findingsFor` expands `contains` children itself, so the parent call
+  // covers every sibling of the anchor.
+  const neighbours = [anchorId, ...(parents.get(anchorId) || [])];
+  for (const neighbour of neighbours) {
+    const got = findingsFor(hidden, neighbour, { limit });
+    if (got.some((node) => node.id === finding.id)) {
+      return { recovered: true, arm: 'traversal', anchorId };
+    }
+  }
+
+  // Arm B needs a query, and the query is the anchor's own key. A dangling
+  // anchor edge -- an edge whose target node was never indexed, which
+  // `expand.promote` produces -- leaves nothing to query with. That is a
+  // question that could not be asked, NOT an observed miss: scoring it a miss
+  // would manufacture a recall loss out of a graph-integrity defect.
+  const anchor = graph.nodes.get(anchorId);
+  const key = anchor && typeof anchor.key === 'string' ? anchor.key : '';
+  if (!key) {
+    return {
+      recovered: false,
+      probeable: false,
+      anchorId,
+      reason: `anchor ${anchorId} has no node in the graph, so there is no anchor key to query BM25 with`,
+    };
+  }
+
+  const hits = rank(key, corpus, { limit });
+  if (hits.some((hit) => hit.finding && hit.finding.id === finding.id)) {
+    return { recovered: true, arm: 'lexical', anchorId };
+  }
+
+  return {
+    recovered: false,
+    probeable: true,
+    anchorId,
+    reason: `no neighbouring anchor reaches it and BM25 over ${key} does not rank it in the top ${limit}`,
+  };
+}
+
+/**
+ * The probe. An OFFLINE measurement over the graph as it stands -- it reads,
+ * ranks and traverses, and writes nothing.
+ */
+export function recallProbe(
+  dir,
+  {
+    limit = 20,
+    graph = null,
+    minProbed = MIN_PROBED,
+    maxFindings = MAX_FINDINGS,
+  } = {}
+) {
+  const refuse = (reason) => ({
+    basis: 'offline probe over the current graph',
+    probed: 0,
+    retrieved: 0,
+    rate: null,
+    reason,
+    misses: [],
+    unprobeable: [],
+  });
+
+  let g;
+  try {
+    g = graph || load(dir);
+  } catch {
+    return refuse('the graph could not be read, so recall was not measured.');
+  }
+
+  try {
+    const all = activeFindings(g);
+    const truncated = all.length > maxFindings;
+    const findings = truncated ? all.slice(0, maxFindings) : all;
+    const parents = parentIndex(g);
+    // The corpus BM25 ranks over is the ACTIVE graph, uncapped: the sample is
+    // which findings are probed, not what they compete against. Every reported
+    // figure below reads `corpus.length` rather than `all.length`, so the
+    // published size IS the ranking corpus rather than a parallel claim about
+    // it. The distinction is not pedantry: a mutation that shrank the ranking
+    // corpus to the probed sample -- making retrieval easier, in this project's
+    // favour -- SURVIVED the first mutation run precisely because the reported
+    // number came from the other variable and could not move.
+    const corpus = all;
+
+    const misses = [];
+    const unprobeable = [];
+    const integrityFailures = [];
+    let probed = 0;
+    let retrieved = 0;
+    let integrityOk = 0;
+    let probedEdges = 0;
+    let recoveredEdges = 0;
+    const byArm = { traversal: 0, lexical: 0 };
+
+    for (const finding of findings) {
+      const anchors = anchorsOf(g, finding.id);
+
+      // INTEGRITY, run on the UNTOUCHED graph: the by-construction check. Its
+      // only honest use is as a smoke test, and it is reported as one.
+      if (!anchors.length) {
+        integrityFailures.push({
+          key: finding.key,
+          reason:
+            'active finding with no anchor -- writeHarvested refuses to create one',
+        });
+      } else if (
+        anchors.every((anchorId) =>
+          findingsFor(g, anchorId, { limit }).some((node) => node.id === finding.id)
+        )
+      ) {
+        integrityOk += 1;
+      } else {
+        integrityFailures.push({
+          key: finding.key,
+          reason: `not returned by findingsFor from one of its own anchors at limit ${limit}`,
+        });
+      }
+
+      // An unanchored finding is a definite miss, not an unaskable question:
+      // nothing traverses to it and there is no anchor key to query from, so
+      // the anchor-driven path that serves findings on a file touch can never
+      // surface it. Only an explicit wiki_query naming its own terms would.
+      if (!anchors.length) {
+        probed += 1;
+        misses.push({
+          key: finding.key,
+          reason:
+            'no anchor: nothing traverses to it and there is no anchor key to query with, so only an explicit wiki_query of its own terms would surface it',
+        });
+        continue;
+      }
+
+      const results = anchors.map((anchorId) =>
+        probeEdge(g, parents, finding, anchorId, corpus, limit)
+      );
+      const askable = results.filter((result) => result.probeable !== false);
+      probedEdges += askable.length;
+      recoveredEdges += askable.filter((result) => result.recovered).length;
+      for (const result of askable) {
+        if (result.recovered) byArm[result.arm] += 1;
+      }
+
+      if (!askable.length) {
+        unprobeable.push({ key: finding.key, reason: results[0].reason });
+        continue;
+      }
+
+      probed += 1;
+      const lost = askable.filter((result) => !result.recovered);
+      if (!lost.length) retrieved += 1;
+      else misses.push({ key: finding.key, reason: lost[0].reason });
+    }
+
+    const integrity = {
+      what:
+        'BY CONSTRUCTION: a finding is returned by findingsFor from its own anchor because that edge is what makes it an anchor. Expected 1 for every graph. NOT a recall rate.',
+      probed: findings.length,
+      retrieved: integrityOk,
+      rate: findings.length ? integrityOk / findings.length : null,
+      ok: integrityFailures.length === 0,
+      failures: integrityFailures,
+    };
+
+    // Arm B is recall@`limit`. Over a corpus of at most `limit` findings nothing
+    // is ever cut for budget, so the arm asks only whether a token matched --
+    // weaker than the bar production applies under a token budget, and a probe
+    // more permissive than the system it measures can only overstate recall.
+    const discriminating = corpus.length > limit;
+
+    const common = {
+      basis: 'offline probe over the current graph',
+      probed,
+      retrieved,
+      misses,
+      unprobeable,
+      probedEdges,
+      recoveredEdges,
+      byArm,
+      corpus: corpus.length,
+      discriminating,
+      truncated,
+      minProbed,
+      integrity,
+    };
+
+    if (probed < minProbed) {
+      return {
+        ...common,
+        rate: null,
+        reason:
+          probed === 0
+            ? `no probeable finding: ${unprobeable.length} of ${findings.length} active finding(s) have no anchor node to query from, so recall was not measured. No rate is reported, which is not the same as a rate of zero.`
+            : `${probed} probeable finding(s), below the floor of ${minProbed}: a proportion over ${probed} has a resolution of ${Math.round(
+                100 / probed
+              )} percentage points, so no rate is published. ${retrieved} of ${probed} were recovered without their own anchor edge, which is a count and not a rate.`,
+      };
+    }
+
+    if (!discriminating) {
+      return {
+        ...common,
+        rate: null,
+        reason: `the active corpus holds ${corpus.length} finding(s) and the retrieval limit is ${limit}, so nothing is ever cut for budget and the lexical arm asks only whether a token matched -- a weaker bar than production applies. No rate is published off a probe more permissive than the system it measures; ${retrieved} of ${probed} were recovered, which is a count and not a rate.`,
+      };
+    }
+
+    return { ...common, rate: retrieved / probed, reason: null };
+  } catch {
+    return refuse('the probe failed, so recall was not measured.');
+  }
+}

--- a/integrations/kilo/hooks/lib/redact.mjs
+++ b/integrations/kilo/hooks/lib/redact.mjs
@@ -1,0 +1,30 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/redact.mjs. Regenerate with `npm run sync:hooks`.
+// hooks-core/redact.mjs
+/**
+ * Redaction for anything derived from captured output.
+ *
+ * WHY THIS IS MANDATORY RATHER THAN PRUDENT. derive.mjs builds claims out of
+ * command stderr. A claim is INJECTED into model context and EXPORTED to
+ * markdown, so a secret that reaches a claim reaches two more places than the
+ * terminal it came from. Pattern matching is imperfect and that is stated in the
+ * spec, but "imperfect" beats "absent" by a wide margin here.
+ */
+
+const PATTERNS = [
+  // Bearer / API-key shaped tokens.
+  [/\b(bearer\s+)[A-Za-z0-9._~+/-]{12,}/gi, '$1[redacted]'],
+  [/\b(sk|pk|ghp|gho|github_pat|xox[baprs])[-_][A-Za-z0-9._-]{10,}/gi, '[redacted]'],
+  // KEY=value where the key name suggests a secret.
+  [/\b([A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|APIKEY|API_KEY|PRIVATE_KEY|CREDENTIAL)[A-Z0-9_]*)\s*[=:]\s*\S+/g, '$1=[redacted]'],
+  // Credentials inside a URL.
+  [/\b([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+):[^\s@]+@/gi, '$1:[redacted]@'],
+  // PEM blocks.
+  [/-----BEGIN[^-]*PRIVATE KEY-----[\s\S]*?-----END[^-]*PRIVATE KEY-----/g, '[redacted key]'],
+];
+
+export function redact(text, { max = 400 } = {}) {
+  let out = String(text ?? '');
+  for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
+}

--- a/integrations/kilo/hooks/lib/redact.mjs
+++ b/integrations/kilo/hooks/lib/redact.mjs
@@ -24,7 +24,21 @@ const PATTERNS = [
 ];
 
 export function redact(text, { max = 400 } = {}) {
+  // `?? ''` matters even though String(null)/String(undefined) never throw:
+  // without it a missing value becomes the literal 4-11 character string
+  // "null"/"undefined" -- a garbage claim that silently reaches the graph
+  // and model context instead of surfacing as an error.
   let out = String(text ?? '');
   for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  // Redact BEFORE truncating, never the reverse. Several patterns above rely
+  // on a minimum-length quantifier (e.g. `{10,}`, `{12,}`) plus a prefix.
+  // Truncating first can cut a match down to fewer characters than that
+  // quantifier requires, so the shortened fragment no longer satisfies the
+  // pattern and a live partial secret would pass through in cleartext. By
+  // redacting the full, untruncated string first, every pattern always sees
+  // the complete secret and removes it before any character budget is
+  // spent; the cap below can then only ever cut into already-redacted text
+  // (a label, or the "[redacted]" placeholder itself), never into raw
+  // secret bytes.
   return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
 }

--- a/integrations/kilo/hooks/lib/transcript.mjs
+++ b/integrations/kilo/hooks/lib/transcript.mjs
@@ -19,9 +19,11 @@
  */
 
 import {
-  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, unlinkSync,
+  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync,
+  unlinkSync, openSync, readSync, closeSync,
 } from 'node:fs';
 import { join } from 'node:path';
+import { redact } from './redact.mjs';
 
 /** Where a project's transcripts live, under the graph it belongs to. */
 export const transcriptDir = (dir) => join(dir, 'transcripts');
@@ -210,4 +212,204 @@ export function readArchive(dir, sessionId) {
   } catch {
     return [];
   }
+}
+
+/**
+ * How much of a transcript's TAIL is scanned for failed tool results.
+ *
+ * A transcript is the largest file this project reads: the three real ones on
+ * the measuring machine are 5.8 MB, 22 MB and 45 MB. `archive()` above already
+ * reads the whole thing once at Stop, so an unbounded second pass doubles the
+ * most expensive read on the session-end path for evidence that is, by
+ * construction, mostly old. The tail is the right half to keep for the same
+ * reason `buildFeedbackDigest` keeps the end: what a session learned is
+ * concentrated where the work went wrong, which is later rather than sooner.
+ */
+const FAILED_SCAN_BYTES = () =>
+  Number(process.env.TOKEN_OPTIMIZER_TRANSCRIPT_SCAN_BYTES) || 8 * 1024 * 1024;
+
+/** Failed results kept, most recent first. The pairing detector needs a handful. */
+const FAILED_MAX = 50;
+
+/** Same 4 KB cap `recordToolOutcome` applies to `output`, for the same reason. */
+const FAILED_OUTPUT_MAX = 4096;
+
+/**
+ * The same 120-character truncation `recordToolOutcome` applies to `anchor`.
+ *
+ * ONE COMMAND MUST PRODUCE ONE KEY FROM EITHER SOURCE. A `tool-outcome` stores
+ * the command as `String(tool_input.command).slice(0, 120)`, and `attemptKey`
+ * reads up to three non-flag tokens off whatever it is handed. A long first
+ * token -- a quoted grep pattern, an absolute Windows path, a heredoc -- is cut
+ * by that cap INSIDE those three tokens, so the untruncated transcript copy of
+ * the same command lands in a DIFFERENT group. Measured against one real
+ * session's own evidence: 266 commands present in both sources, and truncating
+ * here made 266 of 266 keys agree where the untruncated text agreed on only
+ * 240.
+ *
+ * WHAT THAT ACTUALLY BUYS, stated precisely rather than generously. `derive`
+ * refuses to build a claim out of a command at or over the cap at all (see
+ * `quotable` there), so agreement on a TRUNCATED key never produces a finding
+ * on its own. It buys two things that still matter: a transcript failure lands
+ * in the same run as the event outcomes of the same command, so the
+ * nearest-preceding-failure rule sees the real sequence rather than a sparse
+ * one; and the no-call-id fallback in `derive`'s deduplication compares command
+ * TEXT against an already-truncated anchor, which cannot match unless this side
+ * is truncated identically.
+ */
+const ANCHOR_MAX = 120;
+
+/**
+ * A tool result that reports a command that RAN and exited non-zero.
+ *
+ * A POSITIVE ALLOWLIST, and the measurement is why. Claude Code sets
+ * `is_error: true` on every kind of unhappy tool result, and across three real
+ * transcripts 214 of them fell into four shapes:
+ *
+ *   83  `Exit code N` + stderr    -- a command ran and failed. THIS ONE.
+ *   109 hook and policy denials   -- overwhelmingly THIS optimizer's own
+ *                                    PreToolUse text ("Recursive shell searches
+ *                                    return unbounded output. Call the
+ *                                    token-optimizer MCP tool smart_grep
+ *                                    instead"), plus `Remove-Item on system
+ *                                    path` blocks.
+ *   18  `<tool_use_error>...`     -- protocol errors: `String to replace not
+ *                                    found`, `File has not been read yet`,
+ *                                    `Blocked: ...`.
+ *   4   a person declined the call.
+ *
+ * Only the first shape is a command failing. In every other shape THE COMMAND
+ * NEVER RAN, so "`X` failed with: ..." would be a false claim about X, and a
+ * later success would pair with a failure that never happened. The 109 are the
+ * dangerous ones: ingesting them would have this tool derive findings from its
+ * own advice, at 0.9 confidence, and serve them back as observations about the
+ * project -- a self-referential loop that also inflates its own finding count.
+ * That is the measurement-bias class this plan tracks, and a denylist would
+ * have let every future denial string through by default.
+ */
+const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
+
+/** Reads at most `bytes` from the END of a file, without loading the rest. */
+function readTail(path, bytes) {
+  let fd;
+  try {
+    const size = statSync(path).size;
+    const length = Math.min(size, bytes);
+    if (!length) return '';
+    fd = openSync(path, 'r');
+    const buffer = Buffer.allocUnsafe(length);
+    readSync(fd, buffer, 0, length, size - length);
+    const text = buffer.toString('utf8');
+    // A tail almost never starts on a line boundary, and half a JSON object is
+    // not a parse failure worth reporting -- it is a partial record. Drop it.
+    return length < size ? text.slice(text.indexOf('\n') + 1) : text;
+  } catch {
+    return '';
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+}
+
+/**
+ * The failed COMMAND results a transcript holds, which no hook event carries.
+ *
+ * WHY THIS READER EXISTS. Claude Code never fires PostToolUse for a failed tool
+ * call: a deliberately failing command produced no event at all, and 2,238 of
+ * 2,238 live `tool-outcome` events on the measuring machine carry
+ * `success: true`. So `derive.mjs`'s two strongest detectors -- command
+ * failed-then-succeeded at 0.90 and test/build red-to-green at 0.85 -- have no
+ * input whatsoever on the primary client, while working normally on the ten
+ * adapter clients. The failures exist; they exist only here.
+ *
+ * WHY NOT THE ARCHIVE, which the plan for this reader assumed. `readTurns`
+ * DROPS tool results by design -- that is where whole file contents would enter
+ * the record -- so `readArchive` returns no failure, ever, and an extractor over
+ * archived turns would find nothing however well it was written. Making the
+ * archive carry them would also push command stderr into `buildFeedbackDigest`,
+ * which is the one code path in this project that sends anything to a model
+ * endpoint. So this reads the transcript and STORES NOTHING NEW: read-only, no
+ * capture path, no new event kind, and no widening of what leaves the machine.
+ *
+ * REDACTED HERE, at this boundary, exactly as `recordToolOutcome` redacts
+ * `output`. Transcript text has never passed a redaction boundary -- that one
+ * never saw it -- and everything returned from here is destined for a claim that
+ * is injected into model context and exported to markdown.
+ *
+ * @returns {Array<{command: string, output: string, exit: number|null,
+ *   at: number, toolCallId: string|null}>} in transcript order, so a caller can
+ *   sort it beside `tool-outcome` events without re-ordering.
+ */
+export function failedResultsFromTranscript(transcriptPath, options = {}) {
+  const { max = FAILED_MAX, scanBytes = FAILED_SCAN_BYTES() } = options || {};
+  if (!transcriptPath) return [];
+  const text = readTail(transcriptPath, scanBytes);
+  if (!text) return [];
+
+  // tool_use_id -> the command that was attempted. The join is EXACT and it is
+  // the only one available: the result block carries no command of its own, and
+  // the id is the same string `episodeMeta` reads into `toolCallId`, so the same
+  // key also deduplicates against events on clients that do report failures.
+  const commands = new Map();
+  const failures = [];
+
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const message = entry.message || entry;
+    const role = message.role || entry.type;
+    const content = message.content;
+    if (!Array.isArray(content)) continue;
+
+    if (role === 'assistant') {
+      for (const block of content) {
+        if (!block || block.type !== 'tool_use' || !block.id) continue;
+        const command = block.input?.command;
+        if (typeof command !== 'string' || !command.trim()) continue;
+        commands.set(String(block.id), command.slice(0, ANCHOR_MAX));
+      }
+      continue;
+    }
+
+    if (role !== 'user') continue;
+    for (const block of content) {
+      if (!block || block.type !== 'tool_result' || block.is_error !== true) continue;
+      // Only a STRING result can be an exit-code report; every failed Claude
+      // Code result observed was one, and a structured body is a shape this
+      // classifier has not measured, so it is refused rather than guessed at.
+      if (typeof block.content !== 'string') continue;
+      const match = EXIT_CODE_RESULT.exec(block.content);
+      if (!match) continue;
+      const command = commands.get(String(block.tool_use_id || ''));
+      // No command means no claim. The result says something failed; without
+      // the text of what failed there is nothing to say about it, and nothing
+      // to group it with.
+      if (!command) continue;
+      failures.push({
+        command,
+        // The exit line itself is stripped: `exit` carries it structurally, and
+        // leaving it in makes every failure claim read "failed with: Exit code 1".
+        output: redact(block.content.slice(match[0].length).trim(), {
+          max: FAILED_OUTPUT_MAX,
+        }),
+        exit: Number(match[1]),
+        at: Date.parse(entry.timestamp || '') || 0,
+        toolCallId: block.tool_use_id ? String(block.tool_use_id) : null,
+      });
+    }
+  }
+
+  // The MOST RECENT `max`, keeping chronological order. A session that failed
+  // two hundred times teaches its last lessons, not its first.
+  return failures.slice(-max);
 }

--- a/integrations/kilo/hooks/lib/usage.mjs
+++ b/integrations/kilo/hooks/lib/usage.mjs
@@ -42,7 +42,7 @@
  * was referenced" and "nothing could be measured" are different answers and
  * this module gives different answers for them.
  */
-import { readMetrics } from './metrics.mjs';
+import { readMetrics, readTruncation } from './metrics.mjs';
 
 /**
  * The events that name a finding, and it is ONE kind, not the two the plan
@@ -129,17 +129,30 @@ export function classify(dir, { events = null } = {}) {
   try {
     const all = inTimeOrder(events || readMetrics(dir));
 
-    // Every reference, keyed on the finding it names. Only references carrying
-    // a session id are usable -- see `unscopedReferences` in `referenceRate`
-    // for the ones this drops and why they are counted rather than credited.
+    // Every reference, keyed on the finding it names and on nothing else.
+    //
+    // NOT SCOPED BY SESSION, and that is a deliberate reversal. Scoping needs
+    // the query's `sessionId`, which `wiki_query` takes as an OPTIONAL input
+    // the model has to volunteer (`options.sessionId ?? null`) -- so the
+    // numerator depended on the model choosing to identify itself, and an
+    // unverifiable model-supplied id is not evidence. Plan 1 settled that for
+    // the `answers` edge and it settles it here: stop depending on the field
+    // rather than hope for cooperation. The finding key is the specific part
+    // anyway; a key is a graph identity, not a guess.
+    //
+    // THE COST, disclosed here and in `referenceNote` because a reader of the
+    // number has to see it: TWO CONCURRENT SESSIONS ON ONE REPOSITORY CAN
+    // CROSS-ATTRIBUTE. Session A's injection of K plus session B's later query
+    // for K reads as a reference. Nothing in the log can separate them once the
+    // session id is gone, so the exposure is real and is stated rather than
+    // priced.
     const references = new Map();
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       const key = referencedKey(event);
-      const session = sessionOf(event);
-      if (!key || !session) continue;
+      if (!key) continue;
       if (!references.has(key)) references.set(key, []);
-      references.get(key).push({ at: event.at || 0, session });
+      references.get(key).push(event.at || 0);
     }
 
     // Which injections the existing outcome join could attribute. An outcome
@@ -170,9 +183,8 @@ export function classify(dir, { events = null } = {}) {
       const injectionId = event.injectionId ? String(event.injectionId) : null;
       const at = event.at || 0;
       const session = sessionOf(event);
-      // STRICTLY AFTER. A query that PRECEDED the injection is the model
-      // asking on its own initiative; crediting it would let the metric take
-      // the credit for a lookup it had nothing to do with.
+      // STRICTLY AFTER here too: activity that predates the injection is not
+      // an opportunity to have used it.
       const followed = (times) => times.some((t) => t > at);
       const continued =
         (injectionId && attributed.has(injectionId)) ||
@@ -181,9 +193,11 @@ export function classify(dir, { events = null } = {}) {
       for (const raw of keys) {
         const findingKey = String(raw);
         const hits = references.get(findingKey) || [];
-        const referenced = session
-          ? hits.some((hit) => hit.session === session && hit.at > at)
-          : false;
+        // TIME ORDER IS THE ONLY REMAINING GUARD, so it carries the whole
+        // weight of the attribution: a query that PRECEDED the injection is
+        // the model asking on its own initiative, and crediting it would let
+        // the metric take the credit for a lookup it had nothing to do with.
+        const referenced = hits.some((hitAt) => hitAt > at);
         rows.push({
           findingKey,
           injectionId,
@@ -204,9 +218,27 @@ export function classify(dir, { events = null } = {}) {
 /**
  * The rate, with everything needed to tell a real 0 from an absent one.
  *
- * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
- * `unattributable` and `unscopedReferences` are reported beside it, never
- * inside it.
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown` and
+ * `unattributable` are reported beside it, never inside it.
+ *
+ * `windowed` SAYS WHETHER THE DENOMINATOR CAN UNDERSTATE, and it is not
+ * decoration. `readMetrics` reads a 2 MB / 5,000-event TAIL of the firehose,
+ * and injections are rare enough on a real project to age out of it: measured
+ * on this repository, both `inject` events sit at lines 502 and 883 of 6,871
+ * and have scrolled away behind ~6,000 later `read` and `tool-outcome` rows,
+ * so the windowed denominator is 0 where the whole-file truth is 1.
+ *
+ * IT IS REPORTED RATHER THAN FIXED, deliberately. `inject` already gets
+ * unwindowed access through `BALANCE_KINDS` / `EVIDENCE_KINDS`, but `query`
+ * does not -- and reading only the INJECTION arm unwindowed would be worse
+ * than the windowing: every old injection would enter the denominator with no
+ * chance of a matching query in the window and score `not-referenced`,
+ * manufacturing a pessimistic rate out of the asymmetry. Making the query arm
+ * unwindowed means adding `query` to `EVIDENCE_KINDS`, which two other
+ * consumers read, and this project's own standard says a shared-classifier
+ * change needs a per-consumer verdict comparison. So the honest move is to
+ * publish the flag: a caller that needs the unwindowed truth passes its own
+ * `events`, which is exactly what the live measurement in the task report did.
  */
 export function referenceRate(dir, { events = null } = {}) {
   const empty = {
@@ -218,10 +250,15 @@ export function referenceRate(dir, { events = null } = {}) {
     unattributable: 0,
     unattributableWithInjectedToolCall: 0,
     referenceEvents: 0,
-    unscopedReferences: 0,
+    windowed: false,
   };
   try {
     const all = events || readMetrics(dir);
+    // OUT OF BAND, and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` reports on the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
     const rows = classify(dir, { events: all });
     const count = (label) => rows.filter((row) => row.label === label).length;
     const referenced = count('referenced');
@@ -231,17 +268,17 @@ export function referenceRate(dir, { events = null } = {}) {
     // Usable reference events in the window: the numerator's producer. If this
     // is zero the channel never fired, and a 0% rate would be measuring the
     // absence of a producer rather than the uselessness of findings.
+    //
+    // NO SESSION REQUIREMENT, matching the attribution above. The former
+    // `unscopedReferences` counted queries dropped for want of a session id;
+    // nothing is dropped for that reason any more, so the field is GONE rather
+    // than kept at a permanent zero that a later reader would misread as
+    // evidence the loss had been fixed.
     let referenceEvents = 0;
-    let unscopedReferences = 0;
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       if (!referencedKey(event)) continue;
-      if (sessionOf(event)) referenceEvents += 1;
-      // Names a finding but cannot be scoped to one injection. `sessionId` is
-      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
-      // is the expected loss rather than an edge case -- counted here so it is
-      // visible instead of silently deflating the numerator.
-      else unscopedReferences += 1;
+      referenceEvents += 1;
     }
 
     // The tool calls that DID receive findings, keyed the way
@@ -292,7 +329,7 @@ export function referenceRate(dir, { events = null } = {}) {
       unattributable,
       unattributableWithInjectedToolCall,
       referenceEvents,
-      unscopedReferences,
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
     };
   } catch {
     return empty;
@@ -300,11 +337,18 @@ export function referenceRate(dir, { events = null } = {}) {
 }
 
 /**
- * One line for the audit, or nothing at all.
+ * One or two lines for the audit, or nothing at all.
  *
  * Says which of the three things is true -- a measured rate, a live channel
  * with no opportunities yet, or no channel at all -- rather than printing a
  * figure and letting the reader assume the first.
+ *
+ * AND IT CARRIES THE CAVEATS, because this is the only place a human meets the
+ * number. A rate attributed on (finding key, time order) can cross-attribute
+ * between two concurrent sessions on one repository, and a windowed read can
+ * understate the denominator. Both are stated beside the figure they qualify.
+ * Putting them only in a task report would be publishing a clean number and
+ * filing the asterisk somewhere nobody quoting it will look.
  */
 export function referenceNote(dir, { events = null } = {}) {
   const r = referenceRate(dir, { events });
@@ -317,6 +361,11 @@ export function referenceNote(dir, { events = null } = {}) {
   }
   return (
     `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
-    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded. ` +
+    'Matched on finding key and time order, so concurrent sessions on this ' +
+    'repository can cross-attribute' +
+    (r.windowed
+      ? '; and the event log was truncated, so the denominator can understate.'
+      : '.')
   );
 }

--- a/integrations/kilo/hooks/lib/usage.mjs
+++ b/integrations/kilo/hooks/lib/usage.mjs
@@ -1,0 +1,322 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/usage.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 1 -- did the model actually go back and use what we injected?
+ *
+ * The cheap behavioural label. One question, answered from the event log alone:
+ * after we put a finding in front of the model, did the model later ASK FOR
+ * THAT FINDING BY NAME?
+ *
+ * WHY EXPLICIT REFERENCE, AND NOT READ-SUPPRESSION. Read-suppression -- "the
+ * file was not re-read, so the finding must have helped" -- is Layer 2's
+ * estimand, measured causally by withholding a finding and comparing. Layer 1
+ * exists to be calibrated AGAINST that. If both layers derived from
+ * suppression, the calibration would compare two spellings of one quantity,
+ * report a strong correlation, and mean nothing. So Layer 1 is deliberately
+ * built on a signal Layer 2 does not touch: an explicit `query` naming the
+ * finding key.
+ *
+ * WHAT THIS DOES NOT DO. It does not invent a join. `recordToolOutcome`
+ * already joins each post-tool result back to the injection that preceded it,
+ * recording `injectionId`, `findingIds` and a `joinMethod` of `tool-call-id`,
+ * `episode-anchor` or `none` -- preferring an exact tool-call id, which is
+ * strictly better evidence than the `(sessionId, findingKey)` approximation an
+ * earlier draft of this plan proposed. This module consumes that join and adds
+ * none of its own. `inject.mjs` needed no change: it has written `findingIds`
+ * at every call site all along.
+ *
+ * WHAT `unknown` IS FOR, and it is the whole reason this file is careful. An
+ * injection whose session simply stopped afterwards is not a miss. Nothing
+ * happened, so nothing can be concluded, and counting it against the finding
+ * would make the metric read worse the more often sessions end -- a number
+ * that moves with session length rather than with usefulness. `unknown` is
+ * therefore EXCLUDED from the denominator rather than scored zero, and
+ * outcomes the join could not attribute at all are reported as
+ * `unattributable` rather than folded into either arm.
+ *
+ * AND WHY THE RATE CAN BE `null`. This project has already shipped two metrics
+ * whose only producer was their own test suite. A rate of 0% that actually
+ * means "no data" is worse than a refusal, because it is a number and numbers
+ * get quoted. So `rate` is null unless there is a denominator AND the
+ * reference channel produced at least one usable event in the window. "Nothing
+ * was referenced" and "nothing could be measured" are different answers and
+ * this module gives different answers for them.
+ */
+import { readMetrics } from './metrics.mjs';
+
+/**
+ * The events that name a finding, and it is ONE kind, not the two the plan
+ * assumed.
+ *
+ * The brief said "a later `query` or `expand` event". Checked against the code
+ * and against every metrics log on this machine, `expand` does not qualify and
+ * cannot be made to:
+ *
+ *   - `recordExpansion` writes `{ ref, tool, shape, asked, sessionId }`. `ref`
+ *     is a TRUNCATION CAPTURE id (a 16-hex digest of captured tool output),
+ *     not a finding key, and `asked` is free text naming a section of that
+ *     output. Neither is a graph key, and no code path ever puts one there.
+ *   - measured: 64 live `expand` events exist on this machine and all 64 carry
+ *     `sessionId: null`, so they could not be scoped to an injection even if
+ *     they did name one.
+ *
+ * Keying the classifier on `expand` would therefore have added a branch that
+ * can never fire -- a metric with no producer, which is the exact defect this
+ * whole effort exists to close. So it is excluded, deliberately and with the
+ * measurement recorded, rather than included for symmetry with the brief.
+ */
+const REFERENCE_KINDS = new Set(['query']);
+
+/**
+ * What counts as the session having CONTINUED past the injection.
+ *
+ * The distinction between `not-referenced` and `unknown` rests entirely on
+ * this, so the set is explicit rather than "any later event". These are the
+ * kinds a tool call produces: if one of them follows the injection in the same
+ * session, the model had the opportunity to ask and did not. If none does, the
+ * session ended and there was no opportunity.
+ *
+ * `inject` is in the set because a later injection means a later tool call
+ * happened. `forecast`, `mcp-client` and `mcp-tool` are NOT: they are written
+ * by session bookkeeping rather than by the model doing something, and
+ * treating them as opportunity would convert `unknown` rows into misses on
+ * bookkeeping alone.
+ */
+const ACTIVITY_KINDS = new Set([
+  'tool-outcome',
+  'read',
+  'query',
+  'expand',
+  'substitute',
+  'inject',
+]);
+
+/** A usable session id: a non-empty string. `null == null` is not a match. */
+const sessionOf = (event) => {
+  const id = event?.sessionId;
+  return typeof id === 'string' && id ? id : null;
+};
+
+/** The finding key a reference event names, or null if it names none. */
+const referencedKey = (event) => {
+  const key = event?.key;
+  return typeof key === 'string' && key ? key : null;
+};
+
+/** Ordering by the caller's timestamp, with log order breaking ties. */
+function inTimeOrder(events) {
+  return events
+    .map((event, index) => ({ event, index }))
+    .sort(
+      (a, b) =>
+        (a.event.at || 0) - (b.event.at || 0) || a.index - b.index
+    )
+    .map((row) => row.event);
+}
+
+/**
+ * One row per (injection, finding) pair, labelled.
+ *
+ * Per injection rather than per finding: the same finding injected twice is two
+ * separate opportunities, and collapsing them would let one reference excuse
+ * every later injection of that key.
+ *
+ * FAILS OPEN. A malformed log yields an empty classification, never a throw:
+ * this runs on report paths that must not break a tool call.
+ */
+export function classify(dir, { events = null } = {}) {
+  let rows = [];
+  try {
+    const all = inTimeOrder(events || readMetrics(dir));
+
+    // Every reference, keyed on the finding it names. Only references carrying
+    // a session id are usable -- see `unscopedReferences` in `referenceRate`
+    // for the ones this drops and why they are counted rather than credited.
+    const references = new Map();
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      const key = referencedKey(event);
+      const session = sessionOf(event);
+      if (!key || !session) continue;
+      if (!references.has(key)) references.set(key, []);
+      references.get(key).push({ at: event.at || 0, session });
+    }
+
+    // Which injections the existing outcome join could attribute. An outcome
+    // carrying our injectionId is proof the tool call completed, which is
+    // opportunity even when the session id is missing from the log.
+    const attributed = new Set();
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) continue;
+      attributed.add(String(event.injectionId));
+    }
+
+    // Activity per session, so "did anything follow?" is one lookup rather
+    // than a scan per injection.
+    const activity = new Map();
+    for (const event of all) {
+      if (!ACTIVITY_KINDS.has(event.kind)) continue;
+      const session = sessionOf(event);
+      if (!session) continue;
+      if (!activity.has(session)) activity.set(session, []);
+      activity.get(session).push(event.at || 0);
+    }
+
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+      if (!keys.length) continue;
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const at = event.at || 0;
+      const session = sessionOf(event);
+      // STRICTLY AFTER. A query that PRECEDED the injection is the model
+      // asking on its own initiative; crediting it would let the metric take
+      // the credit for a lookup it had nothing to do with.
+      const followed = (times) => times.some((t) => t > at);
+      const continued =
+        (injectionId && attributed.has(injectionId)) ||
+        (session ? followed(activity.get(session) || []) : false);
+
+      for (const raw of keys) {
+        const findingKey = String(raw);
+        const hits = references.get(findingKey) || [];
+        const referenced = session
+          ? hits.some((hit) => hit.session === session && hit.at > at)
+          : false;
+        rows.push({
+          findingKey,
+          injectionId,
+          label: referenced
+            ? 'referenced'
+            : continued
+              ? 'not-referenced'
+              : 'unknown',
+        });
+      }
+    }
+  } catch {
+    rows = [];
+  }
+  return rows;
+}
+
+/**
+ * The rate, with everything needed to tell a real 0 from an absent one.
+ *
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
+ * `unattributable` and `unscopedReferences` are reported beside it, never
+ * inside it.
+ */
+export function referenceRate(dir, { events = null } = {}) {
+  const empty = {
+    referenced: 0,
+    notReferenced: 0,
+    unknown: 0,
+    denominator: 0,
+    rate: null,
+    unattributable: 0,
+    unattributableWithInjectedToolCall: 0,
+    referenceEvents: 0,
+    unscopedReferences: 0,
+  };
+  try {
+    const all = events || readMetrics(dir);
+    const rows = classify(dir, { events: all });
+    const count = (label) => rows.filter((row) => row.label === label).length;
+    const referenced = count('referenced');
+    const notReferenced = count('not-referenced');
+    const denominator = referenced + notReferenced;
+
+    // Usable reference events in the window: the numerator's producer. If this
+    // is zero the channel never fired, and a 0% rate would be measuring the
+    // absence of a producer rather than the uselessness of findings.
+    let referenceEvents = 0;
+    let unscopedReferences = 0;
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      if (!referencedKey(event)) continue;
+      if (sessionOf(event)) referenceEvents += 1;
+      // Names a finding but cannot be scoped to one injection. `sessionId` is
+      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
+      // is the expected loss rather than an edge case -- counted here so it is
+      // visible instead of silently deflating the numerator.
+      else unscopedReferences += 1;
+    }
+
+    // The tool calls that DID receive findings, keyed the way
+    // `recordToolOutcome` keys its own primary join: the tool-call id. An
+    // unattributable outcome for one of these is a join that FAILED. An
+    // unattributable outcome for any other tool call had nothing to join to.
+    //
+    // KEYED ON THE TOOL CALL, NOT THE EPISODE, and the first draft of this
+    // got it wrong in a way worth recording because it is the exact
+    // measurement-bias class this plan hunts. `episodeId` equals the SESSION
+    // id, so "unattributable outcomes in an episode that had an injection"
+    // scored all 2,559 tool calls of a session in which ONE injection
+    // happened. It would have published 2,559 join failures where the true
+    // number is zero -- correct code, lying number, and biased pessimistic
+    // rather than flattering, which is no better.
+    const injectedToolCalls = new Set();
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      if (!Array.isArray(event.findingIds) || !event.findingIds.length)
+        continue;
+      if (event.toolCallId) injectedToolCalls.add(String(event.toolCallId));
+    }
+    let unattributable = 0;
+    let unattributableWithInjectedToolCall = 0;
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome' || event.joinMethod !== 'none')
+        continue;
+      unattributable += 1;
+      // BOTH FIGURES, because the raw one alone lies in the pessimistic
+      // direction. Measured on this machine: 2,991 of 2,992 live outcomes
+      // report `joinMethod: 'none'`, and every one of them because NO
+      // INJECTION EXISTED for that tool call -- the graph holds one finding.
+      // Quoting only the raw count would read as a join that fails 99.97% of
+      // the time, which is a different and false claim.
+      if (event.toolCallId && injectedToolCalls.has(String(event.toolCallId)))
+        unattributableWithInjectedToolCall += 1;
+    }
+
+    return {
+      referenced,
+      notReferenced,
+      unknown: count('unknown'),
+      denominator,
+      rate:
+        denominator > 0 && referenceEvents > 0
+          ? referenced / denominator
+          : null,
+      unattributable,
+      unattributableWithInjectedToolCall,
+      referenceEvents,
+      unscopedReferences,
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/**
+ * One line for the audit, or nothing at all.
+ *
+ * Says which of the three things is true -- a measured rate, a live channel
+ * with no opportunities yet, or no channel at all -- rather than printing a
+ * figure and letting the reader assume the first.
+ */
+export function referenceNote(dir, { events = null } = {}) {
+  const r = referenceRate(dir, { events });
+  if (!r.denominator && !r.unknown && !r.referenceEvents) return null;
+  if (r.rate == null) {
+    const why = !r.referenceEvents
+      ? 'no finding was ever queried by key in this window'
+      : `no injection had a chance to be referenced yet (${r.unknown} unknown)`;
+    return `Injected findings referenced later: not measurable -- ${why}.`;
+  }
+  return (
+    `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+  );
+}

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -103,6 +103,44 @@ const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
 
 /**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because FOUR readers depend on it -- mutation accounting,
+ * success classification, output capture and exit-code capture -- and clients
+ * disagree on the envelope name and on nothing else. Letting each reader name
+ * its own subset is exactly how both classifiers came to miss MCP's failure
+ * flag: `toolSucceeded` listed four envelopes and `mutationSucceeded` listed
+ * three, and neither list mentioned `isError` at all.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/**
+ * Did an MCP result declare itself an error?
+ *
+ * `isError` is the ONLY failure signal an MCP result carries -- there is no
+ * `error` field and no `status` -- and `src/server/index.ts` sets it in seven
+ * places. Shared by both classifiers so they cannot disagree about what a
+ * failed call from this project's own tools looks like.
+ *
+ * `=== true` EXACTLY. A client using the key for anything else must not have
+ * its successful calls silently reclassified, and `isError: false` is a
+ * successful MCP call, not a missing verdict.
+ */
+function reportedMcpError(raw) {
+  return [...responseEnvelopes(raw), raw].some(
+    (envelope) => envelope?.isError === true
+  );
+}
+
+/**
  * A post-tool event is not universally proof of success. Some clients split
  * success and failure into distinct events; others expose a result status.
  * Keep mutation accounting conservative so a failed edit cannot arm Stop.
@@ -112,6 +150,19 @@ export function mutationSucceeded(clientName, raw) {
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
     return false;
+  // BEFORE the status read, the explicit-success read AND the client
+  // allowlist, because all three would otherwise pass a failed MCP write. The
+  // allowlist is the one that actually bit: it returns true for claude-code,
+  // codex, qwen, opencode, kilo and windsurf on any post-tool event with no
+  // error and no status, which is precisely the shape of a failed smart_write.
+  //
+  // WHY THIS IS THE SAME BUG AS THE ONE IN `toolSucceeded` AND NOT A COSMETIC
+  // ECHO OF IT: this function gates edit counting and harvest pressure, so
+  // counting a failed write to THE OPTIMIZER'S OWN TOOLS as a mutation
+  // inflates "the optimizer successfully edited a file". Different consumers
+  // from the effectiveness figures, same direction of bias -- toward
+  // flattering the thing being measured.
+  if (reportedMcpError(raw)) return false;
 
   const status =
     raw?.tool_response?.status ??
@@ -145,24 +196,6 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * Spelled out ONCE because three readers depend on it -- success
- * classification, output capture and exit-code capture -- and clients disagree
- * on the envelope name and on nothing else. Letting each reader name its own
- * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
-}
-
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
@@ -181,8 +214,7 @@ export function toolSucceeded(raw) {
   // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
   // optimizer's favour. A measurement that flatters the thing being measured
   // is worse than no measurement.
-  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
-    return false;
+  if (reportedMcpError(raw)) return false;
   const status =
     raw?.tool_response?.status ??
     raw?.toolResponse?.status ??

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -957,10 +957,12 @@ async function runHook(clientName, event, invocation) {
       // accumulates structure and no verdicts at all. These detectors read only
       // what is already on disk and send nothing anywhere.
       //
-      // The COUNT is recorded rather than the candidates: how many findings a
-      // session's own evidence supports is the number that says whether this is
-      // working, and it is measurable before anything is stored. Storage is the
-      // caller's next step, under a budget.
+      // COUNTS are recorded rather than the candidates, and BOTH counts: how
+      // many findings a session's own evidence supports, and how many of them
+      // survived the storage budget and the anchor discipline. The gap between
+      // the two is the number that says whether the bound is doing anything --
+      // one figure alone cannot distinguish "nothing to derive" from "derived
+      // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
       const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
       const dir = wikiDir(projectRoot);
@@ -976,6 +978,7 @@ async function runHook(clientName, event, invocation) {
         sessionId,
         candidates: derived.candidates.length,
         observations: derived.observations.length,
+        written: derived.written.length,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -172,6 +172,136 @@ export function toolSucceeded(raw) {
   return true;
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * The same family `toolSucceeded` reads above, hoisted so the three readers
+ * cannot drift apart. Clients disagree on the envelope name and on nothing
+ * else, so this is the one place that disagreement is spelled out.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/** A non-empty string, or null.  Blank output is the same as none. */
+function nonEmpty(value) {
+  const text = String(value ?? '');
+  return text.trim() ? text : null;
+}
+
+/**
+ * The human-readable result text inside one envelope, or null.
+ *
+ * RETURNS NULL RATHER THAN GUESSING. An envelope shape nobody here has seen
+ * produces no capture at all, which costs one finding. Stringifying it instead
+ * would put `[object Object]` or a wall of JSON metadata into a claim that gets
+ * injected into model context -- a wrong observation, which is strictly worse
+ * than a missing one.
+ */
+function resultText(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'string') return nonEmpty(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return null;
+
+  // MCP content blocks, which is how THIS PROJECT'S OWN tools now arrive:
+  // `normalizeTool` resolves `mcp__<server>__smart_edit`, so smart_edit and
+  // smart_write reach the post-tool path for the first time and their results
+  // are `{ content: [{ type: 'text', text }], isError }` rather than a shell
+  // result. Both the bare array and the wrapping object are accepted because
+  // hosts differ on whether they hand the hook the result or its content.
+  if (Array.isArray(value)) {
+    const blocks = value
+      .map((block) =>
+        typeof block === 'string' ? block : nonEmpty(block?.text)
+      )
+      .filter(Boolean);
+    return blocks.length ? nonEmpty(blocks.join('\n')) : null;
+  }
+  if (typeof value !== 'object') return null;
+
+  // STDERR FIRST, and not because that is the order it was produced in. The
+  // cap can only ever cut the tail, and the diagnostic that explains a failure
+  // is almost always on stderr while the volume is almost always on stdout --
+  // so appending stderr would let a 3 MB build log push the one line worth
+  // capturing out of the window.
+  const streams = [nonEmpty(value.stderr), nonEmpty(value.stdout)].filter(
+    Boolean
+  );
+  if (streams.length) return streams.join('\n');
+
+  if (Array.isArray(value.content)) {
+    const inner = resultText(value.content);
+    if (inner) return inner;
+  }
+
+  const error = value.error;
+  if (error) {
+    const message =
+      typeof error === 'string' ? error : nonEmpty(error.message ?? error.msg);
+    if (message) return message;
+  }
+
+  return (
+    nonEmpty(value.output) ??
+    nonEmpty(value.text) ??
+    nonEmpty(value.message) ??
+    (typeof value.result === 'string' ? nonEmpty(value.result) : null)
+  );
+}
+
+/**
+ * The result text of a completed tool call, or null when the client reports
+ * none.  Redaction and the size cap are NOT applied here -- they belong at the
+ * `recordToolOutcome` boundary, which is the only place every caller passes.
+ */
+export function outputFrom(raw) {
+  for (const envelope of responseEnvelopes(raw)) {
+    const text = resultText(envelope);
+    if (text) return text;
+  }
+  return resultText(raw?.output) ?? resultText(raw?.stdout) ?? null;
+}
+
+/**
+ * Key names that mean "process exit code" and nothing else.
+ *
+ * `code` is deliberately ABSENT. JSON-RPC errors (`code: -32602`), Node errno
+ * objects (`code: 'ENOENT'`) and HTTP wrappers all reuse that name, so reading
+ * it would record a confident exit code for calls that never had one. A null
+ * here is honest; a -32602 claiming to be an exit status is not.
+ */
+const EXIT_KEYS = [
+  'exit_code',
+  'exitCode',
+  'exit',
+  'exit_status',
+  'exitStatus',
+  'return_code',
+  'returncode',
+];
+
+/** The numeric exit code a client reported, or null when it reported none. */
+export function exitFrom(raw) {
+  for (const envelope of [...responseEnvelopes(raw), raw]) {
+    if (!envelope || typeof envelope !== 'object') continue;
+    for (const key of EXIT_KEYS) {
+      const value = envelope[key];
+      if (Number.isInteger(value)) return value;
+      // A client that serializes the code as a digit string still reported it.
+      // Bounded so a hash or an id cannot be mistaken for a status.
+      if (typeof value === 'string' && /^-?\d{1,5}$/.test(value.trim()))
+        return Number(value.trim());
+    }
+  }
+  return null;
+}
+
 function contextOutput(client, eventName, additionalContext) {
   if (client.contextStyle === 'top-level') return { additionalContext };
   if (client.contextStyle === 'cline') {
@@ -890,6 +1020,11 @@ async function runHook(clientName, event, invocation) {
         anchor,
         toolName: payload.tool_name,
         success: toolSucceeded(raw),
+        // The two fields a boolean cannot carry: which KIND of failure this
+        // was. Read through the same normalisers as `success`, never off `raw`
+        // at this call site.
+        output: outputFrom(raw),
+        exit: exitFrom(raw),
         durationMs:
           Number(
             raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -145,11 +145,43 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because three readers depend on it -- success
+ * classification, output capture and exit-code capture -- and clients disagree
+ * on the envelope name and on nothing else. Letting each reader name its own
+ * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
+    return false;
+  // MCP'S OWN FAILURE FLAG, which this function did not read for as long as it
+  // existed. It did not matter while `normalizeTool` dropped MCP names before
+  // any accounting ran; it matters now that `mcp__<server>__smart_edit` and
+  // `smart_write` reach the post-tool path, because an MCP result carries no
+  // `error` field and no `status` -- only `isError` -- so a failed smart_edit
+  // fell through to the optimistic `return true` below.
+  //
+  // WHY THIS IS A MEASUREMENT BUG AND NOT A COSMETIC ONE: this boolean feeds
+  // episode outcomes and effectiveness accounting, so recording every failed
+  // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
+  // optimizer's favour. A measurement that flatters the thing being measured
+  // is worse than no measurement.
+  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
     return false;
   const status =
     raw?.tool_response?.status ??
@@ -170,23 +202,6 @@ export function toolSucceeded(raw) {
   // that its output proved the task.  `success` here is deliberately scoped to
   // the tool call; task correctness comes only from an eval grader.
   return true;
-}
-
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * The same family `toolSucceeded` reads above, hoisted so the three readers
- * cannot drift apart. Clients disagree on the envelope name and on nothing
- * else, so this is the one place that disagreement is spelled out.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
 }
 
 /** A non-empty string, or null.  Blank output is the same as none. */

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -58,6 +58,7 @@ import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { briefing } from './remedy.mjs';
 import { stableText, transcriptFor } from './cache.mjs';
+import { scoreRefreshes } from './keepwarm.mjs';
 import { cachedRoutingBriefing } from './routing.mjs';
 import {
   forCommand,
@@ -1010,6 +1011,26 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE KEEP-WARM FEEDBACK ARM, at the boundary where a turn has just
+      // ended -- which is the only place the arrival question can be answered.
+      // Every refresh whose TTL has since elapsed is scored here as used or
+      // unused; anything the log cannot settle is left unscored rather than
+      // recorded as a miss, because an absent signal is not a miss.
+      //
+      // Nothing in this repository issues a refresh today -- cache_audit only
+      // recommends one -- so this scores nothing, and what it costs while
+      // dormant is one readBalance: median 70 ms on this machine's 3.5 MB log,
+      // against derive's 71-111 ms a few lines below on the same path. The
+      // firehose is read for ARRIVALS only if an unscored refresh exists, so
+      // the dormant case never pays for that. The moment an issuer exists, the
+      // decision starts learning with no second wiring change.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      scoreRefreshes(dir);
+    } catch {
+      // A refresh that cannot be scored costs a measurement, not a session.
     }
     try {
       // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -40,11 +40,13 @@ import {
   touchedFiles,
 } from './decide.mjs';
 import {
+  record,
   recordRead,
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
 } from './metrics.mjs';
+import { derive } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -948,6 +950,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // ZERO-COST DERIVATION, on every client, with no credential. The semantic
+      // harvest below needs an API key, so on a machine without one the graph
+      // accumulates structure and no verdicts at all. These detectors read only
+      // what is already on disk and send nothing anywhere.
+      //
+      // The COUNT is recorded rather than the candidates: how many findings a
+      // session's own evidence supports is the number that says whether this is
+      // working, and it is measurable before anything is stored. Storage is the
+      // caller's next step, under a budget.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      const dir = wikiDir(projectRoot);
+      const derived = derive(dir, {
+        sessionId,
+        projectRoot,
+        transcriptPath: agentScope,
+        // The hook payload's own identity, not a value a model typed.
+        authoritativeSessionId: sessionId,
+      });
+      record(dir, {
+        kind: 'derive',
+        sessionId,
+        candidates: derived.candidates.length,
+        observations: derived.observations.length,
+      });
+    } catch {
+      // A detector failing must never cost a user the end of their session.
     }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -72,7 +72,8 @@ import {
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
-import { isArchived } from './transcript.mjs';
+import { archive, isArchived } from './transcript.mjs';
+import { harvestMode } from './harvest.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
@@ -577,6 +578,65 @@ function emit(object) {
   process.stdout.write(serialized);
 }
 
+/**
+ * What will and will not extract findings after this session, in one sentence.
+ *
+ * THE STATE WAS ONLY EVER LEGIBLE FROM THE DOCTOR, and the doctor is a place
+ * someone visits after they already suspect something is wrong. A user watching
+ * a graph fill with structural nodes and no verdicts has no reason to suspect
+ * anything, which is the failure this project has now measured twice.
+ *
+ * IT IS ADDRESSED TO THE MODEL, NOT ONLY TO THE READER, which is why it earns a
+ * place in the prefix rather than a systemMessage. "Nothing else will write this
+ * down in words" changes what the model does with a conclusion it is holding;
+ * "here is a configuration variable" would not.
+ *
+ * CACHE-SAFE: derived from configuration, so it differs between sessions only
+ * when the configuration does -- the same standard the rest of this block is
+ * held to, and it carries no digits for `stableText` to reject.
+ *
+ * A local endpoint is named FIRST in the off case on purpose. It is the option
+ * that costs nothing and sends nothing, and it was the one buried deepest.
+ */
+function extractionNotice() {
+  switch (harvestMode()) {
+    case 'local':
+      return (
+        '\n\nA local model endpoint is configured, so semantic extraction also runs after this ' +
+        'session -- free and private, with nothing leaving this machine.'
+      );
+    case 'remote':
+      return (
+        '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
+        'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
+    case 'off:mode':
+      // The whole optimizer is off and this text is not emitted anyway. Saying
+      // anything here would be noise stacked on an explicit choice.
+      return '';
+    case 'off:opted-out':
+      // A DELIBERATE CHOICE, SO NO PITCH. The consequence is stated because the
+      // model needs it; the setting that would reverse it is not, because
+      // arguing with a configured decision on every session is how a notice
+      // stops being read. doctor.mjs draws the same line for the same reason.
+      return (
+        '\n\nFallback extraction is off by configuration, so a conclusion you do not record is ' +
+        'not written down in words anywhere. Findings are still derived locally from exit codes, ' +
+        'red-to-green transitions and corrections.'
+      );
+    default:
+      // off:no-key, and any mode a future harvest adds: no extractor is running
+      // and nobody chose that, so the free option is worth naming.
+      return (
+        '\n\nNo separate extractor will run after this session, so a conclusion you do not record ' +
+        'is not written down in words anywhere. Findings are still derived locally from exit ' +
+        'codes, red-to-green transitions and corrections. Pointing ' +
+        'TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model adds semantic extraction, free and ' +
+        'private.'
+      );
+  }
+}
+
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
 export function policyText(
   canDeny,
@@ -635,7 +695,7 @@ export function policyText(
     .filter(Boolean)
     .join(' ');
   const recording = tools.has('wiki_write')
-    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.`
+    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.${extractionNotice()}`
     : '\n\nStructural graph capture remains active through lifecycle hooks. Durable semantic MCP writes are not requested because the writer schema is not proven available.';
 
   return `# Token optimization is active\n\nLive graph capture is active through the lifecycle adapter.\n\n${connection}${routing}${enforcement}${utilities ? `\n\n${utilities}` : ''}${recording}${projectBriefing()}`;
@@ -950,6 +1010,27 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.
+      //
+      // This was lost rather than retired. `plugin/hooks/stop-harvest.mjs` called
+      // `archive()` at Stop, and #300 replaced that entry in `hooks.json` with the
+      // generated `stop.mjs`, which routes here -- so on Claude Code no session has
+      // been archived since. Nothing failed loudly: `readArchive` simply returns an
+      // empty list, so `derive`'s correction detector fell through to the live
+      // transcript (present only for a client that reports one) and `lessons.mjs`
+      // lost the only corpus it can verify a verbatim quote against, which is the
+      // single test that grants a feedback finding human origin.
+      //
+      // BEFORE `derive`, deliberately: the correction detector reads the archive
+      // first and treats the live transcript as the fallback, and the archive is
+      // the copy that survives into later sessions.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      if (agentScope) archive(dir, agentScope, { sessionId });
+    } catch {
+      // The archive is a record, not a result. A session still ends.
     }
     try {
       // ZERO-COST DERIVATION, on every client, with no credential. The semantic

--- a/integrations/opencode/hooks/lib/audit.mjs
+++ b/integrations/opencode/hooks/lib/audit.mjs
@@ -32,6 +32,7 @@
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
+import { looNote } from './loo.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -401,6 +402,16 @@ export function renderAudit(
   // project with no injections and no queries gains no line at all.
   const reference = referenceNote(dir);
   if (reference) body.push('', reference);
+
+  // WHAT ONE FINDING IS CAUSALLY WORTH (Layer 2).
+  //
+  // The same reasoning as above, and the same refusal: `looNote` returns null
+  // until the leave-one-out experiment has collected an observation, and says
+  // NOT MEASURABLE YET rather than printing a mean until it clears the floor.
+  // A causal number is the most quotable thing this project can produce, so it
+  // is the one that most needs to be absent when it is not earned.
+  const causal = looNote(dir);
+  if (causal) body.push('', causal);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/opencode/hooks/lib/audit.mjs
+++ b/integrations/opencode/hooks/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
 import { looNote } from './loo.mjs';
+import { calibrationNote } from './crosslayer.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -244,9 +245,15 @@ export function renderAudit(
     lines.push(text);
   }
 
+  // SCOPED TO THE QUEUE, because that is all it ever described. The bare
+  // sentence "Nothing addressable found." was printed directly above a Layer 1
+  // reference note and a published Layer 2 causal verdict -- so a reader was
+  // told nothing had been found immediately before being shown a finding. The
+  // headline is about the remediation queue and nothing else, and saying so
+  // costs four words and removes a false negative shown to a human.
   const head = shown.length
     ? ['What to do next, most expensive first:', ...lines]
-    : ['Nothing addressable found.'];
+    : ['Nothing addressable found in the remediation queue.'];
 
   const body = [...head];
 
@@ -412,6 +419,16 @@ export function renderAudit(
   // is the one that most needs to be absent when it is not earned.
   const causal = looNote(dir);
   if (causal) body.push('', causal);
+
+  // WHETHER LAYER 1'S CHEAP LABEL PREDICTS LAYER 2'S EXPENSIVE EFFECT.
+  //
+  // The reason this is printed rather than kept for a dashboard: the reference
+  // rate is the number a reader is most likely to quote as a saving, and it is
+  // not one until this comparison says so. `calibrationNote` returns null while
+  // both layers are silent, and otherwise prints the refusal -- naming which
+  // input was insufficient -- rather than a gap of zero.
+  const calibrated = calibrationNote(dir);
+  if (calibrated) body.push('', calibrated);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/opencode/hooks/lib/audit.mjs
+++ b/integrations/opencode/hooks/lib/audit.mjs
@@ -61,6 +61,28 @@ export function declines(dir, { events = readMetrics(dir) } = {}) {
   return counts;
 }
 
+/**
+ * What the local Stop-time derivation path produced in the visible event log.
+ *
+ * The producer records all three counts because any one of them alone is
+ * ambiguous: zero stored can mean no evidence, no candidates, or a binding
+ * storage/anchor filter. This reader keeps those states distinct and prevents
+ * the telemetry itself from becoming an unobserved cost.
+ */
+export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
+  const runs = events.filter((event) => event.kind === 'derive');
+  if (!runs.length) return null;
+
+  const sum = (field) =>
+    runs.reduce((total, event) => total + Math.max(0, Number(event[field]) || 0), 0);
+  const candidates = sum('candidates');
+  const observations = sum('observations');
+  const written = sum('written');
+  return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
+    `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
+    `across ${runs.length.toLocaleString()} Stop run(s).`;
+}
+
 const idOf = (finding) =>
   finding.remedy
     ? `${finding.remedy.type}:${finding.remedy.anchor || finding.remedy.file || (finding.remedy.anchors || []).join(',')}`
@@ -399,6 +421,15 @@ export function renderAudit(
       );
     }
   }
+
+  // WHAT THE DEFAULT, LOCAL DERIVATION PATH ACTUALLY PRODUCED.
+  //
+  // This event used to have a producer and no reader. Keep its three states
+  // together: evidence seen, candidates derived, and findings that survived
+  // selection/storage. A lone stored count would turn every earlier refusal
+  // into an apparent "nothing found" result.
+  const derived = derivationNote(dir);
+  if (derived) body.push('', derived);
 
   // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
   //

--- a/integrations/opencode/hooks/lib/audit.mjs
+++ b/integrations/opencode/hooks/lib/audit.mjs
@@ -31,6 +31,7 @@
  */
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
+import { referenceNote } from './usage.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -390,6 +391,16 @@ export function renderAudit(
       );
     }
   }
+
+  // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
+  //
+  // Printed here because this is the report that already asks "did the advice
+  // change anything", and because a measurement with no reader is how this
+  // project shipped two metrics whose only consumer was their own test suite.
+  // `referenceNote` returns null when it has nothing honest to say, so a
+  // project with no injections and no queries gains no line at all.
+  const reference = referenceNote(dir);
+  if (reference) body.push('', reference);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/opencode/hooks/lib/consolidate.mjs
+++ b/integrations/opencode/hooks/lib/consolidate.mjs
@@ -142,7 +142,8 @@ const ALWAYS_KEEP = new Set(['failure', 'decision']);
  * Chooses what to promote into the graph, under a token budget.
  *
  * @param {object} graph      Loaded wiki graph, for reuse probability.
- * @param {Array}  candidates Extracted conclusions, each { type, summary, anchors, evidence, at }.
+ * @param {Array}  candidates Extracted conclusions, each { type, claim (or summary),
+ *                              anchors, evidence, at }.
  * @param {object} options    budget: tokens available for promoted findings.
  */
 export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}) {
@@ -221,4 +222,3 @@ export function aggregateConsolidation(findings) {
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
-

--- a/integrations/opencode/hooks/lib/crosslayer.mjs
+++ b/integrations/opencode/hooks/lib/crosslayer.mjs
@@ -1,0 +1,351 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/crosslayer.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The calibration loop: does Layer 1's LABEL predict Layer 2's EFFECT?
+ *
+ * Layer 1 (`usage.mjs`) classifies an injected finding by whether the model
+ * later NAMED it. Layer 2 (`loo.mjs`) measures, by leave-one-out, how many
+ * tokens of reading a finding actually SUPPRESSED. Those are two different
+ * quantities, and the whole point of putting them side by side is that the
+ * cheap one (a label, available on every injection) might stand in for the
+ * expensive one (a causal effect, costing three withheld sessions per finding).
+ *
+ * WHY THIS IS A REAL QUESTION AND NOT A TAUTOLOGY. Task 7 established the
+ * independence three ways -- statically (`loo.mjs` contains no `query` or
+ * `reference`; `usage.mjs` contains no `tokens`, `cost` or `bytes`),
+ * behaviourally in both directions, and by naming the one overlap that does
+ * exist (`recordToolOutcome`'s join, which supplies ATTRIBUTABILITY to both and
+ * the measured quantity to neither). This module is built to preserve that:
+ *
+ *   - from Layer 1 it takes ONLY the categorical label per finding key. No
+ *     rate, no count, no magnitude -- Layer 1 has no magnitude to give.
+ *   - from Layer 2 it takes ONLY the effect magnitude per finding key.
+ *   - the join is the finding key, which is a graph identity and not a
+ *     measurement.
+ *
+ * If a magnitude common to both ever entered, this would correlate a quantity
+ * with itself and report a strong result that means nothing. Two tests pin the
+ * separation from opposite sides: flipping the labels while holding the effects
+ * fixed must move the gap, and changing Layer 1's rate WITHOUT changing any
+ * label must leave the gap byte-identical.
+ *
+ * MEASURED UTILITY RANKS A FINDING. IT MUST NEVER RAISE ITS CONFIDENCE.
+ * A confidently WRONG finding suppresses reads better than a hedged true one,
+ * so utility alone optimises directly against "wrong findings are worse than
+ * none". The plan called for a `mayPromote` gate over
+ * `hasOutstandingContradiction` here. There is nothing to gate: every write of
+ * `confidence` in `hooks-core` happens at CREATION (a per-producer constant in
+ * `derive.mjs` / `lessons.mjs` / `harvest.mjs`, or a human's own number in
+ * `curate.mjs`), and no code path updates a stored finding's confidence
+ * afterwards. `assessFindings` in `utility.mjs` READS confidence into an
+ * ephemeral `netUtility` used for ordering and writes nothing back. So a gate
+ * here would be unreachable, and an unreachable gate is the exact defect class
+ * this work exists to close. `hasOutstandingContradiction` already has its
+ * real consumer -- `staleness.mjs` calls it as the dispute gate on serve.
+ * What is enforceable is the invariant itself, and it is: this module never
+ * writes to the graph, and `tests/hooks/calibration-loop.test.mjs` asserts that
+ * neither it nor either layer under it can move a stored confidence.
+ *
+ * NOTHING HERE IS PRICED. A calibration verdict, a holdout estimate and a
+ * consolidation ratio are all estimates; currency belongs only on a measured
+ * counterfactual, and `balanceSheet`'s `measuredCounterfactual` is the one
+ * section in the sheet below that qualifies.
+ */
+
+import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
+import { classify, referenceRate } from './usage.mjs';
+import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Distinct findings needed in EACH arm before a gap is reported at all.
+ *
+ * Two findings per arm is a difference of two numbers; the comparison would be
+ * dominated by whichever finding happened to sit on a big file. Three is still
+ * small, and the refusal says so rather than implying the gap is solid.
+ */
+export const MIN_FINDINGS_PER_ARM = 3;
+
+/**
+ * The smallest gap that may be PUBLISHED, in tokens per touch.
+ *
+ * Not an effect-size convention: it is tied to the unit the verdict prints. The
+ * published sentence rounds the gap to whole tokens, so a gap of 1e-13 -- which
+ * is what two arms of equal means produce once floating point has had its say --
+ * would publish as "referenced findings suppress 0 more tokens/touch". That is a
+ * calibration claim resting on arithmetic noise, and it leans the only direction
+ * a measurement of this project by this project must never lean.
+ */
+export const MIN_GAP_TOKENS = 1;
+
+/**
+ * The per-finding Layer 1 label, folded from per-injection rows.
+ *
+ * ANY reference wins. `classify` emits one row per (injection, finding) because
+ * one reference must not excuse every later injection -- that is the right unit
+ * for a RATE. For a label the question is different: did the model ever name
+ * this finding? A finding referenced once and ignored nine times is a finding
+ * the model reads, and averaging it into `not-referenced` would put it in the
+ * arm whose mean effect it is meant to predict.
+ *
+ * `unknown` rows are dropped rather than defaulted, exactly as Layer 1 drops
+ * them from its own denominator.
+ */
+export function labelsByFinding(rows) {
+  const labels = new Map();
+  for (const row of rows || []) {
+    const key = row?.findingKey;
+    if (typeof key !== 'string' || !key) continue;
+    if (row.label === 'referenced') labels.set(key, 'referenced');
+    else if (row.label === 'not-referenced' && !labels.has(key))
+      labels.set(key, 'not-referenced');
+  }
+  return labels;
+}
+
+const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * Does Layer 1's label predict Layer 2's effect?
+ *
+ * Returns `publishable`, a `verdict` in English, and `gap` ONLY when a gap was
+ * actually computed. There is no `gap: 0` for the unmeasured case, and that is
+ * deliberate: a permanent zero reads as "measured, and the two agree", which is
+ * the opposite of "nothing was measured". Task 7 deleted a field rather than
+ * zero it for the same reason.
+ *
+ * FAILS OPEN. This runs on report paths that must not break a tool call.
+ */
+export function calibration(dir, options = {}) {
+  const refuse = (verdict, extra = {}) => ({
+    publishable: false,
+    verdict,
+    ...extra,
+  });
+
+  try {
+    // ONE READ for both layers, so the two arms of the comparison cannot cover
+    // different spans of the log. `referenceRate` reports `windowed: false`
+    // when the caller supplies events -- correctly, since the bounds are then
+    // the caller's -- so the truncation flag is taken here, from the read that
+    // actually set it, and republished.
+    const supplied = options.events || null;
+    const events = supplied || readMetrics(dir);
+    const truncation = supplied ? null : readTruncation();
+    const truncated = Boolean(
+      truncation && (truncation.byBytes || truncation.byEvents)
+    );
+
+    const layer1 = referenceRate(dir, { events });
+    const labels = labelsByFinding(classify(dir, { events }));
+
+    const obs = observations(dir, { ...options, events });
+    const rows = effects(dir, { ...options, events, obs });
+
+    // ONE POLICY VERSION. Layer 2 refuses to pool arms across serving
+    // policies; a calibration that pooled them would undo that guard one level
+    // up. Rows from any other policy are excluded and counted.
+    const policy = servingPolicyVersion();
+    const inPolicy = rows.filter((row) => row.policy === policy);
+
+    const layer2 = {
+      rows: rows.length,
+      inPolicy: inPolicy.length,
+      published: rows.filter((row) => row.published).length,
+      observations: obs.rows.length,
+      policy,
+    };
+    const l1 = {
+      referenced: layer1.referenced,
+      notReferenced: layer1.notReferenced,
+      unknown: layer1.unknown,
+      denominator: layer1.denominator,
+      rate: layer1.rate,
+      referenceEvents: layer1.referenceEvents,
+    };
+
+    const excluded = { layer1Unknown: layer1.unknown, unlabelled: 0, noEffect: 0 };
+    const arms = { referenced: [], notReferenced: [] };
+    for (const row of inPolicy) {
+      // THE SHRUNK ESTIMATE, not the raw one. Shrinkage pulls every finding
+      // toward the population mean, so it pulls the GAP toward zero -- the
+      // bias runs against publishing, which is the only direction a
+      // measurement of this project by this project may lean.
+      if (row.shrunk === null || !Number.isFinite(row.shrunk)) {
+        excluded.noEffect += 1;
+        continue;
+      }
+      const label = labels.get(row.findingKey);
+      if (label === 'referenced') arms.referenced.push(row.shrunk);
+      else if (label === 'not-referenced') arms.notReferenced.push(row.shrunk);
+      else excluded.unlabelled += 1;
+    }
+
+    const context = { layer1: l1, layer2, arms: { referenced: arms.referenced.length, notReferenced: arms.notReferenced.length }, excluded, windowed: truncated };
+    const caveat = truncated
+      ? ' The event log was truncated, so both sides can understate.'
+      : '';
+
+    // WHICH INPUT WAS INSUFFICIENT, named. "Not enough data" tells a reader
+    // nothing about which half of the loop to go and fix.
+    const l1Silent = layer1.rate === null;
+    const l2Silent = layer2.observations === 0;
+    if (l1Silent || l2Silent) {
+      const why = [];
+      if (l1Silent)
+        why.push(
+          `Layer 1 has ${layer1.denominator} classifiable observation(s) and ` +
+            `${layer1.referenceEvents} reference event(s), so it publishes no rate`
+        );
+      if (l2Silent)
+        why.push(
+          `Layer 2 has ${layer2.observations} observation(s), so it publishes no effect`
+        );
+      return refuse(
+        `not calibrated: ${why.join('; and ')}. No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+    }
+
+    // A POLICY CHANGE RESETS THE CALIBRATION, and says so rather than reporting
+    // an empty arm. Layer 2 refuses to pool arms across serving policies, so
+    // rows generated under an older one cannot answer a question about how the
+    // graph serves findings today -- but "0 findings per arm" would send a
+    // reader hunting for missing observations that are right there in the log.
+    if (rows.length > 0 && inPolicy.length === 0)
+      return refuse(
+        `not calibrated: all ${rows.length} Layer 2 effect row(s) were measured under a different serving ` +
+          `policy than the current ${policy}, and arms are never pooled across policies. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (layer2.published === 0)
+      return refuse(
+        `not calibrated: Layer 2 has ${layer2.observations} observation(s) but no published effect at q=0.1, ` +
+          'so its per-finding numbers are noise and a difference between two means of them would be too. ' +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (
+      arms.referenced.length < MIN_FINDINGS_PER_ARM ||
+      arms.notReferenced.length < MIN_FINDINGS_PER_ARM
+    )
+      return refuse(
+        `not calibrated: ${arms.referenced.length} referenced and ${arms.notReferenced.length} not-referenced ` +
+          `finding(s) carry a Layer 2 effect, below the floor of ${MIN_FINDINGS_PER_ARM} per arm. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    const referencedMean = mean(arms.referenced);
+    const notReferencedMean = mean(arms.notReferenced);
+    const gap = referencedMean - notReferencedMean;
+    const measured = { ...context, gap, referencedMean, notReferencedMean };
+
+    if (!(gap >= MIN_GAP_TOKENS))
+      return refuse(
+        `uncalibrated: Layer 1's "referenced" label does not predict a larger Layer 2 effect ` +
+          `(referenced ${Math.round(referencedMean).toLocaleString()} vs not-referenced ` +
+          `${Math.round(notReferencedMean).toLocaleString()} tokens/touch, gap ${Math.round(gap).toLocaleString()}). ` +
+          `Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
+    return {
+      publishable: true,
+      verdict:
+        `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
+      ...measured,
+    };
+  } catch {
+    return refuse(
+      'not calibrated: the calibration inputs could not be read. No gap is reported, which is not the same as a gap of zero.'
+    );
+  }
+}
+
+/**
+ * What the graph cost to build against what it carries -- AN ESTIMATE, and
+ * never priced.
+ *
+ * `consolidationRatio` is the per-finding form and the aggregate is the fold.
+ * Both need `derivedCost`, which `expand.promote` persists onto the finding
+ * node it creates (`src/server/disclosure.ts` is its caller) and which
+ * `harvest-write.mjs` does not yet carry through -- so a graph built only by
+ * the harvest reports nothing here rather than a ratio of one.
+ */
+export function consolidation(dir, { graph = null } = {}) {
+  try {
+    const g = graph || load(dir);
+    const findings = [...g.nodes.values()].filter(
+      (node) => node.kind === 'finding' && !node.retired
+    );
+    const rated = [];
+    for (const finding of findings) {
+      const ratio = consolidationRatio(finding);
+      if (ratio === null) continue;
+      rated.push({ key: finding.key, ratio, derivedCost: finding.derivedCost });
+    }
+    const aggregate = aggregateConsolidation(findings);
+    return {
+      what: 'cost to derive against cost to carry',
+      // SAID IN THE DATA, not only in the prose above it, because this is the
+      // field a dashboard will read and a dashboard will not read a comment.
+      basis: 'estimate',
+      priced: false,
+      findings: findings.length,
+      withDerivedCost: rated.length,
+      aggregate,
+      best: rated.sort((a, b) => b.ratio - a.ratio).slice(0, 5),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The balance sheet with the graph's own three measurements attached.
+ *
+ * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
+ * imports, so it cannot import them back. This is where the two meet, and it
+ * is the shape `get_optimization_report` serves.
+ */
+export function graphBalanceSheet(dir, options = {}) {
+  const sheet = balanceSheet(dir);
+  const cal = calibration(dir, options);
+  const { layer1 = null, layer2 = null } = cal;
+  return {
+    ...sheet,
+    layer1,
+    layer2,
+    calibration: cal,
+    consolidation: consolidation(dir, options),
+  };
+}
+
+/**
+ * One audit line, or null when there is nothing honest to say.
+ *
+ * Silent when NEITHER layer has produced anything: a reader of a graph that has
+ * never injected a finding is owed no paragraph about a loop that has not
+ * started. The moment either side speaks, the refusal is worth printing --
+ * because at that point a reader could otherwise take Layer 1's rate for a
+ * saving, which is precisely what this loop exists to stop.
+ */
+export function calibrationNote(dir, options = {}) {
+  try {
+    const result = calibration(dir, options);
+    const l1 = result.layer1;
+    const l2 = result.layer2;
+    if (!l1 || !l2) return null;
+    if (l1.denominator === 0 && l2.observations === 0) return null;
+    return `Layer 1 against Layer 2: ${result.verdict}`;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/opencode/hooks/lib/crosslayer.mjs
+++ b/integrations/opencode/hooks/lib/crosslayer.mjs
@@ -54,7 +54,13 @@
 
 import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
-import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import {
+  effects,
+  observations,
+  servingPolicyVersion,
+  permutationP,
+  FDR_Q,
+} from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
 import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
@@ -106,6 +112,32 @@ export function labelsByFinding(rows) {
 }
 
 const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * A deterministic, label-symmetric permutation test for the headline gap.
+ *
+ * Layer 2 only publishes a per-finding row after a two-sided permutation test.
+ * The calibration headline summarises those rows, so a positive difference of
+ * arm means must clear the same evidential bar rather than being promoted just
+ * because it points in this project's favour.
+ *
+ * Sorting within each arm and then sorting the two arms makes the sampled path
+ * invariant to event order and to swapping the labels. The seed is derived
+ * from that canonical data instead of shared globally, so two different
+ * datasets do not reuse one arbitrary sequence of sampled relabellings.
+ */
+export function calibrationP(referenced, notReferenced) {
+  const arms = [referenced, notReferenced]
+    .map((values) => [...values].sort((a, b) => a - b))
+    .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  const encoded = JSON.stringify(arms);
+  let seed = 2166136261;
+  for (const char of encoded) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return permutationP(arms[0], arms[1], { seed: seed >>> 0 });
+}
 
 /**
  * Does Layer 1's label predict Layer 2's effect?
@@ -244,7 +276,16 @@ export function calibration(dir, options = {}) {
     const referencedMean = mean(arms.referenced);
     const notReferencedMean = mean(arms.notReferenced);
     const gap = referencedMean - notReferencedMean;
-    const measured = { ...context, gap, referencedMean, notReferencedMean };
+    const p = calibrationP(arms.referenced, arms.notReferenced);
+    const measured = {
+      ...context,
+      gap,
+      referencedMean,
+      notReferencedMean,
+      p,
+      alpha: FDR_Q,
+      test: 'two-sided permutation',
+    };
 
     if (!(gap >= MIN_GAP_TOKENS))
       return refuse(
@@ -255,11 +296,20 @@ export function calibration(dir, options = {}) {
         measured
       );
 
+    if (p === null || p > FDR_Q)
+      return refuse(
+        `not calibrated: the positive Layer 1/Layer 2 gap is not statistically resolved by the ` +
+          `two-sided permutation test (p=${p === null ? 'unavailable' : p.toFixed(3)}, ` +
+          `alpha=${FDR_Q.toFixed(3)}). Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
     return {
       publishable: true,
       verdict:
         `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
-        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, ` +
+        `shrunk estimates, two-sided permutation p=${p.toFixed(3)}). ` +
         `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
       ...measured,
     };

--- a/integrations/opencode/hooks/lib/crosslayer.mjs
+++ b/integrations/opencode/hooks/lib/crosslayer.mjs
@@ -56,6 +56,7 @@ import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
 import { effects, observations, servingPolicyVersion } from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
 
 /**
@@ -309,11 +310,19 @@ export function consolidation(dir, { graph = null } = {}) {
 }
 
 /**
- * The balance sheet with the graph's own three measurements attached.
+ * The balance sheet with the graph's own measurements attached.
  *
  * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
  * imports, so it cannot import them back. This is where the two meet, and it
  * is the shape `get_optimization_report` serves.
+ *
+ * `recall` joins them as an OFFLINE PROBE, and that label travels in the data
+ * (`recall.basis`) as well as in the rendered line. It is not an observation of
+ * anything a session did: it deletes an anchor edge in memory and re-runs the
+ * real retrieval primitives over the graph as it stands right now. `recall.mjs`
+ * imports only `wiki.mjs` and `lexical.mjs`, neither of which imports anything
+ * in this direction, so no cycle -- the same reason `calibration` had to live
+ * here rather than in `metrics.mjs`.
  */
 export function graphBalanceSheet(dir, options = {}) {
   const sheet = balanceSheet(dir);
@@ -325,6 +334,7 @@ export function graphBalanceSheet(dir, options = {}) {
     layer2,
     calibration: cal,
     consolidation: consolidation(dir, options),
+    recall: recallProbe(dir, options),
   };
 }
 

--- a/integrations/opencode/hooks/lib/derive.mjs
+++ b/integrations/opencode/hooks/lib/derive.mjs
@@ -23,13 +23,21 @@
  * the observation supports no claim at all are refused rather than downgraded
  * (see `attemptKey` and the identical-text guard below).
  *
- * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
- * budget, belongs to the caller.
+ * WHAT IS STORED IS BOUNDED. Candidates go through `selectForConsolidation`
+ * before `writeHarvested`, so a long session cannot spend the whole retrieval
+ * budget of every later session on one afternoon's exit codes. Nothing enters
+ * the graph unbudgeted, and nothing enters it wearing a human origin.
  */
 
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
 import { readArchive, readTurns } from './transcript.mjs';
 import { redact } from './redact.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { load } from './wiki.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -106,6 +114,92 @@ const triggerFor = (command) =>
   attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
 
 /**
+ * Literal root-level files that define how a project is BUILT, RUN and TESTED,
+ * best first. A `command` claim is a claim about this project's commands, and
+ * this is the file those commands are declared in.
+ */
+const PROJECT_MARKERS = [
+  'package.json', 'pyproject.toml', 'Cargo.toml', 'go.mod', 'pom.xml',
+  'build.gradle.kts', 'build.gradle', 'build.sbt', 'mix.exs', 'composer.json',
+  'Gemfile', 'Package.swift', 'CMakeLists.txt', 'Makefile', 'Taskfile.yml',
+  'requirements.txt', 'setup.py', 'deno.json', 'bun.lockb',
+];
+
+/** .NET has no single literal marker; the solution or project file is one. */
+const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
+
+/**
+ * A REAL FILE to anchor a derived claim to, inside the project root.
+ *
+ * WHY NOT THE PROJECT ROOT ITSELF, which is what the extraction step reaches
+ * for and what `promoteToShared` uses in the shared tier. Because
+ * `writeHarvested` resolves every anchor through `indexFile`, `indexFile` reads
+ * the path, and reading a DIRECTORY returns null -- so a candidate anchored to
+ * `projectRoot` resolves to nothing, is refused as unanchorable, and the whole
+ * pipeline stores zero findings while reporting a healthy candidate count.
+ * Verified directly: `indexFile(dir, dir)` returns null. That refusal is
+ * correct and must not be weakened -- an anchor that cannot be indexed is an
+ * anchor that can never be invalidated -- so the anchor has to be a file.
+ *
+ * STALENESS DOES NOT MISFIRE ON THIS. `command`, `failure` and `feedback` are
+ * all outside `CONTENT_DEPENDENT` (staleness.mjs), so the anchor is a RETRIEVAL
+ * AND EXISTENCE hook rather than a contents claim: editing the manifest does
+ * not mark these findings stale. staleness.mjs names this exact case in its own
+ * comment -- "a claim about `npm test` anchored to package.json" -- and calls
+ * missing that invalidation the better error.
+ *
+ * A project with no recognisable marker gets the root back, which will not
+ * resolve, so its candidates are derived and then refused rather than stored
+ * against a fabricated anchor. That is the fail-open direction: no finding
+ * beats a finding anchored to something that is not what the claim is about.
+ */
+export function projectAnchor(projectRoot) {
+  if (!projectRoot) return null;
+  let entries;
+  try {
+    entries = readdirSync(projectRoot);
+  } catch {
+    return projectRoot;
+  }
+  const present = new Set(entries);
+  for (const marker of PROJECT_MARKERS) {
+    if (!present.has(marker)) continue;
+    const path = join(projectRoot, marker);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // A marker that cannot be stat'ed is not a marker.
+    }
+  }
+  // Sorted so two sessions in the same repository pick the SAME solution file:
+  // readdir order is not guaranteed stable across hosts, and an anchor that
+  // varies by host splits one finding into two nodes.
+  for (const entry of [...entries].sort()) {
+    if (!DOTNET_MARKER.test(entry)) continue;
+    const path = join(projectRoot, entry);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // Same.
+    }
+  }
+  return projectRoot;
+}
+
+/**
+ * Tokens of claim text one session may add to the graph.
+ *
+ * SCALED TO THE RETRIEVAL BUDGET IT COMPETES FOR, not picked round. A single
+ * command's injection budget is 500 tokens (`TOKEN_OPTIMIZER_TOUCH_BUDGET`),
+ * and everything stored here is competing for that budget on every later
+ * command, forever. Two touch-budgets per session is the bound: enough for a
+ * few dozen real claims, and short of one session's exit codes crowding out
+ * every finding a human or a model ever wrote.
+ */
+const storageBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_DERIVE_BUDGET) || 1000;
+
+/**
  * Derives finding candidates from one project's local evidence.
  *
  * @param {string} dir wiki directory.
@@ -118,11 +212,18 @@ const triggerFor = (command) =>
  *   and is refused by `writeHarvested` anyway, so emitting one would only spend
  *   the caller's budget on junk.
  * @param {string|null} options.authoritativeSessionId the session id as the HOOK
- *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
- *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
- *   edge -- `taskForAnchors` returns null without one, so an unverified string
- *   would silently produce no edge. Threaded rather than defaulted from
- *   `sessionId`: defaulting would promote any caller's string to trusted.
+ *   PAYLOAD reported it, never a value a model typed. Passed straight to
+ *   `writeHarvested`, which needs it to resolve the `answers` edge --
+ *   `taskForAnchors` returns null without one, so an unverified string would
+ *   silently produce no edge. Threaded rather than defaulted from `sessionId`:
+ *   defaulting would promote any caller's string to trusted. Also returned, so a
+ *   caller can see what it handed over.
+ * @returns {object} `{ candidates, observations, written, selected, dropped,
+ *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
+ *   everything derived; `written` is the subset of keys the graph actually
+ *   holds, which is smaller for three independent reasons -- the budget, the
+ *   anchor discipline, and the duplicate collapse that returns an EXISTING key
+ *   when a later session derives the same claim again.
  */
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
@@ -152,6 +253,11 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // ONE anchor for the whole run, so every candidate from this session points at
+  // the same node and the duplicate collapse in `writeHarvested` can recognise
+  // the same lesson across sessions.
+  const anchorPath = projectAnchor(projectRoot);
 
   const seen = new Set();
   const add = (candidate) => {
@@ -246,7 +352,7 @@ export function derive(dir, options = {}) {
               `observed in one session: \`${failed.command}\` failed` +
                 `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
                 `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
-                'an intervening edit or a flaky run explains the same pair.',
+                'an intervening edit or an unrelated environment change explains the same pair.',
               { max: EVIDENCE_MAX }
             ),
             applicability: 'when about to run this command in this project',
@@ -255,7 +361,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the failing form later succeeds unchanged'],
             trigger: triggerFor(outcome.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: outcome.at || Date.now(),
@@ -280,7 +386,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the same command later succeeds unchanged'],
             trigger: triggerFor(failed.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: failed.at || Date.now(),
@@ -330,7 +436,7 @@ export function derive(dir, options = {}) {
           confidenceLabel: labelFor(CONFIDENCE.correction),
           scope: 'project',
           invalidators: ['the user later asks for the corrected behaviour'],
-          anchors: [projectRoot],
+          anchors: [anchorPath],
           derivedBy: 'correction',
           sessionId,
           at: Date.parse(turn.at || '') || Date.now(),
@@ -379,6 +485,48 @@ export function derive(dir, options = {}) {
     }
   } catch {
     // One detector, never the session.
+  }
+
+  // ---- storage, under a budget -------------------------------------------
+  //
+  // NOTHING ENTERS THE GRAPH UNBUDGETED. `selectForConsolidation` existed for
+  // exactly this and had no caller, which meant that until now nothing bounded
+  // what a session could add. It admits `failure` and `decision` on a FLOOR
+  // before ranking -- a dead end exists nowhere else and is small, and cheap to
+  // find is not cheap to find again -- then fills the remainder by
+  // cost x irrecoverability x reuse-probability.
+  //
+  // ORIGIN_HARVESTED, EXPLICITLY, never ORIGIN_HUMAN. These are machine
+  // derivations; `curate.mjs` states the reason in its own header -- "a
+  // hand-written assertion and a machine guess look identical three months
+  // later, which quietly destroys the reader's ability to calibrate trust".
+  // `writeHarvested` would refuse a batch-wide human origin anyway, and a
+  // candidate here carries neither `origin` nor `quote`, so it cannot earn one
+  // per finding either. That is deliberate: whether a turn was a correction at
+  // all is a lexical guess, and the standing-rules layer selects on human
+  // origin to inject on EVERY turn.
+  try {
+    if (result.candidates.length) {
+      const selected = selectForConsolidation(load(dir), result.candidates, {
+        budget: storageBudget(),
+      });
+      result.selected = selected.kept.length;
+      result.dropped = selected.dropped;
+      result.selectedTokens = selected.tokens;
+      result.written = writeHarvested(dir, selected.kept, {
+        sessionId,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        // The hook payload's own identity, passed through untouched. Without it
+        // `taskForAnchors` returns null and the `answers` edge never fires --
+        // which is the state a default install has been in, because its only
+        // other producer is credential-gated.
+        authoritativeSessionId,
+      });
+    }
+  } catch {
+    // Storage is the last step and the session is already over. A graph write
+    // that fails must not turn a completed session into a hook error.
   }
 
   return result;

--- a/integrations/opencode/hooks/lib/derive.mjs
+++ b/integrations/opencode/hooks/lib/derive.mjs
@@ -139,17 +139,19 @@ const quotable = (command) => {
  * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
  * found across 163 transcripts on this machine it refuses 2 and keeps 6.
  *
- * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
- * building the key, so the claim is about `npm test` rather than about the `cd`.
- * That changes `attemptKey` for every client and every finding already derived
- * from it, so it belongs in its own change with its own comparison.
+ * `commandBody` below now skips a leading `cd <path> &&`, so those two are
+ * recovered and this guard is left holding only the keys that reached a
+ * separator which is NOT a directory change -- `git fetch && <anything>`, a
+ * pipeline, a `;`-joined pair. Those still name no single attempt.
  */
 const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
 
 /**
  * Did `attemptKey` actually capture a command, or only how one was chained?
  *
- * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart --
+ * which now means AFTER `commandBody` has removed any leading `cd`, so this no
+ * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
 const hasAttemptIdentity = (command) =>
@@ -177,6 +179,81 @@ const CORRECTION_OPENER =
   /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
 
 /**
+ * A leading directory change, stripped before the key is built.
+ *
+ * THE MEASURED CASE, AND ONLY THE MEASURED CASE. `attemptKey` spends up to
+ * three non-flag tokens on identity and the habit on this machine is
+ * `cd <absolute path> && <the real command>`, which spends all three on `cd`,
+ * the path and the separator. This repository's own corpus: 1,400 of 2,243
+ * command outcomes open with a `cd`, and the single key
+ * `cd c:/users/.../token-optimizer-mcp &&` covered 547 distinct command lines.
+ * A `cd` says WHERE a command ran; it says nothing about WHAT ran, so it cannot
+ * be part of the identity of an attempt.
+ *
+ * THE SEPARATOR SET IS THE ONE THAT WAS OBSERVED: `&&` (1,147), a newline (204)
+ * and `;` (38) after a leading `cd`. All three mean "then run this". `||` is
+ * DELIBERATELY EXCLUDED even though it costs one line to add: `cd x || echo
+ * failed` puts an error branch after the separator, not the next step, so
+ * stripping there would key the attempt on a failure handler. It occurred zero
+ * times.
+ *
+ * AND NOTHING WIDER, each refusal for a reason from the same corpus:
+ *
+ *   Environment assignments (`FOO=bar cmd`) DO carry information about what
+ *   ran. The one true instance here is
+ *   `TOKEN_OPTIMIZER_HOLDOUT=1 node ... jest.js ...`, and the holdout arm is a
+ *   genuinely different attempt from the same command without it. The other 20
+ *   are shell variable assignments joined by `;` -- statements, not prefixes --
+ *   whose value is usually a 120-character path that would be stripped down to
+ *   nothing useful.
+ *
+ *   `time`, `env`, `nice`, `sudo`, `bash -c`, `pushd`, `Set-Location`: ZERO
+ *   occurrences in 2,243 commands. Code for an unmeasured prefix is a way to
+ *   over-strip that no evidence asked for, and over-stripping merges commands
+ *   that genuinely differ -- the same bug in the other direction. `bash -c` is
+ *   worse than unmeasured: the command sits inside a quoted string, so stripping
+ *   the wrapper leaves a key beginning with a quote character.
+ *
+ *   `cd /d C:\path &&` and `cd "C:/a b" &&` need no extra rule -- the match runs
+ *   to the separator rather than counting tokens, so flags and quoted paths
+ *   containing spaces are consumed for free. Neither appears here, so neither is
+ *   claimed as tested behaviour beyond its unit test.
+ *
+ * A `cd` with NO separator is left alone: `cd <path>` on its own ran no command,
+ * and its key is as meaningless afterwards as before -- there is nothing to
+ * recover. Stripping is repeated up to `MAX_DIR_PREFIXES` times so
+ * `cd a && cd b && cmd` reaches `cmd`; the bound exists only so a pathological
+ * line cannot loop, since each pass must consume a whole `cd ... <sep>`.
+ *
+ * APPLIED IDENTICALLY TO BOTH SOURCES because it is applied INSIDE `attemptKey`,
+ * which is the single function both the event path and the transcript reader's
+ * output pass through. The 120-character anchor cap that makes the two agree on
+ * 266 of 266 keys is untouched and still applied on both sides before this runs.
+ */
+const DIR_PREFIX = /^\s*cd\s[^\r\n;&|]*?(?:&&|;|\r?\n)\s*/i;
+const MAX_DIR_PREFIXES = 4;
+
+/**
+ * The command text with any leading directory change removed.
+ *
+ * Used for the key AND for the identical-text refusal, which is the half that
+ * keeps this from becoming a licence to pair more loosely: without it,
+ * `cd repo && npm test` failing and `npm test` succeeding would emit
+ * "`npm test` succeeded where `cd repo && npm test` failed" at 0.90 -- two
+ * spellings of one attempt, dressed up as a difference that mattered. The
+ * claim itself still quotes the RAW command, because that is what ran.
+ */
+export function commandBody(command) {
+  let text = String(command || '');
+  for (let i = 0; i < MAX_DIR_PREFIXES; i++) {
+    const stripped = text.replace(DIR_PREFIX, '');
+    if (stripped === text) break;
+    text = stripped;
+  }
+  return text;
+}
+
+/**
  * The prefix that makes two invocations "the same attempt".
  *
  * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
@@ -194,7 +271,7 @@ const CORRECTION_OPENER =
  * ships a false claim into model context.
  */
 export function attemptKey(command) {
-  return String(command || '')
+  return commandBody(command)
     .trim()
     .split(/\s+/)
     .filter((token) => token && !token.startsWith('-'))
@@ -494,7 +571,14 @@ export function derive(dir, options = {}) {
           // is real and supports NEITHER claim, so nothing is emitted. This is
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
-          if (failed.command === outcome.command) continue;
+          // COMPARED WITH THE DIRECTORY CHANGE REMOVED, for the same reason
+          // the key is. `cd repo && npm test` and `npm test` are one attempt
+          // spelled two ways; before `commandBody` they landed in different
+          // groups and never met, and letting them meet without widening this
+          // guard would emit "`npm test` succeeded where `cd repo && npm test`
+          // failed" at 0.90 -- a difference in the claim that is not a
+          // difference in what ran. Same for two `cd`s to different paths.
+          if (commandBody(failed.command) === commandBody(outcome.command)) continue;
 
           // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
           // client both sides of almost every pair are truncated multi-line
@@ -502,10 +586,12 @@ export function derive(dir, options = {}) {
           // spending the retrieval budget of every later session.
           if (!quotable(failed.command) || !quotable(outcome.command)) continue;
 
-          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
-          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
-          // command lines in this repository alone, and any pair drawn from that
-          // group is a false claim about both halves.
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`. The
+          // `cd <path> &&` case that grouped 547 unrelated command lines in this
+          // repository is now handled earlier by `commandBody`; what is left
+          // here is every OTHER separator -- `git fetch && <anything>`, a
+          // pipeline, a `;`-joined pair -- where the key still names no single
+          // attempt and any pair drawn from it is false about both halves.
           if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =

--- a/integrations/opencode/hooks/lib/derive.mjs
+++ b/integrations/opencode/hooks/lib/derive.mjs
@@ -1,0 +1,385 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/derive.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Findings from data we already hold, with no model call.
+ *
+ * WHY THIS EXISTS. The semantic harvest is on by default but its real gate is a
+ * credential: `harvestMode()` returns `off:no-key` on any machine without one,
+ * which is CI, corporate laptops, and every subscription-only login. This
+ * repository's own graph is the evidence -- 2,965 symbol nodes, 904 file nodes,
+ * 128 task nodes and ONE finding -- because the structural layer accumulates
+ * from ordinary tool traffic while every verdict needed an API key this machine
+ * does not have.
+ *
+ * Everything here is derived from outcomes, transitions and corrections that are
+ * ALREADY RECORDED LOCALLY. Nothing is sent anywhere, nothing is billed, so
+ * there is nothing to consent to and this runs by default. It is the only
+ * finding producer on a machine without a key.
+ *
+ * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
+ * second command fixed the first -- an intervening edit, a dependency install or
+ * a flaky test explains it just as well. So each detector carries a confidence
+ * ceiling, the claim text says only what was OBSERVED, and the two shapes where
+ * the observation supports no claim at all are refused rather than downgraded
+ * (see `attemptKey` and the identical-text guard below).
+ *
+ * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
+ * budget, belongs to the caller.
+ */
+
+import { readMetrics, rereadsByAnchor } from './metrics.mjs';
+import { readArchive, readTurns } from './transcript.mjs';
+import { redact } from './redact.mjs';
+
+/**
+ * Ceilings, ordered by how much the evidence actually supports.
+ *
+ * A command that succeeded where a DIFFERENT command failed is close to a direct
+ * observation. A test or build going red-to-green is weaker, because the usual
+ * cause is the code changing between the two runs rather than anything about the
+ * command. A correction is a lexical guess about what a human meant. Churn
+ * describes our own reading behaviour and says nothing about the code at all.
+ */
+export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+
+/** Claim text cap. A finding is one sentence; a paragraph is evidence. */
+const CLAIM_MAX = 300;
+const EVIDENCE_MAX = 400;
+
+/** Bounded so a pathological log cannot turn session end into real work. */
+const MAX_CANDIDATES = 200;
+
+/**
+ * Commands whose red-to-green transition is usually explained by the CODE
+ * changing rather than by the command. They get the lower ceiling.
+ */
+const CODE_SENSITIVE = /\b(test|tests|jest|vitest|pytest|mocha|build|compile|tsc|lint|typecheck)\b/i;
+
+/**
+ * Openers that mark a user turn as a correction rather than an instruction.
+ *
+ * DELIBERATELY NARROW, and anchored to the START of the turn. The model-based
+ * extractor in `lessons.mjs` can read intent; this cannot, so it only claims the
+ * shapes where the first few words carry the whole signal. Recall is poor by
+ * design: a missed correction costs one finding, a false one puts words in the
+ * user's mouth at 0.6 confidence.
+ */
+const CORRECTION_OPENER =
+  /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
+
+/**
+ * The prefix that makes two invocations "the same attempt".
+ *
+ * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
+ * through what the alternatives do to real command lines:
+ *
+ *   Two tokens conflates `npm run build` with `npm run test`, and the pair then
+ *   produces "`npm run test` works where `npm run build` failed" -- a claim that
+ *   is simply false.
+ *
+ *   Counting flags splits `deploy` from `deploy --retry`, which is the single
+ *   most useful pair this detector can find, into two groups that never meet.
+ *
+ * Conservative in the remaining direction: `npm run build:prod` and
+ * `npm run build` do not pair. A missed pair costs one finding; a wrong pair
+ * ships a false claim into model context.
+ */
+export function attemptKey(command) {
+  return String(command || '')
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'))
+    .slice(0, 3)
+    .join(' ')
+    .toLowerCase();
+}
+
+/** Normalised claim text, so the same lesson derived twice is one candidate. */
+const claimKey = (type, claim) =>
+  `${type}|${String(claim).toLowerCase().replace(/\s+/g, ' ').trim()}`;
+
+/** 0.95 is reserved for verified; everything here is inference. */
+const labelFor = (confidence) => (confidence >= 0.75 ? 'probable' : 'speculative');
+
+/** A literal command prefix, safe to hand to `safeTrigger`. */
+const triggerFor = (command) =>
+  attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
+
+/**
+ * Derives finding candidates from one project's local evidence.
+ *
+ * @param {string} dir wiki directory.
+ * @param {object} options
+ * @param {string|null} options.sessionId session this ran for, for provenance.
+ * @param {string|null} options.transcriptPath live transcript, read only when the
+ *   archive holds nothing for this session yet.
+ * @param {string|null} options.projectRoot the anchor every derived claim gets.
+ *   Without it nothing is derived: an unanchored finding cannot be invalidated
+ *   and is refused by `writeHarvested` anyway, so emitting one would only spend
+ *   the caller's budget on junk.
+ * @param {string|null} options.authoritativeSessionId the session id as the HOOK
+ *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
+ *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
+ *   edge -- `taskForAnchors` returns null without one, so an unverified string
+ *   would silently produce no edge. Threaded rather than defaulted from
+ *   `sessionId`: defaulting would promote any caller's string to trusted.
+ */
+export function derive(dir, options = {}) {
+  // `options || {}` rather than a destructuring default. A default only fires on
+  // `undefined`, so a caller passing an explicitly null options object -- which
+  // is what a hook does when it has nothing to say -- threw a TypeError out of
+  // the parameter list itself, before any of the try/catch below could fail open.
+  const {
+    sessionId = null,
+    transcriptPath = null,
+    projectRoot = null,
+    authoritativeSessionId = null,
+  } = options || {};
+
+  const result = {
+    candidates: [],
+    observations: [],
+    written: [],
+    sessionId,
+    authoritativeSessionId,
+  };
+
+  let events;
+  try {
+    events = readMetrics(dir);
+  } catch {
+    // Session end must cost nothing. No evidence is not an error.
+    return result;
+  }
+  if (!Array.isArray(events)) return result;
+
+  const seen = new Set();
+  const add = (candidate) => {
+    if (result.candidates.length >= MAX_CANDIDATES) return;
+    const key = claimKey(candidate.type, candidate.claim);
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.candidates.push(candidate);
+  };
+
+  // ---- 1 & 2: a failed attempt followed by a succeeding one ---------------
+  //
+  // The event is `tool-outcome` and THE COMMAND TEXT IS IN `anchor`: there is no
+  // separate command field, because the anchor of a command surface IS the
+  // command. It is capped at 120 characters at the boundary, so a very long
+  // command line is compared and quoted truncated.
+  try {
+    if (projectRoot) {
+      const outcomes = events
+        .filter(
+          (e) =>
+            e &&
+            e.kind === 'tool-outcome' &&
+            e.surface === 'command' &&
+            typeof e.anchor === 'string' &&
+            e.anchor.trim()
+        )
+        .map((e) => ({
+          command: e.anchor.trim(),
+          output: typeof e.output === 'string' ? e.output : '',
+          exit: Number.isInteger(e.exit) ? e.exit : null,
+          at: e.at ?? 0,
+          // `success` FIRST, `exit` only as a refinement. MCP tools report no
+          // numeric code at all, so a classifier keyed on `exit !== 0` would be
+          // inert for most clients -- and `exit` is null rather than 0 precisely
+          // so that absence is not read as a clean exit.
+          failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
+        }))
+        .sort((a, b) => a.at - b.at);
+
+      const byAttempt = new Map();
+      for (const outcome of outcomes) {
+        const key = attemptKey(outcome.command);
+        if (!key) continue;
+        if (!byAttempt.has(key)) byAttempt.set(key, []);
+        byAttempt.get(key).push(outcome);
+      }
+
+      for (const run of byAttempt.values()) {
+        // The NEAREST preceding failure, not the first one in the session. With
+        // `find` over the whole run, a command that failed at 09:00 and
+        // succeeded at 17:00 after nine unrelated attempts is reported as one
+        // story.
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          // One pair per failure: a command that succeeds twice afterwards has
+          // not taught two lessons.
+          lastFailure = null;
+
+          // THE GUARD THAT REMOVES THE LARGEST JUNK CLASS. The commonest shape
+          // in a coding session is `npm run build` failing, the code being
+          // fixed, and `npm run build` succeeding -- identical text. From that
+          // pair the two available claims are "`npm run build` works where
+          // `npm run build` failed", which is incoherent, and "`npm run build`
+          // fails", which the same evidence has just disproved. The observation
+          // is real and supports NEITHER claim, so nothing is emitted. This is
+          // not a confidence question; a ceiling cannot rescue a claim whose
+          // content is wrong.
+          if (failed.command === outcome.command) continue;
+
+          const codeSensitive =
+            CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);
+          const confidence = codeSensitive ? CONFIDENCE.test : CONFIDENCE.command;
+          const derivedBy = codeSensitive ? 'test-transition' : 'command-transition';
+
+          // "SUCCEEDED WHERE", NOT "FIXES". What is observed is two outcomes in
+          // order on the same attempt; that the difference in the command line
+          // CAUSED the difference in outcome is not observed and is not claimed.
+          add({
+            type: 'command',
+            claim: redact(
+              `\`${outcome.command}\` succeeded in this project where \`${failed.command}\` failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
+                'an intervening edit or a flaky run explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: 'when about to run this command in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the failing form later succeeds unchanged'],
+            trigger: triggerFor(outcome.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+
+          // The error text, only when there is error text. Without it the claim
+          // degrades to "`X` failed with:" and nothing after the colon, which
+          // carries no information and still costs budget.
+          const firstLine = failed.output.split('\n').find((line) => line.trim()) || '';
+          if (firstLine.trim().length < 8) continue;
+          add({
+            type: 'failure',
+            claim: redact(`\`${failed.command}\` failed with: ${firstLine.trim()}`, {
+              max: CLAIM_MAX,
+            }),
+            evidence: redact(`captured output of the failing run:\n${failed.output}`, {
+              max: EVIDENCE_MAX,
+            }),
+            applicability: 'when this command is about to be run in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the same command later succeeds unchanged'],
+            trigger: triggerFor(failed.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: failed.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 3: user corrections ------------------------------------------------
+  //
+  // A `feedback` finding -- the one type whose source is a person saying the
+  // agent was wrong. The MODEL-BASED extractor for this lives in `lessons.mjs`
+  // and needs the credential this module exists to do without, so here the
+  // signal is lexical: the opening words of the user's own turn.
+  //
+  // ORIGIN IS NOT PROMOTED. `writeHarvested` grants ORIGIN_HUMAN to a finding
+  // carrying a verified verbatim quote, and the standing-rules layer selects on
+  // that origin to inject a claim on EVERY turn. The quote here would be
+  // verbatim -- it is copied out of the archive -- but whether the turn was a
+  // correction at all is a guess, and a guess must not buy always-on injection.
+  // So no `origin` and no `quote` field: this stays harvested provenance.
+  try {
+    if (projectRoot) {
+      let turns = readArchive(dir, sessionId);
+      // The archive is written by the Stop hook too, and the order of the two is
+      // not this module's to assume, so fall back to the live transcript.
+      if (!turns.length && transcriptPath) turns = readTurns(transcriptPath);
+
+      for (const turn of turns) {
+        if (!turn || turn.role !== 'user') continue;
+        const text = String(turn.text || '').trim();
+        // Long turns are new instructions with a complaint somewhere inside
+        // them; truncating one into a claim would misquote the user.
+        if (text.length < 12 || text.length > 300) continue;
+        if (!CORRECTION_OPENER.test(text)) continue;
+        add({
+          type: 'feedback',
+          claim: redact(text, { max: CLAIM_MAX }),
+          evidence: redact(`the user opened a turn with a correction: "${text}"`, {
+            max: EVIDENCE_MAX,
+          }),
+          applicability: 'when working in this project, before repeating what was corrected',
+          confidence: CONFIDENCE.correction,
+          confidenceLabel: labelFor(CONFIDENCE.correction),
+          scope: 'project',
+          invalidators: ['the user later asks for the corrected behaviour'],
+          anchors: [projectRoot],
+          derivedBy: 'correction',
+          sessionId,
+          at: Date.parse(turn.at || '') || Date.now(),
+        });
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 4: re-read churn ---------------------------------------------------
+  //
+  // NOT A FINDING, AND THAT IS THE DECISION RATHER THAN AN OMISSION.
+  //
+  // Churn is a claim about OUR OWN reading behaviour: "this file was read three
+  // times unchanged". Every finding type available is a claim about the work --
+  // `map` describes how an area of the codebase is laid out, and is
+  // content-dependent, so a churn claim filed as `map` would be checked for
+  // staleness against contents it makes no claim about and flip stale on the
+  // first edit to a file it never described. Worse, the anchors it would take
+  // are by construction the HOTTEST files in the project, which are exactly the
+  // files that already carry real findings, so a 0.4-confidence row saying
+  // nothing actionable would sit in the injection budget beside them and render
+  // on the same reads. Nothing a future agent could DO differently follows from
+  // it: it does not say what the file contains, so it cannot substitute for
+  // reading it.
+  //
+  // The signal is still worth having -- as the measurement it already is.
+  // `rereadWaste` reports it on the balance sheet, `rereadsByAnchor` names the
+  // offenders, and this returns those rows as OBSERVATIONS: computed, carried,
+  // and deliberately not competing for context. Three detectors produce
+  // findings; the fourth produces a number.
+  try {
+    for (const row of rereadsByAnchor(events).slice(0, 3)) {
+      if (!row.anchor || row.wasteful < 2) continue;
+      result.observations.push({
+        kind: 'churn',
+        anchor: row.anchor,
+        repeats: row.repeats,
+        wasteful: row.wasteful,
+        tokens: row.tokens,
+        confidence: CONFIDENCE.churn,
+        derivedBy: 'churn',
+        note: `re-read ${row.repeats} times, ${row.wasteful} of them unchanged`,
+      });
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  return result;
+}

--- a/integrations/opencode/hooks/lib/derive.mjs
+++ b/integrations/opencode/hooks/lib/derive.mjs
@@ -16,6 +16,13 @@
  * there is nothing to consent to and this runs by default. It is the only
  * finding producer on a machine without a key.
  *
+ * THREE SOURCES, NOT TWO. `tool-outcome` events, the transcript archive, and --
+ * since the transition detectors were measured to have no input at all on the
+ * primary client -- the raw transcript's FAILED tool results, which is the only
+ * place a Claude Code failure is recorded (`failedResultsFromTranscript` in
+ * transcript.mjs, and the note above `quotable` for what that measurement
+ * actually yielded).
+ *
  * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
  * second command fixed the first -- an intervening edit, a dependency install or
  * a flaky test explains it just as well. So each detector carries a confidence
@@ -32,7 +39,11 @@
 import { readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
-import { readArchive, readTurns } from './transcript.mjs';
+import {
+  readArchive,
+  readTurns,
+  failedResultsFromTranscript,
+} from './transcript.mjs';
 import { redact } from './redact.mjs';
 import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
@@ -56,6 +67,96 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * The anchor cap a command surface is stored under, restated here as a TEST.
+ *
+ * `recordToolOutcome` truncates `anchor` to 120 characters, so a command at or
+ * over that length reached this module already cut -- and `quotable` below
+ * refuses to build a claim out of the fragment.
+ */
+const COMMAND_ANCHOR_MAX = 120;
+
+/**
+ * Can this command text be QUOTED in a claim a reader could act on?
+ *
+ * THE SECOND REFUSAL OF ITS KIND, and it exists because measurement forced it.
+ * Wiring the transcript reader gave the transition detectors their first real
+ * input on this client and immediately produced four candidates at 0.9
+ * confidence whose claim text read:
+ *
+ *   `cd /c/Users/.../token-optimizer-mcp\ncat >> docs/superpowers/plans/2026-` succeeded
+ *   in this project where `cd /c/Users/.../token-optimizer-mcp\ncat > /tmp/probe3.mjs
+ *   <<'EOF'\nimport { readdirSync, readFileSync, sta` failed
+ *
+ * -- two truncated fragments of throwaway shell scripts, grouped together only
+ * because `attemptKey`'s three tokens were spent on `cd`, the absolute path, and
+ * the verb. Then measured properly across three real transcripts: **0 of 83**
+ * captured command failures are single-line and inside the cap. 65% of this
+ * project's 2,178 successful command outcomes are not either. On this client a
+ * "command" is usually a whole shell script, so the attempt identity the
+ * transition detectors are built on does not fit most of the traffic.
+ *
+ * This is the same judgement as the identical-text guard below rather than a
+ * confidence question: a claim whose subject is a truncated fragment of a
+ * program is not a weaker claim, it is not a claim. A raised cap would not
+ * rescue it -- quoting the whole 500-character heredoc is no more actionable.
+ *
+ * What survives is exactly what the detector was designed for: `npm test`,
+ * `dotnet build X`, `deploy --retry` -- a repeatable command someone could run
+ * again. This machine captured none failing, which is why the honest yield here
+ * is zero and why that is reported rather than dressed up.
+ *
+ * Applied to BOTH sources. Where the evidence arrived from has no bearing on
+ * whether the resulting sentence says anything, and a rule that let events
+ * through would ship the junk on the ten clients that do report failures.
+ */
+const quotable = (command) => {
+  const text = String(command || '');
+  return (
+    text.trim().length > 0 &&
+    !/[\r\n]/.test(text) &&
+    text.length < COMMAND_ANCHOR_MAX
+  );
+};
+
+/**
+ * Tokens that separate one command from the next rather than naming one.
+ *
+ * MEASURED, LIKE EVERY OTHER REFUSAL HERE. `attemptKey` spends up to three
+ * non-flag tokens on identity, and the habit on this machine is
+ * `cd <absolute path> && <the real command>` -- which spends all three on `cd`,
+ * the path and `&&`, so the real command never enters the key. This project's
+ * own evidence: the single key `cd c:/users/.../token-optimizer-mcp &&` covers
+ * **539 distinct command lines**. One quotable failure in that group would pair
+ * with an arbitrary unrelated success and claim "`cd repo && grep -n ...`
+ * succeeded where `cd repo && git merge ...` failed", which is false about both.
+ *
+ * A KEY THAT REACHED A SEPARATOR NEVER REACHED A COMMAND, so there is no attempt
+ * to compare and nothing to claim -- the same judgement as the identical-text
+ * guard rather than a lower ceiling. Narrow on purpose: `2>&1` and `/F` are not
+ * separators and do not trip this, so `cat commitlint.config.mjs 2>&1` and
+ * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
+ * found across 163 transcripts on this machine it refuses 2 and keeps 6.
+ *
+ * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
+ * building the key, so the claim is about `npm test` rather than about the `cd`.
+ * That changes `attemptKey` for every client and every finding already derived
+ * from it, so it belongs in its own change with its own comparison.
+ */
+const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
+
+/**
+ * Did `attemptKey` actually capture a command, or only how one was chained?
+ *
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * One check per pair is enough: both halves share the key by construction.
+ */
+const hasAttemptIdentity = (command) =>
+  attemptKey(command)
+    .split(' ')
+    .filter(Boolean)
+    .every((token) => !COMMAND_SEPARATORS.has(token));
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -274,6 +375,17 @@ export function derive(dir, options = {}) {
   // separate command field, because the anchor of a command surface IS the
   // command. It is capped at 120 characters at the boundary, so a very long
   // command line is compared and quoted truncated.
+  //
+  // TWO SOURCES OF FAILURE, ONE PAIRING LOOP. Claude Code never fires
+  // PostToolUse for a failed tool call -- 2,238 of 2,238 live `tool-outcome`
+  // events on the measuring machine carry `success: true`, and a deliberately
+  // failing command produced no event at all -- so on the primary client these
+  // two detectors had NO INPUT WHATSOEVER while working normally on the ten
+  // adapter clients. `failedResultsFromTranscript` supplies the missing half
+  // from the only place it exists. The successes still come from events only:
+  // a transcript failure that pairs with nothing stays unclaimed, which is also
+  // what keeps a failure from ANOTHER project's directory out of this project's
+  // graph -- a candidate cannot be emitted without a success recorded HERE.
   try {
     if (projectRoot) {
       const outcomes = events
@@ -290,6 +402,9 @@ export function derive(dir, options = {}) {
           output: typeof e.output === 'string' ? e.output : '',
           exit: Number.isInteger(e.exit) ? e.exit : null,
           at: e.at ?? 0,
+          // Carried purely so the transcript merge below can recognise the same
+          // tool call arriving from the other source.
+          toolCallId: e.toolCallId ? String(e.toolCallId) : null,
           // `success` FIRST, `exit` only as a refinement. MCP tools report no
           // numeric code at all, so a classifier keyed on `exit !== 0` would be
           // inert for most clients -- and `exit` is null rather than 0 precisely
@@ -297,6 +412,53 @@ export function derive(dir, options = {}) {
           failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
         }))
         .sort((a, b) => a.at - b.at);
+
+      // DEDUPLICATED ON `toolCallId`, which is the SAME STRING in both sources:
+      // `episodeMeta` reads `raw.tool_use_id` into `toolCallId`, and that is the
+      // transcript's `tool_use_id` verbatim -- verified against live evidence
+      // (`toolu_01L4Nwr...` in metrics.jsonl, the same ids in the transcript).
+      // So on the ten clients that DO report failures, the event copy wins and
+      // the transcript copy is dropped before grouping. Without this the two
+      // copies of one failure would sit in the same run and the second of them
+      // would be paired against the first as a failed-then-succeeded story about
+      // itself.
+      //
+      // The fallback covers a client that reports a failure with no call id:
+      // identical command text within two seconds is one failure recorded twice,
+      // not two failures, because nothing re-runs a command that fast.
+      const eventIds = new Set(
+        outcomes.map((o) => o.toolCallId).filter(Boolean)
+      );
+      const eventFailures = outcomes.filter((o) => o.failed);
+      const alreadyRecorded = (failure) => {
+        if (failure.toolCallId && eventIds.has(failure.toolCallId)) return true;
+        return eventFailures.some(
+          (o) =>
+            o.command === failure.command &&
+            Math.abs((o.at || 0) - (failure.at || 0)) <= 2000
+        );
+      };
+
+      let transcriptFailures = [];
+      try {
+        transcriptFailures = failedResultsFromTranscript(transcriptPath).filter(
+          (failure) => failure.command.trim() && !alreadyRecorded(failure)
+        );
+      } catch {
+        // The reader is an extra source, never a reason the detector stops.
+      }
+      for (const failure of transcriptFailures) {
+        outcomes.push({
+          command: failure.command.trim(),
+          output: failure.output,
+          exit: failure.exit,
+          at: failure.at,
+          toolCallId: failure.toolCallId,
+          // Read from `Exit code N`, which is the only shape the reader admits.
+          failed: true,
+        });
+      }
+      if (transcriptFailures.length) outcomes.sort((a, b) => a.at - b.at);
 
       const byAttempt = new Map();
       for (const outcome of outcomes) {
@@ -333,6 +495,18 @@ export function derive(dir, options = {}) {
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
           if (failed.command === outcome.command) continue;
+
+          // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
+          // client both sides of almost every pair are truncated multi-line
+          // shell scripts, and a claim quoting a fragment of one is noise
+          // spending the retrieval budget of every later session.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
+          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
+          // command lines in this repository alone, and any pair drawn from that
+          // group is a false claim about both halves.
+          if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =
             CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);

--- a/integrations/opencode/hooks/lib/doctor.mjs
+++ b/integrations/opencode/hooks/lib/doctor.mjs
@@ -197,7 +197,8 @@ function hooksDirFor({ hooksDir, install, root }) {
  * identical from outside: a graph that fills with structural nodes either way.
  *
  * Measured on a real 5.4.0 install: 484 symbol, 286 file and 122 task nodes and
- * ZERO findings, because harvestMode() was 'off:not-opted-in'. Fifteen checks
+ * ZERO findings, because harvestMode() then returned an opt-in refusal (the mode has
+ * since been renamed: it is 'off:no-key' now, and opting in is no longer the gate). Fifteen checks
  * passed and none mentioned harvest. stop-harvest.mjs names this exact gap --
  * "nothing in doctor, audit or waste mentions harvest, so a user sees a graph
  * filling with structural nodes and no findings and has no way to learn why" --
@@ -221,9 +222,15 @@ export function probeHarvest() {
   // optimizer is off" is noise, which is why stop-harvest maps it to no notice.
   if (mode === 'off:mode') return [];
 
+  // SAID PLAINLY, because this is the configuration a user would choose if they
+  // knew it existed and the previous wording buried it in machinery. A local
+  // endpoint is the only setting under which the semantic harvest runs with no
+  // credential, no billing and no digest leaving the machine -- so the two facts
+  // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
     return [ok('finding extraction is available',
-      'active-model wiki_write is primary; local endpoint also enables fallback extraction')];
+      'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
+      'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
@@ -233,10 +240,19 @@ export function probeHarvest() {
 
   // No second-model credential is required for the primary path. The Codex/agent session that
   // already paid to derive the conclusion is the extractor and wiki_write is local.
+  // NAME THE TRADE, not just the missing variable. This is the default state on
+  // every machine without a credential, so it is the text most users will read,
+  // and "unavailable" alone tells them neither what they are missing nor that
+  // the free option exists. Local findings still accumulate: derive.mjs reads
+  // exit codes, red-to-green transitions, corrections and churn out of evidence
+  // already on disk and sends nothing anywhere.
   if (mode === 'off:no-key') {
     return [ok('finding extraction is available',
-      'active model records durable conclusions through local wiki_write; no separate-model ' +
-      'credential is configured, so fallback transcript extraction is unavailable')];
+      'active model records durable conclusions through local wiki_write, and derive runs at ' +
+      'session end with no credential. No separate-model credential is configured, so fallback ' +
+      'transcript extraction is unavailable: point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local ' +
+      'model to run it free and private, or set TOKEN_OPTIMIZER_API_KEY to run it from a bounded ' +
+      'digest of paths, commands, prompts and conclusions -- never file contents')];
   }
 
   // off:opted-out -- a deliberate choice, reported as one. Nagging about a setting somebody chose

--- a/integrations/opencode/hooks/lib/inject.mjs
+++ b/integrations/opencode/hooks/lib/inject.mjs
@@ -1134,10 +1134,25 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // injected more than the budget allowed and recorded fewer tokens than it
   // spent -- in a block whose entire justification is that it is tightly
   // bounded and measured against the control arm.
+  // THE LAST LINE IS HOW THE NEXT RULE GETS HERE, and it is one line because
+  // this block is charged on every session forever. A rule reaches this list
+  // only by being pinned or by being a person's verified correction, and both
+  // start as a `wiki_write` -- so a model reading a set of standing rules with
+  // no idea how they were produced has no way to add to it. Stated at the point
+  // of the evidence rather than as a separate always-on block: the reader is
+  // already looking at the output of the mechanism being described.
+  //
+  // THE COLD GRAPH IS COVERED ELSEWHERE, deliberately. Nothing here renders
+  // until at least one rule qualifies, which is the property the always-on
+  // budget depends on, so this line cannot be the first-session nudge --
+  // `policyText`'s "Record what you work out" section is, and it is emitted at
+  // SessionStart whether or not the graph holds anything.
   const HEADING =
     '# Standing rules for this project' +
     '\n\nEstablished in previous sessions and expected to hold. ' +
-    'These are not suggestions.\n\n';
+    'These are not suggestions.\n\n' +
+    'Record what you work out with wiki_write and a real file anchor; ' +
+    'that is how a rule reaches this list.\n\n';
   const noticeFor = (n) =>
     n
       ? `\n(${n} further standing rule${n === 1 ? '' : 's'} did not fit this budget; ` +

--- a/integrations/opencode/hooks/lib/inject.mjs
+++ b/integrations/opencode/hooks/lib/inject.mjs
@@ -35,6 +35,7 @@ import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
 import { cacheOrdered } from './cache.mjs';
+import { withheldFor, exploreOrder, servingPolicyVersion, LOO_ENABLED } from './loo.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -311,8 +312,38 @@ export function forTouch(
     });
     for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
   }
-  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  // LAYER 2 EXPLORATION, BEFORE the budget decides.
+  //
+  // `assessed.eligible` arrives in net-utility order and `fit` keeps that order
+  // until the budget runs out -- so the ranking decides which findings are ever
+  // served, which decides which ever accumulate observations, which decides
+  // their utility. A tenth of touches therefore promote the least-served
+  // candidate first. This is the only place it can go: after `fit` the choice
+  // has already been made.
+  const ordered = exploreOrder(assessed.eligible, dir, { sessionId, anchor: filePath });
+  const { kept, spent } = fit(ordered.map((item) => item.finding), budget);
   if (!kept.length) return null;
+
+  // LAYER 2 WITHHOLDING, AFTER the budget decides, which is the only ordering
+  // that produces a leave-one-out rather than a substitution: withholding first
+  // would let the next-ranked finding take the freed tokens, so the withheld
+  // arm would differ from the served arm by two findings instead of one and the
+  // effect would belong to neither.
+  //
+  // `holdout` is passed so the two experiments cannot compose into "withhold
+  // everything and call it a leave-one-out": that arm already serves nothing.
+  const withheld = withheldFor(kept.map((finding) => finding.key), sessionId, graph, dir, {
+    surface: 'file',
+    anchor: filePath,
+    holdout,
+  });
+  const delivered = withheld ? kept.filter((finding) => finding.key !== withheld) : kept;
+  // RE-PRICED, because `fit` priced what it KEPT and this delivers less. Using
+  // `spent` would bill the injection-cost side of the balance sheet for text
+  // the model never received.
+  const deliveredSpent = withheld
+    ? delivered.reduce((sum, finding) => sum + estimate(render(finding)), 0)
+    : spent;
 
   record(dir, {
     kind: 'inject',
@@ -321,15 +352,20 @@ export function forTouch(
     surface: 'file',
     anchor: filePath,
     holdout,
-    tokens: holdout ? 0 : spent,
-    deliveredTokens: holdout ? 0 : spent,
+    tokens: holdout ? 0 : deliveredSpent,
+    deliveredTokens: holdout ? 0 : deliveredSpent,
     shadowTokens: spent,
-    count: holdout ? 0 : kept.length,
+    count: holdout ? 0 : delivered.length,
     candidateCount: kept.length,
-    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    findingIds: holdout ? [] : delivered.map((finding) => finding.key),
     shadowFindingIds: kept.map((finding) => finding.key),
-    stale: kept.some((f) => f.stale),
+    stale: delivered.some((f) => f.stale),
     sessionId,
+    // ON EVERY RECORD, not only the withheld ones. A served observation needs
+    // the policy version as much as a withheld one does, or `effects` cannot
+    // keep the two arms of one comparison inside one policy.
+    ...(LOO_ENABLED() ? { looPolicy: servingPolicyVersion() } : {}),
+    ...(withheld ? { loo: withheld } : {}),
   });
 
   // MARKED SEEN IN BOTH ARMS, for the same reason as the command path: a file
@@ -339,11 +375,16 @@ export function forTouch(
   // grow faster purely from repetition.
   //
   // This is the identical defect that was fixed in `forCommand` and not here.
+  //
+  // THE WITHHELD KEY IS MARKED TOO, and that is load-bearing rather than tidy:
+  // an unmarked one would be a candidate again on the next touch of this file,
+  // where the one-per-touch tiebreak could serve it -- flipping its arm inside
+  // the very session the arm hash exists to pin it for.
   for (const f of kept) alreadyInjected.add(f.key);
 
-  if (holdout || !kept.length) return null;
+  if (holdout || !delivered.length) return null;
 
-  return `Known about ${filePath} (from previous sessions):\n${kept.map(render).join('\n')}`;
+  return `Known about ${filePath} (from previous sessions):\n${delivered.map(render).join('\n')}`;
 }
 
 /**

--- a/integrations/opencode/hooks/lib/keepwarm.mjs
+++ b/integrations/opencode/hooks/lib/keepwarm.mjs
@@ -30,6 +30,15 @@ import { record, readMetrics, readBalance } from './metrics.mjs';
 import { WRITE_MULTIPLIER, READ_MULTIPLIER } from './cache.mjs';
 
 /**
+ * The shortest gap that counts as a NEW turn rather than a burst inside one.
+ *
+ * Shared by the gap distribution and by the hit test, because they have to
+ * agree about what a turn is. Two copies of this number would let the decision
+ * be fitted to one definition of a turn and scored against another.
+ */
+export const TURN_GAP_MS = 250;
+
+/**
  * TTL tiers, with what a WRITE costs at each.
  *
  * A five-minute entry is written at 1.25x a plain input token; the one-hour
@@ -85,7 +94,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
     for (let i = 1; i < session.length; i++) {
       const gap = session[i] - session[i - 1];
       // A burst of events inside one turn is not a gap between turns.
-      if (gap > 250) gaps.push(gap);
+      if (gap > TURN_GAP_MS) gaps.push(gap);
     }
   }
   if (gaps.length < 6) return null;
@@ -105,10 +114,91 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
 }
 
 /**
+ * Refreshes to observe at a tier before the observation may bound the decision.
+ *
+ * THE SAME NUMBER THE BACKSTOP DEMANDS, deliberately. The decision and the
+ * tripwire read the same ledger, so letting them disagree about when there is
+ * enough evidence would mean one of them acting on a sample the other calls too
+ * small. Below the floor the decision keeps its expected-value answer, so a
+ * single unlucky miss changes nothing at all.
+ *
+ * NOT A CONFIDENCE INTERVAL, and the reason is arithmetic rather than taste. A
+ * Wilson 95% upper bound at ten refreshes and zero hits is 0.28 -- so a policy
+ * that missed ten times out of ten would still be recommended, which is exactly
+ * the case the loop exists to catch. The point estimate is safe here because of
+ * the bound below: an observation may only ever LOWER the modelled probability,
+ * so sampling noise cannot manufacture a refresh, and the tripwire's realised
+ * ledger is a second guard underneath.
+ */
+export const OBSERVATION_FLOOR = TRIPWIRE_MIN;
+
+/**
+ * The measured hit rate per tier, from recorded outcomes.
+ *
+ * Tiers below the floor are ABSENT rather than present with a small n, because
+ * a rate carrying no weight is the thing most likely to be used as though it
+ * did.
+ */
+export function observedHitRates(outcomes = []) {
+  const byTier = new Map();
+  for (const event of outcomes) {
+    if (event?.kind !== 'keepwarm' || event.action !== 'outcome') continue;
+    const name = TIERS.some((t) => t.name === event.tier) ? event.tier : TIERS[0].name;
+    const row = byTier.get(name) || { refreshes: 0, hits: 0 };
+    row.refreshes += 1;
+    if (event.hit) row.hits += 1;
+    byTier.set(name, row);
+  }
+
+  const qualified = new Map();
+  for (const [name, row] of byTier) {
+    if (row.refreshes < OBSERVATION_FLOOR) continue;
+    qualified.set(name, { ...row, rate: row.hits / row.refreshes });
+  }
+  return qualified;
+}
+
+/**
+ * What the refreshes at this tier actually did, if enough of them have.
+ *
+ * Tolerates being handed anything -- null, a plain object, a Map -- because the
+ * callers are two public functions whose options object is assembled by other
+ * people's code.
+ */
+function observationsFor(observed, tierName) {
+  const row = observed instanceof Map ? observed.get(tierName) : null;
+  return row && Number.isFinite(row.rate) ? row : null;
+}
+
+/**
+ * The modelled probability, BOUNDED BY what was observed and never raised by it.
+ *
+ * The asymmetry is the whole point and runs against this project's interest. A
+ * recorded `hit` says only that a turn arrived before the entry expired; it
+ * cannot say the refresh is what kept the entry alive, because a turn arriving
+ * one minute after a five-minute ping would have found the entry warm anyway.
+ * So the observed rate is an UPPER bound on a refresh's value, and substituting
+ * it for the model would flatter keep-warm badly: on the machine this was
+ * written on, the modelled ping probability is 0.2% and the observable
+ * before-expiry rate is 99.5%, so the substitution would recommend refreshing
+ * forever. A low rate, by contrast, is real evidence against: if turns do not
+ * even arrive inside the TTL, the refresh certainly bought nothing.
+ */
+function bounded(modelled, seen) {
+  return seen ? Math.min(modelled, seen.rate) : modelled;
+}
+
+/**
  * Should we refresh this prefix now?
  *
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
+ *
+ * `observed` is passed IN rather than read from disk here: this function is
+ * pure, its purity is what lets the tests build a distribution by hand, and
+ * `shouldKeepWarm` has already read the outcome log for the tripwire -- so
+ * threading the reader in here would be a second read of the same file and a
+ * second place for the window discipline to be got wrong.
  */
 export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
@@ -125,42 +215,30 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
   const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
-
-  // MEASURED BEATS MODELLED, once there is enough of it.
-  //
-  // The module header already commits to this -- "an expected-value decision is
-  // only as good as the distribution it was fitted to, and distributions
-  // shift" -- and the tripwire underneath was the only thing acting on it, as
-  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
-  // entirely" there was nothing, because the observed hit rate was never
-  // computed: both recording halves had no call site, so ten refreshes that
-  // bought nothing would keep recommending refresh right up to the moment the
-  // tripwire cut the whole feature off.
-  //
-  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
-  // handful of samples would swing the decision harder than the distribution
-  // they replace.
-  const probability = observed ? observed.rate : modelled;
+  const seen = observationsFor(observed, tier.name);
+  const probability = bounded(modelled, seen);
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
-  const basis = observed
-    ? `measured over ${observed.observations} refreshes`
-    : 'modelled from the gap distribution';
+  const note = seen && probability < modelled
+    ? `; bounded by ${seen.refreshes} observed refreshes, ` +
+      `${Math.round(seen.rate * 100)}% used before expiry`
+    : '';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
     modelledProbability: modelled,
-    basis,
+    observedHitRate: seen ? seen.rate : null,
+    observedRefreshes: seen ? seen.refreshes : 0,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
-    reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
+    reason: (ev > 0
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
-        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`) + note,
   };
 }
 
@@ -171,7 +249,12 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
  * long enough that the short tier keeps missing. Returns null when neither tier
  * pays, which is a real answer and the one a default-on product never gives.
  */
-export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS }) {
+export function ttlTier({
+  prefixTokens,
+  gaps,
+  turnsPerSession = DEFAULT_TURNS,
+  observed = null,
+}) {
   if (!prefixTokens || !gaps) return null;
 
   // Expected cost of a turn under each tier, as a multiple of what the prefix
@@ -179,7 +262,16 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   // again; and the FIRST write is amortised over the session, which is what
   // stops the expensive tier from looking free whenever gaps are short.
   const costOf = (tier) => {
-    const hit = gaps.probabilityWithin(tier.ms);
+    // THE SAME QUANTITY THE OUTCOMES RECORD, which is what makes the
+    // observation admissible here at all. `hit` is P(a turn arrives before the
+    // entry expires) and `recordRefreshOutcome`'s `hit` is exactly that event,
+    // measured -- unlike keepWarmDecision, whose probability is the narrower
+    // ping window and for which the same observation is only an upper bound.
+    // Bounded rather than replaced even so: a sample drawn only from moments we
+    // CHOSE to refresh is not a sample of gaps, and its bias runs our way.
+    const modelled = gaps.probabilityWithin(tier.ms);
+    const seen = observationsFor(observed, tier.name);
+    const hit = bounded(modelled, seen);
     const perTurn = hit * READ_MULTIPLIER + (1 - hit) * tier.writeMultiplier;
     // THE SUPPLIED VALUE, not only the computed one. Math.max(1, NaN) is NaN -- Math.max
     // propagates it rather than clamping -- so perTurn became NaN, the `perTurn >= 1` guard below
@@ -192,6 +284,8 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     return {
       tier,
       hit,
+      seen,
+      boundedByObservation: Boolean(seen) && hit < modelled,
       perTurn: (tier.writeMultiplier + (turns - 1) * perTurn) / turns,
     };
   };
@@ -208,99 +302,53 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     action: 'refresh',
     tier: best.tier.name,
     hitProbability: best.hit,
+    observedHitRate: best.seen ? best.seen.rate : null,
+    observedRefreshes: best.seen ? best.seen.refreshes : 0,
     expectedCostPerTurn: Number(best.perTurn.toFixed(3)),
     expectedValue: Math.round((1 - best.perTurn) * prefixTokens),
     reason: `${Math.round(best.hit * 100)}% of gaps land inside ${best.tier.name}; ` +
-      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached`,
+      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached` +
+      (best.boundedByObservation
+        ? `, bounded by ${best.seen.refreshes} observed refreshes ` +
+          `(${Math.round(best.seen.rate * 100)}% used before expiry)`
+        : ''),
   };
 }
 
-/** Observations of a tier before its measured hit rate may override the model. */
-export const OBSERVATION_FLOOR = 5;
-
-/** Records a refresh so its outcome can be scored. */
-export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
-  record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
-}
-
 /**
- * Scores every refresh whose window has since resolved.
+ * Records a refresh so its outcome can be scored.
  *
- * THE MISSING HALF, and it was missing because nobody could see where the
- * signal would come from. `recordRefreshOutcome` needs to know whether a real
- * turn arrived before the entry expired -- and that is not a thing anyone has
- * to instrument, because the event log already records when every turn
- * happened. The answer was in the data the whole time.
+ * `sessionId` IS REQUIRED FOR THE REFRESH TO BE SCOREABLE, and is not defaulted
+ * to anything. The hit test asks whether a turn of THIS conversation arrived
+ * before expiry; pooling arrivals across sessions would let a second concurrent
+ * session's turn pay for this one's ping, which manufactures hits. A refresh
+ * recorded without one is kept in the ledger and reported as unattributable
+ * rather than guessed at.
  *
- * For each unscored refresh at time T on a tier with TTL `ms`:
- *
- *   - a later event within `ms`            -> HIT, observed
- *   - a later event after `ms`             -> MISS, observed
- *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
- *                                             demonstrably closed unused
- *   - no later event, window still open    -> NOTHING RECORDED
- *
- * That last line is the important one and it is Plan 2's own instruction: "if
- * no signal is available for a tier, record nothing rather than guessing
- * `hit: false`". A refresh whose window has not closed yet is not a miss, and
- * scoring it as one would drive the tripwire negative on the newest and least
- * informative records.
- *
- * DRAINED AT READ TIME, which is the pattern this codebase already uses for
- * staleness: the producer cannot know the outcome at the moment it acts, so the
- * next reader resolves what has become knowable since.
+ * Returns the stored record, whose `id` is what `scoreRefreshes` pairs the
+ * outcome to, so an issuer can hold onto it.
  */
-export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
-  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
-  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
-  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
-
-  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
-  // so everything past the number already scored is outstanding. Pairing by
-  // timestamp instead would double-count two refreshes recorded in the same
-  // millisecond, which is reachable: a tool run twice in a loop.
-  const outstanding = refreshes.slice(scored);
-  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
-
-  let recorded = 0;
-  for (const refresh of outstanding) {
-    const at = Number(refresh.at) || 0;
-    if (!at) continue;
-    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
-    const next = timeline.find((t) => t > at);
-
-    let hit;
-    if (next !== undefined) hit = next - at <= tierSpec.ms;
-    else if (now - at > tierSpec.ms) hit = false;
-    else continue; // window still open: not yet knowable
-
-    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
-    recorded += 1;
-  }
-  return { outstanding: outstanding.length, recorded };
-}
-
-/**
- * The measured hit rate for a tier, or null below the observation floor.
- *
- * Null rather than a small-sample number, because the caller substitutes it for
- * a modelled probability and three observations would swing the decision harder
- * than the model they replace.
- */
-export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
-  const relevant = outcomes.filter(
-    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
-  );
-  if (relevant.length < OBSERVATION_FLOOR) return null;
-  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
+export function recordRefresh(dir, { tier, prefixTokens, expectedValue, sessionId, at }) {
+  return record(dir, {
+    kind: 'keepwarm',
+    action: 'refresh',
+    tier,
+    prefixTokens,
+    expectedValue,
+    sessionId,
+    at,
+  });
 }
 
 /**
  * Records whether the refresh was used.
  *
  * `hit` means a real turn arrived before expiry, so the write bought a read.
+ * `refreshId` names the refresh this scores, so the same one cannot be scored
+ * twice -- once per turn for the rest of the session, which is what an
+ * unpaired outcome would become.
  */
-export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
+export function recordRefreshOutcome(dir, { tier, prefixTokens, hit, refreshId = null }) {
   const tierSpec = TIERS.find((t) => t.name === tier) || TIERS[0];
   // THE SAME LEDGER keepWarmDecision BUYS THE REFRESH WITH. That function is explicit that a
   // refresh is a PING, which READS the prefix -- costOfPing = prefixTokens * READ_MULTIPLIER --
@@ -317,7 +365,125 @@ export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
   const realised = hit
     ? prefixTokens * (tierSpec.writeMultiplier - READ_MULTIPLIER) - prefixTokens * READ_MULTIPLIER
     : -prefixTokens * READ_MULTIPLIER;
-  record(dir, { kind: 'keepwarm', action: 'outcome', tier, prefixTokens, hit: Boolean(hit), realised: Math.round(realised) });
+  record(dir, {
+    kind: 'keepwarm',
+    action: 'outcome',
+    tier,
+    prefixTokens,
+    hit: Boolean(hit),
+    refreshId,
+    realised: Math.round(realised),
+  });
+}
+
+/**
+ * Scores every recorded refresh whose window has closed -- and NOTHING ELSE.
+ *
+ * This is the arm that was missing. `recordRefresh` and `recordRefreshOutcome`
+ * were both correct and both called by nothing, so the decision spent money on
+ * refreshes and could never find out whether one bought a read.
+ *
+ * THE SIGNAL IS REAL, not invented. `gapDistribution` already treats this log's
+ * timestamps as turn arrivals -- that is the distribution the whole decision is
+ * fitted to -- so the same log answers the outcome question directly: a refresh
+ * at tier `5m` was used if a turn of the same session arrived within five
+ * minutes of it. Four cases refuse to answer rather than guess, and every one
+ * of them refuses in the direction that costs this project its own good news:
+ *
+ *   - `pending`: the window has not closed yet. A hit could be scored the
+ *     instant it arrives while a miss must wait out the whole TTL, so scoring
+ *     early would mean the recorded hits are always complete and the recorded
+ *     misses always lagging -- right-censoring, biased upward, invisible in any
+ *     test. So a hit waits exactly as long as a miss.
+ *   - `uncovered`: the arrival log no longer reaches back to the refresh, so
+ *     absence of an arrival is absence of evidence. RECORDING `hit: false` HERE
+ *     WOULD BE THE INVENTION THIS IS FORBIDDEN TO MAKE: an absent signal is not
+ *     a miss, and treating it as one biases every rate downward and would
+ *     eventually switch keep-warm off on no evidence at all.
+ *   - `unattributable`: the refresh names no session, so no arrival can be
+ *     shown to belong to it.
+ *   - already scored: an outcome already names this refresh.
+ *
+ * The firehose is READ LAZILY, and only when there is something to score. On a
+ * machine where nothing issues refreshes -- which is every machine today, since
+ * nothing in this repository issues one -- the whole cost is the outcome-log
+ * read: median 70 ms on a 3.5 MB log, of which readBalance is 49 ms, because
+ * that reader also scans the firehose tail for pre-split records.
+ */
+export function scoreRefreshes(dir, {
+  refreshes = readBalance(dir),
+  arrivals = null,
+  now = Date.now(),
+} = {}) {
+  const summary = { scored: 0, hits: 0, pending: 0, uncovered: 0, unattributable: 0 };
+  const keepwarm = refreshes.filter((event) => event?.kind === 'keepwarm');
+  const alreadyScored = new Set(
+    keepwarm
+      .filter((event) => event.action === 'outcome' && event.refreshId)
+      .map((event) => event.refreshId)
+  );
+  const unscored = keepwarm.filter(
+    (event) =>
+      event.action === 'refresh' &&
+      Number.isFinite(event.at) &&
+      event.id &&
+      !alreadyScored.has(event.id)
+  );
+
+  // A refresh with no id cannot be paired, so scoring it would write a fresh
+  // outcome on every turn forever. Reported, not silently dropped.
+  summary.unattributable += keepwarm.filter(
+    (event) => event.action === 'refresh' && (!event.id || !Number.isFinite(event.at))
+  ).length;
+
+  if (!unscored.length) return summary;
+
+  const events = (arrivals ? arrivals() : readMetrics(dir)).filter((event) =>
+    Number.isFinite(event?.at)
+  );
+  // Coverage is judged over EVERY event, including our own bookkeeping: the
+  // refresh's own copy in the firehose is what proves the window is still
+  // inside the read. Arrivals are judged over everything else, because a record
+  // keep-warm wrote about itself is not a turn -- and counting one would
+  // manufacture a hit out of the act of measuring.
+  const earliest = events.reduce((min, event) => Math.min(min, event.at), Infinity);
+  const turns = events.filter((event) => event.kind !== 'keepwarm');
+
+  for (const refresh of unscored) {
+    const tier = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    if (now - refresh.at < tier.ms) {
+      summary.pending += 1;
+      continue;
+    }
+    const session = refresh.sessionId;
+    if (!session) {
+      summary.unattributable += 1;
+      continue;
+    }
+    if (!(earliest <= refresh.at)) {
+      summary.uncovered += 1;
+      continue;
+    }
+
+    const opens = refresh.at + TURN_GAP_MS;
+    const closes = refresh.at + tier.ms;
+    const hit = turns.some(
+      (event) =>
+        (event.sessionId ?? event.episodeId) === session &&
+        event.at > opens &&
+        event.at <= closes
+    );
+    recordRefreshOutcome(dir, {
+      tier: refresh.tier,
+      prefixTokens: refresh.prefixTokens,
+      hit,
+      refreshId: refresh.id,
+    });
+    summary.scored += 1;
+    if (hit) summary.hits += 1;
+  }
+
+  return summary;
 }
 
 /**
@@ -372,23 +538,15 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
-  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
-  // becomes evidence now, so the decision below and the tripwire above both see
-  // the most that is currently knowable -- the same read-time drain the
-  // staleness path uses, and for the same reason: the producer cannot know the
-  // outcome at the moment it acts.
-  try {
-    scoreOutstandingRefreshes(dir, { events, outcomes });
-    outcomes = readBalance(dir);
-  } catch {
-    /* scoring is evidence, never a reason to refuse a decision */
-  }
-
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
+  // THE SAME ARRAY THE TRIPWIRE JUST READ, so closing the loop costs no extra
+  // I/O -- and so the decision and its backstop cannot be looking at different
+  // evidence about the same refreshes.
+  const observed = observedHitRates(outcomes);
   const gaps = gapDistribution(dir, { events });
-  const best = ttlTier({ prefixTokens, gaps });
+  const best = ttlTier({ prefixTokens, gaps, observed });
   if (!best) {
     // THE TWO MODELS ANSWER DIFFERENT QUESTIONS, so they may legitimately disagree. ttlTier asks
     // whether holding a cache beats not caching at all; keepWarmDecision asks whether ONE ping
@@ -397,11 +555,7 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({
-      prefixTokens,
-      gaps,
-      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
-    });
+    const decision = keepWarmDecision({ prefixTokens, gaps, observed });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/integrations/opencode/hooks/lib/loo.mjs
+++ b/integrations/opencode/hooks/lib/loo.mjs
@@ -1,0 +1,788 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/loo.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 2 -- what one finding is actually worth, measured by withholding it.
+ *
+ * Layer 1 asks whether the model went back and named a finding. This asks the
+ * harder question and answers it causally: WITHHOLD ONE FINDING while serving
+ * every other finding for the same touch, and compare what the session spent
+ * READING that anchor afterwards. Nobody in this space measures per-item value
+ * this way in production; the state of the art is an offline evaluation set.
+ * That is also why this file is more refusal than statistics -- a causal claim
+ * from four observations is worse than no claim, because it is a number and
+ * numbers get quoted.
+ *
+ * THE ESTIMAND IS READ-SUPPRESSION, and it is deliberately DISJOINT from Layer
+ * 1. Layer 1 keys on an explicit `query` naming a finding key. This keys on
+ * `read` events against the injection's anchor. Neither signal appears in the
+ * other's arithmetic: no `query` event is consulted here, and `usage.mjs`
+ * consults no `read` event. Task 8 calibrates one against the other, and if
+ * both derived from the same channel that calibration would report a strong
+ * correlation between two spellings of one quantity and mean nothing.
+ *
+ * IT INVENTS NO JOIN. `recordToolOutcome` already joins each post-tool result
+ * back to the injection that preceded it, recording `injectionId`,
+ * `findingIds` and a `joinMethod` of `tool-call-id` / `episode-anchor` /
+ * `none`. Every observation here is GATED on that join: an injection with no
+ * joined outcome is unattributable and enters neither arm, exactly as Layer 1
+ * treats `joinMethod: 'none'`. An earlier draft of this plan proposed a fresh
+ * `(sessionId, findingKey)` join; it was rejected and is not here.
+ *
+ * WHAT IT COSTS THE USER, because an experiment that degrades a turn owes an
+ * accounting. One withheld finding means the model may re-derive what it was
+ * told last time, and the worst case is one read of that anchor: measured on
+ * this machine, a median read is 3,769 tokens and the 90th percentile is
+ * 14,082. Five guards bound that exposure, and they are the reason the numbers
+ * below are as small as they are:
+ *
+ *   1. only on a FILE touch, because a command injection has no anchor a read
+ *      event can be joined to -- withholding there would cost a user a finding
+ *      and buy no observation at all (see `buildReport`, which excludes command
+ *      injections from the holdout balance for the same reason);
+ *   2. never when fewer than two findings were kept, so "leave one out" always
+ *      leaves something in -- otherwise it degenerates into `inHoldout`, which
+ *      withholds EVERY finding for an anchor and is a different experiment;
+ *   3. never in the same breath as `inHoldout`: if that arm already withheld
+ *      everything, there is nothing to leave out and a Layer 2 arm recorded
+ *      there would be a fabricated observation;
+ *   4. at most ONE finding per touch, or the effect is attributable to neither;
+ *   5. at most ONE withheld finding per SESSION, so the worst case a user can
+ *      experience is a single re-read -- not one per file they open.
+ *
+ * AND IT NEVER OVERRIDES A PERSON. A `pinned` or `origin: 'human'` finding is
+ * an explicit human decision to keep something in front of the model.
+ * Withholding it to run an experiment would overrule that decision for the
+ * convenience of the measurement, so those findings are exempt: they are
+ * always served, they get no causal score, and `looNote` says so rather than
+ * leaving a reader to wonder why they are missing from the table.
+ */
+
+import { createHash } from 'node:crypto';
+import { readEvidence, readMetrics, readTruncation, isFixtureAnchor } from './metrics.mjs';
+import { retrievalPolicy } from './utility.mjs';
+import { ORIGIN_HUMAN } from './curate.mjs';
+import { canonicalPath } from './paths.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Injections of a finding before it may enter the experiment.
+ *
+ * A finding nobody has served yet has no established value to measure the
+ * absence of, and withholding it would be measuring the cold start rather than
+ * the finding. Four is also what makes the ratio below reachable: at a quarter
+ * of (key, session) pairs armed, a key needs roughly a dozen enrolled
+ * injections before it can reach a verdict at all.
+ */
+export const MIN_PRIOR_INJECTIONS = 4;
+
+/** The observation floor. Below this there is no verdict -- and NOT a zero. */
+export const MIN_SERVED = 6;
+export const MIN_WITHHELD = 3;
+
+/** Benjamini-Hochberg false-discovery rate for published verdicts. */
+export const FDR_Q = 0.1;
+
+/**
+ * Exploration rate.
+ *
+ * Without this, utility feeds the ranking, the ranking feeds injection
+ * frequency, injection frequency feeds the observation count, and a low score
+ * becomes self-fulfilling: the finding is never served often enough to earn a
+ * better one. A tenth of touches therefore ignore the utility order and
+ * promote the LEAST-served candidate instead.
+ */
+export const EPSILON = 0.1;
+
+/**
+ * The share of (finding, session) pairs assigned to the withheld arm.
+ *
+ * Chosen against the floors rather than picked: MIN_SERVED / MIN_WITHHELD is
+ * 2:1, so a quarter withheld reaches both floors at about the same time while
+ * leaving three touches in four undamaged.
+ */
+export const WITHHOLD_FRACTION = 0.25;
+
+/**
+ * Withheld findings allowed per session. ONE.
+ *
+ * The per-touch cap alone bounds nothing across a session: a session that
+ * opens twelve files with enrolled findings could have withheld twelve. This
+ * makes the worst case a user can experience one re-read, at the price of a
+ * mild confound that is stated rather than hidden -- when the cap binds, the
+ * other armed findings in that session are served, so the served arm is
+ * slightly enriched by sessions that touch many enrolled findings.
+ */
+export const MAX_WITHHELD_PER_SESSION = 1;
+
+/**
+ * Fallback shrinkage weight when the between-finding variance cannot be
+ * estimated (fewer than two findings with both arms, or no dispersion at all).
+ *
+ * MIN_SERVED + MIN_WITHHELD, deliberately: a finding's own data outweighs the
+ * population prior only once it has reached the publication floor.
+ */
+export const SHRINKAGE_K = MIN_SERVED + MIN_WITHHELD;
+
+/** Bounds on the estimated shrinkage weight, so a degenerate variance ratio cannot run away. */
+const K_MIN = 1;
+const K_MAX = 100;
+
+/**
+ * Bumped BY HAND when the serving code changes in a way that could move a
+ * finding's measured effect. It is the part of the policy version a hash of the
+ * configuration cannot see.
+ */
+export const LOO_POLICY_GENERATION = 1;
+
+/** Permutation budget before the exact null distribution is sampled instead of enumerated. */
+const MAX_EXACT_PERMUTATIONS = 20_000;
+const SAMPLED_PERMUTATIONS = 10_000;
+
+/**
+ * On by default, off by `TOKEN_OPTIMIZER_LOO=off`.
+ *
+ * Read per call rather than at module load, for the reason `holdoutFraction`
+ * gives: a long-lived process started before the setting changed would
+ * otherwise honour the old value forever with no way to tell.
+ */
+export function LOO_ENABLED() {
+  return String(process.env.TOKEN_OPTIMIZER_LOO || '').trim().toLowerCase() !== 'off';
+}
+
+/**
+ * The serving policy an observation was collected under.
+ *
+ * WHY EVERY OBSERVATION CARRIES ONE. An effect is only meaningful against a
+ * fixed policy. Halve the touch budget or move the minimum net utility and the
+ * same finding is served in different company, at a different rank, against a
+ * different counterfactual -- so pooling observations from before and after
+ * that change would average two different experiments and call the result
+ * causal. `effects()` therefore groups by (finding, policy) and never across.
+ *
+ * IT IS DELIBERATELY ABSENT FROM THE ARM HASH. Including it would reassign
+ * arms the moment a setting changed, which is precisely the mid-session flip
+ * the arm hash exists to prevent. Configuration decides which experiment an
+ * observation belongs to; it must never decide which arm.
+ */
+export function servingPolicyVersion() {
+  const policy = retrievalPolicy();
+  const parts = [
+    `g${LOO_POLICY_GENERATION}`,
+    `touch=${Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500}`,
+    `benefit=${policy.baseBenefitTokens}`,
+    `minutility=${policy.minimumNetUtility}`,
+    `cooldown=${policy.cooldownMs}`,
+    `quarantine=${policy.quarantineHarmCount}`,
+    `holdout=${process.env.TOKEN_OPTIMIZER_HOLDOUT ?? 'default'}`,
+    `withhold=${WITHHOLD_FRACTION}`,
+    `prior=${MIN_PRIOR_INJECTIONS}`,
+    `epsilon=${EPSILON}`,
+  ];
+  const digest = createHash('sha256').update(parts.join('|')).digest('hex');
+  return `${LOO_POLICY_GENERATION}-${digest.slice(0, 8)}`;
+}
+
+/**
+ * A stable number in [0, 1) from a string.
+ *
+ * SHA-256 rather than SHA-1 for the same reason `inHoldout` uses it: this is a
+ * bucketing hash and nothing here is secret, but arguing that a CodeQL finding
+ * is benign is a worse habit than paying a cost that rounds to nothing.
+ */
+function bucket(text) {
+  return createHash('sha256').update(String(text)).digest().readUInt32BE(0) / 4_294_967_296;
+}
+
+/**
+ * The arm of one finding in one session.
+ *
+ * Keyed on (findingKey, sessionId) AND NOTHING ELSE, so a finding cannot
+ * change arms partway through a session: not when the candidate set changes,
+ * not when the budget changes, not when the graph grows. The measurement is a
+ * comparison between sessions, and an arm that flips inside one contaminates
+ * both sides of it.
+ */
+function armed(findingKey, sessionId) {
+  return bucket(`loo-arm:${findingKey}:${sessionId}`) < WITHHOLD_FRACTION;
+}
+
+/** Deterministic tiebreak among armed candidates: lowest bucket, then key order. */
+function armRank(findingKey, sessionId) {
+  return bucket(`loo-rank:${findingKey}:${sessionId}`);
+}
+
+/** The graph node for a finding key, or null. Keys are unique per graph. */
+function findingNode(graph, key) {
+  const nodes = graph?.nodes;
+  if (!nodes || typeof nodes.values !== 'function') return null;
+  for (const node of nodes.values()) {
+    if (node?.kind === 'finding' && node.key === key) return node;
+    // A fixture graph may omit `kind`; key identity is what this needs.
+    if (node?.key === key && node.kind === undefined) return node;
+  }
+  return null;
+}
+
+/**
+ * May this finding ever be withheld?
+ *
+ * FAILS CLOSED ON AN UNKNOWN KEY, which is the opposite of how the rest of
+ * this module fails. Everywhere else a missing input costs a measurement; here
+ * it could cost a human their explicit decision, because a key whose node
+ * cannot be read is a key whose `pinned` and `origin` cannot be checked.
+ */
+function withholdable(graph, key) {
+  const node = findingNode(graph, key);
+  if (!node) return false;
+  if (node.pinned) return false;
+  if (node.origin === ORIGIN_HUMAN) return false;
+  if (node.retired) return false;
+  return true;
+}
+
+/** Prior SERVED injections per finding key, and withheld injections per session. */
+function history(dir, { evidence = null } = {}) {
+  const priorServed = new Map();
+  const withheldPerSession = new Map();
+  const events = evidence || readEvidence(dir);
+  for (const event of events) {
+    if (event.kind !== 'inject') continue;
+    if (typeof event.loo === 'string' && event.loo) {
+      const session = typeof event.sessionId === 'string' ? event.sessionId : '';
+      withheldPerSession.set(session, (withheldPerSession.get(session) || 0) + 1);
+    }
+    if (event.holdout) continue;
+    const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+    for (const raw of keys) {
+      const key = String(raw);
+      priorServed.set(key, (priorServed.get(key) || 0) + 1);
+    }
+  }
+  return { priorServed, withheldPerSession };
+}
+
+/**
+ * Which single finding to withhold from this touch, or null.
+ *
+ * Called from `forTouch` AFTER `fit` has decided what would have been served,
+ * which is the only ordering that produces a true leave-one-out. Withholding
+ * BEFORE the budget runs would let a lower-ranked finding take the freed
+ * tokens, so the withheld arm would receive different company as well as one
+ * fewer finding, and the comparison would confound the two.
+ *
+ * @param {string[]} findingKeys keys that would otherwise be delivered
+ * @param {string} sessionId the session, which pins the arm
+ * @param {object} graph the loaded graph, for `pinned` / `origin`
+ * @param {string|null} dir graph directory, for the injection history
+ */
+export function withheldFor(findingKeys, sessionId, graph, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return null;
+
+    // Every guard that needs no I/O runs first: this is the PreToolUse path,
+    // and on a project with one finding per anchor the answer is null before
+    // anything is read.
+    const keys = [...new Set((findingKeys || []).map((k) => String(k)).filter(Boolean))];
+    if (keys.length < 2) return null;
+    if (!sessionId || typeof sessionId !== 'string') return null;
+
+    // FILE SURFACE ONLY. A command injection's anchor is the command text, and
+    // no read event will ever match it -- so both arms would score zero
+    // downstream and the finding would be scored on nothing.
+    const { surface = 'file', anchor = '', holdout = false } = options;
+    if (surface !== 'file' || !anchor) return null;
+    // The all-findings holdout already withheld everything for this anchor.
+    if (holdout) return null;
+
+    const eligible = keys.filter((key) => withholdable(graph, key));
+    if (!eligible.length) return null;
+
+    const { priorServed, withheldPerSession } = history(dir, options);
+    if ((withheldPerSession.get(sessionId) || 0) >= MAX_WITHHELD_PER_SESSION) return null;
+
+    const enrolled = eligible.filter(
+      (key) => (priorServed.get(key) || 0) >= MIN_PRIOR_INJECTIONS
+    );
+    if (!enrolled.length) return null;
+
+    const candidates = enrolled.filter((key) => armed(key, sessionId));
+    if (!candidates.length) return null;
+
+    // AT MOST ONE. Sorted deterministically so the same touch always yields the
+    // same choice; the findings that lose the tiebreak are SERVED, and the
+    // observation records what actually happened rather than what the arm hash
+    // intended.
+    candidates.sort(
+      (a, b) => armRank(a, sessionId) - armRank(b, sessionId) || (a < b ? -1 : a > b ? 1 : 0)
+    );
+    return candidates[0];
+  } catch {
+    // An experiment must never break a tool call. Failing open here means
+    // serving everything, which is the undegraded behaviour.
+    return null;
+  }
+}
+
+/**
+ * Reorders candidates so exploration can break the feedback loop.
+ *
+ * A tenth of touches -- deterministic in (session, anchor), not random, so the
+ * same touch behaves the same way twice -- promote the LEAST-served candidate
+ * ahead of the utility order, giving it a chance to survive `fit` and accrue
+ * the observations it needs to earn a score. The other nine tenths are
+ * untouched.
+ *
+ * @param {Array<{finding:{key:string}}>} items assessed candidates, best first
+ */
+export function exploreOrder(items, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return items;
+    const list = Array.isArray(items) ? items : [];
+    if (list.length < 2) return list;
+    const { sessionId = '', anchor = '' } = options;
+    if (bucket(`loo-explore:${sessionId}:${anchor}`) >= EPSILON) return list;
+
+    const keyOf = (item) => String(item?.finding?.key ?? item?.key ?? '');
+    const { priorServed } = history(dir, options);
+    let promoted = 0;
+    for (let i = 1; i < list.length; i += 1) {
+      const a = priorServed.get(keyOf(list[i])) || 0;
+      const b = priorServed.get(keyOf(list[promoted])) || 0;
+      if (a < b || (a === b && keyOf(list[i]) < keyOf(list[promoted]))) promoted = i;
+    }
+    if (promoted === 0) return list;
+    return [list[promoted], ...list.filter((_, i) => i !== promoted)];
+  } catch {
+    return Array.isArray(items) ? items : [];
+  }
+}
+
+const mean = (values) =>
+  values.length ? values.reduce((sum, v) => sum + v, 0) / values.length : 0;
+
+/** Sample variance (n-1). Zero for a single observation: dispersion is unknown, not large. */
+function variance(values) {
+  if (values.length < 2) return 0;
+  const m = mean(values);
+  return values.reduce((sum, v) => sum + (v - m) * (v - m), 0) / (values.length - 1);
+}
+
+/**
+ * Every attributable Layer 2 observation, one per (injection, finding, arm).
+ *
+ * THREE THINGS ARE REPORTED SEPARATELY RATHER THAN FOLDED IN, because each of
+ * them would otherwise turn an absence into a zero:
+ *
+ *   `unattributable`  the outcome join could not attach a tool call to the
+ *                     injection, so nothing is known about what followed it.
+ *   `excluded`        the injection could never produce a read-join at all
+ *                     (command surface, session-start, fixture anchor) or was
+ *                     already in the all-findings holdout.
+ *   `costObservations` how many observations saw a non-zero read cost. If this
+ *                     is zero, "withholding changed nothing" and "the read
+ *                     channel never fired" are the same picture, and only one
+ *                     of them is a finding about findings.
+ */
+export function observations(dir, { events = null, evidence = null } = {}) {
+  const empty = {
+    rows: [],
+    unattributable: 0,
+    unattributableOutcomes: 0,
+    excluded: { command: 0, holdout: 0, fixture: 0, unanchored: 0 },
+    injections: 0,
+    withheldInjections: 0,
+    costObservations: 0,
+    policies: [],
+    windowed: false,
+  };
+  try {
+    const causal = evidence || readEvidence(dir);
+    const all = events || readMetrics(dir);
+    // OUT OF BAND and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` describes the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
+
+    // THE JOIN THIS MODULE CONSUMES AND DOES NOT REPLACE.
+    const joined = new Set();
+    let unattributableOutcomes = 0;
+    for (const event of causal) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) {
+        unattributableOutcomes += 1;
+        continue;
+      }
+      joined.add(String(event.injectionId));
+    }
+
+    // Read cost, grouped the way `buildReport` groups it: (session, anchor),
+    // canonicalised on both sides so two spellings of one file are one anchor.
+    // A mismatch here would make every read invisible and report a clean zero
+    // effect in both arms -- correct code, absent measurement.
+    const reads = new Map();
+    for (const event of all) {
+      if (event.kind !== 'read' || !event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      if (!reads.has(key)) reads.set(key, []);
+      reads.get(key).push(event);
+    }
+
+    const injects = causal
+      .filter((event) => event.kind === 'inject')
+      .map((event, index) => ({ event, index }))
+      .sort((a, b) => (a.event.at || 0) - (b.event.at || 0) || a.index - b.index)
+      .map((row) => row.event);
+
+    // How many injections share each (session, anchor), so a key's read total
+    // is SPLIT between them rather than charged in full to each -- the same
+    // correction `buildReport` applies, and for the same reason: without it the
+    // arm means scale with injections-per-anchor instead of per-touch cost.
+    const perKey = new Map();
+    for (const event of injects) {
+      if (!event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      perKey.set(key, (perKey.get(key) || 0) + 1);
+    }
+
+    const rows = [];
+    const excluded = { command: 0, holdout: 0, fixture: 0, unanchored: 0 };
+    const priorServed = new Map();
+    const policies = new Set();
+    let unattributable = 0;
+    let considered = 0;
+    let withheldInjections = 0;
+
+    for (const event of injects) {
+      const served = (Array.isArray(event.findingIds) ? event.findingIds : []).map(String);
+      const withheldKey = typeof event.loo === 'string' && event.loo ? event.loo : null;
+      const bump = () => {
+        for (const key of served) priorServed.set(key, (priorServed.get(key) || 0) + 1);
+      };
+
+      const isCommand =
+        event.surface === 'command' ||
+        event.trigger === 'command' ||
+        event.surface === 'session-start';
+      if (isCommand) {
+        excluded.command += 1;
+        bump();
+        continue;
+      }
+      if (!event.anchor) {
+        excluded.unanchored += 1;
+        bump();
+        continue;
+      }
+      if (isFixtureAnchor(event.anchor)) {
+        excluded.fixture += 1;
+        bump();
+        continue;
+      }
+      if (event.holdout) {
+        excluded.holdout += 1;
+        bump();
+        continue;
+      }
+
+      considered += 1;
+      if (withheldKey) withheldInjections += 1;
+      const policy = typeof event.looPolicy === 'string' && event.looPolicy
+        ? event.looPolicy
+        : 'unversioned';
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const attributable = Boolean(injectionId && joined.has(injectionId));
+
+      // DOWNSTREAM MEANS AFTER, STRICTLY. The read that triggered the touch is
+      // not caused by the advice; it happened before the advice existed.
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      const at = event.at || 0;
+      const total = (reads.get(key) || []).reduce(
+        (sum, read) => sum + ((read.at || 0) > at ? read.tokens || 0 : 0),
+        0
+      );
+      const cost = total / Math.max(1, perKey.get(key) || 1);
+
+      const observe = (findingKey, arm) => {
+        // ENROLMENT IS RE-DERIVED FROM THE LOG rather than trusted from the
+        // serving decision. It is the one field an old or hand-written record
+        // could contradict, and a served observation from before a finding was
+        // enrolled would compare an established finding against its own cold
+        // start.
+        //
+        // CHECKED BEFORE ATTRIBUTABILITY, so `unattributable` counts only
+        // observations the experiment actually wanted. Counting the rest there
+        // would report a join failure for every finding that was never in the
+        // experiment to begin with -- the same shape as the 2,559-row
+        // measurement-bias defect Layer 1 found in its own first draft.
+        if ((priorServed.get(findingKey) || 0) < MIN_PRIOR_INJECTIONS) return;
+        if (!attributable) {
+          unattributable += 1;
+          return;
+        }
+        policies.add(policy);
+        rows.push({ findingKey, arm, cost, policy, injectionId, anchor: event.anchor });
+      };
+
+      if (withheldKey) observe(withheldKey, 'withheld');
+      for (const findingKey of served) observe(findingKey, 'served');
+      bump();
+    }
+
+    return {
+      rows,
+      unattributable,
+      unattributableOutcomes,
+      excluded,
+      injections: considered,
+      withheldInjections,
+      costObservations: rows.filter((row) => row.cost > 0).length,
+      policies: [...policies].sort(),
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
+function permutationP(servedCosts, withheldCosts) {
+  const pooled = [...servedCosts, ...withheldCosts];
+  const n = pooled.length;
+  const k = withheldCosts.length;
+  if (!k || k === n) return null;
+  const observed = Math.abs(mean(withheldCosts) - mean(servedCosts));
+  const total = pooled.reduce((sum, v) => sum + v, 0);
+  // Mean difference from the withheld-arm sum alone: the served sum is the
+  // complement, so one number decides the statistic.
+  const diffFrom = (withheldSum) =>
+    Math.abs(withheldSum / k - (total - withheldSum) / (n - k));
+
+  const choose = (a, b) => {
+    let out = 1;
+    for (let i = 1; i <= b; i += 1) out = (out * (a - b + i)) / i;
+    return out;
+  };
+
+  const tolerance = 1e-9;
+  if (choose(n, k) <= MAX_EXACT_PERMUTATIONS) {
+    let extreme = 0;
+    let count = 0;
+    const walk = (start, chosen, sum) => {
+      if (chosen === k) {
+        count += 1;
+        if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+        return;
+      }
+      for (let i = start; i <= n - (k - chosen); i += 1) walk(i + 1, chosen + 1, sum + pooled[i]);
+    };
+    walk(0, 0, 0);
+    return count ? extreme / count : null;
+  }
+
+  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
+  // the same p-value and a verdict cannot flicker between two audit runs.
+  let state = 0x9e3779b9;
+  const random = () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4_294_967_296;
+  };
+  let extreme = 0;
+  const order = [...pooled];
+  for (let round = 0; round < SAMPLED_PERMUTATIONS; round += 1) {
+    for (let i = order.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(random() * (i + 1));
+      [order[i], order[j]] = [order[j], order[i]];
+    }
+    let sum = 0;
+    for (let i = 0; i < k; i += 1) sum += order[i];
+    if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+  }
+  return (extreme + 1) / (SAMPLED_PERMUTATIONS + 1);
+}
+
+/**
+ * The per-finding causal effect, shrunk, and whether it may be published.
+ *
+ * `raw` is `mean(withheld) - mean(served)`: POSITIVE means the session read the
+ * anchor more when the finding was withheld, which is the finding earning its
+ * place. `shrunk` is the number a reader should use.
+ *
+ * EMPIRICAL BAYES, and both halves of it come from the data. The prior mean is
+ * the population effect across findings; the weight `k` is the ratio of
+ * within-finding noise to between-finding spread, so a population where every
+ * finding behaves alike shrinks hard and one where they genuinely differ
+ * shrinks little. `SHRINKAGE_K` is the fallback when that spread cannot be
+ * estimated at all. Two observations therefore cannot post a wild score.
+ *
+ * PUBLICATION IS NOT THE SAME QUESTION as having an estimate. A row is
+ * published only if it clears the observation floor AND its permutation
+ * p-value survives Benjamini-Hochberg at q = 0.10 across every candidate row.
+ * Everything else gets `published: false` -- which is not a zero effect, and
+ * `looNote` says which of the two it is. An all-zero-cost population needs no
+ * separate guard: p is exactly 1 there, so nothing can publish anyway.
+ *
+ * NEVER POOLED ACROSS POLICY VERSIONS: rows are keyed on (findingKey, policy).
+ */
+export function effects(dir, options = {}) {
+  try {
+    // `obs` is accepted so `looNote` can read the logs once for both.
+    const obs = options.obs || observations(dir, options);
+    const groups = new Map();
+    for (const row of obs.rows) {
+      const id = JSON.stringify([row.findingKey, row.policy]);
+      if (!groups.has(id))
+        groups.set(id, { findingKey: row.findingKey, policy: row.policy, served: [], withheld: [] });
+      groups.get(id)[row.arm === 'withheld' ? 'withheld' : 'served'].push(row.cost);
+    }
+
+    const raws = [];
+    const withinVars = [];
+    for (const group of groups.values()) {
+      if (!group.served.length || !group.withheld.length) continue;
+      raws.push(mean(group.withheld) - mean(group.served));
+      withinVars.push(
+        variance(group.withheld) / group.withheld.length +
+          variance(group.served) / group.served.length
+      );
+    }
+    const prior = raws.length ? mean(raws) : 0;
+    const within = withinVars.length ? mean(withinVars) : 0;
+    const between = raws.length > 1 ? Math.max(0, variance(raws) - within) : 0;
+    const weight =
+      between > 0 && within > 0
+        ? Math.min(K_MAX, Math.max(K_MIN, within / between))
+        : SHRINKAGE_K;
+
+    const rows = [...groups.values()]
+      .map((group) => {
+        const served = group.served.length;
+        const withheld = group.withheld.length;
+        const both = served > 0 && withheld > 0;
+        const raw = both ? mean(group.withheld) - mean(group.served) : null;
+        const n = served + withheld;
+        const shrunk = raw === null ? null : (n * raw + weight * prior) / (n + weight);
+        const eligible = served >= MIN_SERVED && withheld >= MIN_WITHHELD;
+        return {
+          findingKey: group.findingKey,
+          policy: group.policy,
+          served,
+          withheld,
+          servedMean: mean(group.served),
+          withheldMean: mean(group.withheld),
+          raw,
+          shrunk,
+          p: eligible ? permutationP(group.served, group.withheld) : null,
+          published: false,
+        };
+      })
+      .sort((a, b) =>
+        a.findingKey < b.findingKey ? -1 : a.findingKey > b.findingKey ? 1 : a.policy < b.policy ? -1 : 1
+      );
+
+    // BENJAMINI-HOCHBERG at q = 0.10 over every row that cleared the floor.
+    // One finding tested in isolation would publish at p < 0.10; a hundred
+    // would publish ten false ones, and this module's whole claim is that its
+    // numbers can be quoted.
+    //
+    // THERE IS NO SEPARATE "WAS ANY READ COST OBSERVED" GATE HERE, and its
+    // absence is deliberate rather than an omission. One was written, and
+    // mutation testing showed it could not change a single verdict: if every
+    // observation has zero cost then both arm means are zero, the permutation
+    // statistic is zero for every relabelling, and p is exactly 1 -- which no
+    // BH threshold can pass. The guard was unfalsifiable, and an unfalsifiable
+    // guard is worse than none because it reads as protection nobody can test.
+    // `costObservations` survives as what it can honestly be: a DISCLOSURE, so
+    // `looNote` can say the read channel never fired instead of letting a
+    // reader take an arithmetic zero for a measured one.
+    const candidates = rows
+      .filter((row) => row.p !== null)
+      .sort((a, b) => a.p - b.p);
+    const m = candidates.length;
+    let cutoff = 0;
+    for (let i = 0; i < m; i += 1) {
+      if (candidates[i].p <= ((i + 1) / m) * FDR_Q) cutoff = i + 1;
+    }
+    for (let i = 0; i < cutoff; i += 1) candidates[i].published = true;
+
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * One or two lines for the audit, or nothing at all.
+ *
+ * THE REFUSAL IS THE PRODUCT HERE. On a machine with two injections in sixteen
+ * thousand events, the only honest output is that nothing is measurable yet,
+ * and this says so with the counts that make it checkable rather than printing
+ * a mean of nothing. It returns `null` when Layer 2 has not collected a single
+ * observation, so an idle experiment costs the reader no line at all -- the
+ * same standard `referenceNote` holds itself to.
+ */
+export function looNote(dir, options = {}) {
+  try {
+    const obs = options.obs || observations(dir, options);
+    const rows = effects(dir, { ...options, obs });
+    if (!obs.rows.length && !obs.withheldInjections) return null;
+
+    let graph = options.graph;
+    if (graph === undefined) {
+      try {
+        graph = load(dir);
+      } catch {
+        graph = null;
+      }
+    }
+    let exempt = 0;
+    if (graph?.nodes?.values) {
+      for (const node of graph.nodes.values()) {
+        if (node?.kind !== 'finding' || node.retired) continue;
+        if (node.pinned || node.origin === ORIGIN_HUMAN) exempt += 1;
+      }
+    }
+
+    const published = rows.filter((row) => row.published);
+    const head = published.length
+      ? `Per-finding causal value (leave-one-out): ${published.length} of ${rows.length} ` +
+        `findings show a verdict at q=${FDR_Q}` +
+        published
+          .slice(0, 3)
+          .map(
+            (row) =>
+              `; ${row.findingKey} saves ~${Math.round(row.shrunk)} tokens/touch ` +
+              `(${row.served} served, ${row.withheld} withheld, p=${row.p.toFixed(3)})`
+          )
+          .join('') +
+        '.'
+      : `Per-finding causal value (leave-one-out): NOT MEASURABLE YET -- ` +
+        `${obs.rows.length} attributable observations across ${rows.length} findings, ` +
+        `${obs.withheldInjections} withheld touches; the floor is ${MIN_SERVED} served ` +
+        `and ${MIN_WITHHELD} withheld per finding` +
+        (obs.costObservations ? '' : ', and no read cost has been observed in either arm') +
+        '. No effect is reported, which is not the same as an effect of zero.';
+
+    const caveats = [];
+    if (obs.unattributable)
+      caveats.push(
+        `${obs.unattributable} observations were unattributable (no joined tool outcome) and are in neither arm`
+      );
+    if (exempt)
+      caveats.push(
+        `${exempt} pinned or human-origin findings are exempt from withholding and get no causal score`
+      );
+    if (obs.policies.length > 1)
+      caveats.push(
+        `observations span ${obs.policies.length} serving-policy versions and are never pooled across them`
+      );
+    if (obs.windowed)
+      caveats.push('the read log was truncated, so downstream cost can understate');
+    return caveats.length ? `${head} ${caveats.join('; ')}.` : head;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/opencode/hooks/lib/loo.mjs
+++ b/integrations/opencode/hooks/lib/loo.mjs
@@ -545,8 +545,22 @@ export function observations(dir, { events = null, evidence = null } = {}) {
   }
 }
 
-/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
-function permutationP(servedCosts, withheldCosts) {
+/**
+ * Enumerates or samples arm relabellings and returns a two-sided p-value.
+ *
+ * EXPORTED so the cross-layer headline can be held to the same standard as the
+ * per-finding rows it summarises. `crosslayer.mjs` runs this over the two ARMS
+ * of shrunk effect estimates; the statistic, the enumerate-or-sample switch and the
+ * tolerance are therefore shared rather than reimplemented, and there is one
+ * place where "two-sided" is decided.
+ *
+ * `seed` exists for that caller. The default reproduces the fixed seed this
+ * function has always used, so Layer 2's own p-values are byte-identical; the
+ * cross-layer caller passes a seed DERIVED FROM ITS DATA, because a verdict
+ * printed to a human must not depend on `Math.random()` or on which module
+ * happened to call first.
+ */
+export function permutationP(servedCosts, withheldCosts, { seed = 0x9e3779b9 } = {}) {
   const pooled = [...servedCosts, ...withheldCosts];
   const n = pooled.length;
   const k = withheldCosts.length;
@@ -580,9 +594,10 @@ function permutationP(servedCosts, withheldCosts) {
     return count ? extreme / count : null;
   }
 
-  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
-  // the same p-value and a verdict cannot flicker between two audit runs.
-  let state = 0x9e3779b9;
+  // Mulberry32 off the caller's seed: reproducible, so the same data always
+  // yields the same p-value and a verdict cannot flicker between two audit
+  // runs.
+  let state = seed | 0;
   const random = () => {
     state = (state + 0x6d2b79f5) | 0;
     let t = state;

--- a/integrations/opencode/hooks/lib/metrics.mjs
+++ b/integrations/opencode/hooks/lib/metrics.mjs
@@ -31,6 +31,7 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { createHash, randomBytes } from 'node:crypto';
+import { redact } from './redact.mjs';
 
 /**
  * Read per call, not once at module load.
@@ -517,6 +518,15 @@ export function readEvidence(dir) {
 }
 
 /**
+ * The captured-output budget, in characters.
+ *
+ * Small enough that a 3 MB test log cannot bloat the evidence log or a single
+ * injected claim, large enough to hold the stack trace or compiler diagnostic
+ * that makes a failure finding worth anything.
+ */
+const OUTPUT_MAX_BYTES = 4096;
+
+/**
  * Joins a post-tool result to the most recent matching injection.  The exact
  * tool-call id wins; clients that omit it fall back to episode + surface +
  * anchor, in timestamp order, and the report states the weaker join method.
@@ -545,10 +555,31 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
+  // text is INJECTED into model context and EXPORTED to markdown, so the
+  // boundary is the only place that can guarantee it: a second caller added
+  // later would otherwise have to remember, and the one that forgot would leak
+  // a secret into two more places than the terminal it came from. `undefined`
+  // rather than `''` when nothing was captured, so JSON.stringify omits the
+  // key entirely and an absent capture is distinguishable from an empty one.
+  const output =
+    outcome.output === undefined || outcome.output === null
+      ? undefined
+      : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
+  // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric
+  // code at all, and 0 is the success value -- defaulting to it would claim
+  // every unreported call exited cleanly, which is a fabricated observation
+  // rather than a missing one.
+  const exit = Number.isInteger(outcome.exit) ? outcome.exit : null;
+
   return record(dir, {
     kind: 'tool-outcome',
     ...outcome,
     anchor,
+    // AFTER the spread, so a caller cannot smuggle raw text past the boundary
+    // by setting the field itself.
+    output,
+    exit,
     injectionId: injection?.injectionId || null,
     findingIds: injection?.findingIds || [],
     joinMethod,

--- a/integrations/opencode/hooks/lib/metrics.mjs
+++ b/integrations/opencode/hooks/lib/metrics.mjs
@@ -555,6 +555,22 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // FAILURES ONLY, and that is a deliberate override of the original plan.
+  // The plan predates MCP tool names reaching this path, so it never
+  // considered that a SUCCESSFUL `smart_read` would deposit 4 KB of file
+  // content into the evidence log on every call -- the log would grow with
+  // file text and the privacy surface would be every file the session opened.
+  //
+  // Nothing downstream loses anything. A failure claim quotes the error text;
+  // a "this command works" claim needs only the fact that it worked, which
+  // `success` and `exit` already carry. So the stored text narrows to text
+  // that is already an error message.
+  //
+  // GATED ON `success === true`, not on `!== false`: an outcome that never
+  // said whether it worked is unclassified, not successful, and dropping its
+  // text would lose exactly the failures a client too terse to report status
+  // produces.
+  const captureOutput = outcome.success !== true;
   // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
   // text is INJECTED into model context and EXPORTED to markdown, so the
   // boundary is the only place that can guarantee it: a second caller added
@@ -563,7 +579,7 @@ export function recordToolOutcome(dir, outcome) {
   // rather than `''` when nothing was captured, so JSON.stringify omits the
   // key entirely and an absent capture is distinguishable from an empty one.
   const output =
-    outcome.output === undefined || outcome.output === null
+    !captureOutput || outcome.output === undefined || outcome.output === null
       ? undefined
       : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
   // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric

--- a/integrations/opencode/hooks/lib/metrics.mjs
+++ b/integrations/opencode/hooks/lib/metrics.mjs
@@ -663,6 +663,89 @@ export function isFixtureAnchor(anchor) {
  * Fixture anchors are excluded from both.
  */
 /**
+ * Re-reads grouped by anchor -- the one place that decides what "wasteful" means.
+ *
+ * `rereadWaste` needed only the totals, so the grouping lived inside it and the
+ * per-anchor rows were thrown away. `derive.mjs`'s churn detector needs the
+ * rows, and re-deriving them there would put TWO definitions of "a repeat read
+ * of an unchanged file is waste" in the codebase, free to drift apart -- the
+ * exact divergence `npm run sync:hooks` exists to prevent between hooks-core and
+ * its generated copies. So the grouping lives here and both consumers read it.
+ *
+ * A re-read is only a re-read INSIDE ONE SESSION: grouping is keyed on
+ * session + canonical anchor, and rows are then merged per anchor so a file
+ * re-read across three sessions reports as one anchor with the sum of its
+ * repeats rather than three rows the caller has to add up. Merging cannot move
+ * the totals -- a sum of sums -- which is what makes it safe for `rereadWaste`.
+ *
+ * `tokens` is the WASTEFUL token count, not the total: it is the only one of the
+ * three that names something recoverable, and a row whose headline number
+ * included legitimate re-reads would overstate exactly the way the first
+ * version of this measurement did.
+ *
+ * @returns {Array<{anchor: string, repeats: number, wasteful: number,
+ *   tokens: number, legitimate: number, legitimateTokens: number,
+ *   undecidable: number, undecidableTokens: number}>} descending by `wasteful`,
+ *   then by `repeats`.
+ */
+export function rereadsByAnchor(events = [], { includeFixtures = false } = {}) {
+  const groups = new Map();
+  for (const e of events) {
+    if (!e || e.kind !== 'read' || !e.anchor) continue;
+    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
+    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(e);
+  }
+
+  const rows = new Map();
+  for (const list of groups.values()) {
+    if (list.length < 2) continue;
+    list.sort((a, b) => (a.at || 0) - (b.at || 0));
+
+    const anchorKey = canonicalKeyish(list[0].anchor);
+    let row = rows.get(anchorKey);
+    if (!row) {
+      row = {
+        anchor: list[0].anchor,
+        repeats: 0,
+        wasteful: 0,
+        tokens: 0,
+        legitimate: 0,
+        legitimateTokens: 0,
+        undecidable: 0,
+        undecidableTokens: 0,
+      };
+      rows.set(anchorKey, row);
+    }
+
+    for (let i = 1; i < list.length; i++) {
+      const prev = list[i - 1];
+      const cur = list[i];
+      const tokens = cur.tokens || 0;
+      row.repeats += 1;
+      // THE JUDGEMENT, in one place. A repeat read of a file that CHANGED is
+      // correct behaviour, not waste; a read written before fingerprints
+      // existed cannot be judged at all and says so.
+      if (!prev.fp || !cur.fp) {
+        row.undecidable += 1;
+        row.undecidableTokens += tokens;
+      } else if (prev.fp === cur.fp) {
+        row.wasteful += 1;
+        row.tokens += tokens;
+      } else {
+        row.legitimate += 1;
+        row.legitimateTokens += tokens;
+      }
+    }
+  }
+
+  return [...rows.values()].sort(
+    (a, b) => b.wasteful - a.wasteful || b.repeats - a.repeats
+  );
+}
+
+/**
  * Re-read waste, split into what is KNOWN and what is not.
  *
  * The question is narrow on purpose: how often does one session read the same
@@ -677,6 +760,9 @@ export function isFixtureAnchor(anchor) {
  * `undecidable` is reported rather than hidden. Reads written before the
  * fingerprint existed cannot be classified, and a measurement that quietly
  * counted them either way would be inventing its own answer.
+ *
+ * The aggregate fields are UNCHANGED -- `balanceSheet` reads them -- and are now
+ * a fold over `rereadsByAnchor`'s rows. `worst` is purely additive.
  */
 export function rereadWaste(
   dir,
@@ -685,14 +771,7 @@ export function rereadWaste(
   // excludes by design, making the real path untestable.
   { events = readMetrics(dir), includeFixtures = false } = {}
 ) {
-  const groups = new Map();
-  for (const e of events) {
-    if (e.kind !== 'read' || !e.anchor) continue;
-    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
-    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key).push(e);
-  }
+  const rows = rereadsByAnchor(events, { includeFixtures });
 
   const out = {
     repeats: 0,
@@ -704,29 +783,21 @@ export function rereadWaste(
     undecidableTokens: 0,
   };
 
-  for (const list of groups.values()) {
-    if (list.length < 2) continue;
-    list.sort((a, b) => (a.at || 0) - (b.at || 0));
-    for (let i = 1; i < list.length; i++) {
-      const prev = list[i - 1];
-      const cur = list[i];
-      const tokens = cur.tokens || 0;
-      out.repeats += 1;
-      if (!prev.fp || !cur.fp) {
-        out.undecidable += 1;
-        out.undecidableTokens += tokens;
-      } else if (prev.fp === cur.fp) {
-        out.wasteful += 1;
-        out.wastefulTokens += tokens;
-      } else {
-        out.legitimate += 1;
-        out.legitimateTokens += tokens;
-      }
-    }
+  for (const row of rows) {
+    out.repeats += row.repeats;
+    out.wasteful += row.wasteful;
+    out.wastefulTokens += row.tokens;
+    out.legitimate += row.legitimate;
+    out.legitimateTokens += row.legitimateTokens;
+    out.undecidable += row.undecidable;
+    out.undecidableTokens += row.undecidableTokens;
   }
 
   const decided = out.wasteful + out.legitimate;
   out.coverage = out.repeats ? decided / out.repeats : null;
+  // The offenders behind the totals, bounded: a report needs the handful worth
+  // acting on, not one row per file the session touched twice.
+  out.worst = rows.slice(0, 10);
   return out;
 }
 

--- a/integrations/opencode/hooks/lib/recall.mjs
+++ b/integrations/opencode/hooks/lib/recall.mjs
@@ -1,0 +1,390 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/recall.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Does retrieval FIND a finding, or does it only find what it was told where
+ * to look?
+ *
+ * `docs/WIKI_GRAPH.md` says embeddings get added "if measurement shows real
+ * recall loss". Nothing measured recall, so the no-embeddings stance was
+ * unfalsifiable -- a claim with no observation that could contradict it. This
+ * module is the observation.
+ *
+ * ---------------------------------------------------------------------------
+ * THE TAUTOLOGY THIS DELIBERATELY DOES NOT SHIP, AND WHY IT IS RECORDED HERE
+ * ---------------------------------------------------------------------------
+ * The obvious probe -- for each finding, take its anchors and ask whether
+ * `findingsFor` returns it from each -- CANNOT FAIL. `findingsFor(graph, A)`
+ * walks `derived_from` edges backwards into A, and the edge F -> A is the very
+ * thing that makes A an anchor of F. So F is in the result by CONSTRUCTION, not
+ * by retrieval quality, for every graph, forever. Its rate is 1.0 always, and a
+ * permanent 1.0 published as a recall rate reads to a human as "retrieval is
+ * perfect, embeddings unnecessary" -- one unfalsifiable claim swapped for
+ * another, leaning the one direction a measurement of this project by this
+ * project must never lean.
+ *
+ * That check is still worth running -- if it ever fails, traversal is broken
+ * rather than merely lossy -- so it is kept, and reported as `integrity` with
+ * its own `what` string saying it is not a recall rate. It is NEVER `rate`.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT IS MEASURED INSTEAD: LEAVE-ONE-EDGE-OUT
+ * ---------------------------------------------------------------------------
+ * For each active finding F and each anchor A of F, delete the edge F -> A and
+ * ask whether touching A would STILL surface F. Two independent arms, both of
+ * which can genuinely miss, which is what makes this a measurement:
+ *
+ *   Arm A -- TRAVERSAL FROM THE NEIGHBOURHOOD. Run the real `findingsFor` over
+ *   the edge-deleted graph from A itself and from A's `contains` parents. This
+ *   hits only when F has some OTHER structural route in: a second anchor on the
+ *   same file, or an anchor on a sibling symbol under the same parent. A's
+ *   `contains` children need no separate call because `findingsFor` expands
+ *   them itself -- calling the parent therefore covers every sibling, which is
+ *   why the neighbour list is `[A, ...parents(A)]` and not a hop-counted
+ *   frontier. The REAL primitive is used rather than an equivalent inlined
+ *   here, because a probe that reimplements the thing it measures drifts from
+ *   it and then measures itself.
+ *
+ *   Arm B -- BM25 FROM THE ANCHOR'S OWN KEY. Rank the whole active corpus with
+ *   `lexical.rank`, querying with A's key -- the file path or symbol name the
+ *   user actually touched -- and hit if F comes back inside `limit`.
+ *
+ * WHY ARM B IS NOT QUERIED WITH THE FINDING'S OWN CLAIM. The plan's literal
+ * form was "the finding's claim terms against the rest of the corpus", and both
+ * readings of it are degenerate. Querying F's claim against a corpus that
+ * INCLUDES F is the tautology again: BM25 scores a document against its own
+ * text, so F wins its own query every time. Querying F's claim against a corpus
+ * that EXCLUDES F cannot return F at all, so a "hit" would mean some DIFFERENT
+ * finding matched -- that is redundancy of storage, not recall of F, and it
+ * would score a graph better for holding duplicates. The anchor's key is the
+ * one query text that is available offline, is not derived from F, and matches
+ * the production question: a session touches a file, and the only lexical
+ * handle on it is its own path. It misses exactly when a finding's claim never
+ * names the code it is about, which is the recall gap embeddings are supposed
+ * to close.
+ *
+ * ---------------------------------------------------------------------------
+ * REFUSALS -- four, and each costs this project its own good news
+ * ---------------------------------------------------------------------------
+ *  1. TOO FEW OBSERVATIONS -> `rate: null` with a reason. See `MIN_PROBED`.
+ *  2. A CORPUS NO LARGER THAN THE RETRIEVAL LIMIT -> `rate: null`. Arm B is
+ *     recall@`limit`, and below the limit NO FINDING IS EVER CUT FOR BUDGET:
+ *     every document scoring above zero is returned, so the arm measures
+ *     whether a token matched, which is a strictly weaker bar than the one
+ *     production applies when `forTouch` fills a token budget from a ranked
+ *     list. A probe more permissive than the system it measures can only
+ *     overstate recall, so the rate is withheld in that band and the counts are
+ *     published instead. It bites between `MIN_PROBED` and `limit` findings --
+ *     on this machine's project graph, whose one finding had both anchor edges
+ *     "recovered" that way, the observation-count refusal fires first.
+ *  3. NO ANCHOR NODE -> the pair is UNPROBEABLE, not a miss. Reported and
+ *     excluded from the denominator; see `probeEdge`.
+ *  4. STRICT AGGREGATION -> a finding counts as retrieved only if EVERY one of
+ *     its probeable anchor edges is recoverable. A finding reachable from one
+ *     anchor and lost from another is a miss, with the losing anchor named.
+ *     This biases the rate DOWN, which is the safe direction here.
+ *
+ * FAILS OPEN. It runs on a report path; a graph it cannot read must cost a
+ * section, not the report.
+ */
+
+import { load, findingsFor } from './wiki.mjs';
+import { rank } from './lexical.mjs';
+
+/**
+ * Distinct findings that must be probeable before a RATE is published at all.
+ *
+ * NOT AN EFFECT-SIZE CONVENTION -- it is a resolution argument. A proportion
+ * over n observations has a resolution of 1/n, so below ten findings the
+ * published figure moves in steps coarser than ten percentage points, and the
+ * two extremes a small graph actually produces (`1.0` and `0.0`) are the two a
+ * reader is most likely to mistake for a finding about retrieval. At n = 10 and
+ * zero misses the exact binomial 95% upper bound on the true miss rate is still
+ * 1 - 0.05^(1/10) = 0.26, so even a clean sweep here bounds recall loss only
+ * below about a quarter -- which is why the refusal reason says what the number
+ * would and would not have supported rather than just naming the floor.
+ *
+ * THE FLOOR IS ON DISTINCT FINDINGS, NOT ANCHOR EDGES. Two anchors of one
+ * finding are two edges of the same claim, not two independent observations;
+ * counting them would let a single multi-anchored finding unlock a rate.
+ */
+export const MIN_PROBED = 10;
+
+/**
+ * The most findings probed in one call.
+ *
+ * Each probed anchor edge costs a graph-sized edge filter plus one or two real
+ * `findingsFor` walks plus one BM25 pass over the corpus, and this runs on the
+ * on-demand report path. The cap is deterministic (findings sorted by key) and
+ * `truncated` says when it bit, so a large graph gets a smaller, honestly
+ * labelled sample rather than a slow report.
+ */
+export const MAX_FINDINGS = 200;
+
+/** Active findings only. A retired claim is withdrawn; recalling it is not a win. */
+function activeFindings(graph) {
+  return [...graph.nodes.values()]
+    .filter((node) => node && node.kind === 'finding' && !node.retired)
+    .sort((a, b) => String(a.key || '').localeCompare(String(b.key || '')));
+}
+
+/** The `contains` parents of every node, indexed once for the whole probe. */
+function parentIndex(graph) {
+  const parents = new Map();
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contains') continue;
+    const list = parents.get(edge.to);
+    if (list) list.push(edge.from);
+    else parents.set(edge.to, [edge.from]);
+  }
+  return parents;
+}
+
+/** The anchors of one finding: the targets of its own `derived_from` edges. */
+function anchorsOf(graph, findingId) {
+  const out = new Set();
+  for (const edge of graph.edges) {
+    if (edge.edge === 'derived_from' && edge.from === findingId) out.add(edge.to);
+  }
+  return [...out];
+}
+
+/**
+ * The graph minus exactly one anchor edge.
+ *
+ * `nodes` is shared rather than copied: nothing here mutates it, and a
+ * 2,600-node Map copied once per anchor edge is the difference between a probe
+ * and a stall.
+ */
+function withoutAnchorEdge(graph, findingId, anchorId) {
+  return {
+    nodes: graph.nodes,
+    edges: graph.edges.filter(
+      (edge) =>
+        !(
+          edge.edge === 'derived_from' &&
+          edge.from === findingId &&
+          edge.to === anchorId
+        )
+    ),
+  };
+}
+
+/**
+ * One anchor edge, hidden, then asked after. Returns `recovered` with the arm
+ * that found it, or a reason -- and `probeable: false` when the question could
+ * not be put at all.
+ */
+function probeEdge(graph, parents, finding, anchorId, corpus, limit) {
+  const hidden = withoutAnchorEdge(graph, finding.id, anchorId);
+
+  // Arm A. `findingsFor` expands `contains` children itself, so the parent call
+  // covers every sibling of the anchor.
+  const neighbours = [anchorId, ...(parents.get(anchorId) || [])];
+  for (const neighbour of neighbours) {
+    const got = findingsFor(hidden, neighbour, { limit });
+    if (got.some((node) => node.id === finding.id)) {
+      return { recovered: true, arm: 'traversal', anchorId };
+    }
+  }
+
+  // Arm B needs a query, and the query is the anchor's own key. A dangling
+  // anchor edge -- an edge whose target node was never indexed, which
+  // `expand.promote` produces -- leaves nothing to query with. That is a
+  // question that could not be asked, NOT an observed miss: scoring it a miss
+  // would manufacture a recall loss out of a graph-integrity defect.
+  const anchor = graph.nodes.get(anchorId);
+  const key = anchor && typeof anchor.key === 'string' ? anchor.key : '';
+  if (!key) {
+    return {
+      recovered: false,
+      probeable: false,
+      anchorId,
+      reason: `anchor ${anchorId} has no node in the graph, so there is no anchor key to query BM25 with`,
+    };
+  }
+
+  const hits = rank(key, corpus, { limit });
+  if (hits.some((hit) => hit.finding && hit.finding.id === finding.id)) {
+    return { recovered: true, arm: 'lexical', anchorId };
+  }
+
+  return {
+    recovered: false,
+    probeable: true,
+    anchorId,
+    reason: `no neighbouring anchor reaches it and BM25 over ${key} does not rank it in the top ${limit}`,
+  };
+}
+
+/**
+ * The probe. An OFFLINE measurement over the graph as it stands -- it reads,
+ * ranks and traverses, and writes nothing.
+ */
+export function recallProbe(
+  dir,
+  {
+    limit = 20,
+    graph = null,
+    minProbed = MIN_PROBED,
+    maxFindings = MAX_FINDINGS,
+  } = {}
+) {
+  const refuse = (reason) => ({
+    basis: 'offline probe over the current graph',
+    probed: 0,
+    retrieved: 0,
+    rate: null,
+    reason,
+    misses: [],
+    unprobeable: [],
+  });
+
+  let g;
+  try {
+    g = graph || load(dir);
+  } catch {
+    return refuse('the graph could not be read, so recall was not measured.');
+  }
+
+  try {
+    const all = activeFindings(g);
+    const truncated = all.length > maxFindings;
+    const findings = truncated ? all.slice(0, maxFindings) : all;
+    const parents = parentIndex(g);
+    // The corpus BM25 ranks over is the ACTIVE graph, uncapped: the sample is
+    // which findings are probed, not what they compete against. Every reported
+    // figure below reads `corpus.length` rather than `all.length`, so the
+    // published size IS the ranking corpus rather than a parallel claim about
+    // it. The distinction is not pedantry: a mutation that shrank the ranking
+    // corpus to the probed sample -- making retrieval easier, in this project's
+    // favour -- SURVIVED the first mutation run precisely because the reported
+    // number came from the other variable and could not move.
+    const corpus = all;
+
+    const misses = [];
+    const unprobeable = [];
+    const integrityFailures = [];
+    let probed = 0;
+    let retrieved = 0;
+    let integrityOk = 0;
+    let probedEdges = 0;
+    let recoveredEdges = 0;
+    const byArm = { traversal: 0, lexical: 0 };
+
+    for (const finding of findings) {
+      const anchors = anchorsOf(g, finding.id);
+
+      // INTEGRITY, run on the UNTOUCHED graph: the by-construction check. Its
+      // only honest use is as a smoke test, and it is reported as one.
+      if (!anchors.length) {
+        integrityFailures.push({
+          key: finding.key,
+          reason:
+            'active finding with no anchor -- writeHarvested refuses to create one',
+        });
+      } else if (
+        anchors.every((anchorId) =>
+          findingsFor(g, anchorId, { limit }).some((node) => node.id === finding.id)
+        )
+      ) {
+        integrityOk += 1;
+      } else {
+        integrityFailures.push({
+          key: finding.key,
+          reason: `not returned by findingsFor from one of its own anchors at limit ${limit}`,
+        });
+      }
+
+      // An unanchored finding is a definite miss, not an unaskable question:
+      // nothing traverses to it and there is no anchor key to query from, so
+      // the anchor-driven path that serves findings on a file touch can never
+      // surface it. Only an explicit wiki_query naming its own terms would.
+      if (!anchors.length) {
+        probed += 1;
+        misses.push({
+          key: finding.key,
+          reason:
+            'no anchor: nothing traverses to it and there is no anchor key to query with, so only an explicit wiki_query of its own terms would surface it',
+        });
+        continue;
+      }
+
+      const results = anchors.map((anchorId) =>
+        probeEdge(g, parents, finding, anchorId, corpus, limit)
+      );
+      const askable = results.filter((result) => result.probeable !== false);
+      probedEdges += askable.length;
+      recoveredEdges += askable.filter((result) => result.recovered).length;
+      for (const result of askable) {
+        if (result.recovered) byArm[result.arm] += 1;
+      }
+
+      if (!askable.length) {
+        unprobeable.push({ key: finding.key, reason: results[0].reason });
+        continue;
+      }
+
+      probed += 1;
+      const lost = askable.filter((result) => !result.recovered);
+      if (!lost.length) retrieved += 1;
+      else misses.push({ key: finding.key, reason: lost[0].reason });
+    }
+
+    const integrity = {
+      what:
+        'BY CONSTRUCTION: a finding is returned by findingsFor from its own anchor because that edge is what makes it an anchor. Expected 1 for every graph. NOT a recall rate.',
+      probed: findings.length,
+      retrieved: integrityOk,
+      rate: findings.length ? integrityOk / findings.length : null,
+      ok: integrityFailures.length === 0,
+      failures: integrityFailures,
+    };
+
+    // Arm B is recall@`limit`. Over a corpus of at most `limit` findings nothing
+    // is ever cut for budget, so the arm asks only whether a token matched --
+    // weaker than the bar production applies under a token budget, and a probe
+    // more permissive than the system it measures can only overstate recall.
+    const discriminating = corpus.length > limit;
+
+    const common = {
+      basis: 'offline probe over the current graph',
+      probed,
+      retrieved,
+      misses,
+      unprobeable,
+      probedEdges,
+      recoveredEdges,
+      byArm,
+      corpus: corpus.length,
+      discriminating,
+      truncated,
+      minProbed,
+      integrity,
+    };
+
+    if (probed < minProbed) {
+      return {
+        ...common,
+        rate: null,
+        reason:
+          probed === 0
+            ? `no probeable finding: ${unprobeable.length} of ${findings.length} active finding(s) have no anchor node to query from, so recall was not measured. No rate is reported, which is not the same as a rate of zero.`
+            : `${probed} probeable finding(s), below the floor of ${minProbed}: a proportion over ${probed} has a resolution of ${Math.round(
+                100 / probed
+              )} percentage points, so no rate is published. ${retrieved} of ${probed} were recovered without their own anchor edge, which is a count and not a rate.`,
+      };
+    }
+
+    if (!discriminating) {
+      return {
+        ...common,
+        rate: null,
+        reason: `the active corpus holds ${corpus.length} finding(s) and the retrieval limit is ${limit}, so nothing is ever cut for budget and the lexical arm asks only whether a token matched -- a weaker bar than production applies. No rate is published off a probe more permissive than the system it measures; ${retrieved} of ${probed} were recovered, which is a count and not a rate.`,
+      };
+    }
+
+    return { ...common, rate: retrieved / probed, reason: null };
+  } catch {
+    return refuse('the probe failed, so recall was not measured.');
+  }
+}

--- a/integrations/opencode/hooks/lib/redact.mjs
+++ b/integrations/opencode/hooks/lib/redact.mjs
@@ -1,0 +1,30 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/redact.mjs. Regenerate with `npm run sync:hooks`.
+// hooks-core/redact.mjs
+/**
+ * Redaction for anything derived from captured output.
+ *
+ * WHY THIS IS MANDATORY RATHER THAN PRUDENT. derive.mjs builds claims out of
+ * command stderr. A claim is INJECTED into model context and EXPORTED to
+ * markdown, so a secret that reaches a claim reaches two more places than the
+ * terminal it came from. Pattern matching is imperfect and that is stated in the
+ * spec, but "imperfect" beats "absent" by a wide margin here.
+ */
+
+const PATTERNS = [
+  // Bearer / API-key shaped tokens.
+  [/\b(bearer\s+)[A-Za-z0-9._~+/-]{12,}/gi, '$1[redacted]'],
+  [/\b(sk|pk|ghp|gho|github_pat|xox[baprs])[-_][A-Za-z0-9._-]{10,}/gi, '[redacted]'],
+  // KEY=value where the key name suggests a secret.
+  [/\b([A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|APIKEY|API_KEY|PRIVATE_KEY|CREDENTIAL)[A-Z0-9_]*)\s*[=:]\s*\S+/g, '$1=[redacted]'],
+  // Credentials inside a URL.
+  [/\b([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+):[^\s@]+@/gi, '$1:[redacted]@'],
+  // PEM blocks.
+  [/-----BEGIN[^-]*PRIVATE KEY-----[\s\S]*?-----END[^-]*PRIVATE KEY-----/g, '[redacted key]'],
+];
+
+export function redact(text, { max = 400 } = {}) {
+  let out = String(text ?? '');
+  for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
+}

--- a/integrations/opencode/hooks/lib/redact.mjs
+++ b/integrations/opencode/hooks/lib/redact.mjs
@@ -24,7 +24,21 @@ const PATTERNS = [
 ];
 
 export function redact(text, { max = 400 } = {}) {
+  // `?? ''` matters even though String(null)/String(undefined) never throw:
+  // without it a missing value becomes the literal 4-11 character string
+  // "null"/"undefined" -- a garbage claim that silently reaches the graph
+  // and model context instead of surfacing as an error.
   let out = String(text ?? '');
   for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  // Redact BEFORE truncating, never the reverse. Several patterns above rely
+  // on a minimum-length quantifier (e.g. `{10,}`, `{12,}`) plus a prefix.
+  // Truncating first can cut a match down to fewer characters than that
+  // quantifier requires, so the shortened fragment no longer satisfies the
+  // pattern and a live partial secret would pass through in cleartext. By
+  // redacting the full, untruncated string first, every pattern always sees
+  // the complete secret and removes it before any character budget is
+  // spent; the cap below can then only ever cut into already-redacted text
+  // (a label, or the "[redacted]" placeholder itself), never into raw
+  // secret bytes.
   return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
 }

--- a/integrations/opencode/hooks/lib/transcript.mjs
+++ b/integrations/opencode/hooks/lib/transcript.mjs
@@ -19,9 +19,11 @@
  */
 
 import {
-  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, unlinkSync,
+  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync,
+  unlinkSync, openSync, readSync, closeSync,
 } from 'node:fs';
 import { join } from 'node:path';
+import { redact } from './redact.mjs';
 
 /** Where a project's transcripts live, under the graph it belongs to. */
 export const transcriptDir = (dir) => join(dir, 'transcripts');
@@ -210,4 +212,204 @@ export function readArchive(dir, sessionId) {
   } catch {
     return [];
   }
+}
+
+/**
+ * How much of a transcript's TAIL is scanned for failed tool results.
+ *
+ * A transcript is the largest file this project reads: the three real ones on
+ * the measuring machine are 5.8 MB, 22 MB and 45 MB. `archive()` above already
+ * reads the whole thing once at Stop, so an unbounded second pass doubles the
+ * most expensive read on the session-end path for evidence that is, by
+ * construction, mostly old. The tail is the right half to keep for the same
+ * reason `buildFeedbackDigest` keeps the end: what a session learned is
+ * concentrated where the work went wrong, which is later rather than sooner.
+ */
+const FAILED_SCAN_BYTES = () =>
+  Number(process.env.TOKEN_OPTIMIZER_TRANSCRIPT_SCAN_BYTES) || 8 * 1024 * 1024;
+
+/** Failed results kept, most recent first. The pairing detector needs a handful. */
+const FAILED_MAX = 50;
+
+/** Same 4 KB cap `recordToolOutcome` applies to `output`, for the same reason. */
+const FAILED_OUTPUT_MAX = 4096;
+
+/**
+ * The same 120-character truncation `recordToolOutcome` applies to `anchor`.
+ *
+ * ONE COMMAND MUST PRODUCE ONE KEY FROM EITHER SOURCE. A `tool-outcome` stores
+ * the command as `String(tool_input.command).slice(0, 120)`, and `attemptKey`
+ * reads up to three non-flag tokens off whatever it is handed. A long first
+ * token -- a quoted grep pattern, an absolute Windows path, a heredoc -- is cut
+ * by that cap INSIDE those three tokens, so the untruncated transcript copy of
+ * the same command lands in a DIFFERENT group. Measured against one real
+ * session's own evidence: 266 commands present in both sources, and truncating
+ * here made 266 of 266 keys agree where the untruncated text agreed on only
+ * 240.
+ *
+ * WHAT THAT ACTUALLY BUYS, stated precisely rather than generously. `derive`
+ * refuses to build a claim out of a command at or over the cap at all (see
+ * `quotable` there), so agreement on a TRUNCATED key never produces a finding
+ * on its own. It buys two things that still matter: a transcript failure lands
+ * in the same run as the event outcomes of the same command, so the
+ * nearest-preceding-failure rule sees the real sequence rather than a sparse
+ * one; and the no-call-id fallback in `derive`'s deduplication compares command
+ * TEXT against an already-truncated anchor, which cannot match unless this side
+ * is truncated identically.
+ */
+const ANCHOR_MAX = 120;
+
+/**
+ * A tool result that reports a command that RAN and exited non-zero.
+ *
+ * A POSITIVE ALLOWLIST, and the measurement is why. Claude Code sets
+ * `is_error: true` on every kind of unhappy tool result, and across three real
+ * transcripts 214 of them fell into four shapes:
+ *
+ *   83  `Exit code N` + stderr    -- a command ran and failed. THIS ONE.
+ *   109 hook and policy denials   -- overwhelmingly THIS optimizer's own
+ *                                    PreToolUse text ("Recursive shell searches
+ *                                    return unbounded output. Call the
+ *                                    token-optimizer MCP tool smart_grep
+ *                                    instead"), plus `Remove-Item on system
+ *                                    path` blocks.
+ *   18  `<tool_use_error>...`     -- protocol errors: `String to replace not
+ *                                    found`, `File has not been read yet`,
+ *                                    `Blocked: ...`.
+ *   4   a person declined the call.
+ *
+ * Only the first shape is a command failing. In every other shape THE COMMAND
+ * NEVER RAN, so "`X` failed with: ..." would be a false claim about X, and a
+ * later success would pair with a failure that never happened. The 109 are the
+ * dangerous ones: ingesting them would have this tool derive findings from its
+ * own advice, at 0.9 confidence, and serve them back as observations about the
+ * project -- a self-referential loop that also inflates its own finding count.
+ * That is the measurement-bias class this plan tracks, and a denylist would
+ * have let every future denial string through by default.
+ */
+const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
+
+/** Reads at most `bytes` from the END of a file, without loading the rest. */
+function readTail(path, bytes) {
+  let fd;
+  try {
+    const size = statSync(path).size;
+    const length = Math.min(size, bytes);
+    if (!length) return '';
+    fd = openSync(path, 'r');
+    const buffer = Buffer.allocUnsafe(length);
+    readSync(fd, buffer, 0, length, size - length);
+    const text = buffer.toString('utf8');
+    // A tail almost never starts on a line boundary, and half a JSON object is
+    // not a parse failure worth reporting -- it is a partial record. Drop it.
+    return length < size ? text.slice(text.indexOf('\n') + 1) : text;
+  } catch {
+    return '';
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+}
+
+/**
+ * The failed COMMAND results a transcript holds, which no hook event carries.
+ *
+ * WHY THIS READER EXISTS. Claude Code never fires PostToolUse for a failed tool
+ * call: a deliberately failing command produced no event at all, and 2,238 of
+ * 2,238 live `tool-outcome` events on the measuring machine carry
+ * `success: true`. So `derive.mjs`'s two strongest detectors -- command
+ * failed-then-succeeded at 0.90 and test/build red-to-green at 0.85 -- have no
+ * input whatsoever on the primary client, while working normally on the ten
+ * adapter clients. The failures exist; they exist only here.
+ *
+ * WHY NOT THE ARCHIVE, which the plan for this reader assumed. `readTurns`
+ * DROPS tool results by design -- that is where whole file contents would enter
+ * the record -- so `readArchive` returns no failure, ever, and an extractor over
+ * archived turns would find nothing however well it was written. Making the
+ * archive carry them would also push command stderr into `buildFeedbackDigest`,
+ * which is the one code path in this project that sends anything to a model
+ * endpoint. So this reads the transcript and STORES NOTHING NEW: read-only, no
+ * capture path, no new event kind, and no widening of what leaves the machine.
+ *
+ * REDACTED HERE, at this boundary, exactly as `recordToolOutcome` redacts
+ * `output`. Transcript text has never passed a redaction boundary -- that one
+ * never saw it -- and everything returned from here is destined for a claim that
+ * is injected into model context and exported to markdown.
+ *
+ * @returns {Array<{command: string, output: string, exit: number|null,
+ *   at: number, toolCallId: string|null}>} in transcript order, so a caller can
+ *   sort it beside `tool-outcome` events without re-ordering.
+ */
+export function failedResultsFromTranscript(transcriptPath, options = {}) {
+  const { max = FAILED_MAX, scanBytes = FAILED_SCAN_BYTES() } = options || {};
+  if (!transcriptPath) return [];
+  const text = readTail(transcriptPath, scanBytes);
+  if (!text) return [];
+
+  // tool_use_id -> the command that was attempted. The join is EXACT and it is
+  // the only one available: the result block carries no command of its own, and
+  // the id is the same string `episodeMeta` reads into `toolCallId`, so the same
+  // key also deduplicates against events on clients that do report failures.
+  const commands = new Map();
+  const failures = [];
+
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const message = entry.message || entry;
+    const role = message.role || entry.type;
+    const content = message.content;
+    if (!Array.isArray(content)) continue;
+
+    if (role === 'assistant') {
+      for (const block of content) {
+        if (!block || block.type !== 'tool_use' || !block.id) continue;
+        const command = block.input?.command;
+        if (typeof command !== 'string' || !command.trim()) continue;
+        commands.set(String(block.id), command.slice(0, ANCHOR_MAX));
+      }
+      continue;
+    }
+
+    if (role !== 'user') continue;
+    for (const block of content) {
+      if (!block || block.type !== 'tool_result' || block.is_error !== true) continue;
+      // Only a STRING result can be an exit-code report; every failed Claude
+      // Code result observed was one, and a structured body is a shape this
+      // classifier has not measured, so it is refused rather than guessed at.
+      if (typeof block.content !== 'string') continue;
+      const match = EXIT_CODE_RESULT.exec(block.content);
+      if (!match) continue;
+      const command = commands.get(String(block.tool_use_id || ''));
+      // No command means no claim. The result says something failed; without
+      // the text of what failed there is nothing to say about it, and nothing
+      // to group it with.
+      if (!command) continue;
+      failures.push({
+        command,
+        // The exit line itself is stripped: `exit` carries it structurally, and
+        // leaving it in makes every failure claim read "failed with: Exit code 1".
+        output: redact(block.content.slice(match[0].length).trim(), {
+          max: FAILED_OUTPUT_MAX,
+        }),
+        exit: Number(match[1]),
+        at: Date.parse(entry.timestamp || '') || 0,
+        toolCallId: block.tool_use_id ? String(block.tool_use_id) : null,
+      });
+    }
+  }
+
+  // The MOST RECENT `max`, keeping chronological order. A session that failed
+  // two hundred times teaches its last lessons, not its first.
+  return failures.slice(-max);
 }

--- a/integrations/opencode/hooks/lib/usage.mjs
+++ b/integrations/opencode/hooks/lib/usage.mjs
@@ -42,7 +42,7 @@
  * was referenced" and "nothing could be measured" are different answers and
  * this module gives different answers for them.
  */
-import { readMetrics } from './metrics.mjs';
+import { readMetrics, readTruncation } from './metrics.mjs';
 
 /**
  * The events that name a finding, and it is ONE kind, not the two the plan
@@ -129,17 +129,30 @@ export function classify(dir, { events = null } = {}) {
   try {
     const all = inTimeOrder(events || readMetrics(dir));
 
-    // Every reference, keyed on the finding it names. Only references carrying
-    // a session id are usable -- see `unscopedReferences` in `referenceRate`
-    // for the ones this drops and why they are counted rather than credited.
+    // Every reference, keyed on the finding it names and on nothing else.
+    //
+    // NOT SCOPED BY SESSION, and that is a deliberate reversal. Scoping needs
+    // the query's `sessionId`, which `wiki_query` takes as an OPTIONAL input
+    // the model has to volunteer (`options.sessionId ?? null`) -- so the
+    // numerator depended on the model choosing to identify itself, and an
+    // unverifiable model-supplied id is not evidence. Plan 1 settled that for
+    // the `answers` edge and it settles it here: stop depending on the field
+    // rather than hope for cooperation. The finding key is the specific part
+    // anyway; a key is a graph identity, not a guess.
+    //
+    // THE COST, disclosed here and in `referenceNote` because a reader of the
+    // number has to see it: TWO CONCURRENT SESSIONS ON ONE REPOSITORY CAN
+    // CROSS-ATTRIBUTE. Session A's injection of K plus session B's later query
+    // for K reads as a reference. Nothing in the log can separate them once the
+    // session id is gone, so the exposure is real and is stated rather than
+    // priced.
     const references = new Map();
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       const key = referencedKey(event);
-      const session = sessionOf(event);
-      if (!key || !session) continue;
+      if (!key) continue;
       if (!references.has(key)) references.set(key, []);
-      references.get(key).push({ at: event.at || 0, session });
+      references.get(key).push(event.at || 0);
     }
 
     // Which injections the existing outcome join could attribute. An outcome
@@ -170,9 +183,8 @@ export function classify(dir, { events = null } = {}) {
       const injectionId = event.injectionId ? String(event.injectionId) : null;
       const at = event.at || 0;
       const session = sessionOf(event);
-      // STRICTLY AFTER. A query that PRECEDED the injection is the model
-      // asking on its own initiative; crediting it would let the metric take
-      // the credit for a lookup it had nothing to do with.
+      // STRICTLY AFTER here too: activity that predates the injection is not
+      // an opportunity to have used it.
       const followed = (times) => times.some((t) => t > at);
       const continued =
         (injectionId && attributed.has(injectionId)) ||
@@ -181,9 +193,11 @@ export function classify(dir, { events = null } = {}) {
       for (const raw of keys) {
         const findingKey = String(raw);
         const hits = references.get(findingKey) || [];
-        const referenced = session
-          ? hits.some((hit) => hit.session === session && hit.at > at)
-          : false;
+        // TIME ORDER IS THE ONLY REMAINING GUARD, so it carries the whole
+        // weight of the attribution: a query that PRECEDED the injection is
+        // the model asking on its own initiative, and crediting it would let
+        // the metric take the credit for a lookup it had nothing to do with.
+        const referenced = hits.some((hitAt) => hitAt > at);
         rows.push({
           findingKey,
           injectionId,
@@ -204,9 +218,27 @@ export function classify(dir, { events = null } = {}) {
 /**
  * The rate, with everything needed to tell a real 0 from an absent one.
  *
- * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
- * `unattributable` and `unscopedReferences` are reported beside it, never
- * inside it.
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown` and
+ * `unattributable` are reported beside it, never inside it.
+ *
+ * `windowed` SAYS WHETHER THE DENOMINATOR CAN UNDERSTATE, and it is not
+ * decoration. `readMetrics` reads a 2 MB / 5,000-event TAIL of the firehose,
+ * and injections are rare enough on a real project to age out of it: measured
+ * on this repository, both `inject` events sit at lines 502 and 883 of 6,871
+ * and have scrolled away behind ~6,000 later `read` and `tool-outcome` rows,
+ * so the windowed denominator is 0 where the whole-file truth is 1.
+ *
+ * IT IS REPORTED RATHER THAN FIXED, deliberately. `inject` already gets
+ * unwindowed access through `BALANCE_KINDS` / `EVIDENCE_KINDS`, but `query`
+ * does not -- and reading only the INJECTION arm unwindowed would be worse
+ * than the windowing: every old injection would enter the denominator with no
+ * chance of a matching query in the window and score `not-referenced`,
+ * manufacturing a pessimistic rate out of the asymmetry. Making the query arm
+ * unwindowed means adding `query` to `EVIDENCE_KINDS`, which two other
+ * consumers read, and this project's own standard says a shared-classifier
+ * change needs a per-consumer verdict comparison. So the honest move is to
+ * publish the flag: a caller that needs the unwindowed truth passes its own
+ * `events`, which is exactly what the live measurement in the task report did.
  */
 export function referenceRate(dir, { events = null } = {}) {
   const empty = {
@@ -218,10 +250,15 @@ export function referenceRate(dir, { events = null } = {}) {
     unattributable: 0,
     unattributableWithInjectedToolCall: 0,
     referenceEvents: 0,
-    unscopedReferences: 0,
+    windowed: false,
   };
   try {
     const all = events || readMetrics(dir);
+    // OUT OF BAND, and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` reports on the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
     const rows = classify(dir, { events: all });
     const count = (label) => rows.filter((row) => row.label === label).length;
     const referenced = count('referenced');
@@ -231,17 +268,17 @@ export function referenceRate(dir, { events = null } = {}) {
     // Usable reference events in the window: the numerator's producer. If this
     // is zero the channel never fired, and a 0% rate would be measuring the
     // absence of a producer rather than the uselessness of findings.
+    //
+    // NO SESSION REQUIREMENT, matching the attribution above. The former
+    // `unscopedReferences` counted queries dropped for want of a session id;
+    // nothing is dropped for that reason any more, so the field is GONE rather
+    // than kept at a permanent zero that a later reader would misread as
+    // evidence the loss had been fixed.
     let referenceEvents = 0;
-    let unscopedReferences = 0;
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       if (!referencedKey(event)) continue;
-      if (sessionOf(event)) referenceEvents += 1;
-      // Names a finding but cannot be scoped to one injection. `sessionId` is
-      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
-      // is the expected loss rather than an edge case -- counted here so it is
-      // visible instead of silently deflating the numerator.
-      else unscopedReferences += 1;
+      referenceEvents += 1;
     }
 
     // The tool calls that DID receive findings, keyed the way
@@ -292,7 +329,7 @@ export function referenceRate(dir, { events = null } = {}) {
       unattributable,
       unattributableWithInjectedToolCall,
       referenceEvents,
-      unscopedReferences,
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
     };
   } catch {
     return empty;
@@ -300,11 +337,18 @@ export function referenceRate(dir, { events = null } = {}) {
 }
 
 /**
- * One line for the audit, or nothing at all.
+ * One or two lines for the audit, or nothing at all.
  *
  * Says which of the three things is true -- a measured rate, a live channel
  * with no opportunities yet, or no channel at all -- rather than printing a
  * figure and letting the reader assume the first.
+ *
+ * AND IT CARRIES THE CAVEATS, because this is the only place a human meets the
+ * number. A rate attributed on (finding key, time order) can cross-attribute
+ * between two concurrent sessions on one repository, and a windowed read can
+ * understate the denominator. Both are stated beside the figure they qualify.
+ * Putting them only in a task report would be publishing a clean number and
+ * filing the asterisk somewhere nobody quoting it will look.
  */
 export function referenceNote(dir, { events = null } = {}) {
   const r = referenceRate(dir, { events });
@@ -317,6 +361,11 @@ export function referenceNote(dir, { events = null } = {}) {
   }
   return (
     `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
-    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded. ` +
+    'Matched on finding key and time order, so concurrent sessions on this ' +
+    'repository can cross-attribute' +
+    (r.windowed
+      ? '; and the event log was truncated, so the denominator can understate.'
+      : '.')
   );
 }

--- a/integrations/opencode/hooks/lib/usage.mjs
+++ b/integrations/opencode/hooks/lib/usage.mjs
@@ -1,0 +1,322 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/usage.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 1 -- did the model actually go back and use what we injected?
+ *
+ * The cheap behavioural label. One question, answered from the event log alone:
+ * after we put a finding in front of the model, did the model later ASK FOR
+ * THAT FINDING BY NAME?
+ *
+ * WHY EXPLICIT REFERENCE, AND NOT READ-SUPPRESSION. Read-suppression -- "the
+ * file was not re-read, so the finding must have helped" -- is Layer 2's
+ * estimand, measured causally by withholding a finding and comparing. Layer 1
+ * exists to be calibrated AGAINST that. If both layers derived from
+ * suppression, the calibration would compare two spellings of one quantity,
+ * report a strong correlation, and mean nothing. So Layer 1 is deliberately
+ * built on a signal Layer 2 does not touch: an explicit `query` naming the
+ * finding key.
+ *
+ * WHAT THIS DOES NOT DO. It does not invent a join. `recordToolOutcome`
+ * already joins each post-tool result back to the injection that preceded it,
+ * recording `injectionId`, `findingIds` and a `joinMethod` of `tool-call-id`,
+ * `episode-anchor` or `none` -- preferring an exact tool-call id, which is
+ * strictly better evidence than the `(sessionId, findingKey)` approximation an
+ * earlier draft of this plan proposed. This module consumes that join and adds
+ * none of its own. `inject.mjs` needed no change: it has written `findingIds`
+ * at every call site all along.
+ *
+ * WHAT `unknown` IS FOR, and it is the whole reason this file is careful. An
+ * injection whose session simply stopped afterwards is not a miss. Nothing
+ * happened, so nothing can be concluded, and counting it against the finding
+ * would make the metric read worse the more often sessions end -- a number
+ * that moves with session length rather than with usefulness. `unknown` is
+ * therefore EXCLUDED from the denominator rather than scored zero, and
+ * outcomes the join could not attribute at all are reported as
+ * `unattributable` rather than folded into either arm.
+ *
+ * AND WHY THE RATE CAN BE `null`. This project has already shipped two metrics
+ * whose only producer was their own test suite. A rate of 0% that actually
+ * means "no data" is worse than a refusal, because it is a number and numbers
+ * get quoted. So `rate` is null unless there is a denominator AND the
+ * reference channel produced at least one usable event in the window. "Nothing
+ * was referenced" and "nothing could be measured" are different answers and
+ * this module gives different answers for them.
+ */
+import { readMetrics } from './metrics.mjs';
+
+/**
+ * The events that name a finding, and it is ONE kind, not the two the plan
+ * assumed.
+ *
+ * The brief said "a later `query` or `expand` event". Checked against the code
+ * and against every metrics log on this machine, `expand` does not qualify and
+ * cannot be made to:
+ *
+ *   - `recordExpansion` writes `{ ref, tool, shape, asked, sessionId }`. `ref`
+ *     is a TRUNCATION CAPTURE id (a 16-hex digest of captured tool output),
+ *     not a finding key, and `asked` is free text naming a section of that
+ *     output. Neither is a graph key, and no code path ever puts one there.
+ *   - measured: 64 live `expand` events exist on this machine and all 64 carry
+ *     `sessionId: null`, so they could not be scoped to an injection even if
+ *     they did name one.
+ *
+ * Keying the classifier on `expand` would therefore have added a branch that
+ * can never fire -- a metric with no producer, which is the exact defect this
+ * whole effort exists to close. So it is excluded, deliberately and with the
+ * measurement recorded, rather than included for symmetry with the brief.
+ */
+const REFERENCE_KINDS = new Set(['query']);
+
+/**
+ * What counts as the session having CONTINUED past the injection.
+ *
+ * The distinction between `not-referenced` and `unknown` rests entirely on
+ * this, so the set is explicit rather than "any later event". These are the
+ * kinds a tool call produces: if one of them follows the injection in the same
+ * session, the model had the opportunity to ask and did not. If none does, the
+ * session ended and there was no opportunity.
+ *
+ * `inject` is in the set because a later injection means a later tool call
+ * happened. `forecast`, `mcp-client` and `mcp-tool` are NOT: they are written
+ * by session bookkeeping rather than by the model doing something, and
+ * treating them as opportunity would convert `unknown` rows into misses on
+ * bookkeeping alone.
+ */
+const ACTIVITY_KINDS = new Set([
+  'tool-outcome',
+  'read',
+  'query',
+  'expand',
+  'substitute',
+  'inject',
+]);
+
+/** A usable session id: a non-empty string. `null == null` is not a match. */
+const sessionOf = (event) => {
+  const id = event?.sessionId;
+  return typeof id === 'string' && id ? id : null;
+};
+
+/** The finding key a reference event names, or null if it names none. */
+const referencedKey = (event) => {
+  const key = event?.key;
+  return typeof key === 'string' && key ? key : null;
+};
+
+/** Ordering by the caller's timestamp, with log order breaking ties. */
+function inTimeOrder(events) {
+  return events
+    .map((event, index) => ({ event, index }))
+    .sort(
+      (a, b) =>
+        (a.event.at || 0) - (b.event.at || 0) || a.index - b.index
+    )
+    .map((row) => row.event);
+}
+
+/**
+ * One row per (injection, finding) pair, labelled.
+ *
+ * Per injection rather than per finding: the same finding injected twice is two
+ * separate opportunities, and collapsing them would let one reference excuse
+ * every later injection of that key.
+ *
+ * FAILS OPEN. A malformed log yields an empty classification, never a throw:
+ * this runs on report paths that must not break a tool call.
+ */
+export function classify(dir, { events = null } = {}) {
+  let rows = [];
+  try {
+    const all = inTimeOrder(events || readMetrics(dir));
+
+    // Every reference, keyed on the finding it names. Only references carrying
+    // a session id are usable -- see `unscopedReferences` in `referenceRate`
+    // for the ones this drops and why they are counted rather than credited.
+    const references = new Map();
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      const key = referencedKey(event);
+      const session = sessionOf(event);
+      if (!key || !session) continue;
+      if (!references.has(key)) references.set(key, []);
+      references.get(key).push({ at: event.at || 0, session });
+    }
+
+    // Which injections the existing outcome join could attribute. An outcome
+    // carrying our injectionId is proof the tool call completed, which is
+    // opportunity even when the session id is missing from the log.
+    const attributed = new Set();
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) continue;
+      attributed.add(String(event.injectionId));
+    }
+
+    // Activity per session, so "did anything follow?" is one lookup rather
+    // than a scan per injection.
+    const activity = new Map();
+    for (const event of all) {
+      if (!ACTIVITY_KINDS.has(event.kind)) continue;
+      const session = sessionOf(event);
+      if (!session) continue;
+      if (!activity.has(session)) activity.set(session, []);
+      activity.get(session).push(event.at || 0);
+    }
+
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+      if (!keys.length) continue;
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const at = event.at || 0;
+      const session = sessionOf(event);
+      // STRICTLY AFTER. A query that PRECEDED the injection is the model
+      // asking on its own initiative; crediting it would let the metric take
+      // the credit for a lookup it had nothing to do with.
+      const followed = (times) => times.some((t) => t > at);
+      const continued =
+        (injectionId && attributed.has(injectionId)) ||
+        (session ? followed(activity.get(session) || []) : false);
+
+      for (const raw of keys) {
+        const findingKey = String(raw);
+        const hits = references.get(findingKey) || [];
+        const referenced = session
+          ? hits.some((hit) => hit.session === session && hit.at > at)
+          : false;
+        rows.push({
+          findingKey,
+          injectionId,
+          label: referenced
+            ? 'referenced'
+            : continued
+              ? 'not-referenced'
+              : 'unknown',
+        });
+      }
+    }
+  } catch {
+    rows = [];
+  }
+  return rows;
+}
+
+/**
+ * The rate, with everything needed to tell a real 0 from an absent one.
+ *
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
+ * `unattributable` and `unscopedReferences` are reported beside it, never
+ * inside it.
+ */
+export function referenceRate(dir, { events = null } = {}) {
+  const empty = {
+    referenced: 0,
+    notReferenced: 0,
+    unknown: 0,
+    denominator: 0,
+    rate: null,
+    unattributable: 0,
+    unattributableWithInjectedToolCall: 0,
+    referenceEvents: 0,
+    unscopedReferences: 0,
+  };
+  try {
+    const all = events || readMetrics(dir);
+    const rows = classify(dir, { events: all });
+    const count = (label) => rows.filter((row) => row.label === label).length;
+    const referenced = count('referenced');
+    const notReferenced = count('not-referenced');
+    const denominator = referenced + notReferenced;
+
+    // Usable reference events in the window: the numerator's producer. If this
+    // is zero the channel never fired, and a 0% rate would be measuring the
+    // absence of a producer rather than the uselessness of findings.
+    let referenceEvents = 0;
+    let unscopedReferences = 0;
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      if (!referencedKey(event)) continue;
+      if (sessionOf(event)) referenceEvents += 1;
+      // Names a finding but cannot be scoped to one injection. `sessionId` is
+      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
+      // is the expected loss rather than an edge case -- counted here so it is
+      // visible instead of silently deflating the numerator.
+      else unscopedReferences += 1;
+    }
+
+    // The tool calls that DID receive findings, keyed the way
+    // `recordToolOutcome` keys its own primary join: the tool-call id. An
+    // unattributable outcome for one of these is a join that FAILED. An
+    // unattributable outcome for any other tool call had nothing to join to.
+    //
+    // KEYED ON THE TOOL CALL, NOT THE EPISODE, and the first draft of this
+    // got it wrong in a way worth recording because it is the exact
+    // measurement-bias class this plan hunts. `episodeId` equals the SESSION
+    // id, so "unattributable outcomes in an episode that had an injection"
+    // scored all 2,559 tool calls of a session in which ONE injection
+    // happened. It would have published 2,559 join failures where the true
+    // number is zero -- correct code, lying number, and biased pessimistic
+    // rather than flattering, which is no better.
+    const injectedToolCalls = new Set();
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      if (!Array.isArray(event.findingIds) || !event.findingIds.length)
+        continue;
+      if (event.toolCallId) injectedToolCalls.add(String(event.toolCallId));
+    }
+    let unattributable = 0;
+    let unattributableWithInjectedToolCall = 0;
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome' || event.joinMethod !== 'none')
+        continue;
+      unattributable += 1;
+      // BOTH FIGURES, because the raw one alone lies in the pessimistic
+      // direction. Measured on this machine: 2,991 of 2,992 live outcomes
+      // report `joinMethod: 'none'`, and every one of them because NO
+      // INJECTION EXISTED for that tool call -- the graph holds one finding.
+      // Quoting only the raw count would read as a join that fails 99.97% of
+      // the time, which is a different and false claim.
+      if (event.toolCallId && injectedToolCalls.has(String(event.toolCallId)))
+        unattributableWithInjectedToolCall += 1;
+    }
+
+    return {
+      referenced,
+      notReferenced,
+      unknown: count('unknown'),
+      denominator,
+      rate:
+        denominator > 0 && referenceEvents > 0
+          ? referenced / denominator
+          : null,
+      unattributable,
+      unattributableWithInjectedToolCall,
+      referenceEvents,
+      unscopedReferences,
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/**
+ * One line for the audit, or nothing at all.
+ *
+ * Says which of the three things is true -- a measured rate, a live channel
+ * with no opportunities yet, or no channel at all -- rather than printing a
+ * figure and letting the reader assume the first.
+ */
+export function referenceNote(dir, { events = null } = {}) {
+  const r = referenceRate(dir, { events });
+  if (!r.denominator && !r.unknown && !r.referenceEvents) return null;
+  if (r.rate == null) {
+    const why = !r.referenceEvents
+      ? 'no finding was ever queried by key in this window'
+      : `no injection had a chance to be referenced yet (${r.unknown} unknown)`;
+    return `Injected findings referenced later: not measurable -- ${why}.`;
+  }
+  return (
+    `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+  );
+}

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -103,6 +103,44 @@ const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
 
 /**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because FOUR readers depend on it -- mutation accounting,
+ * success classification, output capture and exit-code capture -- and clients
+ * disagree on the envelope name and on nothing else. Letting each reader name
+ * its own subset is exactly how both classifiers came to miss MCP's failure
+ * flag: `toolSucceeded` listed four envelopes and `mutationSucceeded` listed
+ * three, and neither list mentioned `isError` at all.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/**
+ * Did an MCP result declare itself an error?
+ *
+ * `isError` is the ONLY failure signal an MCP result carries -- there is no
+ * `error` field and no `status` -- and `src/server/index.ts` sets it in seven
+ * places. Shared by both classifiers so they cannot disagree about what a
+ * failed call from this project's own tools looks like.
+ *
+ * `=== true` EXACTLY. A client using the key for anything else must not have
+ * its successful calls silently reclassified, and `isError: false` is a
+ * successful MCP call, not a missing verdict.
+ */
+function reportedMcpError(raw) {
+  return [...responseEnvelopes(raw), raw].some(
+    (envelope) => envelope?.isError === true
+  );
+}
+
+/**
  * A post-tool event is not universally proof of success. Some clients split
  * success and failure into distinct events; others expose a result status.
  * Keep mutation accounting conservative so a failed edit cannot arm Stop.
@@ -112,6 +150,19 @@ export function mutationSucceeded(clientName, raw) {
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
     return false;
+  // BEFORE the status read, the explicit-success read AND the client
+  // allowlist, because all three would otherwise pass a failed MCP write. The
+  // allowlist is the one that actually bit: it returns true for claude-code,
+  // codex, qwen, opencode, kilo and windsurf on any post-tool event with no
+  // error and no status, which is precisely the shape of a failed smart_write.
+  //
+  // WHY THIS IS THE SAME BUG AS THE ONE IN `toolSucceeded` AND NOT A COSMETIC
+  // ECHO OF IT: this function gates edit counting and harvest pressure, so
+  // counting a failed write to THE OPTIMIZER'S OWN TOOLS as a mutation
+  // inflates "the optimizer successfully edited a file". Different consumers
+  // from the effectiveness figures, same direction of bias -- toward
+  // flattering the thing being measured.
+  if (reportedMcpError(raw)) return false;
 
   const status =
     raw?.tool_response?.status ??
@@ -145,24 +196,6 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * Spelled out ONCE because three readers depend on it -- success
- * classification, output capture and exit-code capture -- and clients disagree
- * on the envelope name and on nothing else. Letting each reader name its own
- * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
-}
-
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
@@ -181,8 +214,7 @@ export function toolSucceeded(raw) {
   // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
   // optimizer's favour. A measurement that flatters the thing being measured
   // is worse than no measurement.
-  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
-    return false;
+  if (reportedMcpError(raw)) return false;
   const status =
     raw?.tool_response?.status ??
     raw?.toolResponse?.status ??

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -957,10 +957,12 @@ async function runHook(clientName, event, invocation) {
       // accumulates structure and no verdicts at all. These detectors read only
       // what is already on disk and send nothing anywhere.
       //
-      // The COUNT is recorded rather than the candidates: how many findings a
-      // session's own evidence supports is the number that says whether this is
-      // working, and it is measurable before anything is stored. Storage is the
-      // caller's next step, under a budget.
+      // COUNTS are recorded rather than the candidates, and BOTH counts: how
+      // many findings a session's own evidence supports, and how many of them
+      // survived the storage budget and the anchor discipline. The gap between
+      // the two is the number that says whether the bound is doing anything --
+      // one figure alone cannot distinguish "nothing to derive" from "derived
+      // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
       const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
       const dir = wikiDir(projectRoot);
@@ -976,6 +978,7 @@ async function runHook(clientName, event, invocation) {
         sessionId,
         candidates: derived.candidates.length,
         observations: derived.observations.length,
+        written: derived.written.length,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -172,6 +172,136 @@ export function toolSucceeded(raw) {
   return true;
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * The same family `toolSucceeded` reads above, hoisted so the three readers
+ * cannot drift apart. Clients disagree on the envelope name and on nothing
+ * else, so this is the one place that disagreement is spelled out.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/** A non-empty string, or null.  Blank output is the same as none. */
+function nonEmpty(value) {
+  const text = String(value ?? '');
+  return text.trim() ? text : null;
+}
+
+/**
+ * The human-readable result text inside one envelope, or null.
+ *
+ * RETURNS NULL RATHER THAN GUESSING. An envelope shape nobody here has seen
+ * produces no capture at all, which costs one finding. Stringifying it instead
+ * would put `[object Object]` or a wall of JSON metadata into a claim that gets
+ * injected into model context -- a wrong observation, which is strictly worse
+ * than a missing one.
+ */
+function resultText(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'string') return nonEmpty(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return null;
+
+  // MCP content blocks, which is how THIS PROJECT'S OWN tools now arrive:
+  // `normalizeTool` resolves `mcp__<server>__smart_edit`, so smart_edit and
+  // smart_write reach the post-tool path for the first time and their results
+  // are `{ content: [{ type: 'text', text }], isError }` rather than a shell
+  // result. Both the bare array and the wrapping object are accepted because
+  // hosts differ on whether they hand the hook the result or its content.
+  if (Array.isArray(value)) {
+    const blocks = value
+      .map((block) =>
+        typeof block === 'string' ? block : nonEmpty(block?.text)
+      )
+      .filter(Boolean);
+    return blocks.length ? nonEmpty(blocks.join('\n')) : null;
+  }
+  if (typeof value !== 'object') return null;
+
+  // STDERR FIRST, and not because that is the order it was produced in. The
+  // cap can only ever cut the tail, and the diagnostic that explains a failure
+  // is almost always on stderr while the volume is almost always on stdout --
+  // so appending stderr would let a 3 MB build log push the one line worth
+  // capturing out of the window.
+  const streams = [nonEmpty(value.stderr), nonEmpty(value.stdout)].filter(
+    Boolean
+  );
+  if (streams.length) return streams.join('\n');
+
+  if (Array.isArray(value.content)) {
+    const inner = resultText(value.content);
+    if (inner) return inner;
+  }
+
+  const error = value.error;
+  if (error) {
+    const message =
+      typeof error === 'string' ? error : nonEmpty(error.message ?? error.msg);
+    if (message) return message;
+  }
+
+  return (
+    nonEmpty(value.output) ??
+    nonEmpty(value.text) ??
+    nonEmpty(value.message) ??
+    (typeof value.result === 'string' ? nonEmpty(value.result) : null)
+  );
+}
+
+/**
+ * The result text of a completed tool call, or null when the client reports
+ * none.  Redaction and the size cap are NOT applied here -- they belong at the
+ * `recordToolOutcome` boundary, which is the only place every caller passes.
+ */
+export function outputFrom(raw) {
+  for (const envelope of responseEnvelopes(raw)) {
+    const text = resultText(envelope);
+    if (text) return text;
+  }
+  return resultText(raw?.output) ?? resultText(raw?.stdout) ?? null;
+}
+
+/**
+ * Key names that mean "process exit code" and nothing else.
+ *
+ * `code` is deliberately ABSENT. JSON-RPC errors (`code: -32602`), Node errno
+ * objects (`code: 'ENOENT'`) and HTTP wrappers all reuse that name, so reading
+ * it would record a confident exit code for calls that never had one. A null
+ * here is honest; a -32602 claiming to be an exit status is not.
+ */
+const EXIT_KEYS = [
+  'exit_code',
+  'exitCode',
+  'exit',
+  'exit_status',
+  'exitStatus',
+  'return_code',
+  'returncode',
+];
+
+/** The numeric exit code a client reported, or null when it reported none. */
+export function exitFrom(raw) {
+  for (const envelope of [...responseEnvelopes(raw), raw]) {
+    if (!envelope || typeof envelope !== 'object') continue;
+    for (const key of EXIT_KEYS) {
+      const value = envelope[key];
+      if (Number.isInteger(value)) return value;
+      // A client that serializes the code as a digit string still reported it.
+      // Bounded so a hash or an id cannot be mistaken for a status.
+      if (typeof value === 'string' && /^-?\d{1,5}$/.test(value.trim()))
+        return Number(value.trim());
+    }
+  }
+  return null;
+}
+
 function contextOutput(client, eventName, additionalContext) {
   if (client.contextStyle === 'top-level') return { additionalContext };
   if (client.contextStyle === 'cline') {
@@ -890,6 +1020,11 @@ async function runHook(clientName, event, invocation) {
         anchor,
         toolName: payload.tool_name,
         success: toolSucceeded(raw),
+        // The two fields a boolean cannot carry: which KIND of failure this
+        // was. Read through the same normalisers as `success`, never off `raw`
+        // at this call site.
+        output: outputFrom(raw),
+        exit: exitFrom(raw),
         durationMs:
           Number(
             raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -145,11 +145,43 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because three readers depend on it -- success
+ * classification, output capture and exit-code capture -- and clients disagree
+ * on the envelope name and on nothing else. Letting each reader name its own
+ * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
+    return false;
+  // MCP'S OWN FAILURE FLAG, which this function did not read for as long as it
+  // existed. It did not matter while `normalizeTool` dropped MCP names before
+  // any accounting ran; it matters now that `mcp__<server>__smart_edit` and
+  // `smart_write` reach the post-tool path, because an MCP result carries no
+  // `error` field and no `status` -- only `isError` -- so a failed smart_edit
+  // fell through to the optimistic `return true` below.
+  //
+  // WHY THIS IS A MEASUREMENT BUG AND NOT A COSMETIC ONE: this boolean feeds
+  // episode outcomes and effectiveness accounting, so recording every failed
+  // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
+  // optimizer's favour. A measurement that flatters the thing being measured
+  // is worse than no measurement.
+  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
     return false;
   const status =
     raw?.tool_response?.status ??
@@ -170,23 +202,6 @@ export function toolSucceeded(raw) {
   // that its output proved the task.  `success` here is deliberately scoped to
   // the tool call; task correctness comes only from an eval grader.
   return true;
-}
-
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * The same family `toolSucceeded` reads above, hoisted so the three readers
- * cannot drift apart. Clients disagree on the envelope name and on nothing
- * else, so this is the one place that disagreement is spelled out.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
 }
 
 /** A non-empty string, or null.  Blank output is the same as none. */

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -58,6 +58,7 @@ import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { briefing } from './remedy.mjs';
 import { stableText, transcriptFor } from './cache.mjs';
+import { scoreRefreshes } from './keepwarm.mjs';
 import { cachedRoutingBriefing } from './routing.mjs';
 import {
   forCommand,
@@ -1010,6 +1011,26 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE KEEP-WARM FEEDBACK ARM, at the boundary where a turn has just
+      // ended -- which is the only place the arrival question can be answered.
+      // Every refresh whose TTL has since elapsed is scored here as used or
+      // unused; anything the log cannot settle is left unscored rather than
+      // recorded as a miss, because an absent signal is not a miss.
+      //
+      // Nothing in this repository issues a refresh today -- cache_audit only
+      // recommends one -- so this scores nothing, and what it costs while
+      // dormant is one readBalance: median 70 ms on this machine's 3.5 MB log,
+      // against derive's 71-111 ms a few lines below on the same path. The
+      // firehose is read for ARRIVALS only if an unscored refresh exists, so
+      // the dormant case never pays for that. The moment an issuer exists, the
+      // decision starts learning with no second wiring change.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      scoreRefreshes(dir);
+    } catch {
+      // A refresh that cannot be scored costs a measurement, not a session.
     }
     try {
       // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -40,11 +40,13 @@ import {
   touchedFiles,
 } from './decide.mjs';
 import {
+  record,
   recordRead,
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
 } from './metrics.mjs';
+import { derive } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -948,6 +950,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // ZERO-COST DERIVATION, on every client, with no credential. The semantic
+      // harvest below needs an API key, so on a machine without one the graph
+      // accumulates structure and no verdicts at all. These detectors read only
+      // what is already on disk and send nothing anywhere.
+      //
+      // The COUNT is recorded rather than the candidates: how many findings a
+      // session's own evidence supports is the number that says whether this is
+      // working, and it is measurable before anything is stored. Storage is the
+      // caller's next step, under a budget.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      const dir = wikiDir(projectRoot);
+      const derived = derive(dir, {
+        sessionId,
+        projectRoot,
+        transcriptPath: agentScope,
+        // The hook payload's own identity, not a value a model typed.
+        authoritativeSessionId: sessionId,
+      });
+      record(dir, {
+        kind: 'derive',
+        sessionId,
+        candidates: derived.candidates.length,
+        observations: derived.observations.length,
+      });
+    } catch {
+      // A detector failing must never cost a user the end of their session.
     }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -72,7 +72,8 @@ import {
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
-import { isArchived } from './transcript.mjs';
+import { archive, isArchived } from './transcript.mjs';
+import { harvestMode } from './harvest.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
@@ -577,6 +578,65 @@ function emit(object) {
   process.stdout.write(serialized);
 }
 
+/**
+ * What will and will not extract findings after this session, in one sentence.
+ *
+ * THE STATE WAS ONLY EVER LEGIBLE FROM THE DOCTOR, and the doctor is a place
+ * someone visits after they already suspect something is wrong. A user watching
+ * a graph fill with structural nodes and no verdicts has no reason to suspect
+ * anything, which is the failure this project has now measured twice.
+ *
+ * IT IS ADDRESSED TO THE MODEL, NOT ONLY TO THE READER, which is why it earns a
+ * place in the prefix rather than a systemMessage. "Nothing else will write this
+ * down in words" changes what the model does with a conclusion it is holding;
+ * "here is a configuration variable" would not.
+ *
+ * CACHE-SAFE: derived from configuration, so it differs between sessions only
+ * when the configuration does -- the same standard the rest of this block is
+ * held to, and it carries no digits for `stableText` to reject.
+ *
+ * A local endpoint is named FIRST in the off case on purpose. It is the option
+ * that costs nothing and sends nothing, and it was the one buried deepest.
+ */
+function extractionNotice() {
+  switch (harvestMode()) {
+    case 'local':
+      return (
+        '\n\nA local model endpoint is configured, so semantic extraction also runs after this ' +
+        'session -- free and private, with nothing leaving this machine.'
+      );
+    case 'remote':
+      return (
+        '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
+        'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
+    case 'off:mode':
+      // The whole optimizer is off and this text is not emitted anyway. Saying
+      // anything here would be noise stacked on an explicit choice.
+      return '';
+    case 'off:opted-out':
+      // A DELIBERATE CHOICE, SO NO PITCH. The consequence is stated because the
+      // model needs it; the setting that would reverse it is not, because
+      // arguing with a configured decision on every session is how a notice
+      // stops being read. doctor.mjs draws the same line for the same reason.
+      return (
+        '\n\nFallback extraction is off by configuration, so a conclusion you do not record is ' +
+        'not written down in words anywhere. Findings are still derived locally from exit codes, ' +
+        'red-to-green transitions and corrections.'
+      );
+    default:
+      // off:no-key, and any mode a future harvest adds: no extractor is running
+      // and nobody chose that, so the free option is worth naming.
+      return (
+        '\n\nNo separate extractor will run after this session, so a conclusion you do not record ' +
+        'is not written down in words anywhere. Findings are still derived locally from exit ' +
+        'codes, red-to-green transitions and corrections. Pointing ' +
+        'TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model adds semantic extraction, free and ' +
+        'private.'
+      );
+  }
+}
+
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
 export function policyText(
   canDeny,
@@ -635,7 +695,7 @@ export function policyText(
     .filter(Boolean)
     .join(' ');
   const recording = tools.has('wiki_write')
-    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.`
+    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.${extractionNotice()}`
     : '\n\nStructural graph capture remains active through lifecycle hooks. Durable semantic MCP writes are not requested because the writer schema is not proven available.';
 
   return `# Token optimization is active\n\nLive graph capture is active through the lifecycle adapter.\n\n${connection}${routing}${enforcement}${utilities ? `\n\n${utilities}` : ''}${recording}${projectBriefing()}`;
@@ -950,6 +1010,27 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.
+      //
+      // This was lost rather than retired. `plugin/hooks/stop-harvest.mjs` called
+      // `archive()` at Stop, and #300 replaced that entry in `hooks.json` with the
+      // generated `stop.mjs`, which routes here -- so on Claude Code no session has
+      // been archived since. Nothing failed loudly: `readArchive` simply returns an
+      // empty list, so `derive`'s correction detector fell through to the live
+      // transcript (present only for a client that reports one) and `lessons.mjs`
+      // lost the only corpus it can verify a verbatim quote against, which is the
+      // single test that grants a feedback finding human origin.
+      //
+      // BEFORE `derive`, deliberately: the correction detector reads the archive
+      // first and treats the live transcript as the fallback, and the archive is
+      // the copy that survives into later sessions.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      if (agentScope) archive(dir, agentScope, { sessionId });
+    } catch {
+      // The archive is a record, not a result. A session still ends.
     }
     try {
       // ZERO-COST DERIVATION, on every client, with no credential. The semantic

--- a/integrations/qwen/hooks/lib/audit.mjs
+++ b/integrations/qwen/hooks/lib/audit.mjs
@@ -32,6 +32,7 @@
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
+import { looNote } from './loo.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -401,6 +402,16 @@ export function renderAudit(
   // project with no injections and no queries gains no line at all.
   const reference = referenceNote(dir);
   if (reference) body.push('', reference);
+
+  // WHAT ONE FINDING IS CAUSALLY WORTH (Layer 2).
+  //
+  // The same reasoning as above, and the same refusal: `looNote` returns null
+  // until the leave-one-out experiment has collected an observation, and says
+  // NOT MEASURABLE YET rather than printing a mean until it clears the floor.
+  // A causal number is the most quotable thing this project can produce, so it
+  // is the one that most needs to be absent when it is not earned.
+  const causal = looNote(dir);
+  if (causal) body.push('', causal);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/qwen/hooks/lib/audit.mjs
+++ b/integrations/qwen/hooks/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
 import { looNote } from './loo.mjs';
+import { calibrationNote } from './crosslayer.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -244,9 +245,15 @@ export function renderAudit(
     lines.push(text);
   }
 
+  // SCOPED TO THE QUEUE, because that is all it ever described. The bare
+  // sentence "Nothing addressable found." was printed directly above a Layer 1
+  // reference note and a published Layer 2 causal verdict -- so a reader was
+  // told nothing had been found immediately before being shown a finding. The
+  // headline is about the remediation queue and nothing else, and saying so
+  // costs four words and removes a false negative shown to a human.
   const head = shown.length
     ? ['What to do next, most expensive first:', ...lines]
-    : ['Nothing addressable found.'];
+    : ['Nothing addressable found in the remediation queue.'];
 
   const body = [...head];
 
@@ -412,6 +419,16 @@ export function renderAudit(
   // is the one that most needs to be absent when it is not earned.
   const causal = looNote(dir);
   if (causal) body.push('', causal);
+
+  // WHETHER LAYER 1'S CHEAP LABEL PREDICTS LAYER 2'S EXPENSIVE EFFECT.
+  //
+  // The reason this is printed rather than kept for a dashboard: the reference
+  // rate is the number a reader is most likely to quote as a saving, and it is
+  // not one until this comparison says so. `calibrationNote` returns null while
+  // both layers are silent, and otherwise prints the refusal -- naming which
+  // input was insufficient -- rather than a gap of zero.
+  const calibrated = calibrationNote(dir);
+  if (calibrated) body.push('', calibrated);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/qwen/hooks/lib/audit.mjs
+++ b/integrations/qwen/hooks/lib/audit.mjs
@@ -61,6 +61,28 @@ export function declines(dir, { events = readMetrics(dir) } = {}) {
   return counts;
 }
 
+/**
+ * What the local Stop-time derivation path produced in the visible event log.
+ *
+ * The producer records all three counts because any one of them alone is
+ * ambiguous: zero stored can mean no evidence, no candidates, or a binding
+ * storage/anchor filter. This reader keeps those states distinct and prevents
+ * the telemetry itself from becoming an unobserved cost.
+ */
+export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
+  const runs = events.filter((event) => event.kind === 'derive');
+  if (!runs.length) return null;
+
+  const sum = (field) =>
+    runs.reduce((total, event) => total + Math.max(0, Number(event[field]) || 0), 0);
+  const candidates = sum('candidates');
+  const observations = sum('observations');
+  const written = sum('written');
+  return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
+    `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
+    `across ${runs.length.toLocaleString()} Stop run(s).`;
+}
+
 const idOf = (finding) =>
   finding.remedy
     ? `${finding.remedy.type}:${finding.remedy.anchor || finding.remedy.file || (finding.remedy.anchors || []).join(',')}`
@@ -399,6 +421,15 @@ export function renderAudit(
       );
     }
   }
+
+  // WHAT THE DEFAULT, LOCAL DERIVATION PATH ACTUALLY PRODUCED.
+  //
+  // This event used to have a producer and no reader. Keep its three states
+  // together: evidence seen, candidates derived, and findings that survived
+  // selection/storage. A lone stored count would turn every earlier refusal
+  // into an apparent "nothing found" result.
+  const derived = derivationNote(dir);
+  if (derived) body.push('', derived);
 
   // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
   //

--- a/integrations/qwen/hooks/lib/audit.mjs
+++ b/integrations/qwen/hooks/lib/audit.mjs
@@ -31,6 +31,7 @@
  */
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
+import { referenceNote } from './usage.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -390,6 +391,16 @@ export function renderAudit(
       );
     }
   }
+
+  // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
+  //
+  // Printed here because this is the report that already asks "did the advice
+  // change anything", and because a measurement with no reader is how this
+  // project shipped two metrics whose only consumer was their own test suite.
+  // `referenceNote` returns null when it has nothing honest to say, so a
+  // project with no injections and no queries gains no line at all.
+  const reference = referenceNote(dir);
+  if (reference) body.push('', reference);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/qwen/hooks/lib/consolidate.mjs
+++ b/integrations/qwen/hooks/lib/consolidate.mjs
@@ -142,7 +142,8 @@ const ALWAYS_KEEP = new Set(['failure', 'decision']);
  * Chooses what to promote into the graph, under a token budget.
  *
  * @param {object} graph      Loaded wiki graph, for reuse probability.
- * @param {Array}  candidates Extracted conclusions, each { type, summary, anchors, evidence, at }.
+ * @param {Array}  candidates Extracted conclusions, each { type, claim (or summary),
+ *                              anchors, evidence, at }.
  * @param {object} options    budget: tokens available for promoted findings.
  */
 export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}) {
@@ -221,4 +222,3 @@ export function aggregateConsolidation(findings) {
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
-

--- a/integrations/qwen/hooks/lib/crosslayer.mjs
+++ b/integrations/qwen/hooks/lib/crosslayer.mjs
@@ -1,0 +1,351 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/crosslayer.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The calibration loop: does Layer 1's LABEL predict Layer 2's EFFECT?
+ *
+ * Layer 1 (`usage.mjs`) classifies an injected finding by whether the model
+ * later NAMED it. Layer 2 (`loo.mjs`) measures, by leave-one-out, how many
+ * tokens of reading a finding actually SUPPRESSED. Those are two different
+ * quantities, and the whole point of putting them side by side is that the
+ * cheap one (a label, available on every injection) might stand in for the
+ * expensive one (a causal effect, costing three withheld sessions per finding).
+ *
+ * WHY THIS IS A REAL QUESTION AND NOT A TAUTOLOGY. Task 7 established the
+ * independence three ways -- statically (`loo.mjs` contains no `query` or
+ * `reference`; `usage.mjs` contains no `tokens`, `cost` or `bytes`),
+ * behaviourally in both directions, and by naming the one overlap that does
+ * exist (`recordToolOutcome`'s join, which supplies ATTRIBUTABILITY to both and
+ * the measured quantity to neither). This module is built to preserve that:
+ *
+ *   - from Layer 1 it takes ONLY the categorical label per finding key. No
+ *     rate, no count, no magnitude -- Layer 1 has no magnitude to give.
+ *   - from Layer 2 it takes ONLY the effect magnitude per finding key.
+ *   - the join is the finding key, which is a graph identity and not a
+ *     measurement.
+ *
+ * If a magnitude common to both ever entered, this would correlate a quantity
+ * with itself and report a strong result that means nothing. Two tests pin the
+ * separation from opposite sides: flipping the labels while holding the effects
+ * fixed must move the gap, and changing Layer 1's rate WITHOUT changing any
+ * label must leave the gap byte-identical.
+ *
+ * MEASURED UTILITY RANKS A FINDING. IT MUST NEVER RAISE ITS CONFIDENCE.
+ * A confidently WRONG finding suppresses reads better than a hedged true one,
+ * so utility alone optimises directly against "wrong findings are worse than
+ * none". The plan called for a `mayPromote` gate over
+ * `hasOutstandingContradiction` here. There is nothing to gate: every write of
+ * `confidence` in `hooks-core` happens at CREATION (a per-producer constant in
+ * `derive.mjs` / `lessons.mjs` / `harvest.mjs`, or a human's own number in
+ * `curate.mjs`), and no code path updates a stored finding's confidence
+ * afterwards. `assessFindings` in `utility.mjs` READS confidence into an
+ * ephemeral `netUtility` used for ordering and writes nothing back. So a gate
+ * here would be unreachable, and an unreachable gate is the exact defect class
+ * this work exists to close. `hasOutstandingContradiction` already has its
+ * real consumer -- `staleness.mjs` calls it as the dispute gate on serve.
+ * What is enforceable is the invariant itself, and it is: this module never
+ * writes to the graph, and `tests/hooks/calibration-loop.test.mjs` asserts that
+ * neither it nor either layer under it can move a stored confidence.
+ *
+ * NOTHING HERE IS PRICED. A calibration verdict, a holdout estimate and a
+ * consolidation ratio are all estimates; currency belongs only on a measured
+ * counterfactual, and `balanceSheet`'s `measuredCounterfactual` is the one
+ * section in the sheet below that qualifies.
+ */
+
+import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
+import { classify, referenceRate } from './usage.mjs';
+import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Distinct findings needed in EACH arm before a gap is reported at all.
+ *
+ * Two findings per arm is a difference of two numbers; the comparison would be
+ * dominated by whichever finding happened to sit on a big file. Three is still
+ * small, and the refusal says so rather than implying the gap is solid.
+ */
+export const MIN_FINDINGS_PER_ARM = 3;
+
+/**
+ * The smallest gap that may be PUBLISHED, in tokens per touch.
+ *
+ * Not an effect-size convention: it is tied to the unit the verdict prints. The
+ * published sentence rounds the gap to whole tokens, so a gap of 1e-13 -- which
+ * is what two arms of equal means produce once floating point has had its say --
+ * would publish as "referenced findings suppress 0 more tokens/touch". That is a
+ * calibration claim resting on arithmetic noise, and it leans the only direction
+ * a measurement of this project by this project must never lean.
+ */
+export const MIN_GAP_TOKENS = 1;
+
+/**
+ * The per-finding Layer 1 label, folded from per-injection rows.
+ *
+ * ANY reference wins. `classify` emits one row per (injection, finding) because
+ * one reference must not excuse every later injection -- that is the right unit
+ * for a RATE. For a label the question is different: did the model ever name
+ * this finding? A finding referenced once and ignored nine times is a finding
+ * the model reads, and averaging it into `not-referenced` would put it in the
+ * arm whose mean effect it is meant to predict.
+ *
+ * `unknown` rows are dropped rather than defaulted, exactly as Layer 1 drops
+ * them from its own denominator.
+ */
+export function labelsByFinding(rows) {
+  const labels = new Map();
+  for (const row of rows || []) {
+    const key = row?.findingKey;
+    if (typeof key !== 'string' || !key) continue;
+    if (row.label === 'referenced') labels.set(key, 'referenced');
+    else if (row.label === 'not-referenced' && !labels.has(key))
+      labels.set(key, 'not-referenced');
+  }
+  return labels;
+}
+
+const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * Does Layer 1's label predict Layer 2's effect?
+ *
+ * Returns `publishable`, a `verdict` in English, and `gap` ONLY when a gap was
+ * actually computed. There is no `gap: 0` for the unmeasured case, and that is
+ * deliberate: a permanent zero reads as "measured, and the two agree", which is
+ * the opposite of "nothing was measured". Task 7 deleted a field rather than
+ * zero it for the same reason.
+ *
+ * FAILS OPEN. This runs on report paths that must not break a tool call.
+ */
+export function calibration(dir, options = {}) {
+  const refuse = (verdict, extra = {}) => ({
+    publishable: false,
+    verdict,
+    ...extra,
+  });
+
+  try {
+    // ONE READ for both layers, so the two arms of the comparison cannot cover
+    // different spans of the log. `referenceRate` reports `windowed: false`
+    // when the caller supplies events -- correctly, since the bounds are then
+    // the caller's -- so the truncation flag is taken here, from the read that
+    // actually set it, and republished.
+    const supplied = options.events || null;
+    const events = supplied || readMetrics(dir);
+    const truncation = supplied ? null : readTruncation();
+    const truncated = Boolean(
+      truncation && (truncation.byBytes || truncation.byEvents)
+    );
+
+    const layer1 = referenceRate(dir, { events });
+    const labels = labelsByFinding(classify(dir, { events }));
+
+    const obs = observations(dir, { ...options, events });
+    const rows = effects(dir, { ...options, events, obs });
+
+    // ONE POLICY VERSION. Layer 2 refuses to pool arms across serving
+    // policies; a calibration that pooled them would undo that guard one level
+    // up. Rows from any other policy are excluded and counted.
+    const policy = servingPolicyVersion();
+    const inPolicy = rows.filter((row) => row.policy === policy);
+
+    const layer2 = {
+      rows: rows.length,
+      inPolicy: inPolicy.length,
+      published: rows.filter((row) => row.published).length,
+      observations: obs.rows.length,
+      policy,
+    };
+    const l1 = {
+      referenced: layer1.referenced,
+      notReferenced: layer1.notReferenced,
+      unknown: layer1.unknown,
+      denominator: layer1.denominator,
+      rate: layer1.rate,
+      referenceEvents: layer1.referenceEvents,
+    };
+
+    const excluded = { layer1Unknown: layer1.unknown, unlabelled: 0, noEffect: 0 };
+    const arms = { referenced: [], notReferenced: [] };
+    for (const row of inPolicy) {
+      // THE SHRUNK ESTIMATE, not the raw one. Shrinkage pulls every finding
+      // toward the population mean, so it pulls the GAP toward zero -- the
+      // bias runs against publishing, which is the only direction a
+      // measurement of this project by this project may lean.
+      if (row.shrunk === null || !Number.isFinite(row.shrunk)) {
+        excluded.noEffect += 1;
+        continue;
+      }
+      const label = labels.get(row.findingKey);
+      if (label === 'referenced') arms.referenced.push(row.shrunk);
+      else if (label === 'not-referenced') arms.notReferenced.push(row.shrunk);
+      else excluded.unlabelled += 1;
+    }
+
+    const context = { layer1: l1, layer2, arms: { referenced: arms.referenced.length, notReferenced: arms.notReferenced.length }, excluded, windowed: truncated };
+    const caveat = truncated
+      ? ' The event log was truncated, so both sides can understate.'
+      : '';
+
+    // WHICH INPUT WAS INSUFFICIENT, named. "Not enough data" tells a reader
+    // nothing about which half of the loop to go and fix.
+    const l1Silent = layer1.rate === null;
+    const l2Silent = layer2.observations === 0;
+    if (l1Silent || l2Silent) {
+      const why = [];
+      if (l1Silent)
+        why.push(
+          `Layer 1 has ${layer1.denominator} classifiable observation(s) and ` +
+            `${layer1.referenceEvents} reference event(s), so it publishes no rate`
+        );
+      if (l2Silent)
+        why.push(
+          `Layer 2 has ${layer2.observations} observation(s), so it publishes no effect`
+        );
+      return refuse(
+        `not calibrated: ${why.join('; and ')}. No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+    }
+
+    // A POLICY CHANGE RESETS THE CALIBRATION, and says so rather than reporting
+    // an empty arm. Layer 2 refuses to pool arms across serving policies, so
+    // rows generated under an older one cannot answer a question about how the
+    // graph serves findings today -- but "0 findings per arm" would send a
+    // reader hunting for missing observations that are right there in the log.
+    if (rows.length > 0 && inPolicy.length === 0)
+      return refuse(
+        `not calibrated: all ${rows.length} Layer 2 effect row(s) were measured under a different serving ` +
+          `policy than the current ${policy}, and arms are never pooled across policies. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (layer2.published === 0)
+      return refuse(
+        `not calibrated: Layer 2 has ${layer2.observations} observation(s) but no published effect at q=0.1, ` +
+          'so its per-finding numbers are noise and a difference between two means of them would be too. ' +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (
+      arms.referenced.length < MIN_FINDINGS_PER_ARM ||
+      arms.notReferenced.length < MIN_FINDINGS_PER_ARM
+    )
+      return refuse(
+        `not calibrated: ${arms.referenced.length} referenced and ${arms.notReferenced.length} not-referenced ` +
+          `finding(s) carry a Layer 2 effect, below the floor of ${MIN_FINDINGS_PER_ARM} per arm. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    const referencedMean = mean(arms.referenced);
+    const notReferencedMean = mean(arms.notReferenced);
+    const gap = referencedMean - notReferencedMean;
+    const measured = { ...context, gap, referencedMean, notReferencedMean };
+
+    if (!(gap >= MIN_GAP_TOKENS))
+      return refuse(
+        `uncalibrated: Layer 1's "referenced" label does not predict a larger Layer 2 effect ` +
+          `(referenced ${Math.round(referencedMean).toLocaleString()} vs not-referenced ` +
+          `${Math.round(notReferencedMean).toLocaleString()} tokens/touch, gap ${Math.round(gap).toLocaleString()}). ` +
+          `Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
+    return {
+      publishable: true,
+      verdict:
+        `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
+      ...measured,
+    };
+  } catch {
+    return refuse(
+      'not calibrated: the calibration inputs could not be read. No gap is reported, which is not the same as a gap of zero.'
+    );
+  }
+}
+
+/**
+ * What the graph cost to build against what it carries -- AN ESTIMATE, and
+ * never priced.
+ *
+ * `consolidationRatio` is the per-finding form and the aggregate is the fold.
+ * Both need `derivedCost`, which `expand.promote` persists onto the finding
+ * node it creates (`src/server/disclosure.ts` is its caller) and which
+ * `harvest-write.mjs` does not yet carry through -- so a graph built only by
+ * the harvest reports nothing here rather than a ratio of one.
+ */
+export function consolidation(dir, { graph = null } = {}) {
+  try {
+    const g = graph || load(dir);
+    const findings = [...g.nodes.values()].filter(
+      (node) => node.kind === 'finding' && !node.retired
+    );
+    const rated = [];
+    for (const finding of findings) {
+      const ratio = consolidationRatio(finding);
+      if (ratio === null) continue;
+      rated.push({ key: finding.key, ratio, derivedCost: finding.derivedCost });
+    }
+    const aggregate = aggregateConsolidation(findings);
+    return {
+      what: 'cost to derive against cost to carry',
+      // SAID IN THE DATA, not only in the prose above it, because this is the
+      // field a dashboard will read and a dashboard will not read a comment.
+      basis: 'estimate',
+      priced: false,
+      findings: findings.length,
+      withDerivedCost: rated.length,
+      aggregate,
+      best: rated.sort((a, b) => b.ratio - a.ratio).slice(0, 5),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The balance sheet with the graph's own three measurements attached.
+ *
+ * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
+ * imports, so it cannot import them back. This is where the two meet, and it
+ * is the shape `get_optimization_report` serves.
+ */
+export function graphBalanceSheet(dir, options = {}) {
+  const sheet = balanceSheet(dir);
+  const cal = calibration(dir, options);
+  const { layer1 = null, layer2 = null } = cal;
+  return {
+    ...sheet,
+    layer1,
+    layer2,
+    calibration: cal,
+    consolidation: consolidation(dir, options),
+  };
+}
+
+/**
+ * One audit line, or null when there is nothing honest to say.
+ *
+ * Silent when NEITHER layer has produced anything: a reader of a graph that has
+ * never injected a finding is owed no paragraph about a loop that has not
+ * started. The moment either side speaks, the refusal is worth printing --
+ * because at that point a reader could otherwise take Layer 1's rate for a
+ * saving, which is precisely what this loop exists to stop.
+ */
+export function calibrationNote(dir, options = {}) {
+  try {
+    const result = calibration(dir, options);
+    const l1 = result.layer1;
+    const l2 = result.layer2;
+    if (!l1 || !l2) return null;
+    if (l1.denominator === 0 && l2.observations === 0) return null;
+    return `Layer 1 against Layer 2: ${result.verdict}`;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/qwen/hooks/lib/crosslayer.mjs
+++ b/integrations/qwen/hooks/lib/crosslayer.mjs
@@ -54,7 +54,13 @@
 
 import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
-import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import {
+  effects,
+  observations,
+  servingPolicyVersion,
+  permutationP,
+  FDR_Q,
+} from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
 import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
@@ -106,6 +112,32 @@ export function labelsByFinding(rows) {
 }
 
 const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * A deterministic, label-symmetric permutation test for the headline gap.
+ *
+ * Layer 2 only publishes a per-finding row after a two-sided permutation test.
+ * The calibration headline summarises those rows, so a positive difference of
+ * arm means must clear the same evidential bar rather than being promoted just
+ * because it points in this project's favour.
+ *
+ * Sorting within each arm and then sorting the two arms makes the sampled path
+ * invariant to event order and to swapping the labels. The seed is derived
+ * from that canonical data instead of shared globally, so two different
+ * datasets do not reuse one arbitrary sequence of sampled relabellings.
+ */
+export function calibrationP(referenced, notReferenced) {
+  const arms = [referenced, notReferenced]
+    .map((values) => [...values].sort((a, b) => a - b))
+    .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  const encoded = JSON.stringify(arms);
+  let seed = 2166136261;
+  for (const char of encoded) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return permutationP(arms[0], arms[1], { seed: seed >>> 0 });
+}
 
 /**
  * Does Layer 1's label predict Layer 2's effect?
@@ -244,7 +276,16 @@ export function calibration(dir, options = {}) {
     const referencedMean = mean(arms.referenced);
     const notReferencedMean = mean(arms.notReferenced);
     const gap = referencedMean - notReferencedMean;
-    const measured = { ...context, gap, referencedMean, notReferencedMean };
+    const p = calibrationP(arms.referenced, arms.notReferenced);
+    const measured = {
+      ...context,
+      gap,
+      referencedMean,
+      notReferencedMean,
+      p,
+      alpha: FDR_Q,
+      test: 'two-sided permutation',
+    };
 
     if (!(gap >= MIN_GAP_TOKENS))
       return refuse(
@@ -255,11 +296,20 @@ export function calibration(dir, options = {}) {
         measured
       );
 
+    if (p === null || p > FDR_Q)
+      return refuse(
+        `not calibrated: the positive Layer 1/Layer 2 gap is not statistically resolved by the ` +
+          `two-sided permutation test (p=${p === null ? 'unavailable' : p.toFixed(3)}, ` +
+          `alpha=${FDR_Q.toFixed(3)}). Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
     return {
       publishable: true,
       verdict:
         `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
-        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, ` +
+        `shrunk estimates, two-sided permutation p=${p.toFixed(3)}). ` +
         `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
       ...measured,
     };

--- a/integrations/qwen/hooks/lib/crosslayer.mjs
+++ b/integrations/qwen/hooks/lib/crosslayer.mjs
@@ -56,6 +56,7 @@ import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
 import { effects, observations, servingPolicyVersion } from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
 
 /**
@@ -309,11 +310,19 @@ export function consolidation(dir, { graph = null } = {}) {
 }
 
 /**
- * The balance sheet with the graph's own three measurements attached.
+ * The balance sheet with the graph's own measurements attached.
  *
  * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
  * imports, so it cannot import them back. This is where the two meet, and it
  * is the shape `get_optimization_report` serves.
+ *
+ * `recall` joins them as an OFFLINE PROBE, and that label travels in the data
+ * (`recall.basis`) as well as in the rendered line. It is not an observation of
+ * anything a session did: it deletes an anchor edge in memory and re-runs the
+ * real retrieval primitives over the graph as it stands right now. `recall.mjs`
+ * imports only `wiki.mjs` and `lexical.mjs`, neither of which imports anything
+ * in this direction, so no cycle -- the same reason `calibration` had to live
+ * here rather than in `metrics.mjs`.
  */
 export function graphBalanceSheet(dir, options = {}) {
   const sheet = balanceSheet(dir);
@@ -325,6 +334,7 @@ export function graphBalanceSheet(dir, options = {}) {
     layer2,
     calibration: cal,
     consolidation: consolidation(dir, options),
+    recall: recallProbe(dir, options),
   };
 }
 

--- a/integrations/qwen/hooks/lib/derive.mjs
+++ b/integrations/qwen/hooks/lib/derive.mjs
@@ -23,13 +23,21 @@
  * the observation supports no claim at all are refused rather than downgraded
  * (see `attemptKey` and the identical-text guard below).
  *
- * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
- * budget, belongs to the caller.
+ * WHAT IS STORED IS BOUNDED. Candidates go through `selectForConsolidation`
+ * before `writeHarvested`, so a long session cannot spend the whole retrieval
+ * budget of every later session on one afternoon's exit codes. Nothing enters
+ * the graph unbudgeted, and nothing enters it wearing a human origin.
  */
 
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
 import { readArchive, readTurns } from './transcript.mjs';
 import { redact } from './redact.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { load } from './wiki.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -106,6 +114,92 @@ const triggerFor = (command) =>
   attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
 
 /**
+ * Literal root-level files that define how a project is BUILT, RUN and TESTED,
+ * best first. A `command` claim is a claim about this project's commands, and
+ * this is the file those commands are declared in.
+ */
+const PROJECT_MARKERS = [
+  'package.json', 'pyproject.toml', 'Cargo.toml', 'go.mod', 'pom.xml',
+  'build.gradle.kts', 'build.gradle', 'build.sbt', 'mix.exs', 'composer.json',
+  'Gemfile', 'Package.swift', 'CMakeLists.txt', 'Makefile', 'Taskfile.yml',
+  'requirements.txt', 'setup.py', 'deno.json', 'bun.lockb',
+];
+
+/** .NET has no single literal marker; the solution or project file is one. */
+const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
+
+/**
+ * A REAL FILE to anchor a derived claim to, inside the project root.
+ *
+ * WHY NOT THE PROJECT ROOT ITSELF, which is what the extraction step reaches
+ * for and what `promoteToShared` uses in the shared tier. Because
+ * `writeHarvested` resolves every anchor through `indexFile`, `indexFile` reads
+ * the path, and reading a DIRECTORY returns null -- so a candidate anchored to
+ * `projectRoot` resolves to nothing, is refused as unanchorable, and the whole
+ * pipeline stores zero findings while reporting a healthy candidate count.
+ * Verified directly: `indexFile(dir, dir)` returns null. That refusal is
+ * correct and must not be weakened -- an anchor that cannot be indexed is an
+ * anchor that can never be invalidated -- so the anchor has to be a file.
+ *
+ * STALENESS DOES NOT MISFIRE ON THIS. `command`, `failure` and `feedback` are
+ * all outside `CONTENT_DEPENDENT` (staleness.mjs), so the anchor is a RETRIEVAL
+ * AND EXISTENCE hook rather than a contents claim: editing the manifest does
+ * not mark these findings stale. staleness.mjs names this exact case in its own
+ * comment -- "a claim about `npm test` anchored to package.json" -- and calls
+ * missing that invalidation the better error.
+ *
+ * A project with no recognisable marker gets the root back, which will not
+ * resolve, so its candidates are derived and then refused rather than stored
+ * against a fabricated anchor. That is the fail-open direction: no finding
+ * beats a finding anchored to something that is not what the claim is about.
+ */
+export function projectAnchor(projectRoot) {
+  if (!projectRoot) return null;
+  let entries;
+  try {
+    entries = readdirSync(projectRoot);
+  } catch {
+    return projectRoot;
+  }
+  const present = new Set(entries);
+  for (const marker of PROJECT_MARKERS) {
+    if (!present.has(marker)) continue;
+    const path = join(projectRoot, marker);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // A marker that cannot be stat'ed is not a marker.
+    }
+  }
+  // Sorted so two sessions in the same repository pick the SAME solution file:
+  // readdir order is not guaranteed stable across hosts, and an anchor that
+  // varies by host splits one finding into two nodes.
+  for (const entry of [...entries].sort()) {
+    if (!DOTNET_MARKER.test(entry)) continue;
+    const path = join(projectRoot, entry);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // Same.
+    }
+  }
+  return projectRoot;
+}
+
+/**
+ * Tokens of claim text one session may add to the graph.
+ *
+ * SCALED TO THE RETRIEVAL BUDGET IT COMPETES FOR, not picked round. A single
+ * command's injection budget is 500 tokens (`TOKEN_OPTIMIZER_TOUCH_BUDGET`),
+ * and everything stored here is competing for that budget on every later
+ * command, forever. Two touch-budgets per session is the bound: enough for a
+ * few dozen real claims, and short of one session's exit codes crowding out
+ * every finding a human or a model ever wrote.
+ */
+const storageBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_DERIVE_BUDGET) || 1000;
+
+/**
  * Derives finding candidates from one project's local evidence.
  *
  * @param {string} dir wiki directory.
@@ -118,11 +212,18 @@ const triggerFor = (command) =>
  *   and is refused by `writeHarvested` anyway, so emitting one would only spend
  *   the caller's budget on junk.
  * @param {string|null} options.authoritativeSessionId the session id as the HOOK
- *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
- *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
- *   edge -- `taskForAnchors` returns null without one, so an unverified string
- *   would silently produce no edge. Threaded rather than defaulted from
- *   `sessionId`: defaulting would promote any caller's string to trusted.
+ *   PAYLOAD reported it, never a value a model typed. Passed straight to
+ *   `writeHarvested`, which needs it to resolve the `answers` edge --
+ *   `taskForAnchors` returns null without one, so an unverified string would
+ *   silently produce no edge. Threaded rather than defaulted from `sessionId`:
+ *   defaulting would promote any caller's string to trusted. Also returned, so a
+ *   caller can see what it handed over.
+ * @returns {object} `{ candidates, observations, written, selected, dropped,
+ *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
+ *   everything derived; `written` is the subset of keys the graph actually
+ *   holds, which is smaller for three independent reasons -- the budget, the
+ *   anchor discipline, and the duplicate collapse that returns an EXISTING key
+ *   when a later session derives the same claim again.
  */
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
@@ -152,6 +253,11 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // ONE anchor for the whole run, so every candidate from this session points at
+  // the same node and the duplicate collapse in `writeHarvested` can recognise
+  // the same lesson across sessions.
+  const anchorPath = projectAnchor(projectRoot);
 
   const seen = new Set();
   const add = (candidate) => {
@@ -246,7 +352,7 @@ export function derive(dir, options = {}) {
               `observed in one session: \`${failed.command}\` failed` +
                 `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
                 `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
-                'an intervening edit or a flaky run explains the same pair.',
+                'an intervening edit or an unrelated environment change explains the same pair.',
               { max: EVIDENCE_MAX }
             ),
             applicability: 'when about to run this command in this project',
@@ -255,7 +361,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the failing form later succeeds unchanged'],
             trigger: triggerFor(outcome.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: outcome.at || Date.now(),
@@ -280,7 +386,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the same command later succeeds unchanged'],
             trigger: triggerFor(failed.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: failed.at || Date.now(),
@@ -330,7 +436,7 @@ export function derive(dir, options = {}) {
           confidenceLabel: labelFor(CONFIDENCE.correction),
           scope: 'project',
           invalidators: ['the user later asks for the corrected behaviour'],
-          anchors: [projectRoot],
+          anchors: [anchorPath],
           derivedBy: 'correction',
           sessionId,
           at: Date.parse(turn.at || '') || Date.now(),
@@ -379,6 +485,48 @@ export function derive(dir, options = {}) {
     }
   } catch {
     // One detector, never the session.
+  }
+
+  // ---- storage, under a budget -------------------------------------------
+  //
+  // NOTHING ENTERS THE GRAPH UNBUDGETED. `selectForConsolidation` existed for
+  // exactly this and had no caller, which meant that until now nothing bounded
+  // what a session could add. It admits `failure` and `decision` on a FLOOR
+  // before ranking -- a dead end exists nowhere else and is small, and cheap to
+  // find is not cheap to find again -- then fills the remainder by
+  // cost x irrecoverability x reuse-probability.
+  //
+  // ORIGIN_HARVESTED, EXPLICITLY, never ORIGIN_HUMAN. These are machine
+  // derivations; `curate.mjs` states the reason in its own header -- "a
+  // hand-written assertion and a machine guess look identical three months
+  // later, which quietly destroys the reader's ability to calibrate trust".
+  // `writeHarvested` would refuse a batch-wide human origin anyway, and a
+  // candidate here carries neither `origin` nor `quote`, so it cannot earn one
+  // per finding either. That is deliberate: whether a turn was a correction at
+  // all is a lexical guess, and the standing-rules layer selects on human
+  // origin to inject on EVERY turn.
+  try {
+    if (result.candidates.length) {
+      const selected = selectForConsolidation(load(dir), result.candidates, {
+        budget: storageBudget(),
+      });
+      result.selected = selected.kept.length;
+      result.dropped = selected.dropped;
+      result.selectedTokens = selected.tokens;
+      result.written = writeHarvested(dir, selected.kept, {
+        sessionId,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        // The hook payload's own identity, passed through untouched. Without it
+        // `taskForAnchors` returns null and the `answers` edge never fires --
+        // which is the state a default install has been in, because its only
+        // other producer is credential-gated.
+        authoritativeSessionId,
+      });
+    }
+  } catch {
+    // Storage is the last step and the session is already over. A graph write
+    // that fails must not turn a completed session into a hook error.
   }
 
   return result;

--- a/integrations/qwen/hooks/lib/derive.mjs
+++ b/integrations/qwen/hooks/lib/derive.mjs
@@ -139,17 +139,19 @@ const quotable = (command) => {
  * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
  * found across 163 transcripts on this machine it refuses 2 and keeps 6.
  *
- * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
- * building the key, so the claim is about `npm test` rather than about the `cd`.
- * That changes `attemptKey` for every client and every finding already derived
- * from it, so it belongs in its own change with its own comparison.
+ * `commandBody` below now skips a leading `cd <path> &&`, so those two are
+ * recovered and this guard is left holding only the keys that reached a
+ * separator which is NOT a directory change -- `git fetch && <anything>`, a
+ * pipeline, a `;`-joined pair. Those still name no single attempt.
  */
 const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
 
 /**
  * Did `attemptKey` actually capture a command, or only how one was chained?
  *
- * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart --
+ * which now means AFTER `commandBody` has removed any leading `cd`, so this no
+ * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
 const hasAttemptIdentity = (command) =>
@@ -177,6 +179,81 @@ const CORRECTION_OPENER =
   /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
 
 /**
+ * A leading directory change, stripped before the key is built.
+ *
+ * THE MEASURED CASE, AND ONLY THE MEASURED CASE. `attemptKey` spends up to
+ * three non-flag tokens on identity and the habit on this machine is
+ * `cd <absolute path> && <the real command>`, which spends all three on `cd`,
+ * the path and the separator. This repository's own corpus: 1,400 of 2,243
+ * command outcomes open with a `cd`, and the single key
+ * `cd c:/users/.../token-optimizer-mcp &&` covered 547 distinct command lines.
+ * A `cd` says WHERE a command ran; it says nothing about WHAT ran, so it cannot
+ * be part of the identity of an attempt.
+ *
+ * THE SEPARATOR SET IS THE ONE THAT WAS OBSERVED: `&&` (1,147), a newline (204)
+ * and `;` (38) after a leading `cd`. All three mean "then run this". `||` is
+ * DELIBERATELY EXCLUDED even though it costs one line to add: `cd x || echo
+ * failed` puts an error branch after the separator, not the next step, so
+ * stripping there would key the attempt on a failure handler. It occurred zero
+ * times.
+ *
+ * AND NOTHING WIDER, each refusal for a reason from the same corpus:
+ *
+ *   Environment assignments (`FOO=bar cmd`) DO carry information about what
+ *   ran. The one true instance here is
+ *   `TOKEN_OPTIMIZER_HOLDOUT=1 node ... jest.js ...`, and the holdout arm is a
+ *   genuinely different attempt from the same command without it. The other 20
+ *   are shell variable assignments joined by `;` -- statements, not prefixes --
+ *   whose value is usually a 120-character path that would be stripped down to
+ *   nothing useful.
+ *
+ *   `time`, `env`, `nice`, `sudo`, `bash -c`, `pushd`, `Set-Location`: ZERO
+ *   occurrences in 2,243 commands. Code for an unmeasured prefix is a way to
+ *   over-strip that no evidence asked for, and over-stripping merges commands
+ *   that genuinely differ -- the same bug in the other direction. `bash -c` is
+ *   worse than unmeasured: the command sits inside a quoted string, so stripping
+ *   the wrapper leaves a key beginning with a quote character.
+ *
+ *   `cd /d C:\path &&` and `cd "C:/a b" &&` need no extra rule -- the match runs
+ *   to the separator rather than counting tokens, so flags and quoted paths
+ *   containing spaces are consumed for free. Neither appears here, so neither is
+ *   claimed as tested behaviour beyond its unit test.
+ *
+ * A `cd` with NO separator is left alone: `cd <path>` on its own ran no command,
+ * and its key is as meaningless afterwards as before -- there is nothing to
+ * recover. Stripping is repeated up to `MAX_DIR_PREFIXES` times so
+ * `cd a && cd b && cmd` reaches `cmd`; the bound exists only so a pathological
+ * line cannot loop, since each pass must consume a whole `cd ... <sep>`.
+ *
+ * APPLIED IDENTICALLY TO BOTH SOURCES because it is applied INSIDE `attemptKey`,
+ * which is the single function both the event path and the transcript reader's
+ * output pass through. The 120-character anchor cap that makes the two agree on
+ * 266 of 266 keys is untouched and still applied on both sides before this runs.
+ */
+const DIR_PREFIX = /^\s*cd\s[^\r\n;&|]*?(?:&&|;|\r?\n)\s*/i;
+const MAX_DIR_PREFIXES = 4;
+
+/**
+ * The command text with any leading directory change removed.
+ *
+ * Used for the key AND for the identical-text refusal, which is the half that
+ * keeps this from becoming a licence to pair more loosely: without it,
+ * `cd repo && npm test` failing and `npm test` succeeding would emit
+ * "`npm test` succeeded where `cd repo && npm test` failed" at 0.90 -- two
+ * spellings of one attempt, dressed up as a difference that mattered. The
+ * claim itself still quotes the RAW command, because that is what ran.
+ */
+export function commandBody(command) {
+  let text = String(command || '');
+  for (let i = 0; i < MAX_DIR_PREFIXES; i++) {
+    const stripped = text.replace(DIR_PREFIX, '');
+    if (stripped === text) break;
+    text = stripped;
+  }
+  return text;
+}
+
+/**
  * The prefix that makes two invocations "the same attempt".
  *
  * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
@@ -194,7 +271,7 @@ const CORRECTION_OPENER =
  * ships a false claim into model context.
  */
 export function attemptKey(command) {
-  return String(command || '')
+  return commandBody(command)
     .trim()
     .split(/\s+/)
     .filter((token) => token && !token.startsWith('-'))
@@ -494,7 +571,14 @@ export function derive(dir, options = {}) {
           // is real and supports NEITHER claim, so nothing is emitted. This is
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
-          if (failed.command === outcome.command) continue;
+          // COMPARED WITH THE DIRECTORY CHANGE REMOVED, for the same reason
+          // the key is. `cd repo && npm test` and `npm test` are one attempt
+          // spelled two ways; before `commandBody` they landed in different
+          // groups and never met, and letting them meet without widening this
+          // guard would emit "`npm test` succeeded where `cd repo && npm test`
+          // failed" at 0.90 -- a difference in the claim that is not a
+          // difference in what ran. Same for two `cd`s to different paths.
+          if (commandBody(failed.command) === commandBody(outcome.command)) continue;
 
           // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
           // client both sides of almost every pair are truncated multi-line
@@ -502,10 +586,12 @@ export function derive(dir, options = {}) {
           // spending the retrieval budget of every later session.
           if (!quotable(failed.command) || !quotable(outcome.command)) continue;
 
-          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
-          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
-          // command lines in this repository alone, and any pair drawn from that
-          // group is a false claim about both halves.
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`. The
+          // `cd <path> &&` case that grouped 547 unrelated command lines in this
+          // repository is now handled earlier by `commandBody`; what is left
+          // here is every OTHER separator -- `git fetch && <anything>`, a
+          // pipeline, a `;`-joined pair -- where the key still names no single
+          // attempt and any pair drawn from it is false about both halves.
           if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =

--- a/integrations/qwen/hooks/lib/derive.mjs
+++ b/integrations/qwen/hooks/lib/derive.mjs
@@ -1,0 +1,385 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/derive.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Findings from data we already hold, with no model call.
+ *
+ * WHY THIS EXISTS. The semantic harvest is on by default but its real gate is a
+ * credential: `harvestMode()` returns `off:no-key` on any machine without one,
+ * which is CI, corporate laptops, and every subscription-only login. This
+ * repository's own graph is the evidence -- 2,965 symbol nodes, 904 file nodes,
+ * 128 task nodes and ONE finding -- because the structural layer accumulates
+ * from ordinary tool traffic while every verdict needed an API key this machine
+ * does not have.
+ *
+ * Everything here is derived from outcomes, transitions and corrections that are
+ * ALREADY RECORDED LOCALLY. Nothing is sent anywhere, nothing is billed, so
+ * there is nothing to consent to and this runs by default. It is the only
+ * finding producer on a machine without a key.
+ *
+ * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
+ * second command fixed the first -- an intervening edit, a dependency install or
+ * a flaky test explains it just as well. So each detector carries a confidence
+ * ceiling, the claim text says only what was OBSERVED, and the two shapes where
+ * the observation supports no claim at all are refused rather than downgraded
+ * (see `attemptKey` and the identical-text guard below).
+ *
+ * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
+ * budget, belongs to the caller.
+ */
+
+import { readMetrics, rereadsByAnchor } from './metrics.mjs';
+import { readArchive, readTurns } from './transcript.mjs';
+import { redact } from './redact.mjs';
+
+/**
+ * Ceilings, ordered by how much the evidence actually supports.
+ *
+ * A command that succeeded where a DIFFERENT command failed is close to a direct
+ * observation. A test or build going red-to-green is weaker, because the usual
+ * cause is the code changing between the two runs rather than anything about the
+ * command. A correction is a lexical guess about what a human meant. Churn
+ * describes our own reading behaviour and says nothing about the code at all.
+ */
+export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+
+/** Claim text cap. A finding is one sentence; a paragraph is evidence. */
+const CLAIM_MAX = 300;
+const EVIDENCE_MAX = 400;
+
+/** Bounded so a pathological log cannot turn session end into real work. */
+const MAX_CANDIDATES = 200;
+
+/**
+ * Commands whose red-to-green transition is usually explained by the CODE
+ * changing rather than by the command. They get the lower ceiling.
+ */
+const CODE_SENSITIVE = /\b(test|tests|jest|vitest|pytest|mocha|build|compile|tsc|lint|typecheck)\b/i;
+
+/**
+ * Openers that mark a user turn as a correction rather than an instruction.
+ *
+ * DELIBERATELY NARROW, and anchored to the START of the turn. The model-based
+ * extractor in `lessons.mjs` can read intent; this cannot, so it only claims the
+ * shapes where the first few words carry the whole signal. Recall is poor by
+ * design: a missed correction costs one finding, a false one puts words in the
+ * user's mouth at 0.6 confidence.
+ */
+const CORRECTION_OPENER =
+  /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
+
+/**
+ * The prefix that makes two invocations "the same attempt".
+ *
+ * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
+ * through what the alternatives do to real command lines:
+ *
+ *   Two tokens conflates `npm run build` with `npm run test`, and the pair then
+ *   produces "`npm run test` works where `npm run build` failed" -- a claim that
+ *   is simply false.
+ *
+ *   Counting flags splits `deploy` from `deploy --retry`, which is the single
+ *   most useful pair this detector can find, into two groups that never meet.
+ *
+ * Conservative in the remaining direction: `npm run build:prod` and
+ * `npm run build` do not pair. A missed pair costs one finding; a wrong pair
+ * ships a false claim into model context.
+ */
+export function attemptKey(command) {
+  return String(command || '')
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'))
+    .slice(0, 3)
+    .join(' ')
+    .toLowerCase();
+}
+
+/** Normalised claim text, so the same lesson derived twice is one candidate. */
+const claimKey = (type, claim) =>
+  `${type}|${String(claim).toLowerCase().replace(/\s+/g, ' ').trim()}`;
+
+/** 0.95 is reserved for verified; everything here is inference. */
+const labelFor = (confidence) => (confidence >= 0.75 ? 'probable' : 'speculative');
+
+/** A literal command prefix, safe to hand to `safeTrigger`. */
+const triggerFor = (command) =>
+  attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
+
+/**
+ * Derives finding candidates from one project's local evidence.
+ *
+ * @param {string} dir wiki directory.
+ * @param {object} options
+ * @param {string|null} options.sessionId session this ran for, for provenance.
+ * @param {string|null} options.transcriptPath live transcript, read only when the
+ *   archive holds nothing for this session yet.
+ * @param {string|null} options.projectRoot the anchor every derived claim gets.
+ *   Without it nothing is derived: an unanchored finding cannot be invalidated
+ *   and is refused by `writeHarvested` anyway, so emitting one would only spend
+ *   the caller's budget on junk.
+ * @param {string|null} options.authoritativeSessionId the session id as the HOOK
+ *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
+ *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
+ *   edge -- `taskForAnchors` returns null without one, so an unverified string
+ *   would silently produce no edge. Threaded rather than defaulted from
+ *   `sessionId`: defaulting would promote any caller's string to trusted.
+ */
+export function derive(dir, options = {}) {
+  // `options || {}` rather than a destructuring default. A default only fires on
+  // `undefined`, so a caller passing an explicitly null options object -- which
+  // is what a hook does when it has nothing to say -- threw a TypeError out of
+  // the parameter list itself, before any of the try/catch below could fail open.
+  const {
+    sessionId = null,
+    transcriptPath = null,
+    projectRoot = null,
+    authoritativeSessionId = null,
+  } = options || {};
+
+  const result = {
+    candidates: [],
+    observations: [],
+    written: [],
+    sessionId,
+    authoritativeSessionId,
+  };
+
+  let events;
+  try {
+    events = readMetrics(dir);
+  } catch {
+    // Session end must cost nothing. No evidence is not an error.
+    return result;
+  }
+  if (!Array.isArray(events)) return result;
+
+  const seen = new Set();
+  const add = (candidate) => {
+    if (result.candidates.length >= MAX_CANDIDATES) return;
+    const key = claimKey(candidate.type, candidate.claim);
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.candidates.push(candidate);
+  };
+
+  // ---- 1 & 2: a failed attempt followed by a succeeding one ---------------
+  //
+  // The event is `tool-outcome` and THE COMMAND TEXT IS IN `anchor`: there is no
+  // separate command field, because the anchor of a command surface IS the
+  // command. It is capped at 120 characters at the boundary, so a very long
+  // command line is compared and quoted truncated.
+  try {
+    if (projectRoot) {
+      const outcomes = events
+        .filter(
+          (e) =>
+            e &&
+            e.kind === 'tool-outcome' &&
+            e.surface === 'command' &&
+            typeof e.anchor === 'string' &&
+            e.anchor.trim()
+        )
+        .map((e) => ({
+          command: e.anchor.trim(),
+          output: typeof e.output === 'string' ? e.output : '',
+          exit: Number.isInteger(e.exit) ? e.exit : null,
+          at: e.at ?? 0,
+          // `success` FIRST, `exit` only as a refinement. MCP tools report no
+          // numeric code at all, so a classifier keyed on `exit !== 0` would be
+          // inert for most clients -- and `exit` is null rather than 0 precisely
+          // so that absence is not read as a clean exit.
+          failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
+        }))
+        .sort((a, b) => a.at - b.at);
+
+      const byAttempt = new Map();
+      for (const outcome of outcomes) {
+        const key = attemptKey(outcome.command);
+        if (!key) continue;
+        if (!byAttempt.has(key)) byAttempt.set(key, []);
+        byAttempt.get(key).push(outcome);
+      }
+
+      for (const run of byAttempt.values()) {
+        // The NEAREST preceding failure, not the first one in the session. With
+        // `find` over the whole run, a command that failed at 09:00 and
+        // succeeded at 17:00 after nine unrelated attempts is reported as one
+        // story.
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          // One pair per failure: a command that succeeds twice afterwards has
+          // not taught two lessons.
+          lastFailure = null;
+
+          // THE GUARD THAT REMOVES THE LARGEST JUNK CLASS. The commonest shape
+          // in a coding session is `npm run build` failing, the code being
+          // fixed, and `npm run build` succeeding -- identical text. From that
+          // pair the two available claims are "`npm run build` works where
+          // `npm run build` failed", which is incoherent, and "`npm run build`
+          // fails", which the same evidence has just disproved. The observation
+          // is real and supports NEITHER claim, so nothing is emitted. This is
+          // not a confidence question; a ceiling cannot rescue a claim whose
+          // content is wrong.
+          if (failed.command === outcome.command) continue;
+
+          const codeSensitive =
+            CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);
+          const confidence = codeSensitive ? CONFIDENCE.test : CONFIDENCE.command;
+          const derivedBy = codeSensitive ? 'test-transition' : 'command-transition';
+
+          // "SUCCEEDED WHERE", NOT "FIXES". What is observed is two outcomes in
+          // order on the same attempt; that the difference in the command line
+          // CAUSED the difference in outcome is not observed and is not claimed.
+          add({
+            type: 'command',
+            claim: redact(
+              `\`${outcome.command}\` succeeded in this project where \`${failed.command}\` failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
+                'an intervening edit or a flaky run explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: 'when about to run this command in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the failing form later succeeds unchanged'],
+            trigger: triggerFor(outcome.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+
+          // The error text, only when there is error text. Without it the claim
+          // degrades to "`X` failed with:" and nothing after the colon, which
+          // carries no information and still costs budget.
+          const firstLine = failed.output.split('\n').find((line) => line.trim()) || '';
+          if (firstLine.trim().length < 8) continue;
+          add({
+            type: 'failure',
+            claim: redact(`\`${failed.command}\` failed with: ${firstLine.trim()}`, {
+              max: CLAIM_MAX,
+            }),
+            evidence: redact(`captured output of the failing run:\n${failed.output}`, {
+              max: EVIDENCE_MAX,
+            }),
+            applicability: 'when this command is about to be run in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the same command later succeeds unchanged'],
+            trigger: triggerFor(failed.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: failed.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 3: user corrections ------------------------------------------------
+  //
+  // A `feedback` finding -- the one type whose source is a person saying the
+  // agent was wrong. The MODEL-BASED extractor for this lives in `lessons.mjs`
+  // and needs the credential this module exists to do without, so here the
+  // signal is lexical: the opening words of the user's own turn.
+  //
+  // ORIGIN IS NOT PROMOTED. `writeHarvested` grants ORIGIN_HUMAN to a finding
+  // carrying a verified verbatim quote, and the standing-rules layer selects on
+  // that origin to inject a claim on EVERY turn. The quote here would be
+  // verbatim -- it is copied out of the archive -- but whether the turn was a
+  // correction at all is a guess, and a guess must not buy always-on injection.
+  // So no `origin` and no `quote` field: this stays harvested provenance.
+  try {
+    if (projectRoot) {
+      let turns = readArchive(dir, sessionId);
+      // The archive is written by the Stop hook too, and the order of the two is
+      // not this module's to assume, so fall back to the live transcript.
+      if (!turns.length && transcriptPath) turns = readTurns(transcriptPath);
+
+      for (const turn of turns) {
+        if (!turn || turn.role !== 'user') continue;
+        const text = String(turn.text || '').trim();
+        // Long turns are new instructions with a complaint somewhere inside
+        // them; truncating one into a claim would misquote the user.
+        if (text.length < 12 || text.length > 300) continue;
+        if (!CORRECTION_OPENER.test(text)) continue;
+        add({
+          type: 'feedback',
+          claim: redact(text, { max: CLAIM_MAX }),
+          evidence: redact(`the user opened a turn with a correction: "${text}"`, {
+            max: EVIDENCE_MAX,
+          }),
+          applicability: 'when working in this project, before repeating what was corrected',
+          confidence: CONFIDENCE.correction,
+          confidenceLabel: labelFor(CONFIDENCE.correction),
+          scope: 'project',
+          invalidators: ['the user later asks for the corrected behaviour'],
+          anchors: [projectRoot],
+          derivedBy: 'correction',
+          sessionId,
+          at: Date.parse(turn.at || '') || Date.now(),
+        });
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 4: re-read churn ---------------------------------------------------
+  //
+  // NOT A FINDING, AND THAT IS THE DECISION RATHER THAN AN OMISSION.
+  //
+  // Churn is a claim about OUR OWN reading behaviour: "this file was read three
+  // times unchanged". Every finding type available is a claim about the work --
+  // `map` describes how an area of the codebase is laid out, and is
+  // content-dependent, so a churn claim filed as `map` would be checked for
+  // staleness against contents it makes no claim about and flip stale on the
+  // first edit to a file it never described. Worse, the anchors it would take
+  // are by construction the HOTTEST files in the project, which are exactly the
+  // files that already carry real findings, so a 0.4-confidence row saying
+  // nothing actionable would sit in the injection budget beside them and render
+  // on the same reads. Nothing a future agent could DO differently follows from
+  // it: it does not say what the file contains, so it cannot substitute for
+  // reading it.
+  //
+  // The signal is still worth having -- as the measurement it already is.
+  // `rereadWaste` reports it on the balance sheet, `rereadsByAnchor` names the
+  // offenders, and this returns those rows as OBSERVATIONS: computed, carried,
+  // and deliberately not competing for context. Three detectors produce
+  // findings; the fourth produces a number.
+  try {
+    for (const row of rereadsByAnchor(events).slice(0, 3)) {
+      if (!row.anchor || row.wasteful < 2) continue;
+      result.observations.push({
+        kind: 'churn',
+        anchor: row.anchor,
+        repeats: row.repeats,
+        wasteful: row.wasteful,
+        tokens: row.tokens,
+        confidence: CONFIDENCE.churn,
+        derivedBy: 'churn',
+        note: `re-read ${row.repeats} times, ${row.wasteful} of them unchanged`,
+      });
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  return result;
+}

--- a/integrations/qwen/hooks/lib/derive.mjs
+++ b/integrations/qwen/hooks/lib/derive.mjs
@@ -16,6 +16,13 @@
  * there is nothing to consent to and this runs by default. It is the only
  * finding producer on a machine without a key.
  *
+ * THREE SOURCES, NOT TWO. `tool-outcome` events, the transcript archive, and --
+ * since the transition detectors were measured to have no input at all on the
+ * primary client -- the raw transcript's FAILED tool results, which is the only
+ * place a Claude Code failure is recorded (`failedResultsFromTranscript` in
+ * transcript.mjs, and the note above `quotable` for what that measurement
+ * actually yielded).
+ *
  * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
  * second command fixed the first -- an intervening edit, a dependency install or
  * a flaky test explains it just as well. So each detector carries a confidence
@@ -32,7 +39,11 @@
 import { readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
-import { readArchive, readTurns } from './transcript.mjs';
+import {
+  readArchive,
+  readTurns,
+  failedResultsFromTranscript,
+} from './transcript.mjs';
 import { redact } from './redact.mjs';
 import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
@@ -56,6 +67,96 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * The anchor cap a command surface is stored under, restated here as a TEST.
+ *
+ * `recordToolOutcome` truncates `anchor` to 120 characters, so a command at or
+ * over that length reached this module already cut -- and `quotable` below
+ * refuses to build a claim out of the fragment.
+ */
+const COMMAND_ANCHOR_MAX = 120;
+
+/**
+ * Can this command text be QUOTED in a claim a reader could act on?
+ *
+ * THE SECOND REFUSAL OF ITS KIND, and it exists because measurement forced it.
+ * Wiring the transcript reader gave the transition detectors their first real
+ * input on this client and immediately produced four candidates at 0.9
+ * confidence whose claim text read:
+ *
+ *   `cd /c/Users/.../token-optimizer-mcp\ncat >> docs/superpowers/plans/2026-` succeeded
+ *   in this project where `cd /c/Users/.../token-optimizer-mcp\ncat > /tmp/probe3.mjs
+ *   <<'EOF'\nimport { readdirSync, readFileSync, sta` failed
+ *
+ * -- two truncated fragments of throwaway shell scripts, grouped together only
+ * because `attemptKey`'s three tokens were spent on `cd`, the absolute path, and
+ * the verb. Then measured properly across three real transcripts: **0 of 83**
+ * captured command failures are single-line and inside the cap. 65% of this
+ * project's 2,178 successful command outcomes are not either. On this client a
+ * "command" is usually a whole shell script, so the attempt identity the
+ * transition detectors are built on does not fit most of the traffic.
+ *
+ * This is the same judgement as the identical-text guard below rather than a
+ * confidence question: a claim whose subject is a truncated fragment of a
+ * program is not a weaker claim, it is not a claim. A raised cap would not
+ * rescue it -- quoting the whole 500-character heredoc is no more actionable.
+ *
+ * What survives is exactly what the detector was designed for: `npm test`,
+ * `dotnet build X`, `deploy --retry` -- a repeatable command someone could run
+ * again. This machine captured none failing, which is why the honest yield here
+ * is zero and why that is reported rather than dressed up.
+ *
+ * Applied to BOTH sources. Where the evidence arrived from has no bearing on
+ * whether the resulting sentence says anything, and a rule that let events
+ * through would ship the junk on the ten clients that do report failures.
+ */
+const quotable = (command) => {
+  const text = String(command || '');
+  return (
+    text.trim().length > 0 &&
+    !/[\r\n]/.test(text) &&
+    text.length < COMMAND_ANCHOR_MAX
+  );
+};
+
+/**
+ * Tokens that separate one command from the next rather than naming one.
+ *
+ * MEASURED, LIKE EVERY OTHER REFUSAL HERE. `attemptKey` spends up to three
+ * non-flag tokens on identity, and the habit on this machine is
+ * `cd <absolute path> && <the real command>` -- which spends all three on `cd`,
+ * the path and `&&`, so the real command never enters the key. This project's
+ * own evidence: the single key `cd c:/users/.../token-optimizer-mcp &&` covers
+ * **539 distinct command lines**. One quotable failure in that group would pair
+ * with an arbitrary unrelated success and claim "`cd repo && grep -n ...`
+ * succeeded where `cd repo && git merge ...` failed", which is false about both.
+ *
+ * A KEY THAT REACHED A SEPARATOR NEVER REACHED A COMMAND, so there is no attempt
+ * to compare and nothing to claim -- the same judgement as the identical-text
+ * guard rather than a lower ceiling. Narrow on purpose: `2>&1` and `/F` are not
+ * separators and do not trip this, so `cat commitlint.config.mjs 2>&1` and
+ * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
+ * found across 163 transcripts on this machine it refuses 2 and keeps 6.
+ *
+ * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
+ * building the key, so the claim is about `npm test` rather than about the `cd`.
+ * That changes `attemptKey` for every client and every finding already derived
+ * from it, so it belongs in its own change with its own comparison.
+ */
+const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
+
+/**
+ * Did `attemptKey` actually capture a command, or only how one was chained?
+ *
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * One check per pair is enough: both halves share the key by construction.
+ */
+const hasAttemptIdentity = (command) =>
+  attemptKey(command)
+    .split(' ')
+    .filter(Boolean)
+    .every((token) => !COMMAND_SEPARATORS.has(token));
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -274,6 +375,17 @@ export function derive(dir, options = {}) {
   // separate command field, because the anchor of a command surface IS the
   // command. It is capped at 120 characters at the boundary, so a very long
   // command line is compared and quoted truncated.
+  //
+  // TWO SOURCES OF FAILURE, ONE PAIRING LOOP. Claude Code never fires
+  // PostToolUse for a failed tool call -- 2,238 of 2,238 live `tool-outcome`
+  // events on the measuring machine carry `success: true`, and a deliberately
+  // failing command produced no event at all -- so on the primary client these
+  // two detectors had NO INPUT WHATSOEVER while working normally on the ten
+  // adapter clients. `failedResultsFromTranscript` supplies the missing half
+  // from the only place it exists. The successes still come from events only:
+  // a transcript failure that pairs with nothing stays unclaimed, which is also
+  // what keeps a failure from ANOTHER project's directory out of this project's
+  // graph -- a candidate cannot be emitted without a success recorded HERE.
   try {
     if (projectRoot) {
       const outcomes = events
@@ -290,6 +402,9 @@ export function derive(dir, options = {}) {
           output: typeof e.output === 'string' ? e.output : '',
           exit: Number.isInteger(e.exit) ? e.exit : null,
           at: e.at ?? 0,
+          // Carried purely so the transcript merge below can recognise the same
+          // tool call arriving from the other source.
+          toolCallId: e.toolCallId ? String(e.toolCallId) : null,
           // `success` FIRST, `exit` only as a refinement. MCP tools report no
           // numeric code at all, so a classifier keyed on `exit !== 0` would be
           // inert for most clients -- and `exit` is null rather than 0 precisely
@@ -297,6 +412,53 @@ export function derive(dir, options = {}) {
           failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
         }))
         .sort((a, b) => a.at - b.at);
+
+      // DEDUPLICATED ON `toolCallId`, which is the SAME STRING in both sources:
+      // `episodeMeta` reads `raw.tool_use_id` into `toolCallId`, and that is the
+      // transcript's `tool_use_id` verbatim -- verified against live evidence
+      // (`toolu_01L4Nwr...` in metrics.jsonl, the same ids in the transcript).
+      // So on the ten clients that DO report failures, the event copy wins and
+      // the transcript copy is dropped before grouping. Without this the two
+      // copies of one failure would sit in the same run and the second of them
+      // would be paired against the first as a failed-then-succeeded story about
+      // itself.
+      //
+      // The fallback covers a client that reports a failure with no call id:
+      // identical command text within two seconds is one failure recorded twice,
+      // not two failures, because nothing re-runs a command that fast.
+      const eventIds = new Set(
+        outcomes.map((o) => o.toolCallId).filter(Boolean)
+      );
+      const eventFailures = outcomes.filter((o) => o.failed);
+      const alreadyRecorded = (failure) => {
+        if (failure.toolCallId && eventIds.has(failure.toolCallId)) return true;
+        return eventFailures.some(
+          (o) =>
+            o.command === failure.command &&
+            Math.abs((o.at || 0) - (failure.at || 0)) <= 2000
+        );
+      };
+
+      let transcriptFailures = [];
+      try {
+        transcriptFailures = failedResultsFromTranscript(transcriptPath).filter(
+          (failure) => failure.command.trim() && !alreadyRecorded(failure)
+        );
+      } catch {
+        // The reader is an extra source, never a reason the detector stops.
+      }
+      for (const failure of transcriptFailures) {
+        outcomes.push({
+          command: failure.command.trim(),
+          output: failure.output,
+          exit: failure.exit,
+          at: failure.at,
+          toolCallId: failure.toolCallId,
+          // Read from `Exit code N`, which is the only shape the reader admits.
+          failed: true,
+        });
+      }
+      if (transcriptFailures.length) outcomes.sort((a, b) => a.at - b.at);
 
       const byAttempt = new Map();
       for (const outcome of outcomes) {
@@ -333,6 +495,18 @@ export function derive(dir, options = {}) {
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
           if (failed.command === outcome.command) continue;
+
+          // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
+          // client both sides of almost every pair are truncated multi-line
+          // shell scripts, and a claim quoting a fragment of one is noise
+          // spending the retrieval budget of every later session.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
+          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
+          // command lines in this repository alone, and any pair drawn from that
+          // group is a false claim about both halves.
+          if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =
             CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);

--- a/integrations/qwen/hooks/lib/doctor.mjs
+++ b/integrations/qwen/hooks/lib/doctor.mjs
@@ -197,7 +197,8 @@ function hooksDirFor({ hooksDir, install, root }) {
  * identical from outside: a graph that fills with structural nodes either way.
  *
  * Measured on a real 5.4.0 install: 484 symbol, 286 file and 122 task nodes and
- * ZERO findings, because harvestMode() was 'off:not-opted-in'. Fifteen checks
+ * ZERO findings, because harvestMode() then returned an opt-in refusal (the mode has
+ * since been renamed: it is 'off:no-key' now, and opting in is no longer the gate). Fifteen checks
  * passed and none mentioned harvest. stop-harvest.mjs names this exact gap --
  * "nothing in doctor, audit or waste mentions harvest, so a user sees a graph
  * filling with structural nodes and no findings and has no way to learn why" --
@@ -221,9 +222,15 @@ export function probeHarvest() {
   // optimizer is off" is noise, which is why stop-harvest maps it to no notice.
   if (mode === 'off:mode') return [];
 
+  // SAID PLAINLY, because this is the configuration a user would choose if they
+  // knew it existed and the previous wording buried it in machinery. A local
+  // endpoint is the only setting under which the semantic harvest runs with no
+  // credential, no billing and no digest leaving the machine -- so the two facts
+  // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
     return [ok('finding extraction is available',
-      'active-model wiki_write is primary; local endpoint also enables fallback extraction')];
+      'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
+      'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
@@ -233,10 +240,19 @@ export function probeHarvest() {
 
   // No second-model credential is required for the primary path. The Codex/agent session that
   // already paid to derive the conclusion is the extractor and wiki_write is local.
+  // NAME THE TRADE, not just the missing variable. This is the default state on
+  // every machine without a credential, so it is the text most users will read,
+  // and "unavailable" alone tells them neither what they are missing nor that
+  // the free option exists. Local findings still accumulate: derive.mjs reads
+  // exit codes, red-to-green transitions, corrections and churn out of evidence
+  // already on disk and sends nothing anywhere.
   if (mode === 'off:no-key') {
     return [ok('finding extraction is available',
-      'active model records durable conclusions through local wiki_write; no separate-model ' +
-      'credential is configured, so fallback transcript extraction is unavailable')];
+      'active model records durable conclusions through local wiki_write, and derive runs at ' +
+      'session end with no credential. No separate-model credential is configured, so fallback ' +
+      'transcript extraction is unavailable: point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local ' +
+      'model to run it free and private, or set TOKEN_OPTIMIZER_API_KEY to run it from a bounded ' +
+      'digest of paths, commands, prompts and conclusions -- never file contents')];
   }
 
   // off:opted-out -- a deliberate choice, reported as one. Nagging about a setting somebody chose

--- a/integrations/qwen/hooks/lib/inject.mjs
+++ b/integrations/qwen/hooks/lib/inject.mjs
@@ -1134,10 +1134,25 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // injected more than the budget allowed and recorded fewer tokens than it
   // spent -- in a block whose entire justification is that it is tightly
   // bounded and measured against the control arm.
+  // THE LAST LINE IS HOW THE NEXT RULE GETS HERE, and it is one line because
+  // this block is charged on every session forever. A rule reaches this list
+  // only by being pinned or by being a person's verified correction, and both
+  // start as a `wiki_write` -- so a model reading a set of standing rules with
+  // no idea how they were produced has no way to add to it. Stated at the point
+  // of the evidence rather than as a separate always-on block: the reader is
+  // already looking at the output of the mechanism being described.
+  //
+  // THE COLD GRAPH IS COVERED ELSEWHERE, deliberately. Nothing here renders
+  // until at least one rule qualifies, which is the property the always-on
+  // budget depends on, so this line cannot be the first-session nudge --
+  // `policyText`'s "Record what you work out" section is, and it is emitted at
+  // SessionStart whether or not the graph holds anything.
   const HEADING =
     '# Standing rules for this project' +
     '\n\nEstablished in previous sessions and expected to hold. ' +
-    'These are not suggestions.\n\n';
+    'These are not suggestions.\n\n' +
+    'Record what you work out with wiki_write and a real file anchor; ' +
+    'that is how a rule reaches this list.\n\n';
   const noticeFor = (n) =>
     n
       ? `\n(${n} further standing rule${n === 1 ? '' : 's'} did not fit this budget; ` +

--- a/integrations/qwen/hooks/lib/inject.mjs
+++ b/integrations/qwen/hooks/lib/inject.mjs
@@ -35,6 +35,7 @@ import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
 import { cacheOrdered } from './cache.mjs';
+import { withheldFor, exploreOrder, servingPolicyVersion, LOO_ENABLED } from './loo.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -311,8 +312,38 @@ export function forTouch(
     });
     for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
   }
-  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  // LAYER 2 EXPLORATION, BEFORE the budget decides.
+  //
+  // `assessed.eligible` arrives in net-utility order and `fit` keeps that order
+  // until the budget runs out -- so the ranking decides which findings are ever
+  // served, which decides which ever accumulate observations, which decides
+  // their utility. A tenth of touches therefore promote the least-served
+  // candidate first. This is the only place it can go: after `fit` the choice
+  // has already been made.
+  const ordered = exploreOrder(assessed.eligible, dir, { sessionId, anchor: filePath });
+  const { kept, spent } = fit(ordered.map((item) => item.finding), budget);
   if (!kept.length) return null;
+
+  // LAYER 2 WITHHOLDING, AFTER the budget decides, which is the only ordering
+  // that produces a leave-one-out rather than a substitution: withholding first
+  // would let the next-ranked finding take the freed tokens, so the withheld
+  // arm would differ from the served arm by two findings instead of one and the
+  // effect would belong to neither.
+  //
+  // `holdout` is passed so the two experiments cannot compose into "withhold
+  // everything and call it a leave-one-out": that arm already serves nothing.
+  const withheld = withheldFor(kept.map((finding) => finding.key), sessionId, graph, dir, {
+    surface: 'file',
+    anchor: filePath,
+    holdout,
+  });
+  const delivered = withheld ? kept.filter((finding) => finding.key !== withheld) : kept;
+  // RE-PRICED, because `fit` priced what it KEPT and this delivers less. Using
+  // `spent` would bill the injection-cost side of the balance sheet for text
+  // the model never received.
+  const deliveredSpent = withheld
+    ? delivered.reduce((sum, finding) => sum + estimate(render(finding)), 0)
+    : spent;
 
   record(dir, {
     kind: 'inject',
@@ -321,15 +352,20 @@ export function forTouch(
     surface: 'file',
     anchor: filePath,
     holdout,
-    tokens: holdout ? 0 : spent,
-    deliveredTokens: holdout ? 0 : spent,
+    tokens: holdout ? 0 : deliveredSpent,
+    deliveredTokens: holdout ? 0 : deliveredSpent,
     shadowTokens: spent,
-    count: holdout ? 0 : kept.length,
+    count: holdout ? 0 : delivered.length,
     candidateCount: kept.length,
-    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    findingIds: holdout ? [] : delivered.map((finding) => finding.key),
     shadowFindingIds: kept.map((finding) => finding.key),
-    stale: kept.some((f) => f.stale),
+    stale: delivered.some((f) => f.stale),
     sessionId,
+    // ON EVERY RECORD, not only the withheld ones. A served observation needs
+    // the policy version as much as a withheld one does, or `effects` cannot
+    // keep the two arms of one comparison inside one policy.
+    ...(LOO_ENABLED() ? { looPolicy: servingPolicyVersion() } : {}),
+    ...(withheld ? { loo: withheld } : {}),
   });
 
   // MARKED SEEN IN BOTH ARMS, for the same reason as the command path: a file
@@ -339,11 +375,16 @@ export function forTouch(
   // grow faster purely from repetition.
   //
   // This is the identical defect that was fixed in `forCommand` and not here.
+  //
+  // THE WITHHELD KEY IS MARKED TOO, and that is load-bearing rather than tidy:
+  // an unmarked one would be a candidate again on the next touch of this file,
+  // where the one-per-touch tiebreak could serve it -- flipping its arm inside
+  // the very session the arm hash exists to pin it for.
   for (const f of kept) alreadyInjected.add(f.key);
 
-  if (holdout || !kept.length) return null;
+  if (holdout || !delivered.length) return null;
 
-  return `Known about ${filePath} (from previous sessions):\n${kept.map(render).join('\n')}`;
+  return `Known about ${filePath} (from previous sessions):\n${delivered.map(render).join('\n')}`;
 }
 
 /**

--- a/integrations/qwen/hooks/lib/keepwarm.mjs
+++ b/integrations/qwen/hooks/lib/keepwarm.mjs
@@ -30,6 +30,15 @@ import { record, readMetrics, readBalance } from './metrics.mjs';
 import { WRITE_MULTIPLIER, READ_MULTIPLIER } from './cache.mjs';
 
 /**
+ * The shortest gap that counts as a NEW turn rather than a burst inside one.
+ *
+ * Shared by the gap distribution and by the hit test, because they have to
+ * agree about what a turn is. Two copies of this number would let the decision
+ * be fitted to one definition of a turn and scored against another.
+ */
+export const TURN_GAP_MS = 250;
+
+/**
  * TTL tiers, with what a WRITE costs at each.
  *
  * A five-minute entry is written at 1.25x a plain input token; the one-hour
@@ -85,7 +94,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
     for (let i = 1; i < session.length; i++) {
       const gap = session[i] - session[i - 1];
       // A burst of events inside one turn is not a gap between turns.
-      if (gap > 250) gaps.push(gap);
+      if (gap > TURN_GAP_MS) gaps.push(gap);
     }
   }
   if (gaps.length < 6) return null;
@@ -105,10 +114,91 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
 }
 
 /**
+ * Refreshes to observe at a tier before the observation may bound the decision.
+ *
+ * THE SAME NUMBER THE BACKSTOP DEMANDS, deliberately. The decision and the
+ * tripwire read the same ledger, so letting them disagree about when there is
+ * enough evidence would mean one of them acting on a sample the other calls too
+ * small. Below the floor the decision keeps its expected-value answer, so a
+ * single unlucky miss changes nothing at all.
+ *
+ * NOT A CONFIDENCE INTERVAL, and the reason is arithmetic rather than taste. A
+ * Wilson 95% upper bound at ten refreshes and zero hits is 0.28 -- so a policy
+ * that missed ten times out of ten would still be recommended, which is exactly
+ * the case the loop exists to catch. The point estimate is safe here because of
+ * the bound below: an observation may only ever LOWER the modelled probability,
+ * so sampling noise cannot manufacture a refresh, and the tripwire's realised
+ * ledger is a second guard underneath.
+ */
+export const OBSERVATION_FLOOR = TRIPWIRE_MIN;
+
+/**
+ * The measured hit rate per tier, from recorded outcomes.
+ *
+ * Tiers below the floor are ABSENT rather than present with a small n, because
+ * a rate carrying no weight is the thing most likely to be used as though it
+ * did.
+ */
+export function observedHitRates(outcomes = []) {
+  const byTier = new Map();
+  for (const event of outcomes) {
+    if (event?.kind !== 'keepwarm' || event.action !== 'outcome') continue;
+    const name = TIERS.some((t) => t.name === event.tier) ? event.tier : TIERS[0].name;
+    const row = byTier.get(name) || { refreshes: 0, hits: 0 };
+    row.refreshes += 1;
+    if (event.hit) row.hits += 1;
+    byTier.set(name, row);
+  }
+
+  const qualified = new Map();
+  for (const [name, row] of byTier) {
+    if (row.refreshes < OBSERVATION_FLOOR) continue;
+    qualified.set(name, { ...row, rate: row.hits / row.refreshes });
+  }
+  return qualified;
+}
+
+/**
+ * What the refreshes at this tier actually did, if enough of them have.
+ *
+ * Tolerates being handed anything -- null, a plain object, a Map -- because the
+ * callers are two public functions whose options object is assembled by other
+ * people's code.
+ */
+function observationsFor(observed, tierName) {
+  const row = observed instanceof Map ? observed.get(tierName) : null;
+  return row && Number.isFinite(row.rate) ? row : null;
+}
+
+/**
+ * The modelled probability, BOUNDED BY what was observed and never raised by it.
+ *
+ * The asymmetry is the whole point and runs against this project's interest. A
+ * recorded `hit` says only that a turn arrived before the entry expired; it
+ * cannot say the refresh is what kept the entry alive, because a turn arriving
+ * one minute after a five-minute ping would have found the entry warm anyway.
+ * So the observed rate is an UPPER bound on a refresh's value, and substituting
+ * it for the model would flatter keep-warm badly: on the machine this was
+ * written on, the modelled ping probability is 0.2% and the observable
+ * before-expiry rate is 99.5%, so the substitution would recommend refreshing
+ * forever. A low rate, by contrast, is real evidence against: if turns do not
+ * even arrive inside the TTL, the refresh certainly bought nothing.
+ */
+function bounded(modelled, seen) {
+  return seen ? Math.min(modelled, seen.rate) : modelled;
+}
+
+/**
  * Should we refresh this prefix now?
  *
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
+ *
+ * `observed` is passed IN rather than read from disk here: this function is
+ * pure, its purity is what lets the tests build a distribution by hand, and
+ * `shouldKeepWarm` has already read the outcome log for the tripwire -- so
+ * threading the reader in here would be a second read of the same file and a
+ * second place for the window discipline to be got wrong.
  */
 export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
@@ -125,42 +215,30 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
   const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
-
-  // MEASURED BEATS MODELLED, once there is enough of it.
-  //
-  // The module header already commits to this -- "an expected-value decision is
-  // only as good as the distribution it was fitted to, and distributions
-  // shift" -- and the tripwire underneath was the only thing acting on it, as
-  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
-  // entirely" there was nothing, because the observed hit rate was never
-  // computed: both recording halves had no call site, so ten refreshes that
-  // bought nothing would keep recommending refresh right up to the moment the
-  // tripwire cut the whole feature off.
-  //
-  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
-  // handful of samples would swing the decision harder than the distribution
-  // they replace.
-  const probability = observed ? observed.rate : modelled;
+  const seen = observationsFor(observed, tier.name);
+  const probability = bounded(modelled, seen);
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
-  const basis = observed
-    ? `measured over ${observed.observations} refreshes`
-    : 'modelled from the gap distribution';
+  const note = seen && probability < modelled
+    ? `; bounded by ${seen.refreshes} observed refreshes, ` +
+      `${Math.round(seen.rate * 100)}% used before expiry`
+    : '';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
     modelledProbability: modelled,
-    basis,
+    observedHitRate: seen ? seen.rate : null,
+    observedRefreshes: seen ? seen.refreshes : 0,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
-    reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
+    reason: (ev > 0
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
-        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`) + note,
   };
 }
 
@@ -171,7 +249,12 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
  * long enough that the short tier keeps missing. Returns null when neither tier
  * pays, which is a real answer and the one a default-on product never gives.
  */
-export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS }) {
+export function ttlTier({
+  prefixTokens,
+  gaps,
+  turnsPerSession = DEFAULT_TURNS,
+  observed = null,
+}) {
   if (!prefixTokens || !gaps) return null;
 
   // Expected cost of a turn under each tier, as a multiple of what the prefix
@@ -179,7 +262,16 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   // again; and the FIRST write is amortised over the session, which is what
   // stops the expensive tier from looking free whenever gaps are short.
   const costOf = (tier) => {
-    const hit = gaps.probabilityWithin(tier.ms);
+    // THE SAME QUANTITY THE OUTCOMES RECORD, which is what makes the
+    // observation admissible here at all. `hit` is P(a turn arrives before the
+    // entry expires) and `recordRefreshOutcome`'s `hit` is exactly that event,
+    // measured -- unlike keepWarmDecision, whose probability is the narrower
+    // ping window and for which the same observation is only an upper bound.
+    // Bounded rather than replaced even so: a sample drawn only from moments we
+    // CHOSE to refresh is not a sample of gaps, and its bias runs our way.
+    const modelled = gaps.probabilityWithin(tier.ms);
+    const seen = observationsFor(observed, tier.name);
+    const hit = bounded(modelled, seen);
     const perTurn = hit * READ_MULTIPLIER + (1 - hit) * tier.writeMultiplier;
     // THE SUPPLIED VALUE, not only the computed one. Math.max(1, NaN) is NaN -- Math.max
     // propagates it rather than clamping -- so perTurn became NaN, the `perTurn >= 1` guard below
@@ -192,6 +284,8 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     return {
       tier,
       hit,
+      seen,
+      boundedByObservation: Boolean(seen) && hit < modelled,
       perTurn: (tier.writeMultiplier + (turns - 1) * perTurn) / turns,
     };
   };
@@ -208,99 +302,53 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     action: 'refresh',
     tier: best.tier.name,
     hitProbability: best.hit,
+    observedHitRate: best.seen ? best.seen.rate : null,
+    observedRefreshes: best.seen ? best.seen.refreshes : 0,
     expectedCostPerTurn: Number(best.perTurn.toFixed(3)),
     expectedValue: Math.round((1 - best.perTurn) * prefixTokens),
     reason: `${Math.round(best.hit * 100)}% of gaps land inside ${best.tier.name}; ` +
-      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached`,
+      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached` +
+      (best.boundedByObservation
+        ? `, bounded by ${best.seen.refreshes} observed refreshes ` +
+          `(${Math.round(best.seen.rate * 100)}% used before expiry)`
+        : ''),
   };
 }
 
-/** Observations of a tier before its measured hit rate may override the model. */
-export const OBSERVATION_FLOOR = 5;
-
-/** Records a refresh so its outcome can be scored. */
-export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
-  record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
-}
-
 /**
- * Scores every refresh whose window has since resolved.
+ * Records a refresh so its outcome can be scored.
  *
- * THE MISSING HALF, and it was missing because nobody could see where the
- * signal would come from. `recordRefreshOutcome` needs to know whether a real
- * turn arrived before the entry expired -- and that is not a thing anyone has
- * to instrument, because the event log already records when every turn
- * happened. The answer was in the data the whole time.
+ * `sessionId` IS REQUIRED FOR THE REFRESH TO BE SCOREABLE, and is not defaulted
+ * to anything. The hit test asks whether a turn of THIS conversation arrived
+ * before expiry; pooling arrivals across sessions would let a second concurrent
+ * session's turn pay for this one's ping, which manufactures hits. A refresh
+ * recorded without one is kept in the ledger and reported as unattributable
+ * rather than guessed at.
  *
- * For each unscored refresh at time T on a tier with TTL `ms`:
- *
- *   - a later event within `ms`            -> HIT, observed
- *   - a later event after `ms`             -> MISS, observed
- *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
- *                                             demonstrably closed unused
- *   - no later event, window still open    -> NOTHING RECORDED
- *
- * That last line is the important one and it is Plan 2's own instruction: "if
- * no signal is available for a tier, record nothing rather than guessing
- * `hit: false`". A refresh whose window has not closed yet is not a miss, and
- * scoring it as one would drive the tripwire negative on the newest and least
- * informative records.
- *
- * DRAINED AT READ TIME, which is the pattern this codebase already uses for
- * staleness: the producer cannot know the outcome at the moment it acts, so the
- * next reader resolves what has become knowable since.
+ * Returns the stored record, whose `id` is what `scoreRefreshes` pairs the
+ * outcome to, so an issuer can hold onto it.
  */
-export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
-  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
-  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
-  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
-
-  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
-  // so everything past the number already scored is outstanding. Pairing by
-  // timestamp instead would double-count two refreshes recorded in the same
-  // millisecond, which is reachable: a tool run twice in a loop.
-  const outstanding = refreshes.slice(scored);
-  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
-
-  let recorded = 0;
-  for (const refresh of outstanding) {
-    const at = Number(refresh.at) || 0;
-    if (!at) continue;
-    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
-    const next = timeline.find((t) => t > at);
-
-    let hit;
-    if (next !== undefined) hit = next - at <= tierSpec.ms;
-    else if (now - at > tierSpec.ms) hit = false;
-    else continue; // window still open: not yet knowable
-
-    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
-    recorded += 1;
-  }
-  return { outstanding: outstanding.length, recorded };
-}
-
-/**
- * The measured hit rate for a tier, or null below the observation floor.
- *
- * Null rather than a small-sample number, because the caller substitutes it for
- * a modelled probability and three observations would swing the decision harder
- * than the model they replace.
- */
-export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
-  const relevant = outcomes.filter(
-    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
-  );
-  if (relevant.length < OBSERVATION_FLOOR) return null;
-  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
+export function recordRefresh(dir, { tier, prefixTokens, expectedValue, sessionId, at }) {
+  return record(dir, {
+    kind: 'keepwarm',
+    action: 'refresh',
+    tier,
+    prefixTokens,
+    expectedValue,
+    sessionId,
+    at,
+  });
 }
 
 /**
  * Records whether the refresh was used.
  *
  * `hit` means a real turn arrived before expiry, so the write bought a read.
+ * `refreshId` names the refresh this scores, so the same one cannot be scored
+ * twice -- once per turn for the rest of the session, which is what an
+ * unpaired outcome would become.
  */
-export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
+export function recordRefreshOutcome(dir, { tier, prefixTokens, hit, refreshId = null }) {
   const tierSpec = TIERS.find((t) => t.name === tier) || TIERS[0];
   // THE SAME LEDGER keepWarmDecision BUYS THE REFRESH WITH. That function is explicit that a
   // refresh is a PING, which READS the prefix -- costOfPing = prefixTokens * READ_MULTIPLIER --
@@ -317,7 +365,125 @@ export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
   const realised = hit
     ? prefixTokens * (tierSpec.writeMultiplier - READ_MULTIPLIER) - prefixTokens * READ_MULTIPLIER
     : -prefixTokens * READ_MULTIPLIER;
-  record(dir, { kind: 'keepwarm', action: 'outcome', tier, prefixTokens, hit: Boolean(hit), realised: Math.round(realised) });
+  record(dir, {
+    kind: 'keepwarm',
+    action: 'outcome',
+    tier,
+    prefixTokens,
+    hit: Boolean(hit),
+    refreshId,
+    realised: Math.round(realised),
+  });
+}
+
+/**
+ * Scores every recorded refresh whose window has closed -- and NOTHING ELSE.
+ *
+ * This is the arm that was missing. `recordRefresh` and `recordRefreshOutcome`
+ * were both correct and both called by nothing, so the decision spent money on
+ * refreshes and could never find out whether one bought a read.
+ *
+ * THE SIGNAL IS REAL, not invented. `gapDistribution` already treats this log's
+ * timestamps as turn arrivals -- that is the distribution the whole decision is
+ * fitted to -- so the same log answers the outcome question directly: a refresh
+ * at tier `5m` was used if a turn of the same session arrived within five
+ * minutes of it. Four cases refuse to answer rather than guess, and every one
+ * of them refuses in the direction that costs this project its own good news:
+ *
+ *   - `pending`: the window has not closed yet. A hit could be scored the
+ *     instant it arrives while a miss must wait out the whole TTL, so scoring
+ *     early would mean the recorded hits are always complete and the recorded
+ *     misses always lagging -- right-censoring, biased upward, invisible in any
+ *     test. So a hit waits exactly as long as a miss.
+ *   - `uncovered`: the arrival log no longer reaches back to the refresh, so
+ *     absence of an arrival is absence of evidence. RECORDING `hit: false` HERE
+ *     WOULD BE THE INVENTION THIS IS FORBIDDEN TO MAKE: an absent signal is not
+ *     a miss, and treating it as one biases every rate downward and would
+ *     eventually switch keep-warm off on no evidence at all.
+ *   - `unattributable`: the refresh names no session, so no arrival can be
+ *     shown to belong to it.
+ *   - already scored: an outcome already names this refresh.
+ *
+ * The firehose is READ LAZILY, and only when there is something to score. On a
+ * machine where nothing issues refreshes -- which is every machine today, since
+ * nothing in this repository issues one -- the whole cost is the outcome-log
+ * read: median 70 ms on a 3.5 MB log, of which readBalance is 49 ms, because
+ * that reader also scans the firehose tail for pre-split records.
+ */
+export function scoreRefreshes(dir, {
+  refreshes = readBalance(dir),
+  arrivals = null,
+  now = Date.now(),
+} = {}) {
+  const summary = { scored: 0, hits: 0, pending: 0, uncovered: 0, unattributable: 0 };
+  const keepwarm = refreshes.filter((event) => event?.kind === 'keepwarm');
+  const alreadyScored = new Set(
+    keepwarm
+      .filter((event) => event.action === 'outcome' && event.refreshId)
+      .map((event) => event.refreshId)
+  );
+  const unscored = keepwarm.filter(
+    (event) =>
+      event.action === 'refresh' &&
+      Number.isFinite(event.at) &&
+      event.id &&
+      !alreadyScored.has(event.id)
+  );
+
+  // A refresh with no id cannot be paired, so scoring it would write a fresh
+  // outcome on every turn forever. Reported, not silently dropped.
+  summary.unattributable += keepwarm.filter(
+    (event) => event.action === 'refresh' && (!event.id || !Number.isFinite(event.at))
+  ).length;
+
+  if (!unscored.length) return summary;
+
+  const events = (arrivals ? arrivals() : readMetrics(dir)).filter((event) =>
+    Number.isFinite(event?.at)
+  );
+  // Coverage is judged over EVERY event, including our own bookkeeping: the
+  // refresh's own copy in the firehose is what proves the window is still
+  // inside the read. Arrivals are judged over everything else, because a record
+  // keep-warm wrote about itself is not a turn -- and counting one would
+  // manufacture a hit out of the act of measuring.
+  const earliest = events.reduce((min, event) => Math.min(min, event.at), Infinity);
+  const turns = events.filter((event) => event.kind !== 'keepwarm');
+
+  for (const refresh of unscored) {
+    const tier = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    if (now - refresh.at < tier.ms) {
+      summary.pending += 1;
+      continue;
+    }
+    const session = refresh.sessionId;
+    if (!session) {
+      summary.unattributable += 1;
+      continue;
+    }
+    if (!(earliest <= refresh.at)) {
+      summary.uncovered += 1;
+      continue;
+    }
+
+    const opens = refresh.at + TURN_GAP_MS;
+    const closes = refresh.at + tier.ms;
+    const hit = turns.some(
+      (event) =>
+        (event.sessionId ?? event.episodeId) === session &&
+        event.at > opens &&
+        event.at <= closes
+    );
+    recordRefreshOutcome(dir, {
+      tier: refresh.tier,
+      prefixTokens: refresh.prefixTokens,
+      hit,
+      refreshId: refresh.id,
+    });
+    summary.scored += 1;
+    if (hit) summary.hits += 1;
+  }
+
+  return summary;
 }
 
 /**
@@ -372,23 +538,15 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
-  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
-  // becomes evidence now, so the decision below and the tripwire above both see
-  // the most that is currently knowable -- the same read-time drain the
-  // staleness path uses, and for the same reason: the producer cannot know the
-  // outcome at the moment it acts.
-  try {
-    scoreOutstandingRefreshes(dir, { events, outcomes });
-    outcomes = readBalance(dir);
-  } catch {
-    /* scoring is evidence, never a reason to refuse a decision */
-  }
-
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
+  // THE SAME ARRAY THE TRIPWIRE JUST READ, so closing the loop costs no extra
+  // I/O -- and so the decision and its backstop cannot be looking at different
+  // evidence about the same refreshes.
+  const observed = observedHitRates(outcomes);
   const gaps = gapDistribution(dir, { events });
-  const best = ttlTier({ prefixTokens, gaps });
+  const best = ttlTier({ prefixTokens, gaps, observed });
   if (!best) {
     // THE TWO MODELS ANSWER DIFFERENT QUESTIONS, so they may legitimately disagree. ttlTier asks
     // whether holding a cache beats not caching at all; keepWarmDecision asks whether ONE ping
@@ -397,11 +555,7 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({
-      prefixTokens,
-      gaps,
-      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
-    });
+    const decision = keepWarmDecision({ prefixTokens, gaps, observed });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/integrations/qwen/hooks/lib/loo.mjs
+++ b/integrations/qwen/hooks/lib/loo.mjs
@@ -1,0 +1,788 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/loo.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 2 -- what one finding is actually worth, measured by withholding it.
+ *
+ * Layer 1 asks whether the model went back and named a finding. This asks the
+ * harder question and answers it causally: WITHHOLD ONE FINDING while serving
+ * every other finding for the same touch, and compare what the session spent
+ * READING that anchor afterwards. Nobody in this space measures per-item value
+ * this way in production; the state of the art is an offline evaluation set.
+ * That is also why this file is more refusal than statistics -- a causal claim
+ * from four observations is worse than no claim, because it is a number and
+ * numbers get quoted.
+ *
+ * THE ESTIMAND IS READ-SUPPRESSION, and it is deliberately DISJOINT from Layer
+ * 1. Layer 1 keys on an explicit `query` naming a finding key. This keys on
+ * `read` events against the injection's anchor. Neither signal appears in the
+ * other's arithmetic: no `query` event is consulted here, and `usage.mjs`
+ * consults no `read` event. Task 8 calibrates one against the other, and if
+ * both derived from the same channel that calibration would report a strong
+ * correlation between two spellings of one quantity and mean nothing.
+ *
+ * IT INVENTS NO JOIN. `recordToolOutcome` already joins each post-tool result
+ * back to the injection that preceded it, recording `injectionId`,
+ * `findingIds` and a `joinMethod` of `tool-call-id` / `episode-anchor` /
+ * `none`. Every observation here is GATED on that join: an injection with no
+ * joined outcome is unattributable and enters neither arm, exactly as Layer 1
+ * treats `joinMethod: 'none'`. An earlier draft of this plan proposed a fresh
+ * `(sessionId, findingKey)` join; it was rejected and is not here.
+ *
+ * WHAT IT COSTS THE USER, because an experiment that degrades a turn owes an
+ * accounting. One withheld finding means the model may re-derive what it was
+ * told last time, and the worst case is one read of that anchor: measured on
+ * this machine, a median read is 3,769 tokens and the 90th percentile is
+ * 14,082. Five guards bound that exposure, and they are the reason the numbers
+ * below are as small as they are:
+ *
+ *   1. only on a FILE touch, because a command injection has no anchor a read
+ *      event can be joined to -- withholding there would cost a user a finding
+ *      and buy no observation at all (see `buildReport`, which excludes command
+ *      injections from the holdout balance for the same reason);
+ *   2. never when fewer than two findings were kept, so "leave one out" always
+ *      leaves something in -- otherwise it degenerates into `inHoldout`, which
+ *      withholds EVERY finding for an anchor and is a different experiment;
+ *   3. never in the same breath as `inHoldout`: if that arm already withheld
+ *      everything, there is nothing to leave out and a Layer 2 arm recorded
+ *      there would be a fabricated observation;
+ *   4. at most ONE finding per touch, or the effect is attributable to neither;
+ *   5. at most ONE withheld finding per SESSION, so the worst case a user can
+ *      experience is a single re-read -- not one per file they open.
+ *
+ * AND IT NEVER OVERRIDES A PERSON. A `pinned` or `origin: 'human'` finding is
+ * an explicit human decision to keep something in front of the model.
+ * Withholding it to run an experiment would overrule that decision for the
+ * convenience of the measurement, so those findings are exempt: they are
+ * always served, they get no causal score, and `looNote` says so rather than
+ * leaving a reader to wonder why they are missing from the table.
+ */
+
+import { createHash } from 'node:crypto';
+import { readEvidence, readMetrics, readTruncation, isFixtureAnchor } from './metrics.mjs';
+import { retrievalPolicy } from './utility.mjs';
+import { ORIGIN_HUMAN } from './curate.mjs';
+import { canonicalPath } from './paths.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Injections of a finding before it may enter the experiment.
+ *
+ * A finding nobody has served yet has no established value to measure the
+ * absence of, and withholding it would be measuring the cold start rather than
+ * the finding. Four is also what makes the ratio below reachable: at a quarter
+ * of (key, session) pairs armed, a key needs roughly a dozen enrolled
+ * injections before it can reach a verdict at all.
+ */
+export const MIN_PRIOR_INJECTIONS = 4;
+
+/** The observation floor. Below this there is no verdict -- and NOT a zero. */
+export const MIN_SERVED = 6;
+export const MIN_WITHHELD = 3;
+
+/** Benjamini-Hochberg false-discovery rate for published verdicts. */
+export const FDR_Q = 0.1;
+
+/**
+ * Exploration rate.
+ *
+ * Without this, utility feeds the ranking, the ranking feeds injection
+ * frequency, injection frequency feeds the observation count, and a low score
+ * becomes self-fulfilling: the finding is never served often enough to earn a
+ * better one. A tenth of touches therefore ignore the utility order and
+ * promote the LEAST-served candidate instead.
+ */
+export const EPSILON = 0.1;
+
+/**
+ * The share of (finding, session) pairs assigned to the withheld arm.
+ *
+ * Chosen against the floors rather than picked: MIN_SERVED / MIN_WITHHELD is
+ * 2:1, so a quarter withheld reaches both floors at about the same time while
+ * leaving three touches in four undamaged.
+ */
+export const WITHHOLD_FRACTION = 0.25;
+
+/**
+ * Withheld findings allowed per session. ONE.
+ *
+ * The per-touch cap alone bounds nothing across a session: a session that
+ * opens twelve files with enrolled findings could have withheld twelve. This
+ * makes the worst case a user can experience one re-read, at the price of a
+ * mild confound that is stated rather than hidden -- when the cap binds, the
+ * other armed findings in that session are served, so the served arm is
+ * slightly enriched by sessions that touch many enrolled findings.
+ */
+export const MAX_WITHHELD_PER_SESSION = 1;
+
+/**
+ * Fallback shrinkage weight when the between-finding variance cannot be
+ * estimated (fewer than two findings with both arms, or no dispersion at all).
+ *
+ * MIN_SERVED + MIN_WITHHELD, deliberately: a finding's own data outweighs the
+ * population prior only once it has reached the publication floor.
+ */
+export const SHRINKAGE_K = MIN_SERVED + MIN_WITHHELD;
+
+/** Bounds on the estimated shrinkage weight, so a degenerate variance ratio cannot run away. */
+const K_MIN = 1;
+const K_MAX = 100;
+
+/**
+ * Bumped BY HAND when the serving code changes in a way that could move a
+ * finding's measured effect. It is the part of the policy version a hash of the
+ * configuration cannot see.
+ */
+export const LOO_POLICY_GENERATION = 1;
+
+/** Permutation budget before the exact null distribution is sampled instead of enumerated. */
+const MAX_EXACT_PERMUTATIONS = 20_000;
+const SAMPLED_PERMUTATIONS = 10_000;
+
+/**
+ * On by default, off by `TOKEN_OPTIMIZER_LOO=off`.
+ *
+ * Read per call rather than at module load, for the reason `holdoutFraction`
+ * gives: a long-lived process started before the setting changed would
+ * otherwise honour the old value forever with no way to tell.
+ */
+export function LOO_ENABLED() {
+  return String(process.env.TOKEN_OPTIMIZER_LOO || '').trim().toLowerCase() !== 'off';
+}
+
+/**
+ * The serving policy an observation was collected under.
+ *
+ * WHY EVERY OBSERVATION CARRIES ONE. An effect is only meaningful against a
+ * fixed policy. Halve the touch budget or move the minimum net utility and the
+ * same finding is served in different company, at a different rank, against a
+ * different counterfactual -- so pooling observations from before and after
+ * that change would average two different experiments and call the result
+ * causal. `effects()` therefore groups by (finding, policy) and never across.
+ *
+ * IT IS DELIBERATELY ABSENT FROM THE ARM HASH. Including it would reassign
+ * arms the moment a setting changed, which is precisely the mid-session flip
+ * the arm hash exists to prevent. Configuration decides which experiment an
+ * observation belongs to; it must never decide which arm.
+ */
+export function servingPolicyVersion() {
+  const policy = retrievalPolicy();
+  const parts = [
+    `g${LOO_POLICY_GENERATION}`,
+    `touch=${Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500}`,
+    `benefit=${policy.baseBenefitTokens}`,
+    `minutility=${policy.minimumNetUtility}`,
+    `cooldown=${policy.cooldownMs}`,
+    `quarantine=${policy.quarantineHarmCount}`,
+    `holdout=${process.env.TOKEN_OPTIMIZER_HOLDOUT ?? 'default'}`,
+    `withhold=${WITHHOLD_FRACTION}`,
+    `prior=${MIN_PRIOR_INJECTIONS}`,
+    `epsilon=${EPSILON}`,
+  ];
+  const digest = createHash('sha256').update(parts.join('|')).digest('hex');
+  return `${LOO_POLICY_GENERATION}-${digest.slice(0, 8)}`;
+}
+
+/**
+ * A stable number in [0, 1) from a string.
+ *
+ * SHA-256 rather than SHA-1 for the same reason `inHoldout` uses it: this is a
+ * bucketing hash and nothing here is secret, but arguing that a CodeQL finding
+ * is benign is a worse habit than paying a cost that rounds to nothing.
+ */
+function bucket(text) {
+  return createHash('sha256').update(String(text)).digest().readUInt32BE(0) / 4_294_967_296;
+}
+
+/**
+ * The arm of one finding in one session.
+ *
+ * Keyed on (findingKey, sessionId) AND NOTHING ELSE, so a finding cannot
+ * change arms partway through a session: not when the candidate set changes,
+ * not when the budget changes, not when the graph grows. The measurement is a
+ * comparison between sessions, and an arm that flips inside one contaminates
+ * both sides of it.
+ */
+function armed(findingKey, sessionId) {
+  return bucket(`loo-arm:${findingKey}:${sessionId}`) < WITHHOLD_FRACTION;
+}
+
+/** Deterministic tiebreak among armed candidates: lowest bucket, then key order. */
+function armRank(findingKey, sessionId) {
+  return bucket(`loo-rank:${findingKey}:${sessionId}`);
+}
+
+/** The graph node for a finding key, or null. Keys are unique per graph. */
+function findingNode(graph, key) {
+  const nodes = graph?.nodes;
+  if (!nodes || typeof nodes.values !== 'function') return null;
+  for (const node of nodes.values()) {
+    if (node?.kind === 'finding' && node.key === key) return node;
+    // A fixture graph may omit `kind`; key identity is what this needs.
+    if (node?.key === key && node.kind === undefined) return node;
+  }
+  return null;
+}
+
+/**
+ * May this finding ever be withheld?
+ *
+ * FAILS CLOSED ON AN UNKNOWN KEY, which is the opposite of how the rest of
+ * this module fails. Everywhere else a missing input costs a measurement; here
+ * it could cost a human their explicit decision, because a key whose node
+ * cannot be read is a key whose `pinned` and `origin` cannot be checked.
+ */
+function withholdable(graph, key) {
+  const node = findingNode(graph, key);
+  if (!node) return false;
+  if (node.pinned) return false;
+  if (node.origin === ORIGIN_HUMAN) return false;
+  if (node.retired) return false;
+  return true;
+}
+
+/** Prior SERVED injections per finding key, and withheld injections per session. */
+function history(dir, { evidence = null } = {}) {
+  const priorServed = new Map();
+  const withheldPerSession = new Map();
+  const events = evidence || readEvidence(dir);
+  for (const event of events) {
+    if (event.kind !== 'inject') continue;
+    if (typeof event.loo === 'string' && event.loo) {
+      const session = typeof event.sessionId === 'string' ? event.sessionId : '';
+      withheldPerSession.set(session, (withheldPerSession.get(session) || 0) + 1);
+    }
+    if (event.holdout) continue;
+    const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+    for (const raw of keys) {
+      const key = String(raw);
+      priorServed.set(key, (priorServed.get(key) || 0) + 1);
+    }
+  }
+  return { priorServed, withheldPerSession };
+}
+
+/**
+ * Which single finding to withhold from this touch, or null.
+ *
+ * Called from `forTouch` AFTER `fit` has decided what would have been served,
+ * which is the only ordering that produces a true leave-one-out. Withholding
+ * BEFORE the budget runs would let a lower-ranked finding take the freed
+ * tokens, so the withheld arm would receive different company as well as one
+ * fewer finding, and the comparison would confound the two.
+ *
+ * @param {string[]} findingKeys keys that would otherwise be delivered
+ * @param {string} sessionId the session, which pins the arm
+ * @param {object} graph the loaded graph, for `pinned` / `origin`
+ * @param {string|null} dir graph directory, for the injection history
+ */
+export function withheldFor(findingKeys, sessionId, graph, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return null;
+
+    // Every guard that needs no I/O runs first: this is the PreToolUse path,
+    // and on a project with one finding per anchor the answer is null before
+    // anything is read.
+    const keys = [...new Set((findingKeys || []).map((k) => String(k)).filter(Boolean))];
+    if (keys.length < 2) return null;
+    if (!sessionId || typeof sessionId !== 'string') return null;
+
+    // FILE SURFACE ONLY. A command injection's anchor is the command text, and
+    // no read event will ever match it -- so both arms would score zero
+    // downstream and the finding would be scored on nothing.
+    const { surface = 'file', anchor = '', holdout = false } = options;
+    if (surface !== 'file' || !anchor) return null;
+    // The all-findings holdout already withheld everything for this anchor.
+    if (holdout) return null;
+
+    const eligible = keys.filter((key) => withholdable(graph, key));
+    if (!eligible.length) return null;
+
+    const { priorServed, withheldPerSession } = history(dir, options);
+    if ((withheldPerSession.get(sessionId) || 0) >= MAX_WITHHELD_PER_SESSION) return null;
+
+    const enrolled = eligible.filter(
+      (key) => (priorServed.get(key) || 0) >= MIN_PRIOR_INJECTIONS
+    );
+    if (!enrolled.length) return null;
+
+    const candidates = enrolled.filter((key) => armed(key, sessionId));
+    if (!candidates.length) return null;
+
+    // AT MOST ONE. Sorted deterministically so the same touch always yields the
+    // same choice; the findings that lose the tiebreak are SERVED, and the
+    // observation records what actually happened rather than what the arm hash
+    // intended.
+    candidates.sort(
+      (a, b) => armRank(a, sessionId) - armRank(b, sessionId) || (a < b ? -1 : a > b ? 1 : 0)
+    );
+    return candidates[0];
+  } catch {
+    // An experiment must never break a tool call. Failing open here means
+    // serving everything, which is the undegraded behaviour.
+    return null;
+  }
+}
+
+/**
+ * Reorders candidates so exploration can break the feedback loop.
+ *
+ * A tenth of touches -- deterministic in (session, anchor), not random, so the
+ * same touch behaves the same way twice -- promote the LEAST-served candidate
+ * ahead of the utility order, giving it a chance to survive `fit` and accrue
+ * the observations it needs to earn a score. The other nine tenths are
+ * untouched.
+ *
+ * @param {Array<{finding:{key:string}}>} items assessed candidates, best first
+ */
+export function exploreOrder(items, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return items;
+    const list = Array.isArray(items) ? items : [];
+    if (list.length < 2) return list;
+    const { sessionId = '', anchor = '' } = options;
+    if (bucket(`loo-explore:${sessionId}:${anchor}`) >= EPSILON) return list;
+
+    const keyOf = (item) => String(item?.finding?.key ?? item?.key ?? '');
+    const { priorServed } = history(dir, options);
+    let promoted = 0;
+    for (let i = 1; i < list.length; i += 1) {
+      const a = priorServed.get(keyOf(list[i])) || 0;
+      const b = priorServed.get(keyOf(list[promoted])) || 0;
+      if (a < b || (a === b && keyOf(list[i]) < keyOf(list[promoted]))) promoted = i;
+    }
+    if (promoted === 0) return list;
+    return [list[promoted], ...list.filter((_, i) => i !== promoted)];
+  } catch {
+    return Array.isArray(items) ? items : [];
+  }
+}
+
+const mean = (values) =>
+  values.length ? values.reduce((sum, v) => sum + v, 0) / values.length : 0;
+
+/** Sample variance (n-1). Zero for a single observation: dispersion is unknown, not large. */
+function variance(values) {
+  if (values.length < 2) return 0;
+  const m = mean(values);
+  return values.reduce((sum, v) => sum + (v - m) * (v - m), 0) / (values.length - 1);
+}
+
+/**
+ * Every attributable Layer 2 observation, one per (injection, finding, arm).
+ *
+ * THREE THINGS ARE REPORTED SEPARATELY RATHER THAN FOLDED IN, because each of
+ * them would otherwise turn an absence into a zero:
+ *
+ *   `unattributable`  the outcome join could not attach a tool call to the
+ *                     injection, so nothing is known about what followed it.
+ *   `excluded`        the injection could never produce a read-join at all
+ *                     (command surface, session-start, fixture anchor) or was
+ *                     already in the all-findings holdout.
+ *   `costObservations` how many observations saw a non-zero read cost. If this
+ *                     is zero, "withholding changed nothing" and "the read
+ *                     channel never fired" are the same picture, and only one
+ *                     of them is a finding about findings.
+ */
+export function observations(dir, { events = null, evidence = null } = {}) {
+  const empty = {
+    rows: [],
+    unattributable: 0,
+    unattributableOutcomes: 0,
+    excluded: { command: 0, holdout: 0, fixture: 0, unanchored: 0 },
+    injections: 0,
+    withheldInjections: 0,
+    costObservations: 0,
+    policies: [],
+    windowed: false,
+  };
+  try {
+    const causal = evidence || readEvidence(dir);
+    const all = events || readMetrics(dir);
+    // OUT OF BAND and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` describes the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
+
+    // THE JOIN THIS MODULE CONSUMES AND DOES NOT REPLACE.
+    const joined = new Set();
+    let unattributableOutcomes = 0;
+    for (const event of causal) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) {
+        unattributableOutcomes += 1;
+        continue;
+      }
+      joined.add(String(event.injectionId));
+    }
+
+    // Read cost, grouped the way `buildReport` groups it: (session, anchor),
+    // canonicalised on both sides so two spellings of one file are one anchor.
+    // A mismatch here would make every read invisible and report a clean zero
+    // effect in both arms -- correct code, absent measurement.
+    const reads = new Map();
+    for (const event of all) {
+      if (event.kind !== 'read' || !event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      if (!reads.has(key)) reads.set(key, []);
+      reads.get(key).push(event);
+    }
+
+    const injects = causal
+      .filter((event) => event.kind === 'inject')
+      .map((event, index) => ({ event, index }))
+      .sort((a, b) => (a.event.at || 0) - (b.event.at || 0) || a.index - b.index)
+      .map((row) => row.event);
+
+    // How many injections share each (session, anchor), so a key's read total
+    // is SPLIT between them rather than charged in full to each -- the same
+    // correction `buildReport` applies, and for the same reason: without it the
+    // arm means scale with injections-per-anchor instead of per-touch cost.
+    const perKey = new Map();
+    for (const event of injects) {
+      if (!event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      perKey.set(key, (perKey.get(key) || 0) + 1);
+    }
+
+    const rows = [];
+    const excluded = { command: 0, holdout: 0, fixture: 0, unanchored: 0 };
+    const priorServed = new Map();
+    const policies = new Set();
+    let unattributable = 0;
+    let considered = 0;
+    let withheldInjections = 0;
+
+    for (const event of injects) {
+      const served = (Array.isArray(event.findingIds) ? event.findingIds : []).map(String);
+      const withheldKey = typeof event.loo === 'string' && event.loo ? event.loo : null;
+      const bump = () => {
+        for (const key of served) priorServed.set(key, (priorServed.get(key) || 0) + 1);
+      };
+
+      const isCommand =
+        event.surface === 'command' ||
+        event.trigger === 'command' ||
+        event.surface === 'session-start';
+      if (isCommand) {
+        excluded.command += 1;
+        bump();
+        continue;
+      }
+      if (!event.anchor) {
+        excluded.unanchored += 1;
+        bump();
+        continue;
+      }
+      if (isFixtureAnchor(event.anchor)) {
+        excluded.fixture += 1;
+        bump();
+        continue;
+      }
+      if (event.holdout) {
+        excluded.holdout += 1;
+        bump();
+        continue;
+      }
+
+      considered += 1;
+      if (withheldKey) withheldInjections += 1;
+      const policy = typeof event.looPolicy === 'string' && event.looPolicy
+        ? event.looPolicy
+        : 'unversioned';
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const attributable = Boolean(injectionId && joined.has(injectionId));
+
+      // DOWNSTREAM MEANS AFTER, STRICTLY. The read that triggered the touch is
+      // not caused by the advice; it happened before the advice existed.
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      const at = event.at || 0;
+      const total = (reads.get(key) || []).reduce(
+        (sum, read) => sum + ((read.at || 0) > at ? read.tokens || 0 : 0),
+        0
+      );
+      const cost = total / Math.max(1, perKey.get(key) || 1);
+
+      const observe = (findingKey, arm) => {
+        // ENROLMENT IS RE-DERIVED FROM THE LOG rather than trusted from the
+        // serving decision. It is the one field an old or hand-written record
+        // could contradict, and a served observation from before a finding was
+        // enrolled would compare an established finding against its own cold
+        // start.
+        //
+        // CHECKED BEFORE ATTRIBUTABILITY, so `unattributable` counts only
+        // observations the experiment actually wanted. Counting the rest there
+        // would report a join failure for every finding that was never in the
+        // experiment to begin with -- the same shape as the 2,559-row
+        // measurement-bias defect Layer 1 found in its own first draft.
+        if ((priorServed.get(findingKey) || 0) < MIN_PRIOR_INJECTIONS) return;
+        if (!attributable) {
+          unattributable += 1;
+          return;
+        }
+        policies.add(policy);
+        rows.push({ findingKey, arm, cost, policy, injectionId, anchor: event.anchor });
+      };
+
+      if (withheldKey) observe(withheldKey, 'withheld');
+      for (const findingKey of served) observe(findingKey, 'served');
+      bump();
+    }
+
+    return {
+      rows,
+      unattributable,
+      unattributableOutcomes,
+      excluded,
+      injections: considered,
+      withheldInjections,
+      costObservations: rows.filter((row) => row.cost > 0).length,
+      policies: [...policies].sort(),
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
+function permutationP(servedCosts, withheldCosts) {
+  const pooled = [...servedCosts, ...withheldCosts];
+  const n = pooled.length;
+  const k = withheldCosts.length;
+  if (!k || k === n) return null;
+  const observed = Math.abs(mean(withheldCosts) - mean(servedCosts));
+  const total = pooled.reduce((sum, v) => sum + v, 0);
+  // Mean difference from the withheld-arm sum alone: the served sum is the
+  // complement, so one number decides the statistic.
+  const diffFrom = (withheldSum) =>
+    Math.abs(withheldSum / k - (total - withheldSum) / (n - k));
+
+  const choose = (a, b) => {
+    let out = 1;
+    for (let i = 1; i <= b; i += 1) out = (out * (a - b + i)) / i;
+    return out;
+  };
+
+  const tolerance = 1e-9;
+  if (choose(n, k) <= MAX_EXACT_PERMUTATIONS) {
+    let extreme = 0;
+    let count = 0;
+    const walk = (start, chosen, sum) => {
+      if (chosen === k) {
+        count += 1;
+        if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+        return;
+      }
+      for (let i = start; i <= n - (k - chosen); i += 1) walk(i + 1, chosen + 1, sum + pooled[i]);
+    };
+    walk(0, 0, 0);
+    return count ? extreme / count : null;
+  }
+
+  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
+  // the same p-value and a verdict cannot flicker between two audit runs.
+  let state = 0x9e3779b9;
+  const random = () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4_294_967_296;
+  };
+  let extreme = 0;
+  const order = [...pooled];
+  for (let round = 0; round < SAMPLED_PERMUTATIONS; round += 1) {
+    for (let i = order.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(random() * (i + 1));
+      [order[i], order[j]] = [order[j], order[i]];
+    }
+    let sum = 0;
+    for (let i = 0; i < k; i += 1) sum += order[i];
+    if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+  }
+  return (extreme + 1) / (SAMPLED_PERMUTATIONS + 1);
+}
+
+/**
+ * The per-finding causal effect, shrunk, and whether it may be published.
+ *
+ * `raw` is `mean(withheld) - mean(served)`: POSITIVE means the session read the
+ * anchor more when the finding was withheld, which is the finding earning its
+ * place. `shrunk` is the number a reader should use.
+ *
+ * EMPIRICAL BAYES, and both halves of it come from the data. The prior mean is
+ * the population effect across findings; the weight `k` is the ratio of
+ * within-finding noise to between-finding spread, so a population where every
+ * finding behaves alike shrinks hard and one where they genuinely differ
+ * shrinks little. `SHRINKAGE_K` is the fallback when that spread cannot be
+ * estimated at all. Two observations therefore cannot post a wild score.
+ *
+ * PUBLICATION IS NOT THE SAME QUESTION as having an estimate. A row is
+ * published only if it clears the observation floor AND its permutation
+ * p-value survives Benjamini-Hochberg at q = 0.10 across every candidate row.
+ * Everything else gets `published: false` -- which is not a zero effect, and
+ * `looNote` says which of the two it is. An all-zero-cost population needs no
+ * separate guard: p is exactly 1 there, so nothing can publish anyway.
+ *
+ * NEVER POOLED ACROSS POLICY VERSIONS: rows are keyed on (findingKey, policy).
+ */
+export function effects(dir, options = {}) {
+  try {
+    // `obs` is accepted so `looNote` can read the logs once for both.
+    const obs = options.obs || observations(dir, options);
+    const groups = new Map();
+    for (const row of obs.rows) {
+      const id = JSON.stringify([row.findingKey, row.policy]);
+      if (!groups.has(id))
+        groups.set(id, { findingKey: row.findingKey, policy: row.policy, served: [], withheld: [] });
+      groups.get(id)[row.arm === 'withheld' ? 'withheld' : 'served'].push(row.cost);
+    }
+
+    const raws = [];
+    const withinVars = [];
+    for (const group of groups.values()) {
+      if (!group.served.length || !group.withheld.length) continue;
+      raws.push(mean(group.withheld) - mean(group.served));
+      withinVars.push(
+        variance(group.withheld) / group.withheld.length +
+          variance(group.served) / group.served.length
+      );
+    }
+    const prior = raws.length ? mean(raws) : 0;
+    const within = withinVars.length ? mean(withinVars) : 0;
+    const between = raws.length > 1 ? Math.max(0, variance(raws) - within) : 0;
+    const weight =
+      between > 0 && within > 0
+        ? Math.min(K_MAX, Math.max(K_MIN, within / between))
+        : SHRINKAGE_K;
+
+    const rows = [...groups.values()]
+      .map((group) => {
+        const served = group.served.length;
+        const withheld = group.withheld.length;
+        const both = served > 0 && withheld > 0;
+        const raw = both ? mean(group.withheld) - mean(group.served) : null;
+        const n = served + withheld;
+        const shrunk = raw === null ? null : (n * raw + weight * prior) / (n + weight);
+        const eligible = served >= MIN_SERVED && withheld >= MIN_WITHHELD;
+        return {
+          findingKey: group.findingKey,
+          policy: group.policy,
+          served,
+          withheld,
+          servedMean: mean(group.served),
+          withheldMean: mean(group.withheld),
+          raw,
+          shrunk,
+          p: eligible ? permutationP(group.served, group.withheld) : null,
+          published: false,
+        };
+      })
+      .sort((a, b) =>
+        a.findingKey < b.findingKey ? -1 : a.findingKey > b.findingKey ? 1 : a.policy < b.policy ? -1 : 1
+      );
+
+    // BENJAMINI-HOCHBERG at q = 0.10 over every row that cleared the floor.
+    // One finding tested in isolation would publish at p < 0.10; a hundred
+    // would publish ten false ones, and this module's whole claim is that its
+    // numbers can be quoted.
+    //
+    // THERE IS NO SEPARATE "WAS ANY READ COST OBSERVED" GATE HERE, and its
+    // absence is deliberate rather than an omission. One was written, and
+    // mutation testing showed it could not change a single verdict: if every
+    // observation has zero cost then both arm means are zero, the permutation
+    // statistic is zero for every relabelling, and p is exactly 1 -- which no
+    // BH threshold can pass. The guard was unfalsifiable, and an unfalsifiable
+    // guard is worse than none because it reads as protection nobody can test.
+    // `costObservations` survives as what it can honestly be: a DISCLOSURE, so
+    // `looNote` can say the read channel never fired instead of letting a
+    // reader take an arithmetic zero for a measured one.
+    const candidates = rows
+      .filter((row) => row.p !== null)
+      .sort((a, b) => a.p - b.p);
+    const m = candidates.length;
+    let cutoff = 0;
+    for (let i = 0; i < m; i += 1) {
+      if (candidates[i].p <= ((i + 1) / m) * FDR_Q) cutoff = i + 1;
+    }
+    for (let i = 0; i < cutoff; i += 1) candidates[i].published = true;
+
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * One or two lines for the audit, or nothing at all.
+ *
+ * THE REFUSAL IS THE PRODUCT HERE. On a machine with two injections in sixteen
+ * thousand events, the only honest output is that nothing is measurable yet,
+ * and this says so with the counts that make it checkable rather than printing
+ * a mean of nothing. It returns `null` when Layer 2 has not collected a single
+ * observation, so an idle experiment costs the reader no line at all -- the
+ * same standard `referenceNote` holds itself to.
+ */
+export function looNote(dir, options = {}) {
+  try {
+    const obs = options.obs || observations(dir, options);
+    const rows = effects(dir, { ...options, obs });
+    if (!obs.rows.length && !obs.withheldInjections) return null;
+
+    let graph = options.graph;
+    if (graph === undefined) {
+      try {
+        graph = load(dir);
+      } catch {
+        graph = null;
+      }
+    }
+    let exempt = 0;
+    if (graph?.nodes?.values) {
+      for (const node of graph.nodes.values()) {
+        if (node?.kind !== 'finding' || node.retired) continue;
+        if (node.pinned || node.origin === ORIGIN_HUMAN) exempt += 1;
+      }
+    }
+
+    const published = rows.filter((row) => row.published);
+    const head = published.length
+      ? `Per-finding causal value (leave-one-out): ${published.length} of ${rows.length} ` +
+        `findings show a verdict at q=${FDR_Q}` +
+        published
+          .slice(0, 3)
+          .map(
+            (row) =>
+              `; ${row.findingKey} saves ~${Math.round(row.shrunk)} tokens/touch ` +
+              `(${row.served} served, ${row.withheld} withheld, p=${row.p.toFixed(3)})`
+          )
+          .join('') +
+        '.'
+      : `Per-finding causal value (leave-one-out): NOT MEASURABLE YET -- ` +
+        `${obs.rows.length} attributable observations across ${rows.length} findings, ` +
+        `${obs.withheldInjections} withheld touches; the floor is ${MIN_SERVED} served ` +
+        `and ${MIN_WITHHELD} withheld per finding` +
+        (obs.costObservations ? '' : ', and no read cost has been observed in either arm') +
+        '. No effect is reported, which is not the same as an effect of zero.';
+
+    const caveats = [];
+    if (obs.unattributable)
+      caveats.push(
+        `${obs.unattributable} observations were unattributable (no joined tool outcome) and are in neither arm`
+      );
+    if (exempt)
+      caveats.push(
+        `${exempt} pinned or human-origin findings are exempt from withholding and get no causal score`
+      );
+    if (obs.policies.length > 1)
+      caveats.push(
+        `observations span ${obs.policies.length} serving-policy versions and are never pooled across them`
+      );
+    if (obs.windowed)
+      caveats.push('the read log was truncated, so downstream cost can understate');
+    return caveats.length ? `${head} ${caveats.join('; ')}.` : head;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/qwen/hooks/lib/loo.mjs
+++ b/integrations/qwen/hooks/lib/loo.mjs
@@ -545,8 +545,22 @@ export function observations(dir, { events = null, evidence = null } = {}) {
   }
 }
 
-/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
-function permutationP(servedCosts, withheldCosts) {
+/**
+ * Enumerates or samples arm relabellings and returns a two-sided p-value.
+ *
+ * EXPORTED so the cross-layer headline can be held to the same standard as the
+ * per-finding rows it summarises. `crosslayer.mjs` runs this over the two ARMS
+ * of shrunk effect estimates; the statistic, the enumerate-or-sample switch and the
+ * tolerance are therefore shared rather than reimplemented, and there is one
+ * place where "two-sided" is decided.
+ *
+ * `seed` exists for that caller. The default reproduces the fixed seed this
+ * function has always used, so Layer 2's own p-values are byte-identical; the
+ * cross-layer caller passes a seed DERIVED FROM ITS DATA, because a verdict
+ * printed to a human must not depend on `Math.random()` or on which module
+ * happened to call first.
+ */
+export function permutationP(servedCosts, withheldCosts, { seed = 0x9e3779b9 } = {}) {
   const pooled = [...servedCosts, ...withheldCosts];
   const n = pooled.length;
   const k = withheldCosts.length;
@@ -580,9 +594,10 @@ function permutationP(servedCosts, withheldCosts) {
     return count ? extreme / count : null;
   }
 
-  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
-  // the same p-value and a verdict cannot flicker between two audit runs.
-  let state = 0x9e3779b9;
+  // Mulberry32 off the caller's seed: reproducible, so the same data always
+  // yields the same p-value and a verdict cannot flicker between two audit
+  // runs.
+  let state = seed | 0;
   const random = () => {
     state = (state + 0x6d2b79f5) | 0;
     let t = state;

--- a/integrations/qwen/hooks/lib/metrics.mjs
+++ b/integrations/qwen/hooks/lib/metrics.mjs
@@ -31,6 +31,7 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { createHash, randomBytes } from 'node:crypto';
+import { redact } from './redact.mjs';
 
 /**
  * Read per call, not once at module load.
@@ -517,6 +518,15 @@ export function readEvidence(dir) {
 }
 
 /**
+ * The captured-output budget, in characters.
+ *
+ * Small enough that a 3 MB test log cannot bloat the evidence log or a single
+ * injected claim, large enough to hold the stack trace or compiler diagnostic
+ * that makes a failure finding worth anything.
+ */
+const OUTPUT_MAX_BYTES = 4096;
+
+/**
  * Joins a post-tool result to the most recent matching injection.  The exact
  * tool-call id wins; clients that omit it fall back to episode + surface +
  * anchor, in timestamp order, and the report states the weaker join method.
@@ -545,10 +555,31 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
+  // text is INJECTED into model context and EXPORTED to markdown, so the
+  // boundary is the only place that can guarantee it: a second caller added
+  // later would otherwise have to remember, and the one that forgot would leak
+  // a secret into two more places than the terminal it came from. `undefined`
+  // rather than `''` when nothing was captured, so JSON.stringify omits the
+  // key entirely and an absent capture is distinguishable from an empty one.
+  const output =
+    outcome.output === undefined || outcome.output === null
+      ? undefined
+      : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
+  // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric
+  // code at all, and 0 is the success value -- defaulting to it would claim
+  // every unreported call exited cleanly, which is a fabricated observation
+  // rather than a missing one.
+  const exit = Number.isInteger(outcome.exit) ? outcome.exit : null;
+
   return record(dir, {
     kind: 'tool-outcome',
     ...outcome,
     anchor,
+    // AFTER the spread, so a caller cannot smuggle raw text past the boundary
+    // by setting the field itself.
+    output,
+    exit,
     injectionId: injection?.injectionId || null,
     findingIds: injection?.findingIds || [],
     joinMethod,

--- a/integrations/qwen/hooks/lib/metrics.mjs
+++ b/integrations/qwen/hooks/lib/metrics.mjs
@@ -555,6 +555,22 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // FAILURES ONLY, and that is a deliberate override of the original plan.
+  // The plan predates MCP tool names reaching this path, so it never
+  // considered that a SUCCESSFUL `smart_read` would deposit 4 KB of file
+  // content into the evidence log on every call -- the log would grow with
+  // file text and the privacy surface would be every file the session opened.
+  //
+  // Nothing downstream loses anything. A failure claim quotes the error text;
+  // a "this command works" claim needs only the fact that it worked, which
+  // `success` and `exit` already carry. So the stored text narrows to text
+  // that is already an error message.
+  //
+  // GATED ON `success === true`, not on `!== false`: an outcome that never
+  // said whether it worked is unclassified, not successful, and dropping its
+  // text would lose exactly the failures a client too terse to report status
+  // produces.
+  const captureOutput = outcome.success !== true;
   // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
   // text is INJECTED into model context and EXPORTED to markdown, so the
   // boundary is the only place that can guarantee it: a second caller added
@@ -563,7 +579,7 @@ export function recordToolOutcome(dir, outcome) {
   // rather than `''` when nothing was captured, so JSON.stringify omits the
   // key entirely and an absent capture is distinguishable from an empty one.
   const output =
-    outcome.output === undefined || outcome.output === null
+    !captureOutput || outcome.output === undefined || outcome.output === null
       ? undefined
       : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
   // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric

--- a/integrations/qwen/hooks/lib/metrics.mjs
+++ b/integrations/qwen/hooks/lib/metrics.mjs
@@ -663,6 +663,89 @@ export function isFixtureAnchor(anchor) {
  * Fixture anchors are excluded from both.
  */
 /**
+ * Re-reads grouped by anchor -- the one place that decides what "wasteful" means.
+ *
+ * `rereadWaste` needed only the totals, so the grouping lived inside it and the
+ * per-anchor rows were thrown away. `derive.mjs`'s churn detector needs the
+ * rows, and re-deriving them there would put TWO definitions of "a repeat read
+ * of an unchanged file is waste" in the codebase, free to drift apart -- the
+ * exact divergence `npm run sync:hooks` exists to prevent between hooks-core and
+ * its generated copies. So the grouping lives here and both consumers read it.
+ *
+ * A re-read is only a re-read INSIDE ONE SESSION: grouping is keyed on
+ * session + canonical anchor, and rows are then merged per anchor so a file
+ * re-read across three sessions reports as one anchor with the sum of its
+ * repeats rather than three rows the caller has to add up. Merging cannot move
+ * the totals -- a sum of sums -- which is what makes it safe for `rereadWaste`.
+ *
+ * `tokens` is the WASTEFUL token count, not the total: it is the only one of the
+ * three that names something recoverable, and a row whose headline number
+ * included legitimate re-reads would overstate exactly the way the first
+ * version of this measurement did.
+ *
+ * @returns {Array<{anchor: string, repeats: number, wasteful: number,
+ *   tokens: number, legitimate: number, legitimateTokens: number,
+ *   undecidable: number, undecidableTokens: number}>} descending by `wasteful`,
+ *   then by `repeats`.
+ */
+export function rereadsByAnchor(events = [], { includeFixtures = false } = {}) {
+  const groups = new Map();
+  for (const e of events) {
+    if (!e || e.kind !== 'read' || !e.anchor) continue;
+    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
+    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(e);
+  }
+
+  const rows = new Map();
+  for (const list of groups.values()) {
+    if (list.length < 2) continue;
+    list.sort((a, b) => (a.at || 0) - (b.at || 0));
+
+    const anchorKey = canonicalKeyish(list[0].anchor);
+    let row = rows.get(anchorKey);
+    if (!row) {
+      row = {
+        anchor: list[0].anchor,
+        repeats: 0,
+        wasteful: 0,
+        tokens: 0,
+        legitimate: 0,
+        legitimateTokens: 0,
+        undecidable: 0,
+        undecidableTokens: 0,
+      };
+      rows.set(anchorKey, row);
+    }
+
+    for (let i = 1; i < list.length; i++) {
+      const prev = list[i - 1];
+      const cur = list[i];
+      const tokens = cur.tokens || 0;
+      row.repeats += 1;
+      // THE JUDGEMENT, in one place. A repeat read of a file that CHANGED is
+      // correct behaviour, not waste; a read written before fingerprints
+      // existed cannot be judged at all and says so.
+      if (!prev.fp || !cur.fp) {
+        row.undecidable += 1;
+        row.undecidableTokens += tokens;
+      } else if (prev.fp === cur.fp) {
+        row.wasteful += 1;
+        row.tokens += tokens;
+      } else {
+        row.legitimate += 1;
+        row.legitimateTokens += tokens;
+      }
+    }
+  }
+
+  return [...rows.values()].sort(
+    (a, b) => b.wasteful - a.wasteful || b.repeats - a.repeats
+  );
+}
+
+/**
  * Re-read waste, split into what is KNOWN and what is not.
  *
  * The question is narrow on purpose: how often does one session read the same
@@ -677,6 +760,9 @@ export function isFixtureAnchor(anchor) {
  * `undecidable` is reported rather than hidden. Reads written before the
  * fingerprint existed cannot be classified, and a measurement that quietly
  * counted them either way would be inventing its own answer.
+ *
+ * The aggregate fields are UNCHANGED -- `balanceSheet` reads them -- and are now
+ * a fold over `rereadsByAnchor`'s rows. `worst` is purely additive.
  */
 export function rereadWaste(
   dir,
@@ -685,14 +771,7 @@ export function rereadWaste(
   // excludes by design, making the real path untestable.
   { events = readMetrics(dir), includeFixtures = false } = {}
 ) {
-  const groups = new Map();
-  for (const e of events) {
-    if (e.kind !== 'read' || !e.anchor) continue;
-    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
-    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key).push(e);
-  }
+  const rows = rereadsByAnchor(events, { includeFixtures });
 
   const out = {
     repeats: 0,
@@ -704,29 +783,21 @@ export function rereadWaste(
     undecidableTokens: 0,
   };
 
-  for (const list of groups.values()) {
-    if (list.length < 2) continue;
-    list.sort((a, b) => (a.at || 0) - (b.at || 0));
-    for (let i = 1; i < list.length; i++) {
-      const prev = list[i - 1];
-      const cur = list[i];
-      const tokens = cur.tokens || 0;
-      out.repeats += 1;
-      if (!prev.fp || !cur.fp) {
-        out.undecidable += 1;
-        out.undecidableTokens += tokens;
-      } else if (prev.fp === cur.fp) {
-        out.wasteful += 1;
-        out.wastefulTokens += tokens;
-      } else {
-        out.legitimate += 1;
-        out.legitimateTokens += tokens;
-      }
-    }
+  for (const row of rows) {
+    out.repeats += row.repeats;
+    out.wasteful += row.wasteful;
+    out.wastefulTokens += row.tokens;
+    out.legitimate += row.legitimate;
+    out.legitimateTokens += row.legitimateTokens;
+    out.undecidable += row.undecidable;
+    out.undecidableTokens += row.undecidableTokens;
   }
 
   const decided = out.wasteful + out.legitimate;
   out.coverage = out.repeats ? decided / out.repeats : null;
+  // The offenders behind the totals, bounded: a report needs the handful worth
+  // acting on, not one row per file the session touched twice.
+  out.worst = rows.slice(0, 10);
   return out;
 }
 

--- a/integrations/qwen/hooks/lib/recall.mjs
+++ b/integrations/qwen/hooks/lib/recall.mjs
@@ -1,0 +1,390 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/recall.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Does retrieval FIND a finding, or does it only find what it was told where
+ * to look?
+ *
+ * `docs/WIKI_GRAPH.md` says embeddings get added "if measurement shows real
+ * recall loss". Nothing measured recall, so the no-embeddings stance was
+ * unfalsifiable -- a claim with no observation that could contradict it. This
+ * module is the observation.
+ *
+ * ---------------------------------------------------------------------------
+ * THE TAUTOLOGY THIS DELIBERATELY DOES NOT SHIP, AND WHY IT IS RECORDED HERE
+ * ---------------------------------------------------------------------------
+ * The obvious probe -- for each finding, take its anchors and ask whether
+ * `findingsFor` returns it from each -- CANNOT FAIL. `findingsFor(graph, A)`
+ * walks `derived_from` edges backwards into A, and the edge F -> A is the very
+ * thing that makes A an anchor of F. So F is in the result by CONSTRUCTION, not
+ * by retrieval quality, for every graph, forever. Its rate is 1.0 always, and a
+ * permanent 1.0 published as a recall rate reads to a human as "retrieval is
+ * perfect, embeddings unnecessary" -- one unfalsifiable claim swapped for
+ * another, leaning the one direction a measurement of this project by this
+ * project must never lean.
+ *
+ * That check is still worth running -- if it ever fails, traversal is broken
+ * rather than merely lossy -- so it is kept, and reported as `integrity` with
+ * its own `what` string saying it is not a recall rate. It is NEVER `rate`.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT IS MEASURED INSTEAD: LEAVE-ONE-EDGE-OUT
+ * ---------------------------------------------------------------------------
+ * For each active finding F and each anchor A of F, delete the edge F -> A and
+ * ask whether touching A would STILL surface F. Two independent arms, both of
+ * which can genuinely miss, which is what makes this a measurement:
+ *
+ *   Arm A -- TRAVERSAL FROM THE NEIGHBOURHOOD. Run the real `findingsFor` over
+ *   the edge-deleted graph from A itself and from A's `contains` parents. This
+ *   hits only when F has some OTHER structural route in: a second anchor on the
+ *   same file, or an anchor on a sibling symbol under the same parent. A's
+ *   `contains` children need no separate call because `findingsFor` expands
+ *   them itself -- calling the parent therefore covers every sibling, which is
+ *   why the neighbour list is `[A, ...parents(A)]` and not a hop-counted
+ *   frontier. The REAL primitive is used rather than an equivalent inlined
+ *   here, because a probe that reimplements the thing it measures drifts from
+ *   it and then measures itself.
+ *
+ *   Arm B -- BM25 FROM THE ANCHOR'S OWN KEY. Rank the whole active corpus with
+ *   `lexical.rank`, querying with A's key -- the file path or symbol name the
+ *   user actually touched -- and hit if F comes back inside `limit`.
+ *
+ * WHY ARM B IS NOT QUERIED WITH THE FINDING'S OWN CLAIM. The plan's literal
+ * form was "the finding's claim terms against the rest of the corpus", and both
+ * readings of it are degenerate. Querying F's claim against a corpus that
+ * INCLUDES F is the tautology again: BM25 scores a document against its own
+ * text, so F wins its own query every time. Querying F's claim against a corpus
+ * that EXCLUDES F cannot return F at all, so a "hit" would mean some DIFFERENT
+ * finding matched -- that is redundancy of storage, not recall of F, and it
+ * would score a graph better for holding duplicates. The anchor's key is the
+ * one query text that is available offline, is not derived from F, and matches
+ * the production question: a session touches a file, and the only lexical
+ * handle on it is its own path. It misses exactly when a finding's claim never
+ * names the code it is about, which is the recall gap embeddings are supposed
+ * to close.
+ *
+ * ---------------------------------------------------------------------------
+ * REFUSALS -- four, and each costs this project its own good news
+ * ---------------------------------------------------------------------------
+ *  1. TOO FEW OBSERVATIONS -> `rate: null` with a reason. See `MIN_PROBED`.
+ *  2. A CORPUS NO LARGER THAN THE RETRIEVAL LIMIT -> `rate: null`. Arm B is
+ *     recall@`limit`, and below the limit NO FINDING IS EVER CUT FOR BUDGET:
+ *     every document scoring above zero is returned, so the arm measures
+ *     whether a token matched, which is a strictly weaker bar than the one
+ *     production applies when `forTouch` fills a token budget from a ranked
+ *     list. A probe more permissive than the system it measures can only
+ *     overstate recall, so the rate is withheld in that band and the counts are
+ *     published instead. It bites between `MIN_PROBED` and `limit` findings --
+ *     on this machine's project graph, whose one finding had both anchor edges
+ *     "recovered" that way, the observation-count refusal fires first.
+ *  3. NO ANCHOR NODE -> the pair is UNPROBEABLE, not a miss. Reported and
+ *     excluded from the denominator; see `probeEdge`.
+ *  4. STRICT AGGREGATION -> a finding counts as retrieved only if EVERY one of
+ *     its probeable anchor edges is recoverable. A finding reachable from one
+ *     anchor and lost from another is a miss, with the losing anchor named.
+ *     This biases the rate DOWN, which is the safe direction here.
+ *
+ * FAILS OPEN. It runs on a report path; a graph it cannot read must cost a
+ * section, not the report.
+ */
+
+import { load, findingsFor } from './wiki.mjs';
+import { rank } from './lexical.mjs';
+
+/**
+ * Distinct findings that must be probeable before a RATE is published at all.
+ *
+ * NOT AN EFFECT-SIZE CONVENTION -- it is a resolution argument. A proportion
+ * over n observations has a resolution of 1/n, so below ten findings the
+ * published figure moves in steps coarser than ten percentage points, and the
+ * two extremes a small graph actually produces (`1.0` and `0.0`) are the two a
+ * reader is most likely to mistake for a finding about retrieval. At n = 10 and
+ * zero misses the exact binomial 95% upper bound on the true miss rate is still
+ * 1 - 0.05^(1/10) = 0.26, so even a clean sweep here bounds recall loss only
+ * below about a quarter -- which is why the refusal reason says what the number
+ * would and would not have supported rather than just naming the floor.
+ *
+ * THE FLOOR IS ON DISTINCT FINDINGS, NOT ANCHOR EDGES. Two anchors of one
+ * finding are two edges of the same claim, not two independent observations;
+ * counting them would let a single multi-anchored finding unlock a rate.
+ */
+export const MIN_PROBED = 10;
+
+/**
+ * The most findings probed in one call.
+ *
+ * Each probed anchor edge costs a graph-sized edge filter plus one or two real
+ * `findingsFor` walks plus one BM25 pass over the corpus, and this runs on the
+ * on-demand report path. The cap is deterministic (findings sorted by key) and
+ * `truncated` says when it bit, so a large graph gets a smaller, honestly
+ * labelled sample rather than a slow report.
+ */
+export const MAX_FINDINGS = 200;
+
+/** Active findings only. A retired claim is withdrawn; recalling it is not a win. */
+function activeFindings(graph) {
+  return [...graph.nodes.values()]
+    .filter((node) => node && node.kind === 'finding' && !node.retired)
+    .sort((a, b) => String(a.key || '').localeCompare(String(b.key || '')));
+}
+
+/** The `contains` parents of every node, indexed once for the whole probe. */
+function parentIndex(graph) {
+  const parents = new Map();
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contains') continue;
+    const list = parents.get(edge.to);
+    if (list) list.push(edge.from);
+    else parents.set(edge.to, [edge.from]);
+  }
+  return parents;
+}
+
+/** The anchors of one finding: the targets of its own `derived_from` edges. */
+function anchorsOf(graph, findingId) {
+  const out = new Set();
+  for (const edge of graph.edges) {
+    if (edge.edge === 'derived_from' && edge.from === findingId) out.add(edge.to);
+  }
+  return [...out];
+}
+
+/**
+ * The graph minus exactly one anchor edge.
+ *
+ * `nodes` is shared rather than copied: nothing here mutates it, and a
+ * 2,600-node Map copied once per anchor edge is the difference between a probe
+ * and a stall.
+ */
+function withoutAnchorEdge(graph, findingId, anchorId) {
+  return {
+    nodes: graph.nodes,
+    edges: graph.edges.filter(
+      (edge) =>
+        !(
+          edge.edge === 'derived_from' &&
+          edge.from === findingId &&
+          edge.to === anchorId
+        )
+    ),
+  };
+}
+
+/**
+ * One anchor edge, hidden, then asked after. Returns `recovered` with the arm
+ * that found it, or a reason -- and `probeable: false` when the question could
+ * not be put at all.
+ */
+function probeEdge(graph, parents, finding, anchorId, corpus, limit) {
+  const hidden = withoutAnchorEdge(graph, finding.id, anchorId);
+
+  // Arm A. `findingsFor` expands `contains` children itself, so the parent call
+  // covers every sibling of the anchor.
+  const neighbours = [anchorId, ...(parents.get(anchorId) || [])];
+  for (const neighbour of neighbours) {
+    const got = findingsFor(hidden, neighbour, { limit });
+    if (got.some((node) => node.id === finding.id)) {
+      return { recovered: true, arm: 'traversal', anchorId };
+    }
+  }
+
+  // Arm B needs a query, and the query is the anchor's own key. A dangling
+  // anchor edge -- an edge whose target node was never indexed, which
+  // `expand.promote` produces -- leaves nothing to query with. That is a
+  // question that could not be asked, NOT an observed miss: scoring it a miss
+  // would manufacture a recall loss out of a graph-integrity defect.
+  const anchor = graph.nodes.get(anchorId);
+  const key = anchor && typeof anchor.key === 'string' ? anchor.key : '';
+  if (!key) {
+    return {
+      recovered: false,
+      probeable: false,
+      anchorId,
+      reason: `anchor ${anchorId} has no node in the graph, so there is no anchor key to query BM25 with`,
+    };
+  }
+
+  const hits = rank(key, corpus, { limit });
+  if (hits.some((hit) => hit.finding && hit.finding.id === finding.id)) {
+    return { recovered: true, arm: 'lexical', anchorId };
+  }
+
+  return {
+    recovered: false,
+    probeable: true,
+    anchorId,
+    reason: `no neighbouring anchor reaches it and BM25 over ${key} does not rank it in the top ${limit}`,
+  };
+}
+
+/**
+ * The probe. An OFFLINE measurement over the graph as it stands -- it reads,
+ * ranks and traverses, and writes nothing.
+ */
+export function recallProbe(
+  dir,
+  {
+    limit = 20,
+    graph = null,
+    minProbed = MIN_PROBED,
+    maxFindings = MAX_FINDINGS,
+  } = {}
+) {
+  const refuse = (reason) => ({
+    basis: 'offline probe over the current graph',
+    probed: 0,
+    retrieved: 0,
+    rate: null,
+    reason,
+    misses: [],
+    unprobeable: [],
+  });
+
+  let g;
+  try {
+    g = graph || load(dir);
+  } catch {
+    return refuse('the graph could not be read, so recall was not measured.');
+  }
+
+  try {
+    const all = activeFindings(g);
+    const truncated = all.length > maxFindings;
+    const findings = truncated ? all.slice(0, maxFindings) : all;
+    const parents = parentIndex(g);
+    // The corpus BM25 ranks over is the ACTIVE graph, uncapped: the sample is
+    // which findings are probed, not what they compete against. Every reported
+    // figure below reads `corpus.length` rather than `all.length`, so the
+    // published size IS the ranking corpus rather than a parallel claim about
+    // it. The distinction is not pedantry: a mutation that shrank the ranking
+    // corpus to the probed sample -- making retrieval easier, in this project's
+    // favour -- SURVIVED the first mutation run precisely because the reported
+    // number came from the other variable and could not move.
+    const corpus = all;
+
+    const misses = [];
+    const unprobeable = [];
+    const integrityFailures = [];
+    let probed = 0;
+    let retrieved = 0;
+    let integrityOk = 0;
+    let probedEdges = 0;
+    let recoveredEdges = 0;
+    const byArm = { traversal: 0, lexical: 0 };
+
+    for (const finding of findings) {
+      const anchors = anchorsOf(g, finding.id);
+
+      // INTEGRITY, run on the UNTOUCHED graph: the by-construction check. Its
+      // only honest use is as a smoke test, and it is reported as one.
+      if (!anchors.length) {
+        integrityFailures.push({
+          key: finding.key,
+          reason:
+            'active finding with no anchor -- writeHarvested refuses to create one',
+        });
+      } else if (
+        anchors.every((anchorId) =>
+          findingsFor(g, anchorId, { limit }).some((node) => node.id === finding.id)
+        )
+      ) {
+        integrityOk += 1;
+      } else {
+        integrityFailures.push({
+          key: finding.key,
+          reason: `not returned by findingsFor from one of its own anchors at limit ${limit}`,
+        });
+      }
+
+      // An unanchored finding is a definite miss, not an unaskable question:
+      // nothing traverses to it and there is no anchor key to query from, so
+      // the anchor-driven path that serves findings on a file touch can never
+      // surface it. Only an explicit wiki_query naming its own terms would.
+      if (!anchors.length) {
+        probed += 1;
+        misses.push({
+          key: finding.key,
+          reason:
+            'no anchor: nothing traverses to it and there is no anchor key to query with, so only an explicit wiki_query of its own terms would surface it',
+        });
+        continue;
+      }
+
+      const results = anchors.map((anchorId) =>
+        probeEdge(g, parents, finding, anchorId, corpus, limit)
+      );
+      const askable = results.filter((result) => result.probeable !== false);
+      probedEdges += askable.length;
+      recoveredEdges += askable.filter((result) => result.recovered).length;
+      for (const result of askable) {
+        if (result.recovered) byArm[result.arm] += 1;
+      }
+
+      if (!askable.length) {
+        unprobeable.push({ key: finding.key, reason: results[0].reason });
+        continue;
+      }
+
+      probed += 1;
+      const lost = askable.filter((result) => !result.recovered);
+      if (!lost.length) retrieved += 1;
+      else misses.push({ key: finding.key, reason: lost[0].reason });
+    }
+
+    const integrity = {
+      what:
+        'BY CONSTRUCTION: a finding is returned by findingsFor from its own anchor because that edge is what makes it an anchor. Expected 1 for every graph. NOT a recall rate.',
+      probed: findings.length,
+      retrieved: integrityOk,
+      rate: findings.length ? integrityOk / findings.length : null,
+      ok: integrityFailures.length === 0,
+      failures: integrityFailures,
+    };
+
+    // Arm B is recall@`limit`. Over a corpus of at most `limit` findings nothing
+    // is ever cut for budget, so the arm asks only whether a token matched --
+    // weaker than the bar production applies under a token budget, and a probe
+    // more permissive than the system it measures can only overstate recall.
+    const discriminating = corpus.length > limit;
+
+    const common = {
+      basis: 'offline probe over the current graph',
+      probed,
+      retrieved,
+      misses,
+      unprobeable,
+      probedEdges,
+      recoveredEdges,
+      byArm,
+      corpus: corpus.length,
+      discriminating,
+      truncated,
+      minProbed,
+      integrity,
+    };
+
+    if (probed < minProbed) {
+      return {
+        ...common,
+        rate: null,
+        reason:
+          probed === 0
+            ? `no probeable finding: ${unprobeable.length} of ${findings.length} active finding(s) have no anchor node to query from, so recall was not measured. No rate is reported, which is not the same as a rate of zero.`
+            : `${probed} probeable finding(s), below the floor of ${minProbed}: a proportion over ${probed} has a resolution of ${Math.round(
+                100 / probed
+              )} percentage points, so no rate is published. ${retrieved} of ${probed} were recovered without their own anchor edge, which is a count and not a rate.`,
+      };
+    }
+
+    if (!discriminating) {
+      return {
+        ...common,
+        rate: null,
+        reason: `the active corpus holds ${corpus.length} finding(s) and the retrieval limit is ${limit}, so nothing is ever cut for budget and the lexical arm asks only whether a token matched -- a weaker bar than production applies. No rate is published off a probe more permissive than the system it measures; ${retrieved} of ${probed} were recovered, which is a count and not a rate.`,
+      };
+    }
+
+    return { ...common, rate: retrieved / probed, reason: null };
+  } catch {
+    return refuse('the probe failed, so recall was not measured.');
+  }
+}

--- a/integrations/qwen/hooks/lib/redact.mjs
+++ b/integrations/qwen/hooks/lib/redact.mjs
@@ -1,0 +1,30 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/redact.mjs. Regenerate with `npm run sync:hooks`.
+// hooks-core/redact.mjs
+/**
+ * Redaction for anything derived from captured output.
+ *
+ * WHY THIS IS MANDATORY RATHER THAN PRUDENT. derive.mjs builds claims out of
+ * command stderr. A claim is INJECTED into model context and EXPORTED to
+ * markdown, so a secret that reaches a claim reaches two more places than the
+ * terminal it came from. Pattern matching is imperfect and that is stated in the
+ * spec, but "imperfect" beats "absent" by a wide margin here.
+ */
+
+const PATTERNS = [
+  // Bearer / API-key shaped tokens.
+  [/\b(bearer\s+)[A-Za-z0-9._~+/-]{12,}/gi, '$1[redacted]'],
+  [/\b(sk|pk|ghp|gho|github_pat|xox[baprs])[-_][A-Za-z0-9._-]{10,}/gi, '[redacted]'],
+  // KEY=value where the key name suggests a secret.
+  [/\b([A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|APIKEY|API_KEY|PRIVATE_KEY|CREDENTIAL)[A-Z0-9_]*)\s*[=:]\s*\S+/g, '$1=[redacted]'],
+  // Credentials inside a URL.
+  [/\b([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+):[^\s@]+@/gi, '$1:[redacted]@'],
+  // PEM blocks.
+  [/-----BEGIN[^-]*PRIVATE KEY-----[\s\S]*?-----END[^-]*PRIVATE KEY-----/g, '[redacted key]'],
+];
+
+export function redact(text, { max = 400 } = {}) {
+  let out = String(text ?? '');
+  for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
+}

--- a/integrations/qwen/hooks/lib/redact.mjs
+++ b/integrations/qwen/hooks/lib/redact.mjs
@@ -24,7 +24,21 @@ const PATTERNS = [
 ];
 
 export function redact(text, { max = 400 } = {}) {
+  // `?? ''` matters even though String(null)/String(undefined) never throw:
+  // without it a missing value becomes the literal 4-11 character string
+  // "null"/"undefined" -- a garbage claim that silently reaches the graph
+  // and model context instead of surfacing as an error.
   let out = String(text ?? '');
   for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  // Redact BEFORE truncating, never the reverse. Several patterns above rely
+  // on a minimum-length quantifier (e.g. `{10,}`, `{12,}`) plus a prefix.
+  // Truncating first can cut a match down to fewer characters than that
+  // quantifier requires, so the shortened fragment no longer satisfies the
+  // pattern and a live partial secret would pass through in cleartext. By
+  // redacting the full, untruncated string first, every pattern always sees
+  // the complete secret and removes it before any character budget is
+  // spent; the cap below can then only ever cut into already-redacted text
+  // (a label, or the "[redacted]" placeholder itself), never into raw
+  // secret bytes.
   return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
 }

--- a/integrations/qwen/hooks/lib/transcript.mjs
+++ b/integrations/qwen/hooks/lib/transcript.mjs
@@ -19,9 +19,11 @@
  */
 
 import {
-  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, unlinkSync,
+  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync,
+  unlinkSync, openSync, readSync, closeSync,
 } from 'node:fs';
 import { join } from 'node:path';
+import { redact } from './redact.mjs';
 
 /** Where a project's transcripts live, under the graph it belongs to. */
 export const transcriptDir = (dir) => join(dir, 'transcripts');
@@ -210,4 +212,204 @@ export function readArchive(dir, sessionId) {
   } catch {
     return [];
   }
+}
+
+/**
+ * How much of a transcript's TAIL is scanned for failed tool results.
+ *
+ * A transcript is the largest file this project reads: the three real ones on
+ * the measuring machine are 5.8 MB, 22 MB and 45 MB. `archive()` above already
+ * reads the whole thing once at Stop, so an unbounded second pass doubles the
+ * most expensive read on the session-end path for evidence that is, by
+ * construction, mostly old. The tail is the right half to keep for the same
+ * reason `buildFeedbackDigest` keeps the end: what a session learned is
+ * concentrated where the work went wrong, which is later rather than sooner.
+ */
+const FAILED_SCAN_BYTES = () =>
+  Number(process.env.TOKEN_OPTIMIZER_TRANSCRIPT_SCAN_BYTES) || 8 * 1024 * 1024;
+
+/** Failed results kept, most recent first. The pairing detector needs a handful. */
+const FAILED_MAX = 50;
+
+/** Same 4 KB cap `recordToolOutcome` applies to `output`, for the same reason. */
+const FAILED_OUTPUT_MAX = 4096;
+
+/**
+ * The same 120-character truncation `recordToolOutcome` applies to `anchor`.
+ *
+ * ONE COMMAND MUST PRODUCE ONE KEY FROM EITHER SOURCE. A `tool-outcome` stores
+ * the command as `String(tool_input.command).slice(0, 120)`, and `attemptKey`
+ * reads up to three non-flag tokens off whatever it is handed. A long first
+ * token -- a quoted grep pattern, an absolute Windows path, a heredoc -- is cut
+ * by that cap INSIDE those three tokens, so the untruncated transcript copy of
+ * the same command lands in a DIFFERENT group. Measured against one real
+ * session's own evidence: 266 commands present in both sources, and truncating
+ * here made 266 of 266 keys agree where the untruncated text agreed on only
+ * 240.
+ *
+ * WHAT THAT ACTUALLY BUYS, stated precisely rather than generously. `derive`
+ * refuses to build a claim out of a command at or over the cap at all (see
+ * `quotable` there), so agreement on a TRUNCATED key never produces a finding
+ * on its own. It buys two things that still matter: a transcript failure lands
+ * in the same run as the event outcomes of the same command, so the
+ * nearest-preceding-failure rule sees the real sequence rather than a sparse
+ * one; and the no-call-id fallback in `derive`'s deduplication compares command
+ * TEXT against an already-truncated anchor, which cannot match unless this side
+ * is truncated identically.
+ */
+const ANCHOR_MAX = 120;
+
+/**
+ * A tool result that reports a command that RAN and exited non-zero.
+ *
+ * A POSITIVE ALLOWLIST, and the measurement is why. Claude Code sets
+ * `is_error: true` on every kind of unhappy tool result, and across three real
+ * transcripts 214 of them fell into four shapes:
+ *
+ *   83  `Exit code N` + stderr    -- a command ran and failed. THIS ONE.
+ *   109 hook and policy denials   -- overwhelmingly THIS optimizer's own
+ *                                    PreToolUse text ("Recursive shell searches
+ *                                    return unbounded output. Call the
+ *                                    token-optimizer MCP tool smart_grep
+ *                                    instead"), plus `Remove-Item on system
+ *                                    path` blocks.
+ *   18  `<tool_use_error>...`     -- protocol errors: `String to replace not
+ *                                    found`, `File has not been read yet`,
+ *                                    `Blocked: ...`.
+ *   4   a person declined the call.
+ *
+ * Only the first shape is a command failing. In every other shape THE COMMAND
+ * NEVER RAN, so "`X` failed with: ..." would be a false claim about X, and a
+ * later success would pair with a failure that never happened. The 109 are the
+ * dangerous ones: ingesting them would have this tool derive findings from its
+ * own advice, at 0.9 confidence, and serve them back as observations about the
+ * project -- a self-referential loop that also inflates its own finding count.
+ * That is the measurement-bias class this plan tracks, and a denylist would
+ * have let every future denial string through by default.
+ */
+const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
+
+/** Reads at most `bytes` from the END of a file, without loading the rest. */
+function readTail(path, bytes) {
+  let fd;
+  try {
+    const size = statSync(path).size;
+    const length = Math.min(size, bytes);
+    if (!length) return '';
+    fd = openSync(path, 'r');
+    const buffer = Buffer.allocUnsafe(length);
+    readSync(fd, buffer, 0, length, size - length);
+    const text = buffer.toString('utf8');
+    // A tail almost never starts on a line boundary, and half a JSON object is
+    // not a parse failure worth reporting -- it is a partial record. Drop it.
+    return length < size ? text.slice(text.indexOf('\n') + 1) : text;
+  } catch {
+    return '';
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+}
+
+/**
+ * The failed COMMAND results a transcript holds, which no hook event carries.
+ *
+ * WHY THIS READER EXISTS. Claude Code never fires PostToolUse for a failed tool
+ * call: a deliberately failing command produced no event at all, and 2,238 of
+ * 2,238 live `tool-outcome` events on the measuring machine carry
+ * `success: true`. So `derive.mjs`'s two strongest detectors -- command
+ * failed-then-succeeded at 0.90 and test/build red-to-green at 0.85 -- have no
+ * input whatsoever on the primary client, while working normally on the ten
+ * adapter clients. The failures exist; they exist only here.
+ *
+ * WHY NOT THE ARCHIVE, which the plan for this reader assumed. `readTurns`
+ * DROPS tool results by design -- that is where whole file contents would enter
+ * the record -- so `readArchive` returns no failure, ever, and an extractor over
+ * archived turns would find nothing however well it was written. Making the
+ * archive carry them would also push command stderr into `buildFeedbackDigest`,
+ * which is the one code path in this project that sends anything to a model
+ * endpoint. So this reads the transcript and STORES NOTHING NEW: read-only, no
+ * capture path, no new event kind, and no widening of what leaves the machine.
+ *
+ * REDACTED HERE, at this boundary, exactly as `recordToolOutcome` redacts
+ * `output`. Transcript text has never passed a redaction boundary -- that one
+ * never saw it -- and everything returned from here is destined for a claim that
+ * is injected into model context and exported to markdown.
+ *
+ * @returns {Array<{command: string, output: string, exit: number|null,
+ *   at: number, toolCallId: string|null}>} in transcript order, so a caller can
+ *   sort it beside `tool-outcome` events without re-ordering.
+ */
+export function failedResultsFromTranscript(transcriptPath, options = {}) {
+  const { max = FAILED_MAX, scanBytes = FAILED_SCAN_BYTES() } = options || {};
+  if (!transcriptPath) return [];
+  const text = readTail(transcriptPath, scanBytes);
+  if (!text) return [];
+
+  // tool_use_id -> the command that was attempted. The join is EXACT and it is
+  // the only one available: the result block carries no command of its own, and
+  // the id is the same string `episodeMeta` reads into `toolCallId`, so the same
+  // key also deduplicates against events on clients that do report failures.
+  const commands = new Map();
+  const failures = [];
+
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const message = entry.message || entry;
+    const role = message.role || entry.type;
+    const content = message.content;
+    if (!Array.isArray(content)) continue;
+
+    if (role === 'assistant') {
+      for (const block of content) {
+        if (!block || block.type !== 'tool_use' || !block.id) continue;
+        const command = block.input?.command;
+        if (typeof command !== 'string' || !command.trim()) continue;
+        commands.set(String(block.id), command.slice(0, ANCHOR_MAX));
+      }
+      continue;
+    }
+
+    if (role !== 'user') continue;
+    for (const block of content) {
+      if (!block || block.type !== 'tool_result' || block.is_error !== true) continue;
+      // Only a STRING result can be an exit-code report; every failed Claude
+      // Code result observed was one, and a structured body is a shape this
+      // classifier has not measured, so it is refused rather than guessed at.
+      if (typeof block.content !== 'string') continue;
+      const match = EXIT_CODE_RESULT.exec(block.content);
+      if (!match) continue;
+      const command = commands.get(String(block.tool_use_id || ''));
+      // No command means no claim. The result says something failed; without
+      // the text of what failed there is nothing to say about it, and nothing
+      // to group it with.
+      if (!command) continue;
+      failures.push({
+        command,
+        // The exit line itself is stripped: `exit` carries it structurally, and
+        // leaving it in makes every failure claim read "failed with: Exit code 1".
+        output: redact(block.content.slice(match[0].length).trim(), {
+          max: FAILED_OUTPUT_MAX,
+        }),
+        exit: Number(match[1]),
+        at: Date.parse(entry.timestamp || '') || 0,
+        toolCallId: block.tool_use_id ? String(block.tool_use_id) : null,
+      });
+    }
+  }
+
+  // The MOST RECENT `max`, keeping chronological order. A session that failed
+  // two hundred times teaches its last lessons, not its first.
+  return failures.slice(-max);
 }

--- a/integrations/qwen/hooks/lib/usage.mjs
+++ b/integrations/qwen/hooks/lib/usage.mjs
@@ -42,7 +42,7 @@
  * was referenced" and "nothing could be measured" are different answers and
  * this module gives different answers for them.
  */
-import { readMetrics } from './metrics.mjs';
+import { readMetrics, readTruncation } from './metrics.mjs';
 
 /**
  * The events that name a finding, and it is ONE kind, not the two the plan
@@ -129,17 +129,30 @@ export function classify(dir, { events = null } = {}) {
   try {
     const all = inTimeOrder(events || readMetrics(dir));
 
-    // Every reference, keyed on the finding it names. Only references carrying
-    // a session id are usable -- see `unscopedReferences` in `referenceRate`
-    // for the ones this drops and why they are counted rather than credited.
+    // Every reference, keyed on the finding it names and on nothing else.
+    //
+    // NOT SCOPED BY SESSION, and that is a deliberate reversal. Scoping needs
+    // the query's `sessionId`, which `wiki_query` takes as an OPTIONAL input
+    // the model has to volunteer (`options.sessionId ?? null`) -- so the
+    // numerator depended on the model choosing to identify itself, and an
+    // unverifiable model-supplied id is not evidence. Plan 1 settled that for
+    // the `answers` edge and it settles it here: stop depending on the field
+    // rather than hope for cooperation. The finding key is the specific part
+    // anyway; a key is a graph identity, not a guess.
+    //
+    // THE COST, disclosed here and in `referenceNote` because a reader of the
+    // number has to see it: TWO CONCURRENT SESSIONS ON ONE REPOSITORY CAN
+    // CROSS-ATTRIBUTE. Session A's injection of K plus session B's later query
+    // for K reads as a reference. Nothing in the log can separate them once the
+    // session id is gone, so the exposure is real and is stated rather than
+    // priced.
     const references = new Map();
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       const key = referencedKey(event);
-      const session = sessionOf(event);
-      if (!key || !session) continue;
+      if (!key) continue;
       if (!references.has(key)) references.set(key, []);
-      references.get(key).push({ at: event.at || 0, session });
+      references.get(key).push(event.at || 0);
     }
 
     // Which injections the existing outcome join could attribute. An outcome
@@ -170,9 +183,8 @@ export function classify(dir, { events = null } = {}) {
       const injectionId = event.injectionId ? String(event.injectionId) : null;
       const at = event.at || 0;
       const session = sessionOf(event);
-      // STRICTLY AFTER. A query that PRECEDED the injection is the model
-      // asking on its own initiative; crediting it would let the metric take
-      // the credit for a lookup it had nothing to do with.
+      // STRICTLY AFTER here too: activity that predates the injection is not
+      // an opportunity to have used it.
       const followed = (times) => times.some((t) => t > at);
       const continued =
         (injectionId && attributed.has(injectionId)) ||
@@ -181,9 +193,11 @@ export function classify(dir, { events = null } = {}) {
       for (const raw of keys) {
         const findingKey = String(raw);
         const hits = references.get(findingKey) || [];
-        const referenced = session
-          ? hits.some((hit) => hit.session === session && hit.at > at)
-          : false;
+        // TIME ORDER IS THE ONLY REMAINING GUARD, so it carries the whole
+        // weight of the attribution: a query that PRECEDED the injection is
+        // the model asking on its own initiative, and crediting it would let
+        // the metric take the credit for a lookup it had nothing to do with.
+        const referenced = hits.some((hitAt) => hitAt > at);
         rows.push({
           findingKey,
           injectionId,
@@ -204,9 +218,27 @@ export function classify(dir, { events = null } = {}) {
 /**
  * The rate, with everything needed to tell a real 0 from an absent one.
  *
- * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
- * `unattributable` and `unscopedReferences` are reported beside it, never
- * inside it.
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown` and
+ * `unattributable` are reported beside it, never inside it.
+ *
+ * `windowed` SAYS WHETHER THE DENOMINATOR CAN UNDERSTATE, and it is not
+ * decoration. `readMetrics` reads a 2 MB / 5,000-event TAIL of the firehose,
+ * and injections are rare enough on a real project to age out of it: measured
+ * on this repository, both `inject` events sit at lines 502 and 883 of 6,871
+ * and have scrolled away behind ~6,000 later `read` and `tool-outcome` rows,
+ * so the windowed denominator is 0 where the whole-file truth is 1.
+ *
+ * IT IS REPORTED RATHER THAN FIXED, deliberately. `inject` already gets
+ * unwindowed access through `BALANCE_KINDS` / `EVIDENCE_KINDS`, but `query`
+ * does not -- and reading only the INJECTION arm unwindowed would be worse
+ * than the windowing: every old injection would enter the denominator with no
+ * chance of a matching query in the window and score `not-referenced`,
+ * manufacturing a pessimistic rate out of the asymmetry. Making the query arm
+ * unwindowed means adding `query` to `EVIDENCE_KINDS`, which two other
+ * consumers read, and this project's own standard says a shared-classifier
+ * change needs a per-consumer verdict comparison. So the honest move is to
+ * publish the flag: a caller that needs the unwindowed truth passes its own
+ * `events`, which is exactly what the live measurement in the task report did.
  */
 export function referenceRate(dir, { events = null } = {}) {
   const empty = {
@@ -218,10 +250,15 @@ export function referenceRate(dir, { events = null } = {}) {
     unattributable: 0,
     unattributableWithInjectedToolCall: 0,
     referenceEvents: 0,
-    unscopedReferences: 0,
+    windowed: false,
   };
   try {
     const all = events || readMetrics(dir);
+    // OUT OF BAND, and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` reports on the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
     const rows = classify(dir, { events: all });
     const count = (label) => rows.filter((row) => row.label === label).length;
     const referenced = count('referenced');
@@ -231,17 +268,17 @@ export function referenceRate(dir, { events = null } = {}) {
     // Usable reference events in the window: the numerator's producer. If this
     // is zero the channel never fired, and a 0% rate would be measuring the
     // absence of a producer rather than the uselessness of findings.
+    //
+    // NO SESSION REQUIREMENT, matching the attribution above. The former
+    // `unscopedReferences` counted queries dropped for want of a session id;
+    // nothing is dropped for that reason any more, so the field is GONE rather
+    // than kept at a permanent zero that a later reader would misread as
+    // evidence the loss had been fixed.
     let referenceEvents = 0;
-    let unscopedReferences = 0;
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       if (!referencedKey(event)) continue;
-      if (sessionOf(event)) referenceEvents += 1;
-      // Names a finding but cannot be scoped to one injection. `sessionId` is
-      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
-      // is the expected loss rather than an edge case -- counted here so it is
-      // visible instead of silently deflating the numerator.
-      else unscopedReferences += 1;
+      referenceEvents += 1;
     }
 
     // The tool calls that DID receive findings, keyed the way
@@ -292,7 +329,7 @@ export function referenceRate(dir, { events = null } = {}) {
       unattributable,
       unattributableWithInjectedToolCall,
       referenceEvents,
-      unscopedReferences,
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
     };
   } catch {
     return empty;
@@ -300,11 +337,18 @@ export function referenceRate(dir, { events = null } = {}) {
 }
 
 /**
- * One line for the audit, or nothing at all.
+ * One or two lines for the audit, or nothing at all.
  *
  * Says which of the three things is true -- a measured rate, a live channel
  * with no opportunities yet, or no channel at all -- rather than printing a
  * figure and letting the reader assume the first.
+ *
+ * AND IT CARRIES THE CAVEATS, because this is the only place a human meets the
+ * number. A rate attributed on (finding key, time order) can cross-attribute
+ * between two concurrent sessions on one repository, and a windowed read can
+ * understate the denominator. Both are stated beside the figure they qualify.
+ * Putting them only in a task report would be publishing a clean number and
+ * filing the asterisk somewhere nobody quoting it will look.
  */
 export function referenceNote(dir, { events = null } = {}) {
   const r = referenceRate(dir, { events });
@@ -317,6 +361,11 @@ export function referenceNote(dir, { events = null } = {}) {
   }
   return (
     `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
-    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded. ` +
+    'Matched on finding key and time order, so concurrent sessions on this ' +
+    'repository can cross-attribute' +
+    (r.windowed
+      ? '; and the event log was truncated, so the denominator can understate.'
+      : '.')
   );
 }

--- a/integrations/qwen/hooks/lib/usage.mjs
+++ b/integrations/qwen/hooks/lib/usage.mjs
@@ -1,0 +1,322 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/usage.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 1 -- did the model actually go back and use what we injected?
+ *
+ * The cheap behavioural label. One question, answered from the event log alone:
+ * after we put a finding in front of the model, did the model later ASK FOR
+ * THAT FINDING BY NAME?
+ *
+ * WHY EXPLICIT REFERENCE, AND NOT READ-SUPPRESSION. Read-suppression -- "the
+ * file was not re-read, so the finding must have helped" -- is Layer 2's
+ * estimand, measured causally by withholding a finding and comparing. Layer 1
+ * exists to be calibrated AGAINST that. If both layers derived from
+ * suppression, the calibration would compare two spellings of one quantity,
+ * report a strong correlation, and mean nothing. So Layer 1 is deliberately
+ * built on a signal Layer 2 does not touch: an explicit `query` naming the
+ * finding key.
+ *
+ * WHAT THIS DOES NOT DO. It does not invent a join. `recordToolOutcome`
+ * already joins each post-tool result back to the injection that preceded it,
+ * recording `injectionId`, `findingIds` and a `joinMethod` of `tool-call-id`,
+ * `episode-anchor` or `none` -- preferring an exact tool-call id, which is
+ * strictly better evidence than the `(sessionId, findingKey)` approximation an
+ * earlier draft of this plan proposed. This module consumes that join and adds
+ * none of its own. `inject.mjs` needed no change: it has written `findingIds`
+ * at every call site all along.
+ *
+ * WHAT `unknown` IS FOR, and it is the whole reason this file is careful. An
+ * injection whose session simply stopped afterwards is not a miss. Nothing
+ * happened, so nothing can be concluded, and counting it against the finding
+ * would make the metric read worse the more often sessions end -- a number
+ * that moves with session length rather than with usefulness. `unknown` is
+ * therefore EXCLUDED from the denominator rather than scored zero, and
+ * outcomes the join could not attribute at all are reported as
+ * `unattributable` rather than folded into either arm.
+ *
+ * AND WHY THE RATE CAN BE `null`. This project has already shipped two metrics
+ * whose only producer was their own test suite. A rate of 0% that actually
+ * means "no data" is worse than a refusal, because it is a number and numbers
+ * get quoted. So `rate` is null unless there is a denominator AND the
+ * reference channel produced at least one usable event in the window. "Nothing
+ * was referenced" and "nothing could be measured" are different answers and
+ * this module gives different answers for them.
+ */
+import { readMetrics } from './metrics.mjs';
+
+/**
+ * The events that name a finding, and it is ONE kind, not the two the plan
+ * assumed.
+ *
+ * The brief said "a later `query` or `expand` event". Checked against the code
+ * and against every metrics log on this machine, `expand` does not qualify and
+ * cannot be made to:
+ *
+ *   - `recordExpansion` writes `{ ref, tool, shape, asked, sessionId }`. `ref`
+ *     is a TRUNCATION CAPTURE id (a 16-hex digest of captured tool output),
+ *     not a finding key, and `asked` is free text naming a section of that
+ *     output. Neither is a graph key, and no code path ever puts one there.
+ *   - measured: 64 live `expand` events exist on this machine and all 64 carry
+ *     `sessionId: null`, so they could not be scoped to an injection even if
+ *     they did name one.
+ *
+ * Keying the classifier on `expand` would therefore have added a branch that
+ * can never fire -- a metric with no producer, which is the exact defect this
+ * whole effort exists to close. So it is excluded, deliberately and with the
+ * measurement recorded, rather than included for symmetry with the brief.
+ */
+const REFERENCE_KINDS = new Set(['query']);
+
+/**
+ * What counts as the session having CONTINUED past the injection.
+ *
+ * The distinction between `not-referenced` and `unknown` rests entirely on
+ * this, so the set is explicit rather than "any later event". These are the
+ * kinds a tool call produces: if one of them follows the injection in the same
+ * session, the model had the opportunity to ask and did not. If none does, the
+ * session ended and there was no opportunity.
+ *
+ * `inject` is in the set because a later injection means a later tool call
+ * happened. `forecast`, `mcp-client` and `mcp-tool` are NOT: they are written
+ * by session bookkeeping rather than by the model doing something, and
+ * treating them as opportunity would convert `unknown` rows into misses on
+ * bookkeeping alone.
+ */
+const ACTIVITY_KINDS = new Set([
+  'tool-outcome',
+  'read',
+  'query',
+  'expand',
+  'substitute',
+  'inject',
+]);
+
+/** A usable session id: a non-empty string. `null == null` is not a match. */
+const sessionOf = (event) => {
+  const id = event?.sessionId;
+  return typeof id === 'string' && id ? id : null;
+};
+
+/** The finding key a reference event names, or null if it names none. */
+const referencedKey = (event) => {
+  const key = event?.key;
+  return typeof key === 'string' && key ? key : null;
+};
+
+/** Ordering by the caller's timestamp, with log order breaking ties. */
+function inTimeOrder(events) {
+  return events
+    .map((event, index) => ({ event, index }))
+    .sort(
+      (a, b) =>
+        (a.event.at || 0) - (b.event.at || 0) || a.index - b.index
+    )
+    .map((row) => row.event);
+}
+
+/**
+ * One row per (injection, finding) pair, labelled.
+ *
+ * Per injection rather than per finding: the same finding injected twice is two
+ * separate opportunities, and collapsing them would let one reference excuse
+ * every later injection of that key.
+ *
+ * FAILS OPEN. A malformed log yields an empty classification, never a throw:
+ * this runs on report paths that must not break a tool call.
+ */
+export function classify(dir, { events = null } = {}) {
+  let rows = [];
+  try {
+    const all = inTimeOrder(events || readMetrics(dir));
+
+    // Every reference, keyed on the finding it names. Only references carrying
+    // a session id are usable -- see `unscopedReferences` in `referenceRate`
+    // for the ones this drops and why they are counted rather than credited.
+    const references = new Map();
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      const key = referencedKey(event);
+      const session = sessionOf(event);
+      if (!key || !session) continue;
+      if (!references.has(key)) references.set(key, []);
+      references.get(key).push({ at: event.at || 0, session });
+    }
+
+    // Which injections the existing outcome join could attribute. An outcome
+    // carrying our injectionId is proof the tool call completed, which is
+    // opportunity even when the session id is missing from the log.
+    const attributed = new Set();
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) continue;
+      attributed.add(String(event.injectionId));
+    }
+
+    // Activity per session, so "did anything follow?" is one lookup rather
+    // than a scan per injection.
+    const activity = new Map();
+    for (const event of all) {
+      if (!ACTIVITY_KINDS.has(event.kind)) continue;
+      const session = sessionOf(event);
+      if (!session) continue;
+      if (!activity.has(session)) activity.set(session, []);
+      activity.get(session).push(event.at || 0);
+    }
+
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+      if (!keys.length) continue;
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const at = event.at || 0;
+      const session = sessionOf(event);
+      // STRICTLY AFTER. A query that PRECEDED the injection is the model
+      // asking on its own initiative; crediting it would let the metric take
+      // the credit for a lookup it had nothing to do with.
+      const followed = (times) => times.some((t) => t > at);
+      const continued =
+        (injectionId && attributed.has(injectionId)) ||
+        (session ? followed(activity.get(session) || []) : false);
+
+      for (const raw of keys) {
+        const findingKey = String(raw);
+        const hits = references.get(findingKey) || [];
+        const referenced = session
+          ? hits.some((hit) => hit.session === session && hit.at > at)
+          : false;
+        rows.push({
+          findingKey,
+          injectionId,
+          label: referenced
+            ? 'referenced'
+            : continued
+              ? 'not-referenced'
+              : 'unknown',
+        });
+      }
+    }
+  } catch {
+    rows = [];
+  }
+  return rows;
+}
+
+/**
+ * The rate, with everything needed to tell a real 0 from an absent one.
+ *
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
+ * `unattributable` and `unscopedReferences` are reported beside it, never
+ * inside it.
+ */
+export function referenceRate(dir, { events = null } = {}) {
+  const empty = {
+    referenced: 0,
+    notReferenced: 0,
+    unknown: 0,
+    denominator: 0,
+    rate: null,
+    unattributable: 0,
+    unattributableWithInjectedToolCall: 0,
+    referenceEvents: 0,
+    unscopedReferences: 0,
+  };
+  try {
+    const all = events || readMetrics(dir);
+    const rows = classify(dir, { events: all });
+    const count = (label) => rows.filter((row) => row.label === label).length;
+    const referenced = count('referenced');
+    const notReferenced = count('not-referenced');
+    const denominator = referenced + notReferenced;
+
+    // Usable reference events in the window: the numerator's producer. If this
+    // is zero the channel never fired, and a 0% rate would be measuring the
+    // absence of a producer rather than the uselessness of findings.
+    let referenceEvents = 0;
+    let unscopedReferences = 0;
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      if (!referencedKey(event)) continue;
+      if (sessionOf(event)) referenceEvents += 1;
+      // Names a finding but cannot be scoped to one injection. `sessionId` is
+      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
+      // is the expected loss rather than an edge case -- counted here so it is
+      // visible instead of silently deflating the numerator.
+      else unscopedReferences += 1;
+    }
+
+    // The tool calls that DID receive findings, keyed the way
+    // `recordToolOutcome` keys its own primary join: the tool-call id. An
+    // unattributable outcome for one of these is a join that FAILED. An
+    // unattributable outcome for any other tool call had nothing to join to.
+    //
+    // KEYED ON THE TOOL CALL, NOT THE EPISODE, and the first draft of this
+    // got it wrong in a way worth recording because it is the exact
+    // measurement-bias class this plan hunts. `episodeId` equals the SESSION
+    // id, so "unattributable outcomes in an episode that had an injection"
+    // scored all 2,559 tool calls of a session in which ONE injection
+    // happened. It would have published 2,559 join failures where the true
+    // number is zero -- correct code, lying number, and biased pessimistic
+    // rather than flattering, which is no better.
+    const injectedToolCalls = new Set();
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      if (!Array.isArray(event.findingIds) || !event.findingIds.length)
+        continue;
+      if (event.toolCallId) injectedToolCalls.add(String(event.toolCallId));
+    }
+    let unattributable = 0;
+    let unattributableWithInjectedToolCall = 0;
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome' || event.joinMethod !== 'none')
+        continue;
+      unattributable += 1;
+      // BOTH FIGURES, because the raw one alone lies in the pessimistic
+      // direction. Measured on this machine: 2,991 of 2,992 live outcomes
+      // report `joinMethod: 'none'`, and every one of them because NO
+      // INJECTION EXISTED for that tool call -- the graph holds one finding.
+      // Quoting only the raw count would read as a join that fails 99.97% of
+      // the time, which is a different and false claim.
+      if (event.toolCallId && injectedToolCalls.has(String(event.toolCallId)))
+        unattributableWithInjectedToolCall += 1;
+    }
+
+    return {
+      referenced,
+      notReferenced,
+      unknown: count('unknown'),
+      denominator,
+      rate:
+        denominator > 0 && referenceEvents > 0
+          ? referenced / denominator
+          : null,
+      unattributable,
+      unattributableWithInjectedToolCall,
+      referenceEvents,
+      unscopedReferences,
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/**
+ * One line for the audit, or nothing at all.
+ *
+ * Says which of the three things is true -- a measured rate, a live channel
+ * with no opportunities yet, or no channel at all -- rather than printing a
+ * figure and letting the reader assume the first.
+ */
+export function referenceNote(dir, { events = null } = {}) {
+  const r = referenceRate(dir, { events });
+  if (!r.denominator && !r.unknown && !r.referenceEvents) return null;
+  if (r.rate == null) {
+    const why = !r.referenceEvents
+      ? 'no finding was ever queried by key in this window'
+      : `no injection had a chance to be referenced yet (${r.unknown} unknown)`;
+    return `Injected findings referenced later: not measurable -- ${why}.`;
+  }
+  return (
+    `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+  );
+}

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -103,6 +103,44 @@ const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
 
 /**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because FOUR readers depend on it -- mutation accounting,
+ * success classification, output capture and exit-code capture -- and clients
+ * disagree on the envelope name and on nothing else. Letting each reader name
+ * its own subset is exactly how both classifiers came to miss MCP's failure
+ * flag: `toolSucceeded` listed four envelopes and `mutationSucceeded` listed
+ * three, and neither list mentioned `isError` at all.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/**
+ * Did an MCP result declare itself an error?
+ *
+ * `isError` is the ONLY failure signal an MCP result carries -- there is no
+ * `error` field and no `status` -- and `src/server/index.ts` sets it in seven
+ * places. Shared by both classifiers so they cannot disagree about what a
+ * failed call from this project's own tools looks like.
+ *
+ * `=== true` EXACTLY. A client using the key for anything else must not have
+ * its successful calls silently reclassified, and `isError: false` is a
+ * successful MCP call, not a missing verdict.
+ */
+function reportedMcpError(raw) {
+  return [...responseEnvelopes(raw), raw].some(
+    (envelope) => envelope?.isError === true
+  );
+}
+
+/**
  * A post-tool event is not universally proof of success. Some clients split
  * success and failure into distinct events; others expose a result status.
  * Keep mutation accounting conservative so a failed edit cannot arm Stop.
@@ -112,6 +150,19 @@ export function mutationSucceeded(clientName, raw) {
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
     return false;
+  // BEFORE the status read, the explicit-success read AND the client
+  // allowlist, because all three would otherwise pass a failed MCP write. The
+  // allowlist is the one that actually bit: it returns true for claude-code,
+  // codex, qwen, opencode, kilo and windsurf on any post-tool event with no
+  // error and no status, which is precisely the shape of a failed smart_write.
+  //
+  // WHY THIS IS THE SAME BUG AS THE ONE IN `toolSucceeded` AND NOT A COSMETIC
+  // ECHO OF IT: this function gates edit counting and harvest pressure, so
+  // counting a failed write to THE OPTIMIZER'S OWN TOOLS as a mutation
+  // inflates "the optimizer successfully edited a file". Different consumers
+  // from the effectiveness figures, same direction of bias -- toward
+  // flattering the thing being measured.
+  if (reportedMcpError(raw)) return false;
 
   const status =
     raw?.tool_response?.status ??
@@ -145,24 +196,6 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * Spelled out ONCE because three readers depend on it -- success
- * classification, output capture and exit-code capture -- and clients disagree
- * on the envelope name and on nothing else. Letting each reader name its own
- * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
-}
-
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
@@ -181,8 +214,7 @@ export function toolSucceeded(raw) {
   // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
   // optimizer's favour. A measurement that flatters the thing being measured
   // is worse than no measurement.
-  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
-    return false;
+  if (reportedMcpError(raw)) return false;
   const status =
     raw?.tool_response?.status ??
     raw?.toolResponse?.status ??

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -957,10 +957,12 @@ async function runHook(clientName, event, invocation) {
       // accumulates structure and no verdicts at all. These detectors read only
       // what is already on disk and send nothing anywhere.
       //
-      // The COUNT is recorded rather than the candidates: how many findings a
-      // session's own evidence supports is the number that says whether this is
-      // working, and it is measurable before anything is stored. Storage is the
-      // caller's next step, under a budget.
+      // COUNTS are recorded rather than the candidates, and BOTH counts: how
+      // many findings a session's own evidence supports, and how many of them
+      // survived the storage budget and the anchor discipline. The gap between
+      // the two is the number that says whether the bound is doing anything --
+      // one figure alone cannot distinguish "nothing to derive" from "derived
+      // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
       const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
       const dir = wikiDir(projectRoot);
@@ -976,6 +978,7 @@ async function runHook(clientName, event, invocation) {
         sessionId,
         candidates: derived.candidates.length,
         observations: derived.observations.length,
+        written: derived.written.length,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -172,6 +172,136 @@ export function toolSucceeded(raw) {
   return true;
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * The same family `toolSucceeded` reads above, hoisted so the three readers
+ * cannot drift apart. Clients disagree on the envelope name and on nothing
+ * else, so this is the one place that disagreement is spelled out.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/** A non-empty string, or null.  Blank output is the same as none. */
+function nonEmpty(value) {
+  const text = String(value ?? '');
+  return text.trim() ? text : null;
+}
+
+/**
+ * The human-readable result text inside one envelope, or null.
+ *
+ * RETURNS NULL RATHER THAN GUESSING. An envelope shape nobody here has seen
+ * produces no capture at all, which costs one finding. Stringifying it instead
+ * would put `[object Object]` or a wall of JSON metadata into a claim that gets
+ * injected into model context -- a wrong observation, which is strictly worse
+ * than a missing one.
+ */
+function resultText(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'string') return nonEmpty(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return null;
+
+  // MCP content blocks, which is how THIS PROJECT'S OWN tools now arrive:
+  // `normalizeTool` resolves `mcp__<server>__smart_edit`, so smart_edit and
+  // smart_write reach the post-tool path for the first time and their results
+  // are `{ content: [{ type: 'text', text }], isError }` rather than a shell
+  // result. Both the bare array and the wrapping object are accepted because
+  // hosts differ on whether they hand the hook the result or its content.
+  if (Array.isArray(value)) {
+    const blocks = value
+      .map((block) =>
+        typeof block === 'string' ? block : nonEmpty(block?.text)
+      )
+      .filter(Boolean);
+    return blocks.length ? nonEmpty(blocks.join('\n')) : null;
+  }
+  if (typeof value !== 'object') return null;
+
+  // STDERR FIRST, and not because that is the order it was produced in. The
+  // cap can only ever cut the tail, and the diagnostic that explains a failure
+  // is almost always on stderr while the volume is almost always on stdout --
+  // so appending stderr would let a 3 MB build log push the one line worth
+  // capturing out of the window.
+  const streams = [nonEmpty(value.stderr), nonEmpty(value.stdout)].filter(
+    Boolean
+  );
+  if (streams.length) return streams.join('\n');
+
+  if (Array.isArray(value.content)) {
+    const inner = resultText(value.content);
+    if (inner) return inner;
+  }
+
+  const error = value.error;
+  if (error) {
+    const message =
+      typeof error === 'string' ? error : nonEmpty(error.message ?? error.msg);
+    if (message) return message;
+  }
+
+  return (
+    nonEmpty(value.output) ??
+    nonEmpty(value.text) ??
+    nonEmpty(value.message) ??
+    (typeof value.result === 'string' ? nonEmpty(value.result) : null)
+  );
+}
+
+/**
+ * The result text of a completed tool call, or null when the client reports
+ * none.  Redaction and the size cap are NOT applied here -- they belong at the
+ * `recordToolOutcome` boundary, which is the only place every caller passes.
+ */
+export function outputFrom(raw) {
+  for (const envelope of responseEnvelopes(raw)) {
+    const text = resultText(envelope);
+    if (text) return text;
+  }
+  return resultText(raw?.output) ?? resultText(raw?.stdout) ?? null;
+}
+
+/**
+ * Key names that mean "process exit code" and nothing else.
+ *
+ * `code` is deliberately ABSENT. JSON-RPC errors (`code: -32602`), Node errno
+ * objects (`code: 'ENOENT'`) and HTTP wrappers all reuse that name, so reading
+ * it would record a confident exit code for calls that never had one. A null
+ * here is honest; a -32602 claiming to be an exit status is not.
+ */
+const EXIT_KEYS = [
+  'exit_code',
+  'exitCode',
+  'exit',
+  'exit_status',
+  'exitStatus',
+  'return_code',
+  'returncode',
+];
+
+/** The numeric exit code a client reported, or null when it reported none. */
+export function exitFrom(raw) {
+  for (const envelope of [...responseEnvelopes(raw), raw]) {
+    if (!envelope || typeof envelope !== 'object') continue;
+    for (const key of EXIT_KEYS) {
+      const value = envelope[key];
+      if (Number.isInteger(value)) return value;
+      // A client that serializes the code as a digit string still reported it.
+      // Bounded so a hash or an id cannot be mistaken for a status.
+      if (typeof value === 'string' && /^-?\d{1,5}$/.test(value.trim()))
+        return Number(value.trim());
+    }
+  }
+  return null;
+}
+
 function contextOutput(client, eventName, additionalContext) {
   if (client.contextStyle === 'top-level') return { additionalContext };
   if (client.contextStyle === 'cline') {
@@ -890,6 +1020,11 @@ async function runHook(clientName, event, invocation) {
         anchor,
         toolName: payload.tool_name,
         success: toolSucceeded(raw),
+        // The two fields a boolean cannot carry: which KIND of failure this
+        // was. Read through the same normalisers as `success`, never off `raw`
+        // at this call site.
+        output: outputFrom(raw),
+        exit: exitFrom(raw),
         durationMs:
           Number(
             raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -145,11 +145,43 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because three readers depend on it -- success
+ * classification, output capture and exit-code capture -- and clients disagree
+ * on the envelope name and on nothing else. Letting each reader name its own
+ * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
+    return false;
+  // MCP'S OWN FAILURE FLAG, which this function did not read for as long as it
+  // existed. It did not matter while `normalizeTool` dropped MCP names before
+  // any accounting ran; it matters now that `mcp__<server>__smart_edit` and
+  // `smart_write` reach the post-tool path, because an MCP result carries no
+  // `error` field and no `status` -- only `isError` -- so a failed smart_edit
+  // fell through to the optimistic `return true` below.
+  //
+  // WHY THIS IS A MEASUREMENT BUG AND NOT A COSMETIC ONE: this boolean feeds
+  // episode outcomes and effectiveness accounting, so recording every failed
+  // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
+  // optimizer's favour. A measurement that flatters the thing being measured
+  // is worse than no measurement.
+  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
     return false;
   const status =
     raw?.tool_response?.status ??
@@ -170,23 +202,6 @@ export function toolSucceeded(raw) {
   // that its output proved the task.  `success` here is deliberately scoped to
   // the tool call; task correctness comes only from an eval grader.
   return true;
-}
-
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * The same family `toolSucceeded` reads above, hoisted so the three readers
- * cannot drift apart. Clients disagree on the envelope name and on nothing
- * else, so this is the one place that disagreement is spelled out.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
 }
 
 /** A non-empty string, or null.  Blank output is the same as none. */

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -58,6 +58,7 @@ import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { briefing } from './remedy.mjs';
 import { stableText, transcriptFor } from './cache.mjs';
+import { scoreRefreshes } from './keepwarm.mjs';
 import { cachedRoutingBriefing } from './routing.mjs';
 import {
   forCommand,
@@ -1010,6 +1011,26 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE KEEP-WARM FEEDBACK ARM, at the boundary where a turn has just
+      // ended -- which is the only place the arrival question can be answered.
+      // Every refresh whose TTL has since elapsed is scored here as used or
+      // unused; anything the log cannot settle is left unscored rather than
+      // recorded as a miss, because an absent signal is not a miss.
+      //
+      // Nothing in this repository issues a refresh today -- cache_audit only
+      // recommends one -- so this scores nothing, and what it costs while
+      // dormant is one readBalance: median 70 ms on this machine's 3.5 MB log,
+      // against derive's 71-111 ms a few lines below on the same path. The
+      // firehose is read for ARRIVALS only if an unscored refresh exists, so
+      // the dormant case never pays for that. The moment an issuer exists, the
+      // decision starts learning with no second wiring change.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      scoreRefreshes(dir);
+    } catch {
+      // A refresh that cannot be scored costs a measurement, not a session.
     }
     try {
       // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -40,11 +40,13 @@ import {
   touchedFiles,
 } from './decide.mjs';
 import {
+  record,
   recordRead,
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
 } from './metrics.mjs';
+import { derive } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -948,6 +950,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // ZERO-COST DERIVATION, on every client, with no credential. The semantic
+      // harvest below needs an API key, so on a machine without one the graph
+      // accumulates structure and no verdicts at all. These detectors read only
+      // what is already on disk and send nothing anywhere.
+      //
+      // The COUNT is recorded rather than the candidates: how many findings a
+      // session's own evidence supports is the number that says whether this is
+      // working, and it is measurable before anything is stored. Storage is the
+      // caller's next step, under a budget.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      const dir = wikiDir(projectRoot);
+      const derived = derive(dir, {
+        sessionId,
+        projectRoot,
+        transcriptPath: agentScope,
+        // The hook payload's own identity, not a value a model typed.
+        authoritativeSessionId: sessionId,
+      });
+      record(dir, {
+        kind: 'derive',
+        sessionId,
+        candidates: derived.candidates.length,
+        observations: derived.observations.length,
+      });
+    } catch {
+      // A detector failing must never cost a user the end of their session.
     }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -72,7 +72,8 @@ import {
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
-import { isArchived } from './transcript.mjs';
+import { archive, isArchived } from './transcript.mjs';
+import { harvestMode } from './harvest.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
@@ -577,6 +578,65 @@ function emit(object) {
   process.stdout.write(serialized);
 }
 
+/**
+ * What will and will not extract findings after this session, in one sentence.
+ *
+ * THE STATE WAS ONLY EVER LEGIBLE FROM THE DOCTOR, and the doctor is a place
+ * someone visits after they already suspect something is wrong. A user watching
+ * a graph fill with structural nodes and no verdicts has no reason to suspect
+ * anything, which is the failure this project has now measured twice.
+ *
+ * IT IS ADDRESSED TO THE MODEL, NOT ONLY TO THE READER, which is why it earns a
+ * place in the prefix rather than a systemMessage. "Nothing else will write this
+ * down in words" changes what the model does with a conclusion it is holding;
+ * "here is a configuration variable" would not.
+ *
+ * CACHE-SAFE: derived from configuration, so it differs between sessions only
+ * when the configuration does -- the same standard the rest of this block is
+ * held to, and it carries no digits for `stableText` to reject.
+ *
+ * A local endpoint is named FIRST in the off case on purpose. It is the option
+ * that costs nothing and sends nothing, and it was the one buried deepest.
+ */
+function extractionNotice() {
+  switch (harvestMode()) {
+    case 'local':
+      return (
+        '\n\nA local model endpoint is configured, so semantic extraction also runs after this ' +
+        'session -- free and private, with nothing leaving this machine.'
+      );
+    case 'remote':
+      return (
+        '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
+        'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
+    case 'off:mode':
+      // The whole optimizer is off and this text is not emitted anyway. Saying
+      // anything here would be noise stacked on an explicit choice.
+      return '';
+    case 'off:opted-out':
+      // A DELIBERATE CHOICE, SO NO PITCH. The consequence is stated because the
+      // model needs it; the setting that would reverse it is not, because
+      // arguing with a configured decision on every session is how a notice
+      // stops being read. doctor.mjs draws the same line for the same reason.
+      return (
+        '\n\nFallback extraction is off by configuration, so a conclusion you do not record is ' +
+        'not written down in words anywhere. Findings are still derived locally from exit codes, ' +
+        'red-to-green transitions and corrections.'
+      );
+    default:
+      // off:no-key, and any mode a future harvest adds: no extractor is running
+      // and nobody chose that, so the free option is worth naming.
+      return (
+        '\n\nNo separate extractor will run after this session, so a conclusion you do not record ' +
+        'is not written down in words anywhere. Findings are still derived locally from exit ' +
+        'codes, red-to-green transitions and corrections. Pointing ' +
+        'TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model adds semantic extraction, free and ' +
+        'private.'
+      );
+  }
+}
+
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
 export function policyText(
   canDeny,
@@ -635,7 +695,7 @@ export function policyText(
     .filter(Boolean)
     .join(' ');
   const recording = tools.has('wiki_write')
-    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.`
+    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.${extractionNotice()}`
     : '\n\nStructural graph capture remains active through lifecycle hooks. Durable semantic MCP writes are not requested because the writer schema is not proven available.';
 
   return `# Token optimization is active\n\nLive graph capture is active through the lifecycle adapter.\n\n${connection}${routing}${enforcement}${utilities ? `\n\n${utilities}` : ''}${recording}${projectBriefing()}`;
@@ -950,6 +1010,27 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.
+      //
+      // This was lost rather than retired. `plugin/hooks/stop-harvest.mjs` called
+      // `archive()` at Stop, and #300 replaced that entry in `hooks.json` with the
+      // generated `stop.mjs`, which routes here -- so on Claude Code no session has
+      // been archived since. Nothing failed loudly: `readArchive` simply returns an
+      // empty list, so `derive`'s correction detector fell through to the live
+      // transcript (present only for a client that reports one) and `lessons.mjs`
+      // lost the only corpus it can verify a verbatim quote against, which is the
+      // single test that grants a feedback finding human origin.
+      //
+      // BEFORE `derive`, deliberately: the correction detector reads the archive
+      // first and treats the live transcript as the fallback, and the archive is
+      // the copy that survives into later sessions.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      if (agentScope) archive(dir, agentScope, { sessionId });
+    } catch {
+      // The archive is a record, not a result. A session still ends.
     }
     try {
       // ZERO-COST DERIVATION, on every client, with no credential. The semantic

--- a/integrations/windsurf/hooks/lib/audit.mjs
+++ b/integrations/windsurf/hooks/lib/audit.mjs
@@ -32,6 +32,7 @@
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
+import { looNote } from './loo.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -401,6 +402,16 @@ export function renderAudit(
   // project with no injections and no queries gains no line at all.
   const reference = referenceNote(dir);
   if (reference) body.push('', reference);
+
+  // WHAT ONE FINDING IS CAUSALLY WORTH (Layer 2).
+  //
+  // The same reasoning as above, and the same refusal: `looNote` returns null
+  // until the leave-one-out experiment has collected an observation, and says
+  // NOT MEASURABLE YET rather than printing a mean until it clears the floor.
+  // A causal number is the most quotable thing this project can produce, so it
+  // is the one that most needs to be absent when it is not earned.
+  const causal = looNote(dir);
+  if (causal) body.push('', causal);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/windsurf/hooks/lib/audit.mjs
+++ b/integrations/windsurf/hooks/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
 import { looNote } from './loo.mjs';
+import { calibrationNote } from './crosslayer.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -244,9 +245,15 @@ export function renderAudit(
     lines.push(text);
   }
 
+  // SCOPED TO THE QUEUE, because that is all it ever described. The bare
+  // sentence "Nothing addressable found." was printed directly above a Layer 1
+  // reference note and a published Layer 2 causal verdict -- so a reader was
+  // told nothing had been found immediately before being shown a finding. The
+  // headline is about the remediation queue and nothing else, and saying so
+  // costs four words and removes a false negative shown to a human.
   const head = shown.length
     ? ['What to do next, most expensive first:', ...lines]
-    : ['Nothing addressable found.'];
+    : ['Nothing addressable found in the remediation queue.'];
 
   const body = [...head];
 
@@ -412,6 +419,16 @@ export function renderAudit(
   // is the one that most needs to be absent when it is not earned.
   const causal = looNote(dir);
   if (causal) body.push('', causal);
+
+  // WHETHER LAYER 1'S CHEAP LABEL PREDICTS LAYER 2'S EXPENSIVE EFFECT.
+  //
+  // The reason this is printed rather than kept for a dashboard: the reference
+  // rate is the number a reader is most likely to quote as a saving, and it is
+  // not one until this comparison says so. `calibrationNote` returns null while
+  // both layers are silent, and otherwise prints the refusal -- naming which
+  // input was insufficient -- rather than a gap of zero.
+  const calibrated = calibrationNote(dir);
+  if (calibrated) body.push('', calibrated);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/windsurf/hooks/lib/audit.mjs
+++ b/integrations/windsurf/hooks/lib/audit.mjs
@@ -61,6 +61,28 @@ export function declines(dir, { events = readMetrics(dir) } = {}) {
   return counts;
 }
 
+/**
+ * What the local Stop-time derivation path produced in the visible event log.
+ *
+ * The producer records all three counts because any one of them alone is
+ * ambiguous: zero stored can mean no evidence, no candidates, or a binding
+ * storage/anchor filter. This reader keeps those states distinct and prevents
+ * the telemetry itself from becoming an unobserved cost.
+ */
+export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
+  const runs = events.filter((event) => event.kind === 'derive');
+  if (!runs.length) return null;
+
+  const sum = (field) =>
+    runs.reduce((total, event) => total + Math.max(0, Number(event[field]) || 0), 0);
+  const candidates = sum('candidates');
+  const observations = sum('observations');
+  const written = sum('written');
+  return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
+    `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
+    `across ${runs.length.toLocaleString()} Stop run(s).`;
+}
+
 const idOf = (finding) =>
   finding.remedy
     ? `${finding.remedy.type}:${finding.remedy.anchor || finding.remedy.file || (finding.remedy.anchors || []).join(',')}`
@@ -399,6 +421,15 @@ export function renderAudit(
       );
     }
   }
+
+  // WHAT THE DEFAULT, LOCAL DERIVATION PATH ACTUALLY PRODUCED.
+  //
+  // This event used to have a producer and no reader. Keep its three states
+  // together: evidence seen, candidates derived, and findings that survived
+  // selection/storage. A lone stored count would turn every earlier refusal
+  // into an apparent "nothing found" result.
+  const derived = derivationNote(dir);
+  if (derived) body.push('', derived);
 
   // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
   //

--- a/integrations/windsurf/hooks/lib/audit.mjs
+++ b/integrations/windsurf/hooks/lib/audit.mjs
@@ -31,6 +31,7 @@
  */
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
+import { referenceNote } from './usage.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -390,6 +391,16 @@ export function renderAudit(
       );
     }
   }
+
+  // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
+  //
+  // Printed here because this is the report that already asks "did the advice
+  // change anything", and because a measurement with no reader is how this
+  // project shipped two metrics whose only consumer was their own test suite.
+  // `referenceNote` returns null when it has nothing honest to say, so a
+  // project with no injections and no queries gains no line at all.
+  const reference = referenceNote(dir);
+  if (reference) body.push('', reference);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/integrations/windsurf/hooks/lib/consolidate.mjs
+++ b/integrations/windsurf/hooks/lib/consolidate.mjs
@@ -142,7 +142,8 @@ const ALWAYS_KEEP = new Set(['failure', 'decision']);
  * Chooses what to promote into the graph, under a token budget.
  *
  * @param {object} graph      Loaded wiki graph, for reuse probability.
- * @param {Array}  candidates Extracted conclusions, each { type, summary, anchors, evidence, at }.
+ * @param {Array}  candidates Extracted conclusions, each { type, claim (or summary),
+ *                              anchors, evidence, at }.
  * @param {object} options    budget: tokens available for promoted findings.
  */
 export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}) {
@@ -221,4 +222,3 @@ export function aggregateConsolidation(findings) {
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
-

--- a/integrations/windsurf/hooks/lib/crosslayer.mjs
+++ b/integrations/windsurf/hooks/lib/crosslayer.mjs
@@ -1,0 +1,351 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/crosslayer.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The calibration loop: does Layer 1's LABEL predict Layer 2's EFFECT?
+ *
+ * Layer 1 (`usage.mjs`) classifies an injected finding by whether the model
+ * later NAMED it. Layer 2 (`loo.mjs`) measures, by leave-one-out, how many
+ * tokens of reading a finding actually SUPPRESSED. Those are two different
+ * quantities, and the whole point of putting them side by side is that the
+ * cheap one (a label, available on every injection) might stand in for the
+ * expensive one (a causal effect, costing three withheld sessions per finding).
+ *
+ * WHY THIS IS A REAL QUESTION AND NOT A TAUTOLOGY. Task 7 established the
+ * independence three ways -- statically (`loo.mjs` contains no `query` or
+ * `reference`; `usage.mjs` contains no `tokens`, `cost` or `bytes`),
+ * behaviourally in both directions, and by naming the one overlap that does
+ * exist (`recordToolOutcome`'s join, which supplies ATTRIBUTABILITY to both and
+ * the measured quantity to neither). This module is built to preserve that:
+ *
+ *   - from Layer 1 it takes ONLY the categorical label per finding key. No
+ *     rate, no count, no magnitude -- Layer 1 has no magnitude to give.
+ *   - from Layer 2 it takes ONLY the effect magnitude per finding key.
+ *   - the join is the finding key, which is a graph identity and not a
+ *     measurement.
+ *
+ * If a magnitude common to both ever entered, this would correlate a quantity
+ * with itself and report a strong result that means nothing. Two tests pin the
+ * separation from opposite sides: flipping the labels while holding the effects
+ * fixed must move the gap, and changing Layer 1's rate WITHOUT changing any
+ * label must leave the gap byte-identical.
+ *
+ * MEASURED UTILITY RANKS A FINDING. IT MUST NEVER RAISE ITS CONFIDENCE.
+ * A confidently WRONG finding suppresses reads better than a hedged true one,
+ * so utility alone optimises directly against "wrong findings are worse than
+ * none". The plan called for a `mayPromote` gate over
+ * `hasOutstandingContradiction` here. There is nothing to gate: every write of
+ * `confidence` in `hooks-core` happens at CREATION (a per-producer constant in
+ * `derive.mjs` / `lessons.mjs` / `harvest.mjs`, or a human's own number in
+ * `curate.mjs`), and no code path updates a stored finding's confidence
+ * afterwards. `assessFindings` in `utility.mjs` READS confidence into an
+ * ephemeral `netUtility` used for ordering and writes nothing back. So a gate
+ * here would be unreachable, and an unreachable gate is the exact defect class
+ * this work exists to close. `hasOutstandingContradiction` already has its
+ * real consumer -- `staleness.mjs` calls it as the dispute gate on serve.
+ * What is enforceable is the invariant itself, and it is: this module never
+ * writes to the graph, and `tests/hooks/calibration-loop.test.mjs` asserts that
+ * neither it nor either layer under it can move a stored confidence.
+ *
+ * NOTHING HERE IS PRICED. A calibration verdict, a holdout estimate and a
+ * consolidation ratio are all estimates; currency belongs only on a measured
+ * counterfactual, and `balanceSheet`'s `measuredCounterfactual` is the one
+ * section in the sheet below that qualifies.
+ */
+
+import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
+import { classify, referenceRate } from './usage.mjs';
+import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Distinct findings needed in EACH arm before a gap is reported at all.
+ *
+ * Two findings per arm is a difference of two numbers; the comparison would be
+ * dominated by whichever finding happened to sit on a big file. Three is still
+ * small, and the refusal says so rather than implying the gap is solid.
+ */
+export const MIN_FINDINGS_PER_ARM = 3;
+
+/**
+ * The smallest gap that may be PUBLISHED, in tokens per touch.
+ *
+ * Not an effect-size convention: it is tied to the unit the verdict prints. The
+ * published sentence rounds the gap to whole tokens, so a gap of 1e-13 -- which
+ * is what two arms of equal means produce once floating point has had its say --
+ * would publish as "referenced findings suppress 0 more tokens/touch". That is a
+ * calibration claim resting on arithmetic noise, and it leans the only direction
+ * a measurement of this project by this project must never lean.
+ */
+export const MIN_GAP_TOKENS = 1;
+
+/**
+ * The per-finding Layer 1 label, folded from per-injection rows.
+ *
+ * ANY reference wins. `classify` emits one row per (injection, finding) because
+ * one reference must not excuse every later injection -- that is the right unit
+ * for a RATE. For a label the question is different: did the model ever name
+ * this finding? A finding referenced once and ignored nine times is a finding
+ * the model reads, and averaging it into `not-referenced` would put it in the
+ * arm whose mean effect it is meant to predict.
+ *
+ * `unknown` rows are dropped rather than defaulted, exactly as Layer 1 drops
+ * them from its own denominator.
+ */
+export function labelsByFinding(rows) {
+  const labels = new Map();
+  for (const row of rows || []) {
+    const key = row?.findingKey;
+    if (typeof key !== 'string' || !key) continue;
+    if (row.label === 'referenced') labels.set(key, 'referenced');
+    else if (row.label === 'not-referenced' && !labels.has(key))
+      labels.set(key, 'not-referenced');
+  }
+  return labels;
+}
+
+const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * Does Layer 1's label predict Layer 2's effect?
+ *
+ * Returns `publishable`, a `verdict` in English, and `gap` ONLY when a gap was
+ * actually computed. There is no `gap: 0` for the unmeasured case, and that is
+ * deliberate: a permanent zero reads as "measured, and the two agree", which is
+ * the opposite of "nothing was measured". Task 7 deleted a field rather than
+ * zero it for the same reason.
+ *
+ * FAILS OPEN. This runs on report paths that must not break a tool call.
+ */
+export function calibration(dir, options = {}) {
+  const refuse = (verdict, extra = {}) => ({
+    publishable: false,
+    verdict,
+    ...extra,
+  });
+
+  try {
+    // ONE READ for both layers, so the two arms of the comparison cannot cover
+    // different spans of the log. `referenceRate` reports `windowed: false`
+    // when the caller supplies events -- correctly, since the bounds are then
+    // the caller's -- so the truncation flag is taken here, from the read that
+    // actually set it, and republished.
+    const supplied = options.events || null;
+    const events = supplied || readMetrics(dir);
+    const truncation = supplied ? null : readTruncation();
+    const truncated = Boolean(
+      truncation && (truncation.byBytes || truncation.byEvents)
+    );
+
+    const layer1 = referenceRate(dir, { events });
+    const labels = labelsByFinding(classify(dir, { events }));
+
+    const obs = observations(dir, { ...options, events });
+    const rows = effects(dir, { ...options, events, obs });
+
+    // ONE POLICY VERSION. Layer 2 refuses to pool arms across serving
+    // policies; a calibration that pooled them would undo that guard one level
+    // up. Rows from any other policy are excluded and counted.
+    const policy = servingPolicyVersion();
+    const inPolicy = rows.filter((row) => row.policy === policy);
+
+    const layer2 = {
+      rows: rows.length,
+      inPolicy: inPolicy.length,
+      published: rows.filter((row) => row.published).length,
+      observations: obs.rows.length,
+      policy,
+    };
+    const l1 = {
+      referenced: layer1.referenced,
+      notReferenced: layer1.notReferenced,
+      unknown: layer1.unknown,
+      denominator: layer1.denominator,
+      rate: layer1.rate,
+      referenceEvents: layer1.referenceEvents,
+    };
+
+    const excluded = { layer1Unknown: layer1.unknown, unlabelled: 0, noEffect: 0 };
+    const arms = { referenced: [], notReferenced: [] };
+    for (const row of inPolicy) {
+      // THE SHRUNK ESTIMATE, not the raw one. Shrinkage pulls every finding
+      // toward the population mean, so it pulls the GAP toward zero -- the
+      // bias runs against publishing, which is the only direction a
+      // measurement of this project by this project may lean.
+      if (row.shrunk === null || !Number.isFinite(row.shrunk)) {
+        excluded.noEffect += 1;
+        continue;
+      }
+      const label = labels.get(row.findingKey);
+      if (label === 'referenced') arms.referenced.push(row.shrunk);
+      else if (label === 'not-referenced') arms.notReferenced.push(row.shrunk);
+      else excluded.unlabelled += 1;
+    }
+
+    const context = { layer1: l1, layer2, arms: { referenced: arms.referenced.length, notReferenced: arms.notReferenced.length }, excluded, windowed: truncated };
+    const caveat = truncated
+      ? ' The event log was truncated, so both sides can understate.'
+      : '';
+
+    // WHICH INPUT WAS INSUFFICIENT, named. "Not enough data" tells a reader
+    // nothing about which half of the loop to go and fix.
+    const l1Silent = layer1.rate === null;
+    const l2Silent = layer2.observations === 0;
+    if (l1Silent || l2Silent) {
+      const why = [];
+      if (l1Silent)
+        why.push(
+          `Layer 1 has ${layer1.denominator} classifiable observation(s) and ` +
+            `${layer1.referenceEvents} reference event(s), so it publishes no rate`
+        );
+      if (l2Silent)
+        why.push(
+          `Layer 2 has ${layer2.observations} observation(s), so it publishes no effect`
+        );
+      return refuse(
+        `not calibrated: ${why.join('; and ')}. No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+    }
+
+    // A POLICY CHANGE RESETS THE CALIBRATION, and says so rather than reporting
+    // an empty arm. Layer 2 refuses to pool arms across serving policies, so
+    // rows generated under an older one cannot answer a question about how the
+    // graph serves findings today -- but "0 findings per arm" would send a
+    // reader hunting for missing observations that are right there in the log.
+    if (rows.length > 0 && inPolicy.length === 0)
+      return refuse(
+        `not calibrated: all ${rows.length} Layer 2 effect row(s) were measured under a different serving ` +
+          `policy than the current ${policy}, and arms are never pooled across policies. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (layer2.published === 0)
+      return refuse(
+        `not calibrated: Layer 2 has ${layer2.observations} observation(s) but no published effect at q=0.1, ` +
+          'so its per-finding numbers are noise and a difference between two means of them would be too. ' +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (
+      arms.referenced.length < MIN_FINDINGS_PER_ARM ||
+      arms.notReferenced.length < MIN_FINDINGS_PER_ARM
+    )
+      return refuse(
+        `not calibrated: ${arms.referenced.length} referenced and ${arms.notReferenced.length} not-referenced ` +
+          `finding(s) carry a Layer 2 effect, below the floor of ${MIN_FINDINGS_PER_ARM} per arm. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    const referencedMean = mean(arms.referenced);
+    const notReferencedMean = mean(arms.notReferenced);
+    const gap = referencedMean - notReferencedMean;
+    const measured = { ...context, gap, referencedMean, notReferencedMean };
+
+    if (!(gap >= MIN_GAP_TOKENS))
+      return refuse(
+        `uncalibrated: Layer 1's "referenced" label does not predict a larger Layer 2 effect ` +
+          `(referenced ${Math.round(referencedMean).toLocaleString()} vs not-referenced ` +
+          `${Math.round(notReferencedMean).toLocaleString()} tokens/touch, gap ${Math.round(gap).toLocaleString()}). ` +
+          `Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
+    return {
+      publishable: true,
+      verdict:
+        `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
+      ...measured,
+    };
+  } catch {
+    return refuse(
+      'not calibrated: the calibration inputs could not be read. No gap is reported, which is not the same as a gap of zero.'
+    );
+  }
+}
+
+/**
+ * What the graph cost to build against what it carries -- AN ESTIMATE, and
+ * never priced.
+ *
+ * `consolidationRatio` is the per-finding form and the aggregate is the fold.
+ * Both need `derivedCost`, which `expand.promote` persists onto the finding
+ * node it creates (`src/server/disclosure.ts` is its caller) and which
+ * `harvest-write.mjs` does not yet carry through -- so a graph built only by
+ * the harvest reports nothing here rather than a ratio of one.
+ */
+export function consolidation(dir, { graph = null } = {}) {
+  try {
+    const g = graph || load(dir);
+    const findings = [...g.nodes.values()].filter(
+      (node) => node.kind === 'finding' && !node.retired
+    );
+    const rated = [];
+    for (const finding of findings) {
+      const ratio = consolidationRatio(finding);
+      if (ratio === null) continue;
+      rated.push({ key: finding.key, ratio, derivedCost: finding.derivedCost });
+    }
+    const aggregate = aggregateConsolidation(findings);
+    return {
+      what: 'cost to derive against cost to carry',
+      // SAID IN THE DATA, not only in the prose above it, because this is the
+      // field a dashboard will read and a dashboard will not read a comment.
+      basis: 'estimate',
+      priced: false,
+      findings: findings.length,
+      withDerivedCost: rated.length,
+      aggregate,
+      best: rated.sort((a, b) => b.ratio - a.ratio).slice(0, 5),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The balance sheet with the graph's own three measurements attached.
+ *
+ * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
+ * imports, so it cannot import them back. This is where the two meet, and it
+ * is the shape `get_optimization_report` serves.
+ */
+export function graphBalanceSheet(dir, options = {}) {
+  const sheet = balanceSheet(dir);
+  const cal = calibration(dir, options);
+  const { layer1 = null, layer2 = null } = cal;
+  return {
+    ...sheet,
+    layer1,
+    layer2,
+    calibration: cal,
+    consolidation: consolidation(dir, options),
+  };
+}
+
+/**
+ * One audit line, or null when there is nothing honest to say.
+ *
+ * Silent when NEITHER layer has produced anything: a reader of a graph that has
+ * never injected a finding is owed no paragraph about a loop that has not
+ * started. The moment either side speaks, the refusal is worth printing --
+ * because at that point a reader could otherwise take Layer 1's rate for a
+ * saving, which is precisely what this loop exists to stop.
+ */
+export function calibrationNote(dir, options = {}) {
+  try {
+    const result = calibration(dir, options);
+    const l1 = result.layer1;
+    const l2 = result.layer2;
+    if (!l1 || !l2) return null;
+    if (l1.denominator === 0 && l2.observations === 0) return null;
+    return `Layer 1 against Layer 2: ${result.verdict}`;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/windsurf/hooks/lib/crosslayer.mjs
+++ b/integrations/windsurf/hooks/lib/crosslayer.mjs
@@ -54,7 +54,13 @@
 
 import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
-import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import {
+  effects,
+  observations,
+  servingPolicyVersion,
+  permutationP,
+  FDR_Q,
+} from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
 import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
@@ -106,6 +112,32 @@ export function labelsByFinding(rows) {
 }
 
 const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * A deterministic, label-symmetric permutation test for the headline gap.
+ *
+ * Layer 2 only publishes a per-finding row after a two-sided permutation test.
+ * The calibration headline summarises those rows, so a positive difference of
+ * arm means must clear the same evidential bar rather than being promoted just
+ * because it points in this project's favour.
+ *
+ * Sorting within each arm and then sorting the two arms makes the sampled path
+ * invariant to event order and to swapping the labels. The seed is derived
+ * from that canonical data instead of shared globally, so two different
+ * datasets do not reuse one arbitrary sequence of sampled relabellings.
+ */
+export function calibrationP(referenced, notReferenced) {
+  const arms = [referenced, notReferenced]
+    .map((values) => [...values].sort((a, b) => a - b))
+    .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  const encoded = JSON.stringify(arms);
+  let seed = 2166136261;
+  for (const char of encoded) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return permutationP(arms[0], arms[1], { seed: seed >>> 0 });
+}
 
 /**
  * Does Layer 1's label predict Layer 2's effect?
@@ -244,7 +276,16 @@ export function calibration(dir, options = {}) {
     const referencedMean = mean(arms.referenced);
     const notReferencedMean = mean(arms.notReferenced);
     const gap = referencedMean - notReferencedMean;
-    const measured = { ...context, gap, referencedMean, notReferencedMean };
+    const p = calibrationP(arms.referenced, arms.notReferenced);
+    const measured = {
+      ...context,
+      gap,
+      referencedMean,
+      notReferencedMean,
+      p,
+      alpha: FDR_Q,
+      test: 'two-sided permutation',
+    };
 
     if (!(gap >= MIN_GAP_TOKENS))
       return refuse(
@@ -255,11 +296,20 @@ export function calibration(dir, options = {}) {
         measured
       );
 
+    if (p === null || p > FDR_Q)
+      return refuse(
+        `not calibrated: the positive Layer 1/Layer 2 gap is not statistically resolved by the ` +
+          `two-sided permutation test (p=${p === null ? 'unavailable' : p.toFixed(3)}, ` +
+          `alpha=${FDR_Q.toFixed(3)}). Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
     return {
       publishable: true,
       verdict:
         `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
-        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, ` +
+        `shrunk estimates, two-sided permutation p=${p.toFixed(3)}). ` +
         `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
       ...measured,
     };

--- a/integrations/windsurf/hooks/lib/crosslayer.mjs
+++ b/integrations/windsurf/hooks/lib/crosslayer.mjs
@@ -56,6 +56,7 @@ import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
 import { effects, observations, servingPolicyVersion } from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
 
 /**
@@ -309,11 +310,19 @@ export function consolidation(dir, { graph = null } = {}) {
 }
 
 /**
- * The balance sheet with the graph's own three measurements attached.
+ * The balance sheet with the graph's own measurements attached.
  *
  * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
  * imports, so it cannot import them back. This is where the two meet, and it
  * is the shape `get_optimization_report` serves.
+ *
+ * `recall` joins them as an OFFLINE PROBE, and that label travels in the data
+ * (`recall.basis`) as well as in the rendered line. It is not an observation of
+ * anything a session did: it deletes an anchor edge in memory and re-runs the
+ * real retrieval primitives over the graph as it stands right now. `recall.mjs`
+ * imports only `wiki.mjs` and `lexical.mjs`, neither of which imports anything
+ * in this direction, so no cycle -- the same reason `calibration` had to live
+ * here rather than in `metrics.mjs`.
  */
 export function graphBalanceSheet(dir, options = {}) {
   const sheet = balanceSheet(dir);
@@ -325,6 +334,7 @@ export function graphBalanceSheet(dir, options = {}) {
     layer2,
     calibration: cal,
     consolidation: consolidation(dir, options),
+    recall: recallProbe(dir, options),
   };
 }
 

--- a/integrations/windsurf/hooks/lib/derive.mjs
+++ b/integrations/windsurf/hooks/lib/derive.mjs
@@ -23,13 +23,21 @@
  * the observation supports no claim at all are refused rather than downgraded
  * (see `attemptKey` and the identical-text guard below).
  *
- * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
- * budget, belongs to the caller.
+ * WHAT IS STORED IS BOUNDED. Candidates go through `selectForConsolidation`
+ * before `writeHarvested`, so a long session cannot spend the whole retrieval
+ * budget of every later session on one afternoon's exit codes. Nothing enters
+ * the graph unbudgeted, and nothing enters it wearing a human origin.
  */
 
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
 import { readArchive, readTurns } from './transcript.mjs';
 import { redact } from './redact.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { load } from './wiki.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -106,6 +114,92 @@ const triggerFor = (command) =>
   attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
 
 /**
+ * Literal root-level files that define how a project is BUILT, RUN and TESTED,
+ * best first. A `command` claim is a claim about this project's commands, and
+ * this is the file those commands are declared in.
+ */
+const PROJECT_MARKERS = [
+  'package.json', 'pyproject.toml', 'Cargo.toml', 'go.mod', 'pom.xml',
+  'build.gradle.kts', 'build.gradle', 'build.sbt', 'mix.exs', 'composer.json',
+  'Gemfile', 'Package.swift', 'CMakeLists.txt', 'Makefile', 'Taskfile.yml',
+  'requirements.txt', 'setup.py', 'deno.json', 'bun.lockb',
+];
+
+/** .NET has no single literal marker; the solution or project file is one. */
+const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
+
+/**
+ * A REAL FILE to anchor a derived claim to, inside the project root.
+ *
+ * WHY NOT THE PROJECT ROOT ITSELF, which is what the extraction step reaches
+ * for and what `promoteToShared` uses in the shared tier. Because
+ * `writeHarvested` resolves every anchor through `indexFile`, `indexFile` reads
+ * the path, and reading a DIRECTORY returns null -- so a candidate anchored to
+ * `projectRoot` resolves to nothing, is refused as unanchorable, and the whole
+ * pipeline stores zero findings while reporting a healthy candidate count.
+ * Verified directly: `indexFile(dir, dir)` returns null. That refusal is
+ * correct and must not be weakened -- an anchor that cannot be indexed is an
+ * anchor that can never be invalidated -- so the anchor has to be a file.
+ *
+ * STALENESS DOES NOT MISFIRE ON THIS. `command`, `failure` and `feedback` are
+ * all outside `CONTENT_DEPENDENT` (staleness.mjs), so the anchor is a RETRIEVAL
+ * AND EXISTENCE hook rather than a contents claim: editing the manifest does
+ * not mark these findings stale. staleness.mjs names this exact case in its own
+ * comment -- "a claim about `npm test` anchored to package.json" -- and calls
+ * missing that invalidation the better error.
+ *
+ * A project with no recognisable marker gets the root back, which will not
+ * resolve, so its candidates are derived and then refused rather than stored
+ * against a fabricated anchor. That is the fail-open direction: no finding
+ * beats a finding anchored to something that is not what the claim is about.
+ */
+export function projectAnchor(projectRoot) {
+  if (!projectRoot) return null;
+  let entries;
+  try {
+    entries = readdirSync(projectRoot);
+  } catch {
+    return projectRoot;
+  }
+  const present = new Set(entries);
+  for (const marker of PROJECT_MARKERS) {
+    if (!present.has(marker)) continue;
+    const path = join(projectRoot, marker);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // A marker that cannot be stat'ed is not a marker.
+    }
+  }
+  // Sorted so two sessions in the same repository pick the SAME solution file:
+  // readdir order is not guaranteed stable across hosts, and an anchor that
+  // varies by host splits one finding into two nodes.
+  for (const entry of [...entries].sort()) {
+    if (!DOTNET_MARKER.test(entry)) continue;
+    const path = join(projectRoot, entry);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // Same.
+    }
+  }
+  return projectRoot;
+}
+
+/**
+ * Tokens of claim text one session may add to the graph.
+ *
+ * SCALED TO THE RETRIEVAL BUDGET IT COMPETES FOR, not picked round. A single
+ * command's injection budget is 500 tokens (`TOKEN_OPTIMIZER_TOUCH_BUDGET`),
+ * and everything stored here is competing for that budget on every later
+ * command, forever. Two touch-budgets per session is the bound: enough for a
+ * few dozen real claims, and short of one session's exit codes crowding out
+ * every finding a human or a model ever wrote.
+ */
+const storageBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_DERIVE_BUDGET) || 1000;
+
+/**
  * Derives finding candidates from one project's local evidence.
  *
  * @param {string} dir wiki directory.
@@ -118,11 +212,18 @@ const triggerFor = (command) =>
  *   and is refused by `writeHarvested` anyway, so emitting one would only spend
  *   the caller's budget on junk.
  * @param {string|null} options.authoritativeSessionId the session id as the HOOK
- *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
- *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
- *   edge -- `taskForAnchors` returns null without one, so an unverified string
- *   would silently produce no edge. Threaded rather than defaulted from
- *   `sessionId`: defaulting would promote any caller's string to trusted.
+ *   PAYLOAD reported it, never a value a model typed. Passed straight to
+ *   `writeHarvested`, which needs it to resolve the `answers` edge --
+ *   `taskForAnchors` returns null without one, so an unverified string would
+ *   silently produce no edge. Threaded rather than defaulted from `sessionId`:
+ *   defaulting would promote any caller's string to trusted. Also returned, so a
+ *   caller can see what it handed over.
+ * @returns {object} `{ candidates, observations, written, selected, dropped,
+ *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
+ *   everything derived; `written` is the subset of keys the graph actually
+ *   holds, which is smaller for three independent reasons -- the budget, the
+ *   anchor discipline, and the duplicate collapse that returns an EXISTING key
+ *   when a later session derives the same claim again.
  */
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
@@ -152,6 +253,11 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // ONE anchor for the whole run, so every candidate from this session points at
+  // the same node and the duplicate collapse in `writeHarvested` can recognise
+  // the same lesson across sessions.
+  const anchorPath = projectAnchor(projectRoot);
 
   const seen = new Set();
   const add = (candidate) => {
@@ -246,7 +352,7 @@ export function derive(dir, options = {}) {
               `observed in one session: \`${failed.command}\` failed` +
                 `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
                 `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
-                'an intervening edit or a flaky run explains the same pair.',
+                'an intervening edit or an unrelated environment change explains the same pair.',
               { max: EVIDENCE_MAX }
             ),
             applicability: 'when about to run this command in this project',
@@ -255,7 +361,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the failing form later succeeds unchanged'],
             trigger: triggerFor(outcome.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: outcome.at || Date.now(),
@@ -280,7 +386,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the same command later succeeds unchanged'],
             trigger: triggerFor(failed.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: failed.at || Date.now(),
@@ -330,7 +436,7 @@ export function derive(dir, options = {}) {
           confidenceLabel: labelFor(CONFIDENCE.correction),
           scope: 'project',
           invalidators: ['the user later asks for the corrected behaviour'],
-          anchors: [projectRoot],
+          anchors: [anchorPath],
           derivedBy: 'correction',
           sessionId,
           at: Date.parse(turn.at || '') || Date.now(),
@@ -379,6 +485,48 @@ export function derive(dir, options = {}) {
     }
   } catch {
     // One detector, never the session.
+  }
+
+  // ---- storage, under a budget -------------------------------------------
+  //
+  // NOTHING ENTERS THE GRAPH UNBUDGETED. `selectForConsolidation` existed for
+  // exactly this and had no caller, which meant that until now nothing bounded
+  // what a session could add. It admits `failure` and `decision` on a FLOOR
+  // before ranking -- a dead end exists nowhere else and is small, and cheap to
+  // find is not cheap to find again -- then fills the remainder by
+  // cost x irrecoverability x reuse-probability.
+  //
+  // ORIGIN_HARVESTED, EXPLICITLY, never ORIGIN_HUMAN. These are machine
+  // derivations; `curate.mjs` states the reason in its own header -- "a
+  // hand-written assertion and a machine guess look identical three months
+  // later, which quietly destroys the reader's ability to calibrate trust".
+  // `writeHarvested` would refuse a batch-wide human origin anyway, and a
+  // candidate here carries neither `origin` nor `quote`, so it cannot earn one
+  // per finding either. That is deliberate: whether a turn was a correction at
+  // all is a lexical guess, and the standing-rules layer selects on human
+  // origin to inject on EVERY turn.
+  try {
+    if (result.candidates.length) {
+      const selected = selectForConsolidation(load(dir), result.candidates, {
+        budget: storageBudget(),
+      });
+      result.selected = selected.kept.length;
+      result.dropped = selected.dropped;
+      result.selectedTokens = selected.tokens;
+      result.written = writeHarvested(dir, selected.kept, {
+        sessionId,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        // The hook payload's own identity, passed through untouched. Without it
+        // `taskForAnchors` returns null and the `answers` edge never fires --
+        // which is the state a default install has been in, because its only
+        // other producer is credential-gated.
+        authoritativeSessionId,
+      });
+    }
+  } catch {
+    // Storage is the last step and the session is already over. A graph write
+    // that fails must not turn a completed session into a hook error.
   }
 
   return result;

--- a/integrations/windsurf/hooks/lib/derive.mjs
+++ b/integrations/windsurf/hooks/lib/derive.mjs
@@ -139,17 +139,19 @@ const quotable = (command) => {
  * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
  * found across 163 transcripts on this machine it refuses 2 and keeps 6.
  *
- * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
- * building the key, so the claim is about `npm test` rather than about the `cd`.
- * That changes `attemptKey` for every client and every finding already derived
- * from it, so it belongs in its own change with its own comparison.
+ * `commandBody` below now skips a leading `cd <path> &&`, so those two are
+ * recovered and this guard is left holding only the keys that reached a
+ * separator which is NOT a directory change -- `git fetch && <anything>`, a
+ * pipeline, a `;`-joined pair. Those still name no single attempt.
  */
 const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
 
 /**
  * Did `attemptKey` actually capture a command, or only how one was chained?
  *
- * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart --
+ * which now means AFTER `commandBody` has removed any leading `cd`, so this no
+ * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
 const hasAttemptIdentity = (command) =>
@@ -177,6 +179,81 @@ const CORRECTION_OPENER =
   /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
 
 /**
+ * A leading directory change, stripped before the key is built.
+ *
+ * THE MEASURED CASE, AND ONLY THE MEASURED CASE. `attemptKey` spends up to
+ * three non-flag tokens on identity and the habit on this machine is
+ * `cd <absolute path> && <the real command>`, which spends all three on `cd`,
+ * the path and the separator. This repository's own corpus: 1,400 of 2,243
+ * command outcomes open with a `cd`, and the single key
+ * `cd c:/users/.../token-optimizer-mcp &&` covered 547 distinct command lines.
+ * A `cd` says WHERE a command ran; it says nothing about WHAT ran, so it cannot
+ * be part of the identity of an attempt.
+ *
+ * THE SEPARATOR SET IS THE ONE THAT WAS OBSERVED: `&&` (1,147), a newline (204)
+ * and `;` (38) after a leading `cd`. All three mean "then run this". `||` is
+ * DELIBERATELY EXCLUDED even though it costs one line to add: `cd x || echo
+ * failed` puts an error branch after the separator, not the next step, so
+ * stripping there would key the attempt on a failure handler. It occurred zero
+ * times.
+ *
+ * AND NOTHING WIDER, each refusal for a reason from the same corpus:
+ *
+ *   Environment assignments (`FOO=bar cmd`) DO carry information about what
+ *   ran. The one true instance here is
+ *   `TOKEN_OPTIMIZER_HOLDOUT=1 node ... jest.js ...`, and the holdout arm is a
+ *   genuinely different attempt from the same command without it. The other 20
+ *   are shell variable assignments joined by `;` -- statements, not prefixes --
+ *   whose value is usually a 120-character path that would be stripped down to
+ *   nothing useful.
+ *
+ *   `time`, `env`, `nice`, `sudo`, `bash -c`, `pushd`, `Set-Location`: ZERO
+ *   occurrences in 2,243 commands. Code for an unmeasured prefix is a way to
+ *   over-strip that no evidence asked for, and over-stripping merges commands
+ *   that genuinely differ -- the same bug in the other direction. `bash -c` is
+ *   worse than unmeasured: the command sits inside a quoted string, so stripping
+ *   the wrapper leaves a key beginning with a quote character.
+ *
+ *   `cd /d C:\path &&` and `cd "C:/a b" &&` need no extra rule -- the match runs
+ *   to the separator rather than counting tokens, so flags and quoted paths
+ *   containing spaces are consumed for free. Neither appears here, so neither is
+ *   claimed as tested behaviour beyond its unit test.
+ *
+ * A `cd` with NO separator is left alone: `cd <path>` on its own ran no command,
+ * and its key is as meaningless afterwards as before -- there is nothing to
+ * recover. Stripping is repeated up to `MAX_DIR_PREFIXES` times so
+ * `cd a && cd b && cmd` reaches `cmd`; the bound exists only so a pathological
+ * line cannot loop, since each pass must consume a whole `cd ... <sep>`.
+ *
+ * APPLIED IDENTICALLY TO BOTH SOURCES because it is applied INSIDE `attemptKey`,
+ * which is the single function both the event path and the transcript reader's
+ * output pass through. The 120-character anchor cap that makes the two agree on
+ * 266 of 266 keys is untouched and still applied on both sides before this runs.
+ */
+const DIR_PREFIX = /^\s*cd\s[^\r\n;&|]*?(?:&&|;|\r?\n)\s*/i;
+const MAX_DIR_PREFIXES = 4;
+
+/**
+ * The command text with any leading directory change removed.
+ *
+ * Used for the key AND for the identical-text refusal, which is the half that
+ * keeps this from becoming a licence to pair more loosely: without it,
+ * `cd repo && npm test` failing and `npm test` succeeding would emit
+ * "`npm test` succeeded where `cd repo && npm test` failed" at 0.90 -- two
+ * spellings of one attempt, dressed up as a difference that mattered. The
+ * claim itself still quotes the RAW command, because that is what ran.
+ */
+export function commandBody(command) {
+  let text = String(command || '');
+  for (let i = 0; i < MAX_DIR_PREFIXES; i++) {
+    const stripped = text.replace(DIR_PREFIX, '');
+    if (stripped === text) break;
+    text = stripped;
+  }
+  return text;
+}
+
+/**
  * The prefix that makes two invocations "the same attempt".
  *
  * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
@@ -194,7 +271,7 @@ const CORRECTION_OPENER =
  * ships a false claim into model context.
  */
 export function attemptKey(command) {
-  return String(command || '')
+  return commandBody(command)
     .trim()
     .split(/\s+/)
     .filter((token) => token && !token.startsWith('-'))
@@ -494,7 +571,14 @@ export function derive(dir, options = {}) {
           // is real and supports NEITHER claim, so nothing is emitted. This is
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
-          if (failed.command === outcome.command) continue;
+          // COMPARED WITH THE DIRECTORY CHANGE REMOVED, for the same reason
+          // the key is. `cd repo && npm test` and `npm test` are one attempt
+          // spelled two ways; before `commandBody` they landed in different
+          // groups and never met, and letting them meet without widening this
+          // guard would emit "`npm test` succeeded where `cd repo && npm test`
+          // failed" at 0.90 -- a difference in the claim that is not a
+          // difference in what ran. Same for two `cd`s to different paths.
+          if (commandBody(failed.command) === commandBody(outcome.command)) continue;
 
           // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
           // client both sides of almost every pair are truncated multi-line
@@ -502,10 +586,12 @@ export function derive(dir, options = {}) {
           // spending the retrieval budget of every later session.
           if (!quotable(failed.command) || !quotable(outcome.command)) continue;
 
-          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
-          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
-          // command lines in this repository alone, and any pair drawn from that
-          // group is a false claim about both halves.
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`. The
+          // `cd <path> &&` case that grouped 547 unrelated command lines in this
+          // repository is now handled earlier by `commandBody`; what is left
+          // here is every OTHER separator -- `git fetch && <anything>`, a
+          // pipeline, a `;`-joined pair -- where the key still names no single
+          // attempt and any pair drawn from it is false about both halves.
           if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =

--- a/integrations/windsurf/hooks/lib/derive.mjs
+++ b/integrations/windsurf/hooks/lib/derive.mjs
@@ -1,0 +1,385 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/derive.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Findings from data we already hold, with no model call.
+ *
+ * WHY THIS EXISTS. The semantic harvest is on by default but its real gate is a
+ * credential: `harvestMode()` returns `off:no-key` on any machine without one,
+ * which is CI, corporate laptops, and every subscription-only login. This
+ * repository's own graph is the evidence -- 2,965 symbol nodes, 904 file nodes,
+ * 128 task nodes and ONE finding -- because the structural layer accumulates
+ * from ordinary tool traffic while every verdict needed an API key this machine
+ * does not have.
+ *
+ * Everything here is derived from outcomes, transitions and corrections that are
+ * ALREADY RECORDED LOCALLY. Nothing is sent anywhere, nothing is billed, so
+ * there is nothing to consent to and this runs by default. It is the only
+ * finding producer on a machine without a key.
+ *
+ * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
+ * second command fixed the first -- an intervening edit, a dependency install or
+ * a flaky test explains it just as well. So each detector carries a confidence
+ * ceiling, the claim text says only what was OBSERVED, and the two shapes where
+ * the observation supports no claim at all are refused rather than downgraded
+ * (see `attemptKey` and the identical-text guard below).
+ *
+ * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
+ * budget, belongs to the caller.
+ */
+
+import { readMetrics, rereadsByAnchor } from './metrics.mjs';
+import { readArchive, readTurns } from './transcript.mjs';
+import { redact } from './redact.mjs';
+
+/**
+ * Ceilings, ordered by how much the evidence actually supports.
+ *
+ * A command that succeeded where a DIFFERENT command failed is close to a direct
+ * observation. A test or build going red-to-green is weaker, because the usual
+ * cause is the code changing between the two runs rather than anything about the
+ * command. A correction is a lexical guess about what a human meant. Churn
+ * describes our own reading behaviour and says nothing about the code at all.
+ */
+export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+
+/** Claim text cap. A finding is one sentence; a paragraph is evidence. */
+const CLAIM_MAX = 300;
+const EVIDENCE_MAX = 400;
+
+/** Bounded so a pathological log cannot turn session end into real work. */
+const MAX_CANDIDATES = 200;
+
+/**
+ * Commands whose red-to-green transition is usually explained by the CODE
+ * changing rather than by the command. They get the lower ceiling.
+ */
+const CODE_SENSITIVE = /\b(test|tests|jest|vitest|pytest|mocha|build|compile|tsc|lint|typecheck)\b/i;
+
+/**
+ * Openers that mark a user turn as a correction rather than an instruction.
+ *
+ * DELIBERATELY NARROW, and anchored to the START of the turn. The model-based
+ * extractor in `lessons.mjs` can read intent; this cannot, so it only claims the
+ * shapes where the first few words carry the whole signal. Recall is poor by
+ * design: a missed correction costs one finding, a false one puts words in the
+ * user's mouth at 0.6 confidence.
+ */
+const CORRECTION_OPENER =
+  /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
+
+/**
+ * The prefix that makes two invocations "the same attempt".
+ *
+ * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
+ * through what the alternatives do to real command lines:
+ *
+ *   Two tokens conflates `npm run build` with `npm run test`, and the pair then
+ *   produces "`npm run test` works where `npm run build` failed" -- a claim that
+ *   is simply false.
+ *
+ *   Counting flags splits `deploy` from `deploy --retry`, which is the single
+ *   most useful pair this detector can find, into two groups that never meet.
+ *
+ * Conservative in the remaining direction: `npm run build:prod` and
+ * `npm run build` do not pair. A missed pair costs one finding; a wrong pair
+ * ships a false claim into model context.
+ */
+export function attemptKey(command) {
+  return String(command || '')
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'))
+    .slice(0, 3)
+    .join(' ')
+    .toLowerCase();
+}
+
+/** Normalised claim text, so the same lesson derived twice is one candidate. */
+const claimKey = (type, claim) =>
+  `${type}|${String(claim).toLowerCase().replace(/\s+/g, ' ').trim()}`;
+
+/** 0.95 is reserved for verified; everything here is inference. */
+const labelFor = (confidence) => (confidence >= 0.75 ? 'probable' : 'speculative');
+
+/** A literal command prefix, safe to hand to `safeTrigger`. */
+const triggerFor = (command) =>
+  attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
+
+/**
+ * Derives finding candidates from one project's local evidence.
+ *
+ * @param {string} dir wiki directory.
+ * @param {object} options
+ * @param {string|null} options.sessionId session this ran for, for provenance.
+ * @param {string|null} options.transcriptPath live transcript, read only when the
+ *   archive holds nothing for this session yet.
+ * @param {string|null} options.projectRoot the anchor every derived claim gets.
+ *   Without it nothing is derived: an unanchored finding cannot be invalidated
+ *   and is refused by `writeHarvested` anyway, so emitting one would only spend
+ *   the caller's budget on junk.
+ * @param {string|null} options.authoritativeSessionId the session id as the HOOK
+ *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
+ *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
+ *   edge -- `taskForAnchors` returns null without one, so an unverified string
+ *   would silently produce no edge. Threaded rather than defaulted from
+ *   `sessionId`: defaulting would promote any caller's string to trusted.
+ */
+export function derive(dir, options = {}) {
+  // `options || {}` rather than a destructuring default. A default only fires on
+  // `undefined`, so a caller passing an explicitly null options object -- which
+  // is what a hook does when it has nothing to say -- threw a TypeError out of
+  // the parameter list itself, before any of the try/catch below could fail open.
+  const {
+    sessionId = null,
+    transcriptPath = null,
+    projectRoot = null,
+    authoritativeSessionId = null,
+  } = options || {};
+
+  const result = {
+    candidates: [],
+    observations: [],
+    written: [],
+    sessionId,
+    authoritativeSessionId,
+  };
+
+  let events;
+  try {
+    events = readMetrics(dir);
+  } catch {
+    // Session end must cost nothing. No evidence is not an error.
+    return result;
+  }
+  if (!Array.isArray(events)) return result;
+
+  const seen = new Set();
+  const add = (candidate) => {
+    if (result.candidates.length >= MAX_CANDIDATES) return;
+    const key = claimKey(candidate.type, candidate.claim);
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.candidates.push(candidate);
+  };
+
+  // ---- 1 & 2: a failed attempt followed by a succeeding one ---------------
+  //
+  // The event is `tool-outcome` and THE COMMAND TEXT IS IN `anchor`: there is no
+  // separate command field, because the anchor of a command surface IS the
+  // command. It is capped at 120 characters at the boundary, so a very long
+  // command line is compared and quoted truncated.
+  try {
+    if (projectRoot) {
+      const outcomes = events
+        .filter(
+          (e) =>
+            e &&
+            e.kind === 'tool-outcome' &&
+            e.surface === 'command' &&
+            typeof e.anchor === 'string' &&
+            e.anchor.trim()
+        )
+        .map((e) => ({
+          command: e.anchor.trim(),
+          output: typeof e.output === 'string' ? e.output : '',
+          exit: Number.isInteger(e.exit) ? e.exit : null,
+          at: e.at ?? 0,
+          // `success` FIRST, `exit` only as a refinement. MCP tools report no
+          // numeric code at all, so a classifier keyed on `exit !== 0` would be
+          // inert for most clients -- and `exit` is null rather than 0 precisely
+          // so that absence is not read as a clean exit.
+          failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
+        }))
+        .sort((a, b) => a.at - b.at);
+
+      const byAttempt = new Map();
+      for (const outcome of outcomes) {
+        const key = attemptKey(outcome.command);
+        if (!key) continue;
+        if (!byAttempt.has(key)) byAttempt.set(key, []);
+        byAttempt.get(key).push(outcome);
+      }
+
+      for (const run of byAttempt.values()) {
+        // The NEAREST preceding failure, not the first one in the session. With
+        // `find` over the whole run, a command that failed at 09:00 and
+        // succeeded at 17:00 after nine unrelated attempts is reported as one
+        // story.
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          // One pair per failure: a command that succeeds twice afterwards has
+          // not taught two lessons.
+          lastFailure = null;
+
+          // THE GUARD THAT REMOVES THE LARGEST JUNK CLASS. The commonest shape
+          // in a coding session is `npm run build` failing, the code being
+          // fixed, and `npm run build` succeeding -- identical text. From that
+          // pair the two available claims are "`npm run build` works where
+          // `npm run build` failed", which is incoherent, and "`npm run build`
+          // fails", which the same evidence has just disproved. The observation
+          // is real and supports NEITHER claim, so nothing is emitted. This is
+          // not a confidence question; a ceiling cannot rescue a claim whose
+          // content is wrong.
+          if (failed.command === outcome.command) continue;
+
+          const codeSensitive =
+            CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);
+          const confidence = codeSensitive ? CONFIDENCE.test : CONFIDENCE.command;
+          const derivedBy = codeSensitive ? 'test-transition' : 'command-transition';
+
+          // "SUCCEEDED WHERE", NOT "FIXES". What is observed is two outcomes in
+          // order on the same attempt; that the difference in the command line
+          // CAUSED the difference in outcome is not observed and is not claimed.
+          add({
+            type: 'command',
+            claim: redact(
+              `\`${outcome.command}\` succeeded in this project where \`${failed.command}\` failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
+                'an intervening edit or a flaky run explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: 'when about to run this command in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the failing form later succeeds unchanged'],
+            trigger: triggerFor(outcome.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+
+          // The error text, only when there is error text. Without it the claim
+          // degrades to "`X` failed with:" and nothing after the colon, which
+          // carries no information and still costs budget.
+          const firstLine = failed.output.split('\n').find((line) => line.trim()) || '';
+          if (firstLine.trim().length < 8) continue;
+          add({
+            type: 'failure',
+            claim: redact(`\`${failed.command}\` failed with: ${firstLine.trim()}`, {
+              max: CLAIM_MAX,
+            }),
+            evidence: redact(`captured output of the failing run:\n${failed.output}`, {
+              max: EVIDENCE_MAX,
+            }),
+            applicability: 'when this command is about to be run in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the same command later succeeds unchanged'],
+            trigger: triggerFor(failed.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: failed.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 3: user corrections ------------------------------------------------
+  //
+  // A `feedback` finding -- the one type whose source is a person saying the
+  // agent was wrong. The MODEL-BASED extractor for this lives in `lessons.mjs`
+  // and needs the credential this module exists to do without, so here the
+  // signal is lexical: the opening words of the user's own turn.
+  //
+  // ORIGIN IS NOT PROMOTED. `writeHarvested` grants ORIGIN_HUMAN to a finding
+  // carrying a verified verbatim quote, and the standing-rules layer selects on
+  // that origin to inject a claim on EVERY turn. The quote here would be
+  // verbatim -- it is copied out of the archive -- but whether the turn was a
+  // correction at all is a guess, and a guess must not buy always-on injection.
+  // So no `origin` and no `quote` field: this stays harvested provenance.
+  try {
+    if (projectRoot) {
+      let turns = readArchive(dir, sessionId);
+      // The archive is written by the Stop hook too, and the order of the two is
+      // not this module's to assume, so fall back to the live transcript.
+      if (!turns.length && transcriptPath) turns = readTurns(transcriptPath);
+
+      for (const turn of turns) {
+        if (!turn || turn.role !== 'user') continue;
+        const text = String(turn.text || '').trim();
+        // Long turns are new instructions with a complaint somewhere inside
+        // them; truncating one into a claim would misquote the user.
+        if (text.length < 12 || text.length > 300) continue;
+        if (!CORRECTION_OPENER.test(text)) continue;
+        add({
+          type: 'feedback',
+          claim: redact(text, { max: CLAIM_MAX }),
+          evidence: redact(`the user opened a turn with a correction: "${text}"`, {
+            max: EVIDENCE_MAX,
+          }),
+          applicability: 'when working in this project, before repeating what was corrected',
+          confidence: CONFIDENCE.correction,
+          confidenceLabel: labelFor(CONFIDENCE.correction),
+          scope: 'project',
+          invalidators: ['the user later asks for the corrected behaviour'],
+          anchors: [projectRoot],
+          derivedBy: 'correction',
+          sessionId,
+          at: Date.parse(turn.at || '') || Date.now(),
+        });
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 4: re-read churn ---------------------------------------------------
+  //
+  // NOT A FINDING, AND THAT IS THE DECISION RATHER THAN AN OMISSION.
+  //
+  // Churn is a claim about OUR OWN reading behaviour: "this file was read three
+  // times unchanged". Every finding type available is a claim about the work --
+  // `map` describes how an area of the codebase is laid out, and is
+  // content-dependent, so a churn claim filed as `map` would be checked for
+  // staleness against contents it makes no claim about and flip stale on the
+  // first edit to a file it never described. Worse, the anchors it would take
+  // are by construction the HOTTEST files in the project, which are exactly the
+  // files that already carry real findings, so a 0.4-confidence row saying
+  // nothing actionable would sit in the injection budget beside them and render
+  // on the same reads. Nothing a future agent could DO differently follows from
+  // it: it does not say what the file contains, so it cannot substitute for
+  // reading it.
+  //
+  // The signal is still worth having -- as the measurement it already is.
+  // `rereadWaste` reports it on the balance sheet, `rereadsByAnchor` names the
+  // offenders, and this returns those rows as OBSERVATIONS: computed, carried,
+  // and deliberately not competing for context. Three detectors produce
+  // findings; the fourth produces a number.
+  try {
+    for (const row of rereadsByAnchor(events).slice(0, 3)) {
+      if (!row.anchor || row.wasteful < 2) continue;
+      result.observations.push({
+        kind: 'churn',
+        anchor: row.anchor,
+        repeats: row.repeats,
+        wasteful: row.wasteful,
+        tokens: row.tokens,
+        confidence: CONFIDENCE.churn,
+        derivedBy: 'churn',
+        note: `re-read ${row.repeats} times, ${row.wasteful} of them unchanged`,
+      });
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  return result;
+}

--- a/integrations/windsurf/hooks/lib/derive.mjs
+++ b/integrations/windsurf/hooks/lib/derive.mjs
@@ -16,6 +16,13 @@
  * there is nothing to consent to and this runs by default. It is the only
  * finding producer on a machine without a key.
  *
+ * THREE SOURCES, NOT TWO. `tool-outcome` events, the transcript archive, and --
+ * since the transition detectors were measured to have no input at all on the
+ * primary client -- the raw transcript's FAILED tool results, which is the only
+ * place a Claude Code failure is recorded (`failedResultsFromTranscript` in
+ * transcript.mjs, and the note above `quotable` for what that measurement
+ * actually yielded).
+ *
  * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
  * second command fixed the first -- an intervening edit, a dependency install or
  * a flaky test explains it just as well. So each detector carries a confidence
@@ -32,7 +39,11 @@
 import { readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
-import { readArchive, readTurns } from './transcript.mjs';
+import {
+  readArchive,
+  readTurns,
+  failedResultsFromTranscript,
+} from './transcript.mjs';
 import { redact } from './redact.mjs';
 import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
@@ -56,6 +67,96 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * The anchor cap a command surface is stored under, restated here as a TEST.
+ *
+ * `recordToolOutcome` truncates `anchor` to 120 characters, so a command at or
+ * over that length reached this module already cut -- and `quotable` below
+ * refuses to build a claim out of the fragment.
+ */
+const COMMAND_ANCHOR_MAX = 120;
+
+/**
+ * Can this command text be QUOTED in a claim a reader could act on?
+ *
+ * THE SECOND REFUSAL OF ITS KIND, and it exists because measurement forced it.
+ * Wiring the transcript reader gave the transition detectors their first real
+ * input on this client and immediately produced four candidates at 0.9
+ * confidence whose claim text read:
+ *
+ *   `cd /c/Users/.../token-optimizer-mcp\ncat >> docs/superpowers/plans/2026-` succeeded
+ *   in this project where `cd /c/Users/.../token-optimizer-mcp\ncat > /tmp/probe3.mjs
+ *   <<'EOF'\nimport { readdirSync, readFileSync, sta` failed
+ *
+ * -- two truncated fragments of throwaway shell scripts, grouped together only
+ * because `attemptKey`'s three tokens were spent on `cd`, the absolute path, and
+ * the verb. Then measured properly across three real transcripts: **0 of 83**
+ * captured command failures are single-line and inside the cap. 65% of this
+ * project's 2,178 successful command outcomes are not either. On this client a
+ * "command" is usually a whole shell script, so the attempt identity the
+ * transition detectors are built on does not fit most of the traffic.
+ *
+ * This is the same judgement as the identical-text guard below rather than a
+ * confidence question: a claim whose subject is a truncated fragment of a
+ * program is not a weaker claim, it is not a claim. A raised cap would not
+ * rescue it -- quoting the whole 500-character heredoc is no more actionable.
+ *
+ * What survives is exactly what the detector was designed for: `npm test`,
+ * `dotnet build X`, `deploy --retry` -- a repeatable command someone could run
+ * again. This machine captured none failing, which is why the honest yield here
+ * is zero and why that is reported rather than dressed up.
+ *
+ * Applied to BOTH sources. Where the evidence arrived from has no bearing on
+ * whether the resulting sentence says anything, and a rule that let events
+ * through would ship the junk on the ten clients that do report failures.
+ */
+const quotable = (command) => {
+  const text = String(command || '');
+  return (
+    text.trim().length > 0 &&
+    !/[\r\n]/.test(text) &&
+    text.length < COMMAND_ANCHOR_MAX
+  );
+};
+
+/**
+ * Tokens that separate one command from the next rather than naming one.
+ *
+ * MEASURED, LIKE EVERY OTHER REFUSAL HERE. `attemptKey` spends up to three
+ * non-flag tokens on identity, and the habit on this machine is
+ * `cd <absolute path> && <the real command>` -- which spends all three on `cd`,
+ * the path and `&&`, so the real command never enters the key. This project's
+ * own evidence: the single key `cd c:/users/.../token-optimizer-mcp &&` covers
+ * **539 distinct command lines**. One quotable failure in that group would pair
+ * with an arbitrary unrelated success and claim "`cd repo && grep -n ...`
+ * succeeded where `cd repo && git merge ...` failed", which is false about both.
+ *
+ * A KEY THAT REACHED A SEPARATOR NEVER REACHED A COMMAND, so there is no attempt
+ * to compare and nothing to claim -- the same judgement as the identical-text
+ * guard rather than a lower ceiling. Narrow on purpose: `2>&1` and `/F` are not
+ * separators and do not trip this, so `cat commitlint.config.mjs 2>&1` and
+ * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
+ * found across 163 transcripts on this machine it refuses 2 and keeps 6.
+ *
+ * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
+ * building the key, so the claim is about `npm test` rather than about the `cd`.
+ * That changes `attemptKey` for every client and every finding already derived
+ * from it, so it belongs in its own change with its own comparison.
+ */
+const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
+
+/**
+ * Did `attemptKey` actually capture a command, or only how one was chained?
+ *
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * One check per pair is enough: both halves share the key by construction.
+ */
+const hasAttemptIdentity = (command) =>
+  attemptKey(command)
+    .split(' ')
+    .filter(Boolean)
+    .every((token) => !COMMAND_SEPARATORS.has(token));
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -274,6 +375,17 @@ export function derive(dir, options = {}) {
   // separate command field, because the anchor of a command surface IS the
   // command. It is capped at 120 characters at the boundary, so a very long
   // command line is compared and quoted truncated.
+  //
+  // TWO SOURCES OF FAILURE, ONE PAIRING LOOP. Claude Code never fires
+  // PostToolUse for a failed tool call -- 2,238 of 2,238 live `tool-outcome`
+  // events on the measuring machine carry `success: true`, and a deliberately
+  // failing command produced no event at all -- so on the primary client these
+  // two detectors had NO INPUT WHATSOEVER while working normally on the ten
+  // adapter clients. `failedResultsFromTranscript` supplies the missing half
+  // from the only place it exists. The successes still come from events only:
+  // a transcript failure that pairs with nothing stays unclaimed, which is also
+  // what keeps a failure from ANOTHER project's directory out of this project's
+  // graph -- a candidate cannot be emitted without a success recorded HERE.
   try {
     if (projectRoot) {
       const outcomes = events
@@ -290,6 +402,9 @@ export function derive(dir, options = {}) {
           output: typeof e.output === 'string' ? e.output : '',
           exit: Number.isInteger(e.exit) ? e.exit : null,
           at: e.at ?? 0,
+          // Carried purely so the transcript merge below can recognise the same
+          // tool call arriving from the other source.
+          toolCallId: e.toolCallId ? String(e.toolCallId) : null,
           // `success` FIRST, `exit` only as a refinement. MCP tools report no
           // numeric code at all, so a classifier keyed on `exit !== 0` would be
           // inert for most clients -- and `exit` is null rather than 0 precisely
@@ -297,6 +412,53 @@ export function derive(dir, options = {}) {
           failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
         }))
         .sort((a, b) => a.at - b.at);
+
+      // DEDUPLICATED ON `toolCallId`, which is the SAME STRING in both sources:
+      // `episodeMeta` reads `raw.tool_use_id` into `toolCallId`, and that is the
+      // transcript's `tool_use_id` verbatim -- verified against live evidence
+      // (`toolu_01L4Nwr...` in metrics.jsonl, the same ids in the transcript).
+      // So on the ten clients that DO report failures, the event copy wins and
+      // the transcript copy is dropped before grouping. Without this the two
+      // copies of one failure would sit in the same run and the second of them
+      // would be paired against the first as a failed-then-succeeded story about
+      // itself.
+      //
+      // The fallback covers a client that reports a failure with no call id:
+      // identical command text within two seconds is one failure recorded twice,
+      // not two failures, because nothing re-runs a command that fast.
+      const eventIds = new Set(
+        outcomes.map((o) => o.toolCallId).filter(Boolean)
+      );
+      const eventFailures = outcomes.filter((o) => o.failed);
+      const alreadyRecorded = (failure) => {
+        if (failure.toolCallId && eventIds.has(failure.toolCallId)) return true;
+        return eventFailures.some(
+          (o) =>
+            o.command === failure.command &&
+            Math.abs((o.at || 0) - (failure.at || 0)) <= 2000
+        );
+      };
+
+      let transcriptFailures = [];
+      try {
+        transcriptFailures = failedResultsFromTranscript(transcriptPath).filter(
+          (failure) => failure.command.trim() && !alreadyRecorded(failure)
+        );
+      } catch {
+        // The reader is an extra source, never a reason the detector stops.
+      }
+      for (const failure of transcriptFailures) {
+        outcomes.push({
+          command: failure.command.trim(),
+          output: failure.output,
+          exit: failure.exit,
+          at: failure.at,
+          toolCallId: failure.toolCallId,
+          // Read from `Exit code N`, which is the only shape the reader admits.
+          failed: true,
+        });
+      }
+      if (transcriptFailures.length) outcomes.sort((a, b) => a.at - b.at);
 
       const byAttempt = new Map();
       for (const outcome of outcomes) {
@@ -333,6 +495,18 @@ export function derive(dir, options = {}) {
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
           if (failed.command === outcome.command) continue;
+
+          // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
+          // client both sides of almost every pair are truncated multi-line
+          // shell scripts, and a claim quoting a fragment of one is noise
+          // spending the retrieval budget of every later session.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
+          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
+          // command lines in this repository alone, and any pair drawn from that
+          // group is a false claim about both halves.
+          if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =
             CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);

--- a/integrations/windsurf/hooks/lib/doctor.mjs
+++ b/integrations/windsurf/hooks/lib/doctor.mjs
@@ -197,7 +197,8 @@ function hooksDirFor({ hooksDir, install, root }) {
  * identical from outside: a graph that fills with structural nodes either way.
  *
  * Measured on a real 5.4.0 install: 484 symbol, 286 file and 122 task nodes and
- * ZERO findings, because harvestMode() was 'off:not-opted-in'. Fifteen checks
+ * ZERO findings, because harvestMode() then returned an opt-in refusal (the mode has
+ * since been renamed: it is 'off:no-key' now, and opting in is no longer the gate). Fifteen checks
  * passed and none mentioned harvest. stop-harvest.mjs names this exact gap --
  * "nothing in doctor, audit or waste mentions harvest, so a user sees a graph
  * filling with structural nodes and no findings and has no way to learn why" --
@@ -221,9 +222,15 @@ export function probeHarvest() {
   // optimizer is off" is noise, which is why stop-harvest maps it to no notice.
   if (mode === 'off:mode') return [];
 
+  // SAID PLAINLY, because this is the configuration a user would choose if they
+  // knew it existed and the previous wording buried it in machinery. A local
+  // endpoint is the only setting under which the semantic harvest runs with no
+  // credential, no billing and no digest leaving the machine -- so the two facts
+  // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
     return [ok('finding extraction is available',
-      'active-model wiki_write is primary; local endpoint also enables fallback extraction')];
+      'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
+      'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
@@ -233,10 +240,19 @@ export function probeHarvest() {
 
   // No second-model credential is required for the primary path. The Codex/agent session that
   // already paid to derive the conclusion is the extractor and wiki_write is local.
+  // NAME THE TRADE, not just the missing variable. This is the default state on
+  // every machine without a credential, so it is the text most users will read,
+  // and "unavailable" alone tells them neither what they are missing nor that
+  // the free option exists. Local findings still accumulate: derive.mjs reads
+  // exit codes, red-to-green transitions, corrections and churn out of evidence
+  // already on disk and sends nothing anywhere.
   if (mode === 'off:no-key') {
     return [ok('finding extraction is available',
-      'active model records durable conclusions through local wiki_write; no separate-model ' +
-      'credential is configured, so fallback transcript extraction is unavailable')];
+      'active model records durable conclusions through local wiki_write, and derive runs at ' +
+      'session end with no credential. No separate-model credential is configured, so fallback ' +
+      'transcript extraction is unavailable: point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local ' +
+      'model to run it free and private, or set TOKEN_OPTIMIZER_API_KEY to run it from a bounded ' +
+      'digest of paths, commands, prompts and conclusions -- never file contents')];
   }
 
   // off:opted-out -- a deliberate choice, reported as one. Nagging about a setting somebody chose

--- a/integrations/windsurf/hooks/lib/inject.mjs
+++ b/integrations/windsurf/hooks/lib/inject.mjs
@@ -1134,10 +1134,25 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // injected more than the budget allowed and recorded fewer tokens than it
   // spent -- in a block whose entire justification is that it is tightly
   // bounded and measured against the control arm.
+  // THE LAST LINE IS HOW THE NEXT RULE GETS HERE, and it is one line because
+  // this block is charged on every session forever. A rule reaches this list
+  // only by being pinned or by being a person's verified correction, and both
+  // start as a `wiki_write` -- so a model reading a set of standing rules with
+  // no idea how they were produced has no way to add to it. Stated at the point
+  // of the evidence rather than as a separate always-on block: the reader is
+  // already looking at the output of the mechanism being described.
+  //
+  // THE COLD GRAPH IS COVERED ELSEWHERE, deliberately. Nothing here renders
+  // until at least one rule qualifies, which is the property the always-on
+  // budget depends on, so this line cannot be the first-session nudge --
+  // `policyText`'s "Record what you work out" section is, and it is emitted at
+  // SessionStart whether or not the graph holds anything.
   const HEADING =
     '# Standing rules for this project' +
     '\n\nEstablished in previous sessions and expected to hold. ' +
-    'These are not suggestions.\n\n';
+    'These are not suggestions.\n\n' +
+    'Record what you work out with wiki_write and a real file anchor; ' +
+    'that is how a rule reaches this list.\n\n';
   const noticeFor = (n) =>
     n
       ? `\n(${n} further standing rule${n === 1 ? '' : 's'} did not fit this budget; ` +

--- a/integrations/windsurf/hooks/lib/inject.mjs
+++ b/integrations/windsurf/hooks/lib/inject.mjs
@@ -35,6 +35,7 @@ import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
 import { cacheOrdered } from './cache.mjs';
+import { withheldFor, exploreOrder, servingPolicyVersion, LOO_ENABLED } from './loo.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -311,8 +312,38 @@ export function forTouch(
     });
     for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
   }
-  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  // LAYER 2 EXPLORATION, BEFORE the budget decides.
+  //
+  // `assessed.eligible` arrives in net-utility order and `fit` keeps that order
+  // until the budget runs out -- so the ranking decides which findings are ever
+  // served, which decides which ever accumulate observations, which decides
+  // their utility. A tenth of touches therefore promote the least-served
+  // candidate first. This is the only place it can go: after `fit` the choice
+  // has already been made.
+  const ordered = exploreOrder(assessed.eligible, dir, { sessionId, anchor: filePath });
+  const { kept, spent } = fit(ordered.map((item) => item.finding), budget);
   if (!kept.length) return null;
+
+  // LAYER 2 WITHHOLDING, AFTER the budget decides, which is the only ordering
+  // that produces a leave-one-out rather than a substitution: withholding first
+  // would let the next-ranked finding take the freed tokens, so the withheld
+  // arm would differ from the served arm by two findings instead of one and the
+  // effect would belong to neither.
+  //
+  // `holdout` is passed so the two experiments cannot compose into "withhold
+  // everything and call it a leave-one-out": that arm already serves nothing.
+  const withheld = withheldFor(kept.map((finding) => finding.key), sessionId, graph, dir, {
+    surface: 'file',
+    anchor: filePath,
+    holdout,
+  });
+  const delivered = withheld ? kept.filter((finding) => finding.key !== withheld) : kept;
+  // RE-PRICED, because `fit` priced what it KEPT and this delivers less. Using
+  // `spent` would bill the injection-cost side of the balance sheet for text
+  // the model never received.
+  const deliveredSpent = withheld
+    ? delivered.reduce((sum, finding) => sum + estimate(render(finding)), 0)
+    : spent;
 
   record(dir, {
     kind: 'inject',
@@ -321,15 +352,20 @@ export function forTouch(
     surface: 'file',
     anchor: filePath,
     holdout,
-    tokens: holdout ? 0 : spent,
-    deliveredTokens: holdout ? 0 : spent,
+    tokens: holdout ? 0 : deliveredSpent,
+    deliveredTokens: holdout ? 0 : deliveredSpent,
     shadowTokens: spent,
-    count: holdout ? 0 : kept.length,
+    count: holdout ? 0 : delivered.length,
     candidateCount: kept.length,
-    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    findingIds: holdout ? [] : delivered.map((finding) => finding.key),
     shadowFindingIds: kept.map((finding) => finding.key),
-    stale: kept.some((f) => f.stale),
+    stale: delivered.some((f) => f.stale),
     sessionId,
+    // ON EVERY RECORD, not only the withheld ones. A served observation needs
+    // the policy version as much as a withheld one does, or `effects` cannot
+    // keep the two arms of one comparison inside one policy.
+    ...(LOO_ENABLED() ? { looPolicy: servingPolicyVersion() } : {}),
+    ...(withheld ? { loo: withheld } : {}),
   });
 
   // MARKED SEEN IN BOTH ARMS, for the same reason as the command path: a file
@@ -339,11 +375,16 @@ export function forTouch(
   // grow faster purely from repetition.
   //
   // This is the identical defect that was fixed in `forCommand` and not here.
+  //
+  // THE WITHHELD KEY IS MARKED TOO, and that is load-bearing rather than tidy:
+  // an unmarked one would be a candidate again on the next touch of this file,
+  // where the one-per-touch tiebreak could serve it -- flipping its arm inside
+  // the very session the arm hash exists to pin it for.
   for (const f of kept) alreadyInjected.add(f.key);
 
-  if (holdout || !kept.length) return null;
+  if (holdout || !delivered.length) return null;
 
-  return `Known about ${filePath} (from previous sessions):\n${kept.map(render).join('\n')}`;
+  return `Known about ${filePath} (from previous sessions):\n${delivered.map(render).join('\n')}`;
 }
 
 /**

--- a/integrations/windsurf/hooks/lib/keepwarm.mjs
+++ b/integrations/windsurf/hooks/lib/keepwarm.mjs
@@ -30,6 +30,15 @@ import { record, readMetrics, readBalance } from './metrics.mjs';
 import { WRITE_MULTIPLIER, READ_MULTIPLIER } from './cache.mjs';
 
 /**
+ * The shortest gap that counts as a NEW turn rather than a burst inside one.
+ *
+ * Shared by the gap distribution and by the hit test, because they have to
+ * agree about what a turn is. Two copies of this number would let the decision
+ * be fitted to one definition of a turn and scored against another.
+ */
+export const TURN_GAP_MS = 250;
+
+/**
  * TTL tiers, with what a WRITE costs at each.
  *
  * A five-minute entry is written at 1.25x a plain input token; the one-hour
@@ -85,7 +94,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
     for (let i = 1; i < session.length; i++) {
       const gap = session[i] - session[i - 1];
       // A burst of events inside one turn is not a gap between turns.
-      if (gap > 250) gaps.push(gap);
+      if (gap > TURN_GAP_MS) gaps.push(gap);
     }
   }
   if (gaps.length < 6) return null;
@@ -105,10 +114,91 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
 }
 
 /**
+ * Refreshes to observe at a tier before the observation may bound the decision.
+ *
+ * THE SAME NUMBER THE BACKSTOP DEMANDS, deliberately. The decision and the
+ * tripwire read the same ledger, so letting them disagree about when there is
+ * enough evidence would mean one of them acting on a sample the other calls too
+ * small. Below the floor the decision keeps its expected-value answer, so a
+ * single unlucky miss changes nothing at all.
+ *
+ * NOT A CONFIDENCE INTERVAL, and the reason is arithmetic rather than taste. A
+ * Wilson 95% upper bound at ten refreshes and zero hits is 0.28 -- so a policy
+ * that missed ten times out of ten would still be recommended, which is exactly
+ * the case the loop exists to catch. The point estimate is safe here because of
+ * the bound below: an observation may only ever LOWER the modelled probability,
+ * so sampling noise cannot manufacture a refresh, and the tripwire's realised
+ * ledger is a second guard underneath.
+ */
+export const OBSERVATION_FLOOR = TRIPWIRE_MIN;
+
+/**
+ * The measured hit rate per tier, from recorded outcomes.
+ *
+ * Tiers below the floor are ABSENT rather than present with a small n, because
+ * a rate carrying no weight is the thing most likely to be used as though it
+ * did.
+ */
+export function observedHitRates(outcomes = []) {
+  const byTier = new Map();
+  for (const event of outcomes) {
+    if (event?.kind !== 'keepwarm' || event.action !== 'outcome') continue;
+    const name = TIERS.some((t) => t.name === event.tier) ? event.tier : TIERS[0].name;
+    const row = byTier.get(name) || { refreshes: 0, hits: 0 };
+    row.refreshes += 1;
+    if (event.hit) row.hits += 1;
+    byTier.set(name, row);
+  }
+
+  const qualified = new Map();
+  for (const [name, row] of byTier) {
+    if (row.refreshes < OBSERVATION_FLOOR) continue;
+    qualified.set(name, { ...row, rate: row.hits / row.refreshes });
+  }
+  return qualified;
+}
+
+/**
+ * What the refreshes at this tier actually did, if enough of them have.
+ *
+ * Tolerates being handed anything -- null, a plain object, a Map -- because the
+ * callers are two public functions whose options object is assembled by other
+ * people's code.
+ */
+function observationsFor(observed, tierName) {
+  const row = observed instanceof Map ? observed.get(tierName) : null;
+  return row && Number.isFinite(row.rate) ? row : null;
+}
+
+/**
+ * The modelled probability, BOUNDED BY what was observed and never raised by it.
+ *
+ * The asymmetry is the whole point and runs against this project's interest. A
+ * recorded `hit` says only that a turn arrived before the entry expired; it
+ * cannot say the refresh is what kept the entry alive, because a turn arriving
+ * one minute after a five-minute ping would have found the entry warm anyway.
+ * So the observed rate is an UPPER bound on a refresh's value, and substituting
+ * it for the model would flatter keep-warm badly: on the machine this was
+ * written on, the modelled ping probability is 0.2% and the observable
+ * before-expiry rate is 99.5%, so the substitution would recommend refreshing
+ * forever. A low rate, by contrast, is real evidence against: if turns do not
+ * even arrive inside the TTL, the refresh certainly bought nothing.
+ */
+function bounded(modelled, seen) {
+  return seen ? Math.min(modelled, seen.rate) : modelled;
+}
+
+/**
  * Should we refresh this prefix now?
  *
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
+ *
+ * `observed` is passed IN rather than read from disk here: this function is
+ * pure, its purity is what lets the tests build a distribution by hand, and
+ * `shouldKeepWarm` has already read the outcome log for the tripwire -- so
+ * threading the reader in here would be a second read of the same file and a
+ * second place for the window discipline to be got wrong.
  */
 export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
@@ -125,42 +215,30 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
   const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
-
-  // MEASURED BEATS MODELLED, once there is enough of it.
-  //
-  // The module header already commits to this -- "an expected-value decision is
-  // only as good as the distribution it was fitted to, and distributions
-  // shift" -- and the tripwire underneath was the only thing acting on it, as
-  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
-  // entirely" there was nothing, because the observed hit rate was never
-  // computed: both recording halves had no call site, so ten refreshes that
-  // bought nothing would keep recommending refresh right up to the moment the
-  // tripwire cut the whole feature off.
-  //
-  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
-  // handful of samples would swing the decision harder than the distribution
-  // they replace.
-  const probability = observed ? observed.rate : modelled;
+  const seen = observationsFor(observed, tier.name);
+  const probability = bounded(modelled, seen);
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
-  const basis = observed
-    ? `measured over ${observed.observations} refreshes`
-    : 'modelled from the gap distribution';
+  const note = seen && probability < modelled
+    ? `; bounded by ${seen.refreshes} observed refreshes, ` +
+      `${Math.round(seen.rate * 100)}% used before expiry`
+    : '';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
     modelledProbability: modelled,
-    basis,
+    observedHitRate: seen ? seen.rate : null,
+    observedRefreshes: seen ? seen.refreshes : 0,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
-    reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
+    reason: (ev > 0
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
-        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`) + note,
   };
 }
 
@@ -171,7 +249,12 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
  * long enough that the short tier keeps missing. Returns null when neither tier
  * pays, which is a real answer and the one a default-on product never gives.
  */
-export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS }) {
+export function ttlTier({
+  prefixTokens,
+  gaps,
+  turnsPerSession = DEFAULT_TURNS,
+  observed = null,
+}) {
   if (!prefixTokens || !gaps) return null;
 
   // Expected cost of a turn under each tier, as a multiple of what the prefix
@@ -179,7 +262,16 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   // again; and the FIRST write is amortised over the session, which is what
   // stops the expensive tier from looking free whenever gaps are short.
   const costOf = (tier) => {
-    const hit = gaps.probabilityWithin(tier.ms);
+    // THE SAME QUANTITY THE OUTCOMES RECORD, which is what makes the
+    // observation admissible here at all. `hit` is P(a turn arrives before the
+    // entry expires) and `recordRefreshOutcome`'s `hit` is exactly that event,
+    // measured -- unlike keepWarmDecision, whose probability is the narrower
+    // ping window and for which the same observation is only an upper bound.
+    // Bounded rather than replaced even so: a sample drawn only from moments we
+    // CHOSE to refresh is not a sample of gaps, and its bias runs our way.
+    const modelled = gaps.probabilityWithin(tier.ms);
+    const seen = observationsFor(observed, tier.name);
+    const hit = bounded(modelled, seen);
     const perTurn = hit * READ_MULTIPLIER + (1 - hit) * tier.writeMultiplier;
     // THE SUPPLIED VALUE, not only the computed one. Math.max(1, NaN) is NaN -- Math.max
     // propagates it rather than clamping -- so perTurn became NaN, the `perTurn >= 1` guard below
@@ -192,6 +284,8 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     return {
       tier,
       hit,
+      seen,
+      boundedByObservation: Boolean(seen) && hit < modelled,
       perTurn: (tier.writeMultiplier + (turns - 1) * perTurn) / turns,
     };
   };
@@ -208,99 +302,53 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     action: 'refresh',
     tier: best.tier.name,
     hitProbability: best.hit,
+    observedHitRate: best.seen ? best.seen.rate : null,
+    observedRefreshes: best.seen ? best.seen.refreshes : 0,
     expectedCostPerTurn: Number(best.perTurn.toFixed(3)),
     expectedValue: Math.round((1 - best.perTurn) * prefixTokens),
     reason: `${Math.round(best.hit * 100)}% of gaps land inside ${best.tier.name}; ` +
-      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached`,
+      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached` +
+      (best.boundedByObservation
+        ? `, bounded by ${best.seen.refreshes} observed refreshes ` +
+          `(${Math.round(best.seen.rate * 100)}% used before expiry)`
+        : ''),
   };
 }
 
-/** Observations of a tier before its measured hit rate may override the model. */
-export const OBSERVATION_FLOOR = 5;
-
-/** Records a refresh so its outcome can be scored. */
-export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
-  record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
-}
-
 /**
- * Scores every refresh whose window has since resolved.
+ * Records a refresh so its outcome can be scored.
  *
- * THE MISSING HALF, and it was missing because nobody could see where the
- * signal would come from. `recordRefreshOutcome` needs to know whether a real
- * turn arrived before the entry expired -- and that is not a thing anyone has
- * to instrument, because the event log already records when every turn
- * happened. The answer was in the data the whole time.
+ * `sessionId` IS REQUIRED FOR THE REFRESH TO BE SCOREABLE, and is not defaulted
+ * to anything. The hit test asks whether a turn of THIS conversation arrived
+ * before expiry; pooling arrivals across sessions would let a second concurrent
+ * session's turn pay for this one's ping, which manufactures hits. A refresh
+ * recorded without one is kept in the ledger and reported as unattributable
+ * rather than guessed at.
  *
- * For each unscored refresh at time T on a tier with TTL `ms`:
- *
- *   - a later event within `ms`            -> HIT, observed
- *   - a later event after `ms`             -> MISS, observed
- *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
- *                                             demonstrably closed unused
- *   - no later event, window still open    -> NOTHING RECORDED
- *
- * That last line is the important one and it is Plan 2's own instruction: "if
- * no signal is available for a tier, record nothing rather than guessing
- * `hit: false`". A refresh whose window has not closed yet is not a miss, and
- * scoring it as one would drive the tripwire negative on the newest and least
- * informative records.
- *
- * DRAINED AT READ TIME, which is the pattern this codebase already uses for
- * staleness: the producer cannot know the outcome at the moment it acts, so the
- * next reader resolves what has become knowable since.
+ * Returns the stored record, whose `id` is what `scoreRefreshes` pairs the
+ * outcome to, so an issuer can hold onto it.
  */
-export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
-  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
-  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
-  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
-
-  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
-  // so everything past the number already scored is outstanding. Pairing by
-  // timestamp instead would double-count two refreshes recorded in the same
-  // millisecond, which is reachable: a tool run twice in a loop.
-  const outstanding = refreshes.slice(scored);
-  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
-
-  let recorded = 0;
-  for (const refresh of outstanding) {
-    const at = Number(refresh.at) || 0;
-    if (!at) continue;
-    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
-    const next = timeline.find((t) => t > at);
-
-    let hit;
-    if (next !== undefined) hit = next - at <= tierSpec.ms;
-    else if (now - at > tierSpec.ms) hit = false;
-    else continue; // window still open: not yet knowable
-
-    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
-    recorded += 1;
-  }
-  return { outstanding: outstanding.length, recorded };
-}
-
-/**
- * The measured hit rate for a tier, or null below the observation floor.
- *
- * Null rather than a small-sample number, because the caller substitutes it for
- * a modelled probability and three observations would swing the decision harder
- * than the model they replace.
- */
-export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
-  const relevant = outcomes.filter(
-    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
-  );
-  if (relevant.length < OBSERVATION_FLOOR) return null;
-  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
+export function recordRefresh(dir, { tier, prefixTokens, expectedValue, sessionId, at }) {
+  return record(dir, {
+    kind: 'keepwarm',
+    action: 'refresh',
+    tier,
+    prefixTokens,
+    expectedValue,
+    sessionId,
+    at,
+  });
 }
 
 /**
  * Records whether the refresh was used.
  *
  * `hit` means a real turn arrived before expiry, so the write bought a read.
+ * `refreshId` names the refresh this scores, so the same one cannot be scored
+ * twice -- once per turn for the rest of the session, which is what an
+ * unpaired outcome would become.
  */
-export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
+export function recordRefreshOutcome(dir, { tier, prefixTokens, hit, refreshId = null }) {
   const tierSpec = TIERS.find((t) => t.name === tier) || TIERS[0];
   // THE SAME LEDGER keepWarmDecision BUYS THE REFRESH WITH. That function is explicit that a
   // refresh is a PING, which READS the prefix -- costOfPing = prefixTokens * READ_MULTIPLIER --
@@ -317,7 +365,125 @@ export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
   const realised = hit
     ? prefixTokens * (tierSpec.writeMultiplier - READ_MULTIPLIER) - prefixTokens * READ_MULTIPLIER
     : -prefixTokens * READ_MULTIPLIER;
-  record(dir, { kind: 'keepwarm', action: 'outcome', tier, prefixTokens, hit: Boolean(hit), realised: Math.round(realised) });
+  record(dir, {
+    kind: 'keepwarm',
+    action: 'outcome',
+    tier,
+    prefixTokens,
+    hit: Boolean(hit),
+    refreshId,
+    realised: Math.round(realised),
+  });
+}
+
+/**
+ * Scores every recorded refresh whose window has closed -- and NOTHING ELSE.
+ *
+ * This is the arm that was missing. `recordRefresh` and `recordRefreshOutcome`
+ * were both correct and both called by nothing, so the decision spent money on
+ * refreshes and could never find out whether one bought a read.
+ *
+ * THE SIGNAL IS REAL, not invented. `gapDistribution` already treats this log's
+ * timestamps as turn arrivals -- that is the distribution the whole decision is
+ * fitted to -- so the same log answers the outcome question directly: a refresh
+ * at tier `5m` was used if a turn of the same session arrived within five
+ * minutes of it. Four cases refuse to answer rather than guess, and every one
+ * of them refuses in the direction that costs this project its own good news:
+ *
+ *   - `pending`: the window has not closed yet. A hit could be scored the
+ *     instant it arrives while a miss must wait out the whole TTL, so scoring
+ *     early would mean the recorded hits are always complete and the recorded
+ *     misses always lagging -- right-censoring, biased upward, invisible in any
+ *     test. So a hit waits exactly as long as a miss.
+ *   - `uncovered`: the arrival log no longer reaches back to the refresh, so
+ *     absence of an arrival is absence of evidence. RECORDING `hit: false` HERE
+ *     WOULD BE THE INVENTION THIS IS FORBIDDEN TO MAKE: an absent signal is not
+ *     a miss, and treating it as one biases every rate downward and would
+ *     eventually switch keep-warm off on no evidence at all.
+ *   - `unattributable`: the refresh names no session, so no arrival can be
+ *     shown to belong to it.
+ *   - already scored: an outcome already names this refresh.
+ *
+ * The firehose is READ LAZILY, and only when there is something to score. On a
+ * machine where nothing issues refreshes -- which is every machine today, since
+ * nothing in this repository issues one -- the whole cost is the outcome-log
+ * read: median 70 ms on a 3.5 MB log, of which readBalance is 49 ms, because
+ * that reader also scans the firehose tail for pre-split records.
+ */
+export function scoreRefreshes(dir, {
+  refreshes = readBalance(dir),
+  arrivals = null,
+  now = Date.now(),
+} = {}) {
+  const summary = { scored: 0, hits: 0, pending: 0, uncovered: 0, unattributable: 0 };
+  const keepwarm = refreshes.filter((event) => event?.kind === 'keepwarm');
+  const alreadyScored = new Set(
+    keepwarm
+      .filter((event) => event.action === 'outcome' && event.refreshId)
+      .map((event) => event.refreshId)
+  );
+  const unscored = keepwarm.filter(
+    (event) =>
+      event.action === 'refresh' &&
+      Number.isFinite(event.at) &&
+      event.id &&
+      !alreadyScored.has(event.id)
+  );
+
+  // A refresh with no id cannot be paired, so scoring it would write a fresh
+  // outcome on every turn forever. Reported, not silently dropped.
+  summary.unattributable += keepwarm.filter(
+    (event) => event.action === 'refresh' && (!event.id || !Number.isFinite(event.at))
+  ).length;
+
+  if (!unscored.length) return summary;
+
+  const events = (arrivals ? arrivals() : readMetrics(dir)).filter((event) =>
+    Number.isFinite(event?.at)
+  );
+  // Coverage is judged over EVERY event, including our own bookkeeping: the
+  // refresh's own copy in the firehose is what proves the window is still
+  // inside the read. Arrivals are judged over everything else, because a record
+  // keep-warm wrote about itself is not a turn -- and counting one would
+  // manufacture a hit out of the act of measuring.
+  const earliest = events.reduce((min, event) => Math.min(min, event.at), Infinity);
+  const turns = events.filter((event) => event.kind !== 'keepwarm');
+
+  for (const refresh of unscored) {
+    const tier = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    if (now - refresh.at < tier.ms) {
+      summary.pending += 1;
+      continue;
+    }
+    const session = refresh.sessionId;
+    if (!session) {
+      summary.unattributable += 1;
+      continue;
+    }
+    if (!(earliest <= refresh.at)) {
+      summary.uncovered += 1;
+      continue;
+    }
+
+    const opens = refresh.at + TURN_GAP_MS;
+    const closes = refresh.at + tier.ms;
+    const hit = turns.some(
+      (event) =>
+        (event.sessionId ?? event.episodeId) === session &&
+        event.at > opens &&
+        event.at <= closes
+    );
+    recordRefreshOutcome(dir, {
+      tier: refresh.tier,
+      prefixTokens: refresh.prefixTokens,
+      hit,
+      refreshId: refresh.id,
+    });
+    summary.scored += 1;
+    if (hit) summary.hits += 1;
+  }
+
+  return summary;
 }
 
 /**
@@ -372,23 +538,15 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
-  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
-  // becomes evidence now, so the decision below and the tripwire above both see
-  // the most that is currently knowable -- the same read-time drain the
-  // staleness path uses, and for the same reason: the producer cannot know the
-  // outcome at the moment it acts.
-  try {
-    scoreOutstandingRefreshes(dir, { events, outcomes });
-    outcomes = readBalance(dir);
-  } catch {
-    /* scoring is evidence, never a reason to refuse a decision */
-  }
-
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
+  // THE SAME ARRAY THE TRIPWIRE JUST READ, so closing the loop costs no extra
+  // I/O -- and so the decision and its backstop cannot be looking at different
+  // evidence about the same refreshes.
+  const observed = observedHitRates(outcomes);
   const gaps = gapDistribution(dir, { events });
-  const best = ttlTier({ prefixTokens, gaps });
+  const best = ttlTier({ prefixTokens, gaps, observed });
   if (!best) {
     // THE TWO MODELS ANSWER DIFFERENT QUESTIONS, so they may legitimately disagree. ttlTier asks
     // whether holding a cache beats not caching at all; keepWarmDecision asks whether ONE ping
@@ -397,11 +555,7 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({
-      prefixTokens,
-      gaps,
-      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
-    });
+    const decision = keepWarmDecision({ prefixTokens, gaps, observed });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/integrations/windsurf/hooks/lib/loo.mjs
+++ b/integrations/windsurf/hooks/lib/loo.mjs
@@ -1,0 +1,788 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/loo.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 2 -- what one finding is actually worth, measured by withholding it.
+ *
+ * Layer 1 asks whether the model went back and named a finding. This asks the
+ * harder question and answers it causally: WITHHOLD ONE FINDING while serving
+ * every other finding for the same touch, and compare what the session spent
+ * READING that anchor afterwards. Nobody in this space measures per-item value
+ * this way in production; the state of the art is an offline evaluation set.
+ * That is also why this file is more refusal than statistics -- a causal claim
+ * from four observations is worse than no claim, because it is a number and
+ * numbers get quoted.
+ *
+ * THE ESTIMAND IS READ-SUPPRESSION, and it is deliberately DISJOINT from Layer
+ * 1. Layer 1 keys on an explicit `query` naming a finding key. This keys on
+ * `read` events against the injection's anchor. Neither signal appears in the
+ * other's arithmetic: no `query` event is consulted here, and `usage.mjs`
+ * consults no `read` event. Task 8 calibrates one against the other, and if
+ * both derived from the same channel that calibration would report a strong
+ * correlation between two spellings of one quantity and mean nothing.
+ *
+ * IT INVENTS NO JOIN. `recordToolOutcome` already joins each post-tool result
+ * back to the injection that preceded it, recording `injectionId`,
+ * `findingIds` and a `joinMethod` of `tool-call-id` / `episode-anchor` /
+ * `none`. Every observation here is GATED on that join: an injection with no
+ * joined outcome is unattributable and enters neither arm, exactly as Layer 1
+ * treats `joinMethod: 'none'`. An earlier draft of this plan proposed a fresh
+ * `(sessionId, findingKey)` join; it was rejected and is not here.
+ *
+ * WHAT IT COSTS THE USER, because an experiment that degrades a turn owes an
+ * accounting. One withheld finding means the model may re-derive what it was
+ * told last time, and the worst case is one read of that anchor: measured on
+ * this machine, a median read is 3,769 tokens and the 90th percentile is
+ * 14,082. Five guards bound that exposure, and they are the reason the numbers
+ * below are as small as they are:
+ *
+ *   1. only on a FILE touch, because a command injection has no anchor a read
+ *      event can be joined to -- withholding there would cost a user a finding
+ *      and buy no observation at all (see `buildReport`, which excludes command
+ *      injections from the holdout balance for the same reason);
+ *   2. never when fewer than two findings were kept, so "leave one out" always
+ *      leaves something in -- otherwise it degenerates into `inHoldout`, which
+ *      withholds EVERY finding for an anchor and is a different experiment;
+ *   3. never in the same breath as `inHoldout`: if that arm already withheld
+ *      everything, there is nothing to leave out and a Layer 2 arm recorded
+ *      there would be a fabricated observation;
+ *   4. at most ONE finding per touch, or the effect is attributable to neither;
+ *   5. at most ONE withheld finding per SESSION, so the worst case a user can
+ *      experience is a single re-read -- not one per file they open.
+ *
+ * AND IT NEVER OVERRIDES A PERSON. A `pinned` or `origin: 'human'` finding is
+ * an explicit human decision to keep something in front of the model.
+ * Withholding it to run an experiment would overrule that decision for the
+ * convenience of the measurement, so those findings are exempt: they are
+ * always served, they get no causal score, and `looNote` says so rather than
+ * leaving a reader to wonder why they are missing from the table.
+ */
+
+import { createHash } from 'node:crypto';
+import { readEvidence, readMetrics, readTruncation, isFixtureAnchor } from './metrics.mjs';
+import { retrievalPolicy } from './utility.mjs';
+import { ORIGIN_HUMAN } from './curate.mjs';
+import { canonicalPath } from './paths.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Injections of a finding before it may enter the experiment.
+ *
+ * A finding nobody has served yet has no established value to measure the
+ * absence of, and withholding it would be measuring the cold start rather than
+ * the finding. Four is also what makes the ratio below reachable: at a quarter
+ * of (key, session) pairs armed, a key needs roughly a dozen enrolled
+ * injections before it can reach a verdict at all.
+ */
+export const MIN_PRIOR_INJECTIONS = 4;
+
+/** The observation floor. Below this there is no verdict -- and NOT a zero. */
+export const MIN_SERVED = 6;
+export const MIN_WITHHELD = 3;
+
+/** Benjamini-Hochberg false-discovery rate for published verdicts. */
+export const FDR_Q = 0.1;
+
+/**
+ * Exploration rate.
+ *
+ * Without this, utility feeds the ranking, the ranking feeds injection
+ * frequency, injection frequency feeds the observation count, and a low score
+ * becomes self-fulfilling: the finding is never served often enough to earn a
+ * better one. A tenth of touches therefore ignore the utility order and
+ * promote the LEAST-served candidate instead.
+ */
+export const EPSILON = 0.1;
+
+/**
+ * The share of (finding, session) pairs assigned to the withheld arm.
+ *
+ * Chosen against the floors rather than picked: MIN_SERVED / MIN_WITHHELD is
+ * 2:1, so a quarter withheld reaches both floors at about the same time while
+ * leaving three touches in four undamaged.
+ */
+export const WITHHOLD_FRACTION = 0.25;
+
+/**
+ * Withheld findings allowed per session. ONE.
+ *
+ * The per-touch cap alone bounds nothing across a session: a session that
+ * opens twelve files with enrolled findings could have withheld twelve. This
+ * makes the worst case a user can experience one re-read, at the price of a
+ * mild confound that is stated rather than hidden -- when the cap binds, the
+ * other armed findings in that session are served, so the served arm is
+ * slightly enriched by sessions that touch many enrolled findings.
+ */
+export const MAX_WITHHELD_PER_SESSION = 1;
+
+/**
+ * Fallback shrinkage weight when the between-finding variance cannot be
+ * estimated (fewer than two findings with both arms, or no dispersion at all).
+ *
+ * MIN_SERVED + MIN_WITHHELD, deliberately: a finding's own data outweighs the
+ * population prior only once it has reached the publication floor.
+ */
+export const SHRINKAGE_K = MIN_SERVED + MIN_WITHHELD;
+
+/** Bounds on the estimated shrinkage weight, so a degenerate variance ratio cannot run away. */
+const K_MIN = 1;
+const K_MAX = 100;
+
+/**
+ * Bumped BY HAND when the serving code changes in a way that could move a
+ * finding's measured effect. It is the part of the policy version a hash of the
+ * configuration cannot see.
+ */
+export const LOO_POLICY_GENERATION = 1;
+
+/** Permutation budget before the exact null distribution is sampled instead of enumerated. */
+const MAX_EXACT_PERMUTATIONS = 20_000;
+const SAMPLED_PERMUTATIONS = 10_000;
+
+/**
+ * On by default, off by `TOKEN_OPTIMIZER_LOO=off`.
+ *
+ * Read per call rather than at module load, for the reason `holdoutFraction`
+ * gives: a long-lived process started before the setting changed would
+ * otherwise honour the old value forever with no way to tell.
+ */
+export function LOO_ENABLED() {
+  return String(process.env.TOKEN_OPTIMIZER_LOO || '').trim().toLowerCase() !== 'off';
+}
+
+/**
+ * The serving policy an observation was collected under.
+ *
+ * WHY EVERY OBSERVATION CARRIES ONE. An effect is only meaningful against a
+ * fixed policy. Halve the touch budget or move the minimum net utility and the
+ * same finding is served in different company, at a different rank, against a
+ * different counterfactual -- so pooling observations from before and after
+ * that change would average two different experiments and call the result
+ * causal. `effects()` therefore groups by (finding, policy) and never across.
+ *
+ * IT IS DELIBERATELY ABSENT FROM THE ARM HASH. Including it would reassign
+ * arms the moment a setting changed, which is precisely the mid-session flip
+ * the arm hash exists to prevent. Configuration decides which experiment an
+ * observation belongs to; it must never decide which arm.
+ */
+export function servingPolicyVersion() {
+  const policy = retrievalPolicy();
+  const parts = [
+    `g${LOO_POLICY_GENERATION}`,
+    `touch=${Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500}`,
+    `benefit=${policy.baseBenefitTokens}`,
+    `minutility=${policy.minimumNetUtility}`,
+    `cooldown=${policy.cooldownMs}`,
+    `quarantine=${policy.quarantineHarmCount}`,
+    `holdout=${process.env.TOKEN_OPTIMIZER_HOLDOUT ?? 'default'}`,
+    `withhold=${WITHHOLD_FRACTION}`,
+    `prior=${MIN_PRIOR_INJECTIONS}`,
+    `epsilon=${EPSILON}`,
+  ];
+  const digest = createHash('sha256').update(parts.join('|')).digest('hex');
+  return `${LOO_POLICY_GENERATION}-${digest.slice(0, 8)}`;
+}
+
+/**
+ * A stable number in [0, 1) from a string.
+ *
+ * SHA-256 rather than SHA-1 for the same reason `inHoldout` uses it: this is a
+ * bucketing hash and nothing here is secret, but arguing that a CodeQL finding
+ * is benign is a worse habit than paying a cost that rounds to nothing.
+ */
+function bucket(text) {
+  return createHash('sha256').update(String(text)).digest().readUInt32BE(0) / 4_294_967_296;
+}
+
+/**
+ * The arm of one finding in one session.
+ *
+ * Keyed on (findingKey, sessionId) AND NOTHING ELSE, so a finding cannot
+ * change arms partway through a session: not when the candidate set changes,
+ * not when the budget changes, not when the graph grows. The measurement is a
+ * comparison between sessions, and an arm that flips inside one contaminates
+ * both sides of it.
+ */
+function armed(findingKey, sessionId) {
+  return bucket(`loo-arm:${findingKey}:${sessionId}`) < WITHHOLD_FRACTION;
+}
+
+/** Deterministic tiebreak among armed candidates: lowest bucket, then key order. */
+function armRank(findingKey, sessionId) {
+  return bucket(`loo-rank:${findingKey}:${sessionId}`);
+}
+
+/** The graph node for a finding key, or null. Keys are unique per graph. */
+function findingNode(graph, key) {
+  const nodes = graph?.nodes;
+  if (!nodes || typeof nodes.values !== 'function') return null;
+  for (const node of nodes.values()) {
+    if (node?.kind === 'finding' && node.key === key) return node;
+    // A fixture graph may omit `kind`; key identity is what this needs.
+    if (node?.key === key && node.kind === undefined) return node;
+  }
+  return null;
+}
+
+/**
+ * May this finding ever be withheld?
+ *
+ * FAILS CLOSED ON AN UNKNOWN KEY, which is the opposite of how the rest of
+ * this module fails. Everywhere else a missing input costs a measurement; here
+ * it could cost a human their explicit decision, because a key whose node
+ * cannot be read is a key whose `pinned` and `origin` cannot be checked.
+ */
+function withholdable(graph, key) {
+  const node = findingNode(graph, key);
+  if (!node) return false;
+  if (node.pinned) return false;
+  if (node.origin === ORIGIN_HUMAN) return false;
+  if (node.retired) return false;
+  return true;
+}
+
+/** Prior SERVED injections per finding key, and withheld injections per session. */
+function history(dir, { evidence = null } = {}) {
+  const priorServed = new Map();
+  const withheldPerSession = new Map();
+  const events = evidence || readEvidence(dir);
+  for (const event of events) {
+    if (event.kind !== 'inject') continue;
+    if (typeof event.loo === 'string' && event.loo) {
+      const session = typeof event.sessionId === 'string' ? event.sessionId : '';
+      withheldPerSession.set(session, (withheldPerSession.get(session) || 0) + 1);
+    }
+    if (event.holdout) continue;
+    const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+    for (const raw of keys) {
+      const key = String(raw);
+      priorServed.set(key, (priorServed.get(key) || 0) + 1);
+    }
+  }
+  return { priorServed, withheldPerSession };
+}
+
+/**
+ * Which single finding to withhold from this touch, or null.
+ *
+ * Called from `forTouch` AFTER `fit` has decided what would have been served,
+ * which is the only ordering that produces a true leave-one-out. Withholding
+ * BEFORE the budget runs would let a lower-ranked finding take the freed
+ * tokens, so the withheld arm would receive different company as well as one
+ * fewer finding, and the comparison would confound the two.
+ *
+ * @param {string[]} findingKeys keys that would otherwise be delivered
+ * @param {string} sessionId the session, which pins the arm
+ * @param {object} graph the loaded graph, for `pinned` / `origin`
+ * @param {string|null} dir graph directory, for the injection history
+ */
+export function withheldFor(findingKeys, sessionId, graph, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return null;
+
+    // Every guard that needs no I/O runs first: this is the PreToolUse path,
+    // and on a project with one finding per anchor the answer is null before
+    // anything is read.
+    const keys = [...new Set((findingKeys || []).map((k) => String(k)).filter(Boolean))];
+    if (keys.length < 2) return null;
+    if (!sessionId || typeof sessionId !== 'string') return null;
+
+    // FILE SURFACE ONLY. A command injection's anchor is the command text, and
+    // no read event will ever match it -- so both arms would score zero
+    // downstream and the finding would be scored on nothing.
+    const { surface = 'file', anchor = '', holdout = false } = options;
+    if (surface !== 'file' || !anchor) return null;
+    // The all-findings holdout already withheld everything for this anchor.
+    if (holdout) return null;
+
+    const eligible = keys.filter((key) => withholdable(graph, key));
+    if (!eligible.length) return null;
+
+    const { priorServed, withheldPerSession } = history(dir, options);
+    if ((withheldPerSession.get(sessionId) || 0) >= MAX_WITHHELD_PER_SESSION) return null;
+
+    const enrolled = eligible.filter(
+      (key) => (priorServed.get(key) || 0) >= MIN_PRIOR_INJECTIONS
+    );
+    if (!enrolled.length) return null;
+
+    const candidates = enrolled.filter((key) => armed(key, sessionId));
+    if (!candidates.length) return null;
+
+    // AT MOST ONE. Sorted deterministically so the same touch always yields the
+    // same choice; the findings that lose the tiebreak are SERVED, and the
+    // observation records what actually happened rather than what the arm hash
+    // intended.
+    candidates.sort(
+      (a, b) => armRank(a, sessionId) - armRank(b, sessionId) || (a < b ? -1 : a > b ? 1 : 0)
+    );
+    return candidates[0];
+  } catch {
+    // An experiment must never break a tool call. Failing open here means
+    // serving everything, which is the undegraded behaviour.
+    return null;
+  }
+}
+
+/**
+ * Reorders candidates so exploration can break the feedback loop.
+ *
+ * A tenth of touches -- deterministic in (session, anchor), not random, so the
+ * same touch behaves the same way twice -- promote the LEAST-served candidate
+ * ahead of the utility order, giving it a chance to survive `fit` and accrue
+ * the observations it needs to earn a score. The other nine tenths are
+ * untouched.
+ *
+ * @param {Array<{finding:{key:string}}>} items assessed candidates, best first
+ */
+export function exploreOrder(items, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return items;
+    const list = Array.isArray(items) ? items : [];
+    if (list.length < 2) return list;
+    const { sessionId = '', anchor = '' } = options;
+    if (bucket(`loo-explore:${sessionId}:${anchor}`) >= EPSILON) return list;
+
+    const keyOf = (item) => String(item?.finding?.key ?? item?.key ?? '');
+    const { priorServed } = history(dir, options);
+    let promoted = 0;
+    for (let i = 1; i < list.length; i += 1) {
+      const a = priorServed.get(keyOf(list[i])) || 0;
+      const b = priorServed.get(keyOf(list[promoted])) || 0;
+      if (a < b || (a === b && keyOf(list[i]) < keyOf(list[promoted]))) promoted = i;
+    }
+    if (promoted === 0) return list;
+    return [list[promoted], ...list.filter((_, i) => i !== promoted)];
+  } catch {
+    return Array.isArray(items) ? items : [];
+  }
+}
+
+const mean = (values) =>
+  values.length ? values.reduce((sum, v) => sum + v, 0) / values.length : 0;
+
+/** Sample variance (n-1). Zero for a single observation: dispersion is unknown, not large. */
+function variance(values) {
+  if (values.length < 2) return 0;
+  const m = mean(values);
+  return values.reduce((sum, v) => sum + (v - m) * (v - m), 0) / (values.length - 1);
+}
+
+/**
+ * Every attributable Layer 2 observation, one per (injection, finding, arm).
+ *
+ * THREE THINGS ARE REPORTED SEPARATELY RATHER THAN FOLDED IN, because each of
+ * them would otherwise turn an absence into a zero:
+ *
+ *   `unattributable`  the outcome join could not attach a tool call to the
+ *                     injection, so nothing is known about what followed it.
+ *   `excluded`        the injection could never produce a read-join at all
+ *                     (command surface, session-start, fixture anchor) or was
+ *                     already in the all-findings holdout.
+ *   `costObservations` how many observations saw a non-zero read cost. If this
+ *                     is zero, "withholding changed nothing" and "the read
+ *                     channel never fired" are the same picture, and only one
+ *                     of them is a finding about findings.
+ */
+export function observations(dir, { events = null, evidence = null } = {}) {
+  const empty = {
+    rows: [],
+    unattributable: 0,
+    unattributableOutcomes: 0,
+    excluded: { command: 0, holdout: 0, fixture: 0, unanchored: 0 },
+    injections: 0,
+    withheldInjections: 0,
+    costObservations: 0,
+    policies: [],
+    windowed: false,
+  };
+  try {
+    const causal = evidence || readEvidence(dir);
+    const all = events || readMetrics(dir);
+    // OUT OF BAND and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` describes the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
+
+    // THE JOIN THIS MODULE CONSUMES AND DOES NOT REPLACE.
+    const joined = new Set();
+    let unattributableOutcomes = 0;
+    for (const event of causal) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) {
+        unattributableOutcomes += 1;
+        continue;
+      }
+      joined.add(String(event.injectionId));
+    }
+
+    // Read cost, grouped the way `buildReport` groups it: (session, anchor),
+    // canonicalised on both sides so two spellings of one file are one anchor.
+    // A mismatch here would make every read invisible and report a clean zero
+    // effect in both arms -- correct code, absent measurement.
+    const reads = new Map();
+    for (const event of all) {
+      if (event.kind !== 'read' || !event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      if (!reads.has(key)) reads.set(key, []);
+      reads.get(key).push(event);
+    }
+
+    const injects = causal
+      .filter((event) => event.kind === 'inject')
+      .map((event, index) => ({ event, index }))
+      .sort((a, b) => (a.event.at || 0) - (b.event.at || 0) || a.index - b.index)
+      .map((row) => row.event);
+
+    // How many injections share each (session, anchor), so a key's read total
+    // is SPLIT between them rather than charged in full to each -- the same
+    // correction `buildReport` applies, and for the same reason: without it the
+    // arm means scale with injections-per-anchor instead of per-touch cost.
+    const perKey = new Map();
+    for (const event of injects) {
+      if (!event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      perKey.set(key, (perKey.get(key) || 0) + 1);
+    }
+
+    const rows = [];
+    const excluded = { command: 0, holdout: 0, fixture: 0, unanchored: 0 };
+    const priorServed = new Map();
+    const policies = new Set();
+    let unattributable = 0;
+    let considered = 0;
+    let withheldInjections = 0;
+
+    for (const event of injects) {
+      const served = (Array.isArray(event.findingIds) ? event.findingIds : []).map(String);
+      const withheldKey = typeof event.loo === 'string' && event.loo ? event.loo : null;
+      const bump = () => {
+        for (const key of served) priorServed.set(key, (priorServed.get(key) || 0) + 1);
+      };
+
+      const isCommand =
+        event.surface === 'command' ||
+        event.trigger === 'command' ||
+        event.surface === 'session-start';
+      if (isCommand) {
+        excluded.command += 1;
+        bump();
+        continue;
+      }
+      if (!event.anchor) {
+        excluded.unanchored += 1;
+        bump();
+        continue;
+      }
+      if (isFixtureAnchor(event.anchor)) {
+        excluded.fixture += 1;
+        bump();
+        continue;
+      }
+      if (event.holdout) {
+        excluded.holdout += 1;
+        bump();
+        continue;
+      }
+
+      considered += 1;
+      if (withheldKey) withheldInjections += 1;
+      const policy = typeof event.looPolicy === 'string' && event.looPolicy
+        ? event.looPolicy
+        : 'unversioned';
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const attributable = Boolean(injectionId && joined.has(injectionId));
+
+      // DOWNSTREAM MEANS AFTER, STRICTLY. The read that triggered the touch is
+      // not caused by the advice; it happened before the advice existed.
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      const at = event.at || 0;
+      const total = (reads.get(key) || []).reduce(
+        (sum, read) => sum + ((read.at || 0) > at ? read.tokens || 0 : 0),
+        0
+      );
+      const cost = total / Math.max(1, perKey.get(key) || 1);
+
+      const observe = (findingKey, arm) => {
+        // ENROLMENT IS RE-DERIVED FROM THE LOG rather than trusted from the
+        // serving decision. It is the one field an old or hand-written record
+        // could contradict, and a served observation from before a finding was
+        // enrolled would compare an established finding against its own cold
+        // start.
+        //
+        // CHECKED BEFORE ATTRIBUTABILITY, so `unattributable` counts only
+        // observations the experiment actually wanted. Counting the rest there
+        // would report a join failure for every finding that was never in the
+        // experiment to begin with -- the same shape as the 2,559-row
+        // measurement-bias defect Layer 1 found in its own first draft.
+        if ((priorServed.get(findingKey) || 0) < MIN_PRIOR_INJECTIONS) return;
+        if (!attributable) {
+          unattributable += 1;
+          return;
+        }
+        policies.add(policy);
+        rows.push({ findingKey, arm, cost, policy, injectionId, anchor: event.anchor });
+      };
+
+      if (withheldKey) observe(withheldKey, 'withheld');
+      for (const findingKey of served) observe(findingKey, 'served');
+      bump();
+    }
+
+    return {
+      rows,
+      unattributable,
+      unattributableOutcomes,
+      excluded,
+      injections: considered,
+      withheldInjections,
+      costObservations: rows.filter((row) => row.cost > 0).length,
+      policies: [...policies].sort(),
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
+function permutationP(servedCosts, withheldCosts) {
+  const pooled = [...servedCosts, ...withheldCosts];
+  const n = pooled.length;
+  const k = withheldCosts.length;
+  if (!k || k === n) return null;
+  const observed = Math.abs(mean(withheldCosts) - mean(servedCosts));
+  const total = pooled.reduce((sum, v) => sum + v, 0);
+  // Mean difference from the withheld-arm sum alone: the served sum is the
+  // complement, so one number decides the statistic.
+  const diffFrom = (withheldSum) =>
+    Math.abs(withheldSum / k - (total - withheldSum) / (n - k));
+
+  const choose = (a, b) => {
+    let out = 1;
+    for (let i = 1; i <= b; i += 1) out = (out * (a - b + i)) / i;
+    return out;
+  };
+
+  const tolerance = 1e-9;
+  if (choose(n, k) <= MAX_EXACT_PERMUTATIONS) {
+    let extreme = 0;
+    let count = 0;
+    const walk = (start, chosen, sum) => {
+      if (chosen === k) {
+        count += 1;
+        if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+        return;
+      }
+      for (let i = start; i <= n - (k - chosen); i += 1) walk(i + 1, chosen + 1, sum + pooled[i]);
+    };
+    walk(0, 0, 0);
+    return count ? extreme / count : null;
+  }
+
+  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
+  // the same p-value and a verdict cannot flicker between two audit runs.
+  let state = 0x9e3779b9;
+  const random = () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4_294_967_296;
+  };
+  let extreme = 0;
+  const order = [...pooled];
+  for (let round = 0; round < SAMPLED_PERMUTATIONS; round += 1) {
+    for (let i = order.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(random() * (i + 1));
+      [order[i], order[j]] = [order[j], order[i]];
+    }
+    let sum = 0;
+    for (let i = 0; i < k; i += 1) sum += order[i];
+    if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+  }
+  return (extreme + 1) / (SAMPLED_PERMUTATIONS + 1);
+}
+
+/**
+ * The per-finding causal effect, shrunk, and whether it may be published.
+ *
+ * `raw` is `mean(withheld) - mean(served)`: POSITIVE means the session read the
+ * anchor more when the finding was withheld, which is the finding earning its
+ * place. `shrunk` is the number a reader should use.
+ *
+ * EMPIRICAL BAYES, and both halves of it come from the data. The prior mean is
+ * the population effect across findings; the weight `k` is the ratio of
+ * within-finding noise to between-finding spread, so a population where every
+ * finding behaves alike shrinks hard and one where they genuinely differ
+ * shrinks little. `SHRINKAGE_K` is the fallback when that spread cannot be
+ * estimated at all. Two observations therefore cannot post a wild score.
+ *
+ * PUBLICATION IS NOT THE SAME QUESTION as having an estimate. A row is
+ * published only if it clears the observation floor AND its permutation
+ * p-value survives Benjamini-Hochberg at q = 0.10 across every candidate row.
+ * Everything else gets `published: false` -- which is not a zero effect, and
+ * `looNote` says which of the two it is. An all-zero-cost population needs no
+ * separate guard: p is exactly 1 there, so nothing can publish anyway.
+ *
+ * NEVER POOLED ACROSS POLICY VERSIONS: rows are keyed on (findingKey, policy).
+ */
+export function effects(dir, options = {}) {
+  try {
+    // `obs` is accepted so `looNote` can read the logs once for both.
+    const obs = options.obs || observations(dir, options);
+    const groups = new Map();
+    for (const row of obs.rows) {
+      const id = JSON.stringify([row.findingKey, row.policy]);
+      if (!groups.has(id))
+        groups.set(id, { findingKey: row.findingKey, policy: row.policy, served: [], withheld: [] });
+      groups.get(id)[row.arm === 'withheld' ? 'withheld' : 'served'].push(row.cost);
+    }
+
+    const raws = [];
+    const withinVars = [];
+    for (const group of groups.values()) {
+      if (!group.served.length || !group.withheld.length) continue;
+      raws.push(mean(group.withheld) - mean(group.served));
+      withinVars.push(
+        variance(group.withheld) / group.withheld.length +
+          variance(group.served) / group.served.length
+      );
+    }
+    const prior = raws.length ? mean(raws) : 0;
+    const within = withinVars.length ? mean(withinVars) : 0;
+    const between = raws.length > 1 ? Math.max(0, variance(raws) - within) : 0;
+    const weight =
+      between > 0 && within > 0
+        ? Math.min(K_MAX, Math.max(K_MIN, within / between))
+        : SHRINKAGE_K;
+
+    const rows = [...groups.values()]
+      .map((group) => {
+        const served = group.served.length;
+        const withheld = group.withheld.length;
+        const both = served > 0 && withheld > 0;
+        const raw = both ? mean(group.withheld) - mean(group.served) : null;
+        const n = served + withheld;
+        const shrunk = raw === null ? null : (n * raw + weight * prior) / (n + weight);
+        const eligible = served >= MIN_SERVED && withheld >= MIN_WITHHELD;
+        return {
+          findingKey: group.findingKey,
+          policy: group.policy,
+          served,
+          withheld,
+          servedMean: mean(group.served),
+          withheldMean: mean(group.withheld),
+          raw,
+          shrunk,
+          p: eligible ? permutationP(group.served, group.withheld) : null,
+          published: false,
+        };
+      })
+      .sort((a, b) =>
+        a.findingKey < b.findingKey ? -1 : a.findingKey > b.findingKey ? 1 : a.policy < b.policy ? -1 : 1
+      );
+
+    // BENJAMINI-HOCHBERG at q = 0.10 over every row that cleared the floor.
+    // One finding tested in isolation would publish at p < 0.10; a hundred
+    // would publish ten false ones, and this module's whole claim is that its
+    // numbers can be quoted.
+    //
+    // THERE IS NO SEPARATE "WAS ANY READ COST OBSERVED" GATE HERE, and its
+    // absence is deliberate rather than an omission. One was written, and
+    // mutation testing showed it could not change a single verdict: if every
+    // observation has zero cost then both arm means are zero, the permutation
+    // statistic is zero for every relabelling, and p is exactly 1 -- which no
+    // BH threshold can pass. The guard was unfalsifiable, and an unfalsifiable
+    // guard is worse than none because it reads as protection nobody can test.
+    // `costObservations` survives as what it can honestly be: a DISCLOSURE, so
+    // `looNote` can say the read channel never fired instead of letting a
+    // reader take an arithmetic zero for a measured one.
+    const candidates = rows
+      .filter((row) => row.p !== null)
+      .sort((a, b) => a.p - b.p);
+    const m = candidates.length;
+    let cutoff = 0;
+    for (let i = 0; i < m; i += 1) {
+      if (candidates[i].p <= ((i + 1) / m) * FDR_Q) cutoff = i + 1;
+    }
+    for (let i = 0; i < cutoff; i += 1) candidates[i].published = true;
+
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * One or two lines for the audit, or nothing at all.
+ *
+ * THE REFUSAL IS THE PRODUCT HERE. On a machine with two injections in sixteen
+ * thousand events, the only honest output is that nothing is measurable yet,
+ * and this says so with the counts that make it checkable rather than printing
+ * a mean of nothing. It returns `null` when Layer 2 has not collected a single
+ * observation, so an idle experiment costs the reader no line at all -- the
+ * same standard `referenceNote` holds itself to.
+ */
+export function looNote(dir, options = {}) {
+  try {
+    const obs = options.obs || observations(dir, options);
+    const rows = effects(dir, { ...options, obs });
+    if (!obs.rows.length && !obs.withheldInjections) return null;
+
+    let graph = options.graph;
+    if (graph === undefined) {
+      try {
+        graph = load(dir);
+      } catch {
+        graph = null;
+      }
+    }
+    let exempt = 0;
+    if (graph?.nodes?.values) {
+      for (const node of graph.nodes.values()) {
+        if (node?.kind !== 'finding' || node.retired) continue;
+        if (node.pinned || node.origin === ORIGIN_HUMAN) exempt += 1;
+      }
+    }
+
+    const published = rows.filter((row) => row.published);
+    const head = published.length
+      ? `Per-finding causal value (leave-one-out): ${published.length} of ${rows.length} ` +
+        `findings show a verdict at q=${FDR_Q}` +
+        published
+          .slice(0, 3)
+          .map(
+            (row) =>
+              `; ${row.findingKey} saves ~${Math.round(row.shrunk)} tokens/touch ` +
+              `(${row.served} served, ${row.withheld} withheld, p=${row.p.toFixed(3)})`
+          )
+          .join('') +
+        '.'
+      : `Per-finding causal value (leave-one-out): NOT MEASURABLE YET -- ` +
+        `${obs.rows.length} attributable observations across ${rows.length} findings, ` +
+        `${obs.withheldInjections} withheld touches; the floor is ${MIN_SERVED} served ` +
+        `and ${MIN_WITHHELD} withheld per finding` +
+        (obs.costObservations ? '' : ', and no read cost has been observed in either arm') +
+        '. No effect is reported, which is not the same as an effect of zero.';
+
+    const caveats = [];
+    if (obs.unattributable)
+      caveats.push(
+        `${obs.unattributable} observations were unattributable (no joined tool outcome) and are in neither arm`
+      );
+    if (exempt)
+      caveats.push(
+        `${exempt} pinned or human-origin findings are exempt from withholding and get no causal score`
+      );
+    if (obs.policies.length > 1)
+      caveats.push(
+        `observations span ${obs.policies.length} serving-policy versions and are never pooled across them`
+      );
+    if (obs.windowed)
+      caveats.push('the read log was truncated, so downstream cost can understate');
+    return caveats.length ? `${head} ${caveats.join('; ')}.` : head;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/windsurf/hooks/lib/loo.mjs
+++ b/integrations/windsurf/hooks/lib/loo.mjs
@@ -545,8 +545,22 @@ export function observations(dir, { events = null, evidence = null } = {}) {
   }
 }
 
-/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
-function permutationP(servedCosts, withheldCosts) {
+/**
+ * Enumerates or samples arm relabellings and returns a two-sided p-value.
+ *
+ * EXPORTED so the cross-layer headline can be held to the same standard as the
+ * per-finding rows it summarises. `crosslayer.mjs` runs this over the two ARMS
+ * of shrunk effect estimates; the statistic, the enumerate-or-sample switch and the
+ * tolerance are therefore shared rather than reimplemented, and there is one
+ * place where "two-sided" is decided.
+ *
+ * `seed` exists for that caller. The default reproduces the fixed seed this
+ * function has always used, so Layer 2's own p-values are byte-identical; the
+ * cross-layer caller passes a seed DERIVED FROM ITS DATA, because a verdict
+ * printed to a human must not depend on `Math.random()` or on which module
+ * happened to call first.
+ */
+export function permutationP(servedCosts, withheldCosts, { seed = 0x9e3779b9 } = {}) {
   const pooled = [...servedCosts, ...withheldCosts];
   const n = pooled.length;
   const k = withheldCosts.length;
@@ -580,9 +594,10 @@ function permutationP(servedCosts, withheldCosts) {
     return count ? extreme / count : null;
   }
 
-  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
-  // the same p-value and a verdict cannot flicker between two audit runs.
-  let state = 0x9e3779b9;
+  // Mulberry32 off the caller's seed: reproducible, so the same data always
+  // yields the same p-value and a verdict cannot flicker between two audit
+  // runs.
+  let state = seed | 0;
   const random = () => {
     state = (state + 0x6d2b79f5) | 0;
     let t = state;

--- a/integrations/windsurf/hooks/lib/metrics.mjs
+++ b/integrations/windsurf/hooks/lib/metrics.mjs
@@ -31,6 +31,7 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { createHash, randomBytes } from 'node:crypto';
+import { redact } from './redact.mjs';
 
 /**
  * Read per call, not once at module load.
@@ -517,6 +518,15 @@ export function readEvidence(dir) {
 }
 
 /**
+ * The captured-output budget, in characters.
+ *
+ * Small enough that a 3 MB test log cannot bloat the evidence log or a single
+ * injected claim, large enough to hold the stack trace or compiler diagnostic
+ * that makes a failure finding worth anything.
+ */
+const OUTPUT_MAX_BYTES = 4096;
+
+/**
  * Joins a post-tool result to the most recent matching injection.  The exact
  * tool-call id wins; clients that omit it fall back to episode + surface +
  * anchor, in timestamp order, and the report states the weaker join method.
@@ -545,10 +555,31 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
+  // text is INJECTED into model context and EXPORTED to markdown, so the
+  // boundary is the only place that can guarantee it: a second caller added
+  // later would otherwise have to remember, and the one that forgot would leak
+  // a secret into two more places than the terminal it came from. `undefined`
+  // rather than `''` when nothing was captured, so JSON.stringify omits the
+  // key entirely and an absent capture is distinguishable from an empty one.
+  const output =
+    outcome.output === undefined || outcome.output === null
+      ? undefined
+      : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
+  // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric
+  // code at all, and 0 is the success value -- defaulting to it would claim
+  // every unreported call exited cleanly, which is a fabricated observation
+  // rather than a missing one.
+  const exit = Number.isInteger(outcome.exit) ? outcome.exit : null;
+
   return record(dir, {
     kind: 'tool-outcome',
     ...outcome,
     anchor,
+    // AFTER the spread, so a caller cannot smuggle raw text past the boundary
+    // by setting the field itself.
+    output,
+    exit,
     injectionId: injection?.injectionId || null,
     findingIds: injection?.findingIds || [],
     joinMethod,

--- a/integrations/windsurf/hooks/lib/metrics.mjs
+++ b/integrations/windsurf/hooks/lib/metrics.mjs
@@ -555,6 +555,22 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // FAILURES ONLY, and that is a deliberate override of the original plan.
+  // The plan predates MCP tool names reaching this path, so it never
+  // considered that a SUCCESSFUL `smart_read` would deposit 4 KB of file
+  // content into the evidence log on every call -- the log would grow with
+  // file text and the privacy surface would be every file the session opened.
+  //
+  // Nothing downstream loses anything. A failure claim quotes the error text;
+  // a "this command works" claim needs only the fact that it worked, which
+  // `success` and `exit` already carry. So the stored text narrows to text
+  // that is already an error message.
+  //
+  // GATED ON `success === true`, not on `!== false`: an outcome that never
+  // said whether it worked is unclassified, not successful, and dropping its
+  // text would lose exactly the failures a client too terse to report status
+  // produces.
+  const captureOutput = outcome.success !== true;
   // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
   // text is INJECTED into model context and EXPORTED to markdown, so the
   // boundary is the only place that can guarantee it: a second caller added
@@ -563,7 +579,7 @@ export function recordToolOutcome(dir, outcome) {
   // rather than `''` when nothing was captured, so JSON.stringify omits the
   // key entirely and an absent capture is distinguishable from an empty one.
   const output =
-    outcome.output === undefined || outcome.output === null
+    !captureOutput || outcome.output === undefined || outcome.output === null
       ? undefined
       : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
   // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric

--- a/integrations/windsurf/hooks/lib/metrics.mjs
+++ b/integrations/windsurf/hooks/lib/metrics.mjs
@@ -663,6 +663,89 @@ export function isFixtureAnchor(anchor) {
  * Fixture anchors are excluded from both.
  */
 /**
+ * Re-reads grouped by anchor -- the one place that decides what "wasteful" means.
+ *
+ * `rereadWaste` needed only the totals, so the grouping lived inside it and the
+ * per-anchor rows were thrown away. `derive.mjs`'s churn detector needs the
+ * rows, and re-deriving them there would put TWO definitions of "a repeat read
+ * of an unchanged file is waste" in the codebase, free to drift apart -- the
+ * exact divergence `npm run sync:hooks` exists to prevent between hooks-core and
+ * its generated copies. So the grouping lives here and both consumers read it.
+ *
+ * A re-read is only a re-read INSIDE ONE SESSION: grouping is keyed on
+ * session + canonical anchor, and rows are then merged per anchor so a file
+ * re-read across three sessions reports as one anchor with the sum of its
+ * repeats rather than three rows the caller has to add up. Merging cannot move
+ * the totals -- a sum of sums -- which is what makes it safe for `rereadWaste`.
+ *
+ * `tokens` is the WASTEFUL token count, not the total: it is the only one of the
+ * three that names something recoverable, and a row whose headline number
+ * included legitimate re-reads would overstate exactly the way the first
+ * version of this measurement did.
+ *
+ * @returns {Array<{anchor: string, repeats: number, wasteful: number,
+ *   tokens: number, legitimate: number, legitimateTokens: number,
+ *   undecidable: number, undecidableTokens: number}>} descending by `wasteful`,
+ *   then by `repeats`.
+ */
+export function rereadsByAnchor(events = [], { includeFixtures = false } = {}) {
+  const groups = new Map();
+  for (const e of events) {
+    if (!e || e.kind !== 'read' || !e.anchor) continue;
+    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
+    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(e);
+  }
+
+  const rows = new Map();
+  for (const list of groups.values()) {
+    if (list.length < 2) continue;
+    list.sort((a, b) => (a.at || 0) - (b.at || 0));
+
+    const anchorKey = canonicalKeyish(list[0].anchor);
+    let row = rows.get(anchorKey);
+    if (!row) {
+      row = {
+        anchor: list[0].anchor,
+        repeats: 0,
+        wasteful: 0,
+        tokens: 0,
+        legitimate: 0,
+        legitimateTokens: 0,
+        undecidable: 0,
+        undecidableTokens: 0,
+      };
+      rows.set(anchorKey, row);
+    }
+
+    for (let i = 1; i < list.length; i++) {
+      const prev = list[i - 1];
+      const cur = list[i];
+      const tokens = cur.tokens || 0;
+      row.repeats += 1;
+      // THE JUDGEMENT, in one place. A repeat read of a file that CHANGED is
+      // correct behaviour, not waste; a read written before fingerprints
+      // existed cannot be judged at all and says so.
+      if (!prev.fp || !cur.fp) {
+        row.undecidable += 1;
+        row.undecidableTokens += tokens;
+      } else if (prev.fp === cur.fp) {
+        row.wasteful += 1;
+        row.tokens += tokens;
+      } else {
+        row.legitimate += 1;
+        row.legitimateTokens += tokens;
+      }
+    }
+  }
+
+  return [...rows.values()].sort(
+    (a, b) => b.wasteful - a.wasteful || b.repeats - a.repeats
+  );
+}
+
+/**
  * Re-read waste, split into what is KNOWN and what is not.
  *
  * The question is narrow on purpose: how often does one session read the same
@@ -677,6 +760,9 @@ export function isFixtureAnchor(anchor) {
  * `undecidable` is reported rather than hidden. Reads written before the
  * fingerprint existed cannot be classified, and a measurement that quietly
  * counted them either way would be inventing its own answer.
+ *
+ * The aggregate fields are UNCHANGED -- `balanceSheet` reads them -- and are now
+ * a fold over `rereadsByAnchor`'s rows. `worst` is purely additive.
  */
 export function rereadWaste(
   dir,
@@ -685,14 +771,7 @@ export function rereadWaste(
   // excludes by design, making the real path untestable.
   { events = readMetrics(dir), includeFixtures = false } = {}
 ) {
-  const groups = new Map();
-  for (const e of events) {
-    if (e.kind !== 'read' || !e.anchor) continue;
-    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
-    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key).push(e);
-  }
+  const rows = rereadsByAnchor(events, { includeFixtures });
 
   const out = {
     repeats: 0,
@@ -704,29 +783,21 @@ export function rereadWaste(
     undecidableTokens: 0,
   };
 
-  for (const list of groups.values()) {
-    if (list.length < 2) continue;
-    list.sort((a, b) => (a.at || 0) - (b.at || 0));
-    for (let i = 1; i < list.length; i++) {
-      const prev = list[i - 1];
-      const cur = list[i];
-      const tokens = cur.tokens || 0;
-      out.repeats += 1;
-      if (!prev.fp || !cur.fp) {
-        out.undecidable += 1;
-        out.undecidableTokens += tokens;
-      } else if (prev.fp === cur.fp) {
-        out.wasteful += 1;
-        out.wastefulTokens += tokens;
-      } else {
-        out.legitimate += 1;
-        out.legitimateTokens += tokens;
-      }
-    }
+  for (const row of rows) {
+    out.repeats += row.repeats;
+    out.wasteful += row.wasteful;
+    out.wastefulTokens += row.tokens;
+    out.legitimate += row.legitimate;
+    out.legitimateTokens += row.legitimateTokens;
+    out.undecidable += row.undecidable;
+    out.undecidableTokens += row.undecidableTokens;
   }
 
   const decided = out.wasteful + out.legitimate;
   out.coverage = out.repeats ? decided / out.repeats : null;
+  // The offenders behind the totals, bounded: a report needs the handful worth
+  // acting on, not one row per file the session touched twice.
+  out.worst = rows.slice(0, 10);
   return out;
 }
 

--- a/integrations/windsurf/hooks/lib/recall.mjs
+++ b/integrations/windsurf/hooks/lib/recall.mjs
@@ -1,0 +1,390 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/recall.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Does retrieval FIND a finding, or does it only find what it was told where
+ * to look?
+ *
+ * `docs/WIKI_GRAPH.md` says embeddings get added "if measurement shows real
+ * recall loss". Nothing measured recall, so the no-embeddings stance was
+ * unfalsifiable -- a claim with no observation that could contradict it. This
+ * module is the observation.
+ *
+ * ---------------------------------------------------------------------------
+ * THE TAUTOLOGY THIS DELIBERATELY DOES NOT SHIP, AND WHY IT IS RECORDED HERE
+ * ---------------------------------------------------------------------------
+ * The obvious probe -- for each finding, take its anchors and ask whether
+ * `findingsFor` returns it from each -- CANNOT FAIL. `findingsFor(graph, A)`
+ * walks `derived_from` edges backwards into A, and the edge F -> A is the very
+ * thing that makes A an anchor of F. So F is in the result by CONSTRUCTION, not
+ * by retrieval quality, for every graph, forever. Its rate is 1.0 always, and a
+ * permanent 1.0 published as a recall rate reads to a human as "retrieval is
+ * perfect, embeddings unnecessary" -- one unfalsifiable claim swapped for
+ * another, leaning the one direction a measurement of this project by this
+ * project must never lean.
+ *
+ * That check is still worth running -- if it ever fails, traversal is broken
+ * rather than merely lossy -- so it is kept, and reported as `integrity` with
+ * its own `what` string saying it is not a recall rate. It is NEVER `rate`.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT IS MEASURED INSTEAD: LEAVE-ONE-EDGE-OUT
+ * ---------------------------------------------------------------------------
+ * For each active finding F and each anchor A of F, delete the edge F -> A and
+ * ask whether touching A would STILL surface F. Two independent arms, both of
+ * which can genuinely miss, which is what makes this a measurement:
+ *
+ *   Arm A -- TRAVERSAL FROM THE NEIGHBOURHOOD. Run the real `findingsFor` over
+ *   the edge-deleted graph from A itself and from A's `contains` parents. This
+ *   hits only when F has some OTHER structural route in: a second anchor on the
+ *   same file, or an anchor on a sibling symbol under the same parent. A's
+ *   `contains` children need no separate call because `findingsFor` expands
+ *   them itself -- calling the parent therefore covers every sibling, which is
+ *   why the neighbour list is `[A, ...parents(A)]` and not a hop-counted
+ *   frontier. The REAL primitive is used rather than an equivalent inlined
+ *   here, because a probe that reimplements the thing it measures drifts from
+ *   it and then measures itself.
+ *
+ *   Arm B -- BM25 FROM THE ANCHOR'S OWN KEY. Rank the whole active corpus with
+ *   `lexical.rank`, querying with A's key -- the file path or symbol name the
+ *   user actually touched -- and hit if F comes back inside `limit`.
+ *
+ * WHY ARM B IS NOT QUERIED WITH THE FINDING'S OWN CLAIM. The plan's literal
+ * form was "the finding's claim terms against the rest of the corpus", and both
+ * readings of it are degenerate. Querying F's claim against a corpus that
+ * INCLUDES F is the tautology again: BM25 scores a document against its own
+ * text, so F wins its own query every time. Querying F's claim against a corpus
+ * that EXCLUDES F cannot return F at all, so a "hit" would mean some DIFFERENT
+ * finding matched -- that is redundancy of storage, not recall of F, and it
+ * would score a graph better for holding duplicates. The anchor's key is the
+ * one query text that is available offline, is not derived from F, and matches
+ * the production question: a session touches a file, and the only lexical
+ * handle on it is its own path. It misses exactly when a finding's claim never
+ * names the code it is about, which is the recall gap embeddings are supposed
+ * to close.
+ *
+ * ---------------------------------------------------------------------------
+ * REFUSALS -- four, and each costs this project its own good news
+ * ---------------------------------------------------------------------------
+ *  1. TOO FEW OBSERVATIONS -> `rate: null` with a reason. See `MIN_PROBED`.
+ *  2. A CORPUS NO LARGER THAN THE RETRIEVAL LIMIT -> `rate: null`. Arm B is
+ *     recall@`limit`, and below the limit NO FINDING IS EVER CUT FOR BUDGET:
+ *     every document scoring above zero is returned, so the arm measures
+ *     whether a token matched, which is a strictly weaker bar than the one
+ *     production applies when `forTouch` fills a token budget from a ranked
+ *     list. A probe more permissive than the system it measures can only
+ *     overstate recall, so the rate is withheld in that band and the counts are
+ *     published instead. It bites between `MIN_PROBED` and `limit` findings --
+ *     on this machine's project graph, whose one finding had both anchor edges
+ *     "recovered" that way, the observation-count refusal fires first.
+ *  3. NO ANCHOR NODE -> the pair is UNPROBEABLE, not a miss. Reported and
+ *     excluded from the denominator; see `probeEdge`.
+ *  4. STRICT AGGREGATION -> a finding counts as retrieved only if EVERY one of
+ *     its probeable anchor edges is recoverable. A finding reachable from one
+ *     anchor and lost from another is a miss, with the losing anchor named.
+ *     This biases the rate DOWN, which is the safe direction here.
+ *
+ * FAILS OPEN. It runs on a report path; a graph it cannot read must cost a
+ * section, not the report.
+ */
+
+import { load, findingsFor } from './wiki.mjs';
+import { rank } from './lexical.mjs';
+
+/**
+ * Distinct findings that must be probeable before a RATE is published at all.
+ *
+ * NOT AN EFFECT-SIZE CONVENTION -- it is a resolution argument. A proportion
+ * over n observations has a resolution of 1/n, so below ten findings the
+ * published figure moves in steps coarser than ten percentage points, and the
+ * two extremes a small graph actually produces (`1.0` and `0.0`) are the two a
+ * reader is most likely to mistake for a finding about retrieval. At n = 10 and
+ * zero misses the exact binomial 95% upper bound on the true miss rate is still
+ * 1 - 0.05^(1/10) = 0.26, so even a clean sweep here bounds recall loss only
+ * below about a quarter -- which is why the refusal reason says what the number
+ * would and would not have supported rather than just naming the floor.
+ *
+ * THE FLOOR IS ON DISTINCT FINDINGS, NOT ANCHOR EDGES. Two anchors of one
+ * finding are two edges of the same claim, not two independent observations;
+ * counting them would let a single multi-anchored finding unlock a rate.
+ */
+export const MIN_PROBED = 10;
+
+/**
+ * The most findings probed in one call.
+ *
+ * Each probed anchor edge costs a graph-sized edge filter plus one or two real
+ * `findingsFor` walks plus one BM25 pass over the corpus, and this runs on the
+ * on-demand report path. The cap is deterministic (findings sorted by key) and
+ * `truncated` says when it bit, so a large graph gets a smaller, honestly
+ * labelled sample rather than a slow report.
+ */
+export const MAX_FINDINGS = 200;
+
+/** Active findings only. A retired claim is withdrawn; recalling it is not a win. */
+function activeFindings(graph) {
+  return [...graph.nodes.values()]
+    .filter((node) => node && node.kind === 'finding' && !node.retired)
+    .sort((a, b) => String(a.key || '').localeCompare(String(b.key || '')));
+}
+
+/** The `contains` parents of every node, indexed once for the whole probe. */
+function parentIndex(graph) {
+  const parents = new Map();
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contains') continue;
+    const list = parents.get(edge.to);
+    if (list) list.push(edge.from);
+    else parents.set(edge.to, [edge.from]);
+  }
+  return parents;
+}
+
+/** The anchors of one finding: the targets of its own `derived_from` edges. */
+function anchorsOf(graph, findingId) {
+  const out = new Set();
+  for (const edge of graph.edges) {
+    if (edge.edge === 'derived_from' && edge.from === findingId) out.add(edge.to);
+  }
+  return [...out];
+}
+
+/**
+ * The graph minus exactly one anchor edge.
+ *
+ * `nodes` is shared rather than copied: nothing here mutates it, and a
+ * 2,600-node Map copied once per anchor edge is the difference between a probe
+ * and a stall.
+ */
+function withoutAnchorEdge(graph, findingId, anchorId) {
+  return {
+    nodes: graph.nodes,
+    edges: graph.edges.filter(
+      (edge) =>
+        !(
+          edge.edge === 'derived_from' &&
+          edge.from === findingId &&
+          edge.to === anchorId
+        )
+    ),
+  };
+}
+
+/**
+ * One anchor edge, hidden, then asked after. Returns `recovered` with the arm
+ * that found it, or a reason -- and `probeable: false` when the question could
+ * not be put at all.
+ */
+function probeEdge(graph, parents, finding, anchorId, corpus, limit) {
+  const hidden = withoutAnchorEdge(graph, finding.id, anchorId);
+
+  // Arm A. `findingsFor` expands `contains` children itself, so the parent call
+  // covers every sibling of the anchor.
+  const neighbours = [anchorId, ...(parents.get(anchorId) || [])];
+  for (const neighbour of neighbours) {
+    const got = findingsFor(hidden, neighbour, { limit });
+    if (got.some((node) => node.id === finding.id)) {
+      return { recovered: true, arm: 'traversal', anchorId };
+    }
+  }
+
+  // Arm B needs a query, and the query is the anchor's own key. A dangling
+  // anchor edge -- an edge whose target node was never indexed, which
+  // `expand.promote` produces -- leaves nothing to query with. That is a
+  // question that could not be asked, NOT an observed miss: scoring it a miss
+  // would manufacture a recall loss out of a graph-integrity defect.
+  const anchor = graph.nodes.get(anchorId);
+  const key = anchor && typeof anchor.key === 'string' ? anchor.key : '';
+  if (!key) {
+    return {
+      recovered: false,
+      probeable: false,
+      anchorId,
+      reason: `anchor ${anchorId} has no node in the graph, so there is no anchor key to query BM25 with`,
+    };
+  }
+
+  const hits = rank(key, corpus, { limit });
+  if (hits.some((hit) => hit.finding && hit.finding.id === finding.id)) {
+    return { recovered: true, arm: 'lexical', anchorId };
+  }
+
+  return {
+    recovered: false,
+    probeable: true,
+    anchorId,
+    reason: `no neighbouring anchor reaches it and BM25 over ${key} does not rank it in the top ${limit}`,
+  };
+}
+
+/**
+ * The probe. An OFFLINE measurement over the graph as it stands -- it reads,
+ * ranks and traverses, and writes nothing.
+ */
+export function recallProbe(
+  dir,
+  {
+    limit = 20,
+    graph = null,
+    minProbed = MIN_PROBED,
+    maxFindings = MAX_FINDINGS,
+  } = {}
+) {
+  const refuse = (reason) => ({
+    basis: 'offline probe over the current graph',
+    probed: 0,
+    retrieved: 0,
+    rate: null,
+    reason,
+    misses: [],
+    unprobeable: [],
+  });
+
+  let g;
+  try {
+    g = graph || load(dir);
+  } catch {
+    return refuse('the graph could not be read, so recall was not measured.');
+  }
+
+  try {
+    const all = activeFindings(g);
+    const truncated = all.length > maxFindings;
+    const findings = truncated ? all.slice(0, maxFindings) : all;
+    const parents = parentIndex(g);
+    // The corpus BM25 ranks over is the ACTIVE graph, uncapped: the sample is
+    // which findings are probed, not what they compete against. Every reported
+    // figure below reads `corpus.length` rather than `all.length`, so the
+    // published size IS the ranking corpus rather than a parallel claim about
+    // it. The distinction is not pedantry: a mutation that shrank the ranking
+    // corpus to the probed sample -- making retrieval easier, in this project's
+    // favour -- SURVIVED the first mutation run precisely because the reported
+    // number came from the other variable and could not move.
+    const corpus = all;
+
+    const misses = [];
+    const unprobeable = [];
+    const integrityFailures = [];
+    let probed = 0;
+    let retrieved = 0;
+    let integrityOk = 0;
+    let probedEdges = 0;
+    let recoveredEdges = 0;
+    const byArm = { traversal: 0, lexical: 0 };
+
+    for (const finding of findings) {
+      const anchors = anchorsOf(g, finding.id);
+
+      // INTEGRITY, run on the UNTOUCHED graph: the by-construction check. Its
+      // only honest use is as a smoke test, and it is reported as one.
+      if (!anchors.length) {
+        integrityFailures.push({
+          key: finding.key,
+          reason:
+            'active finding with no anchor -- writeHarvested refuses to create one',
+        });
+      } else if (
+        anchors.every((anchorId) =>
+          findingsFor(g, anchorId, { limit }).some((node) => node.id === finding.id)
+        )
+      ) {
+        integrityOk += 1;
+      } else {
+        integrityFailures.push({
+          key: finding.key,
+          reason: `not returned by findingsFor from one of its own anchors at limit ${limit}`,
+        });
+      }
+
+      // An unanchored finding is a definite miss, not an unaskable question:
+      // nothing traverses to it and there is no anchor key to query from, so
+      // the anchor-driven path that serves findings on a file touch can never
+      // surface it. Only an explicit wiki_query naming its own terms would.
+      if (!anchors.length) {
+        probed += 1;
+        misses.push({
+          key: finding.key,
+          reason:
+            'no anchor: nothing traverses to it and there is no anchor key to query with, so only an explicit wiki_query of its own terms would surface it',
+        });
+        continue;
+      }
+
+      const results = anchors.map((anchorId) =>
+        probeEdge(g, parents, finding, anchorId, corpus, limit)
+      );
+      const askable = results.filter((result) => result.probeable !== false);
+      probedEdges += askable.length;
+      recoveredEdges += askable.filter((result) => result.recovered).length;
+      for (const result of askable) {
+        if (result.recovered) byArm[result.arm] += 1;
+      }
+
+      if (!askable.length) {
+        unprobeable.push({ key: finding.key, reason: results[0].reason });
+        continue;
+      }
+
+      probed += 1;
+      const lost = askable.filter((result) => !result.recovered);
+      if (!lost.length) retrieved += 1;
+      else misses.push({ key: finding.key, reason: lost[0].reason });
+    }
+
+    const integrity = {
+      what:
+        'BY CONSTRUCTION: a finding is returned by findingsFor from its own anchor because that edge is what makes it an anchor. Expected 1 for every graph. NOT a recall rate.',
+      probed: findings.length,
+      retrieved: integrityOk,
+      rate: findings.length ? integrityOk / findings.length : null,
+      ok: integrityFailures.length === 0,
+      failures: integrityFailures,
+    };
+
+    // Arm B is recall@`limit`. Over a corpus of at most `limit` findings nothing
+    // is ever cut for budget, so the arm asks only whether a token matched --
+    // weaker than the bar production applies under a token budget, and a probe
+    // more permissive than the system it measures can only overstate recall.
+    const discriminating = corpus.length > limit;
+
+    const common = {
+      basis: 'offline probe over the current graph',
+      probed,
+      retrieved,
+      misses,
+      unprobeable,
+      probedEdges,
+      recoveredEdges,
+      byArm,
+      corpus: corpus.length,
+      discriminating,
+      truncated,
+      minProbed,
+      integrity,
+    };
+
+    if (probed < minProbed) {
+      return {
+        ...common,
+        rate: null,
+        reason:
+          probed === 0
+            ? `no probeable finding: ${unprobeable.length} of ${findings.length} active finding(s) have no anchor node to query from, so recall was not measured. No rate is reported, which is not the same as a rate of zero.`
+            : `${probed} probeable finding(s), below the floor of ${minProbed}: a proportion over ${probed} has a resolution of ${Math.round(
+                100 / probed
+              )} percentage points, so no rate is published. ${retrieved} of ${probed} were recovered without their own anchor edge, which is a count and not a rate.`,
+      };
+    }
+
+    if (!discriminating) {
+      return {
+        ...common,
+        rate: null,
+        reason: `the active corpus holds ${corpus.length} finding(s) and the retrieval limit is ${limit}, so nothing is ever cut for budget and the lexical arm asks only whether a token matched -- a weaker bar than production applies. No rate is published off a probe more permissive than the system it measures; ${retrieved} of ${probed} were recovered, which is a count and not a rate.`,
+      };
+    }
+
+    return { ...common, rate: retrieved / probed, reason: null };
+  } catch {
+    return refuse('the probe failed, so recall was not measured.');
+  }
+}

--- a/integrations/windsurf/hooks/lib/redact.mjs
+++ b/integrations/windsurf/hooks/lib/redact.mjs
@@ -1,0 +1,30 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/redact.mjs. Regenerate with `npm run sync:hooks`.
+// hooks-core/redact.mjs
+/**
+ * Redaction for anything derived from captured output.
+ *
+ * WHY THIS IS MANDATORY RATHER THAN PRUDENT. derive.mjs builds claims out of
+ * command stderr. A claim is INJECTED into model context and EXPORTED to
+ * markdown, so a secret that reaches a claim reaches two more places than the
+ * terminal it came from. Pattern matching is imperfect and that is stated in the
+ * spec, but "imperfect" beats "absent" by a wide margin here.
+ */
+
+const PATTERNS = [
+  // Bearer / API-key shaped tokens.
+  [/\b(bearer\s+)[A-Za-z0-9._~+/-]{12,}/gi, '$1[redacted]'],
+  [/\b(sk|pk|ghp|gho|github_pat|xox[baprs])[-_][A-Za-z0-9._-]{10,}/gi, '[redacted]'],
+  // KEY=value where the key name suggests a secret.
+  [/\b([A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|APIKEY|API_KEY|PRIVATE_KEY|CREDENTIAL)[A-Z0-9_]*)\s*[=:]\s*\S+/g, '$1=[redacted]'],
+  // Credentials inside a URL.
+  [/\b([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+):[^\s@]+@/gi, '$1:[redacted]@'],
+  // PEM blocks.
+  [/-----BEGIN[^-]*PRIVATE KEY-----[\s\S]*?-----END[^-]*PRIVATE KEY-----/g, '[redacted key]'],
+];
+
+export function redact(text, { max = 400 } = {}) {
+  let out = String(text ?? '');
+  for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
+}

--- a/integrations/windsurf/hooks/lib/redact.mjs
+++ b/integrations/windsurf/hooks/lib/redact.mjs
@@ -24,7 +24,21 @@ const PATTERNS = [
 ];
 
 export function redact(text, { max = 400 } = {}) {
+  // `?? ''` matters even though String(null)/String(undefined) never throw:
+  // without it a missing value becomes the literal 4-11 character string
+  // "null"/"undefined" -- a garbage claim that silently reaches the graph
+  // and model context instead of surfacing as an error.
   let out = String(text ?? '');
   for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  // Redact BEFORE truncating, never the reverse. Several patterns above rely
+  // on a minimum-length quantifier (e.g. `{10,}`, `{12,}`) plus a prefix.
+  // Truncating first can cut a match down to fewer characters than that
+  // quantifier requires, so the shortened fragment no longer satisfies the
+  // pattern and a live partial secret would pass through in cleartext. By
+  // redacting the full, untruncated string first, every pattern always sees
+  // the complete secret and removes it before any character budget is
+  // spent; the cap below can then only ever cut into already-redacted text
+  // (a label, or the "[redacted]" placeholder itself), never into raw
+  // secret bytes.
   return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
 }

--- a/integrations/windsurf/hooks/lib/transcript.mjs
+++ b/integrations/windsurf/hooks/lib/transcript.mjs
@@ -19,9 +19,11 @@
  */
 
 import {
-  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, unlinkSync,
+  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync,
+  unlinkSync, openSync, readSync, closeSync,
 } from 'node:fs';
 import { join } from 'node:path';
+import { redact } from './redact.mjs';
 
 /** Where a project's transcripts live, under the graph it belongs to. */
 export const transcriptDir = (dir) => join(dir, 'transcripts');
@@ -210,4 +212,204 @@ export function readArchive(dir, sessionId) {
   } catch {
     return [];
   }
+}
+
+/**
+ * How much of a transcript's TAIL is scanned for failed tool results.
+ *
+ * A transcript is the largest file this project reads: the three real ones on
+ * the measuring machine are 5.8 MB, 22 MB and 45 MB. `archive()` above already
+ * reads the whole thing once at Stop, so an unbounded second pass doubles the
+ * most expensive read on the session-end path for evidence that is, by
+ * construction, mostly old. The tail is the right half to keep for the same
+ * reason `buildFeedbackDigest` keeps the end: what a session learned is
+ * concentrated where the work went wrong, which is later rather than sooner.
+ */
+const FAILED_SCAN_BYTES = () =>
+  Number(process.env.TOKEN_OPTIMIZER_TRANSCRIPT_SCAN_BYTES) || 8 * 1024 * 1024;
+
+/** Failed results kept, most recent first. The pairing detector needs a handful. */
+const FAILED_MAX = 50;
+
+/** Same 4 KB cap `recordToolOutcome` applies to `output`, for the same reason. */
+const FAILED_OUTPUT_MAX = 4096;
+
+/**
+ * The same 120-character truncation `recordToolOutcome` applies to `anchor`.
+ *
+ * ONE COMMAND MUST PRODUCE ONE KEY FROM EITHER SOURCE. A `tool-outcome` stores
+ * the command as `String(tool_input.command).slice(0, 120)`, and `attemptKey`
+ * reads up to three non-flag tokens off whatever it is handed. A long first
+ * token -- a quoted grep pattern, an absolute Windows path, a heredoc -- is cut
+ * by that cap INSIDE those three tokens, so the untruncated transcript copy of
+ * the same command lands in a DIFFERENT group. Measured against one real
+ * session's own evidence: 266 commands present in both sources, and truncating
+ * here made 266 of 266 keys agree where the untruncated text agreed on only
+ * 240.
+ *
+ * WHAT THAT ACTUALLY BUYS, stated precisely rather than generously. `derive`
+ * refuses to build a claim out of a command at or over the cap at all (see
+ * `quotable` there), so agreement on a TRUNCATED key never produces a finding
+ * on its own. It buys two things that still matter: a transcript failure lands
+ * in the same run as the event outcomes of the same command, so the
+ * nearest-preceding-failure rule sees the real sequence rather than a sparse
+ * one; and the no-call-id fallback in `derive`'s deduplication compares command
+ * TEXT against an already-truncated anchor, which cannot match unless this side
+ * is truncated identically.
+ */
+const ANCHOR_MAX = 120;
+
+/**
+ * A tool result that reports a command that RAN and exited non-zero.
+ *
+ * A POSITIVE ALLOWLIST, and the measurement is why. Claude Code sets
+ * `is_error: true` on every kind of unhappy tool result, and across three real
+ * transcripts 214 of them fell into four shapes:
+ *
+ *   83  `Exit code N` + stderr    -- a command ran and failed. THIS ONE.
+ *   109 hook and policy denials   -- overwhelmingly THIS optimizer's own
+ *                                    PreToolUse text ("Recursive shell searches
+ *                                    return unbounded output. Call the
+ *                                    token-optimizer MCP tool smart_grep
+ *                                    instead"), plus `Remove-Item on system
+ *                                    path` blocks.
+ *   18  `<tool_use_error>...`     -- protocol errors: `String to replace not
+ *                                    found`, `File has not been read yet`,
+ *                                    `Blocked: ...`.
+ *   4   a person declined the call.
+ *
+ * Only the first shape is a command failing. In every other shape THE COMMAND
+ * NEVER RAN, so "`X` failed with: ..." would be a false claim about X, and a
+ * later success would pair with a failure that never happened. The 109 are the
+ * dangerous ones: ingesting them would have this tool derive findings from its
+ * own advice, at 0.9 confidence, and serve them back as observations about the
+ * project -- a self-referential loop that also inflates its own finding count.
+ * That is the measurement-bias class this plan tracks, and a denylist would
+ * have let every future denial string through by default.
+ */
+const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
+
+/** Reads at most `bytes` from the END of a file, without loading the rest. */
+function readTail(path, bytes) {
+  let fd;
+  try {
+    const size = statSync(path).size;
+    const length = Math.min(size, bytes);
+    if (!length) return '';
+    fd = openSync(path, 'r');
+    const buffer = Buffer.allocUnsafe(length);
+    readSync(fd, buffer, 0, length, size - length);
+    const text = buffer.toString('utf8');
+    // A tail almost never starts on a line boundary, and half a JSON object is
+    // not a parse failure worth reporting -- it is a partial record. Drop it.
+    return length < size ? text.slice(text.indexOf('\n') + 1) : text;
+  } catch {
+    return '';
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+}
+
+/**
+ * The failed COMMAND results a transcript holds, which no hook event carries.
+ *
+ * WHY THIS READER EXISTS. Claude Code never fires PostToolUse for a failed tool
+ * call: a deliberately failing command produced no event at all, and 2,238 of
+ * 2,238 live `tool-outcome` events on the measuring machine carry
+ * `success: true`. So `derive.mjs`'s two strongest detectors -- command
+ * failed-then-succeeded at 0.90 and test/build red-to-green at 0.85 -- have no
+ * input whatsoever on the primary client, while working normally on the ten
+ * adapter clients. The failures exist; they exist only here.
+ *
+ * WHY NOT THE ARCHIVE, which the plan for this reader assumed. `readTurns`
+ * DROPS tool results by design -- that is where whole file contents would enter
+ * the record -- so `readArchive` returns no failure, ever, and an extractor over
+ * archived turns would find nothing however well it was written. Making the
+ * archive carry them would also push command stderr into `buildFeedbackDigest`,
+ * which is the one code path in this project that sends anything to a model
+ * endpoint. So this reads the transcript and STORES NOTHING NEW: read-only, no
+ * capture path, no new event kind, and no widening of what leaves the machine.
+ *
+ * REDACTED HERE, at this boundary, exactly as `recordToolOutcome` redacts
+ * `output`. Transcript text has never passed a redaction boundary -- that one
+ * never saw it -- and everything returned from here is destined for a claim that
+ * is injected into model context and exported to markdown.
+ *
+ * @returns {Array<{command: string, output: string, exit: number|null,
+ *   at: number, toolCallId: string|null}>} in transcript order, so a caller can
+ *   sort it beside `tool-outcome` events without re-ordering.
+ */
+export function failedResultsFromTranscript(transcriptPath, options = {}) {
+  const { max = FAILED_MAX, scanBytes = FAILED_SCAN_BYTES() } = options || {};
+  if (!transcriptPath) return [];
+  const text = readTail(transcriptPath, scanBytes);
+  if (!text) return [];
+
+  // tool_use_id -> the command that was attempted. The join is EXACT and it is
+  // the only one available: the result block carries no command of its own, and
+  // the id is the same string `episodeMeta` reads into `toolCallId`, so the same
+  // key also deduplicates against events on clients that do report failures.
+  const commands = new Map();
+  const failures = [];
+
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const message = entry.message || entry;
+    const role = message.role || entry.type;
+    const content = message.content;
+    if (!Array.isArray(content)) continue;
+
+    if (role === 'assistant') {
+      for (const block of content) {
+        if (!block || block.type !== 'tool_use' || !block.id) continue;
+        const command = block.input?.command;
+        if (typeof command !== 'string' || !command.trim()) continue;
+        commands.set(String(block.id), command.slice(0, ANCHOR_MAX));
+      }
+      continue;
+    }
+
+    if (role !== 'user') continue;
+    for (const block of content) {
+      if (!block || block.type !== 'tool_result' || block.is_error !== true) continue;
+      // Only a STRING result can be an exit-code report; every failed Claude
+      // Code result observed was one, and a structured body is a shape this
+      // classifier has not measured, so it is refused rather than guessed at.
+      if (typeof block.content !== 'string') continue;
+      const match = EXIT_CODE_RESULT.exec(block.content);
+      if (!match) continue;
+      const command = commands.get(String(block.tool_use_id || ''));
+      // No command means no claim. The result says something failed; without
+      // the text of what failed there is nothing to say about it, and nothing
+      // to group it with.
+      if (!command) continue;
+      failures.push({
+        command,
+        // The exit line itself is stripped: `exit` carries it structurally, and
+        // leaving it in makes every failure claim read "failed with: Exit code 1".
+        output: redact(block.content.slice(match[0].length).trim(), {
+          max: FAILED_OUTPUT_MAX,
+        }),
+        exit: Number(match[1]),
+        at: Date.parse(entry.timestamp || '') || 0,
+        toolCallId: block.tool_use_id ? String(block.tool_use_id) : null,
+      });
+    }
+  }
+
+  // The MOST RECENT `max`, keeping chronological order. A session that failed
+  // two hundred times teaches its last lessons, not its first.
+  return failures.slice(-max);
 }

--- a/integrations/windsurf/hooks/lib/usage.mjs
+++ b/integrations/windsurf/hooks/lib/usage.mjs
@@ -42,7 +42,7 @@
  * was referenced" and "nothing could be measured" are different answers and
  * this module gives different answers for them.
  */
-import { readMetrics } from './metrics.mjs';
+import { readMetrics, readTruncation } from './metrics.mjs';
 
 /**
  * The events that name a finding, and it is ONE kind, not the two the plan
@@ -129,17 +129,30 @@ export function classify(dir, { events = null } = {}) {
   try {
     const all = inTimeOrder(events || readMetrics(dir));
 
-    // Every reference, keyed on the finding it names. Only references carrying
-    // a session id are usable -- see `unscopedReferences` in `referenceRate`
-    // for the ones this drops and why they are counted rather than credited.
+    // Every reference, keyed on the finding it names and on nothing else.
+    //
+    // NOT SCOPED BY SESSION, and that is a deliberate reversal. Scoping needs
+    // the query's `sessionId`, which `wiki_query` takes as an OPTIONAL input
+    // the model has to volunteer (`options.sessionId ?? null`) -- so the
+    // numerator depended on the model choosing to identify itself, and an
+    // unverifiable model-supplied id is not evidence. Plan 1 settled that for
+    // the `answers` edge and it settles it here: stop depending on the field
+    // rather than hope for cooperation. The finding key is the specific part
+    // anyway; a key is a graph identity, not a guess.
+    //
+    // THE COST, disclosed here and in `referenceNote` because a reader of the
+    // number has to see it: TWO CONCURRENT SESSIONS ON ONE REPOSITORY CAN
+    // CROSS-ATTRIBUTE. Session A's injection of K plus session B's later query
+    // for K reads as a reference. Nothing in the log can separate them once the
+    // session id is gone, so the exposure is real and is stated rather than
+    // priced.
     const references = new Map();
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       const key = referencedKey(event);
-      const session = sessionOf(event);
-      if (!key || !session) continue;
+      if (!key) continue;
       if (!references.has(key)) references.set(key, []);
-      references.get(key).push({ at: event.at || 0, session });
+      references.get(key).push(event.at || 0);
     }
 
     // Which injections the existing outcome join could attribute. An outcome
@@ -170,9 +183,8 @@ export function classify(dir, { events = null } = {}) {
       const injectionId = event.injectionId ? String(event.injectionId) : null;
       const at = event.at || 0;
       const session = sessionOf(event);
-      // STRICTLY AFTER. A query that PRECEDED the injection is the model
-      // asking on its own initiative; crediting it would let the metric take
-      // the credit for a lookup it had nothing to do with.
+      // STRICTLY AFTER here too: activity that predates the injection is not
+      // an opportunity to have used it.
       const followed = (times) => times.some((t) => t > at);
       const continued =
         (injectionId && attributed.has(injectionId)) ||
@@ -181,9 +193,11 @@ export function classify(dir, { events = null } = {}) {
       for (const raw of keys) {
         const findingKey = String(raw);
         const hits = references.get(findingKey) || [];
-        const referenced = session
-          ? hits.some((hit) => hit.session === session && hit.at > at)
-          : false;
+        // TIME ORDER IS THE ONLY REMAINING GUARD, so it carries the whole
+        // weight of the attribution: a query that PRECEDED the injection is
+        // the model asking on its own initiative, and crediting it would let
+        // the metric take the credit for a lookup it had nothing to do with.
+        const referenced = hits.some((hitAt) => hitAt > at);
         rows.push({
           findingKey,
           injectionId,
@@ -204,9 +218,27 @@ export function classify(dir, { events = null } = {}) {
 /**
  * The rate, with everything needed to tell a real 0 from an absent one.
  *
- * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
- * `unattributable` and `unscopedReferences` are reported beside it, never
- * inside it.
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown` and
+ * `unattributable` are reported beside it, never inside it.
+ *
+ * `windowed` SAYS WHETHER THE DENOMINATOR CAN UNDERSTATE, and it is not
+ * decoration. `readMetrics` reads a 2 MB / 5,000-event TAIL of the firehose,
+ * and injections are rare enough on a real project to age out of it: measured
+ * on this repository, both `inject` events sit at lines 502 and 883 of 6,871
+ * and have scrolled away behind ~6,000 later `read` and `tool-outcome` rows,
+ * so the windowed denominator is 0 where the whole-file truth is 1.
+ *
+ * IT IS REPORTED RATHER THAN FIXED, deliberately. `inject` already gets
+ * unwindowed access through `BALANCE_KINDS` / `EVIDENCE_KINDS`, but `query`
+ * does not -- and reading only the INJECTION arm unwindowed would be worse
+ * than the windowing: every old injection would enter the denominator with no
+ * chance of a matching query in the window and score `not-referenced`,
+ * manufacturing a pessimistic rate out of the asymmetry. Making the query arm
+ * unwindowed means adding `query` to `EVIDENCE_KINDS`, which two other
+ * consumers read, and this project's own standard says a shared-classifier
+ * change needs a per-consumer verdict comparison. So the honest move is to
+ * publish the flag: a caller that needs the unwindowed truth passes its own
+ * `events`, which is exactly what the live measurement in the task report did.
  */
 export function referenceRate(dir, { events = null } = {}) {
   const empty = {
@@ -218,10 +250,15 @@ export function referenceRate(dir, { events = null } = {}) {
     unattributable: 0,
     unattributableWithInjectedToolCall: 0,
     referenceEvents: 0,
-    unscopedReferences: 0,
+    windowed: false,
   };
   try {
     const all = events || readMetrics(dir);
+    // OUT OF BAND, and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` reports on the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
     const rows = classify(dir, { events: all });
     const count = (label) => rows.filter((row) => row.label === label).length;
     const referenced = count('referenced');
@@ -231,17 +268,17 @@ export function referenceRate(dir, { events = null } = {}) {
     // Usable reference events in the window: the numerator's producer. If this
     // is zero the channel never fired, and a 0% rate would be measuring the
     // absence of a producer rather than the uselessness of findings.
+    //
+    // NO SESSION REQUIREMENT, matching the attribution above. The former
+    // `unscopedReferences` counted queries dropped for want of a session id;
+    // nothing is dropped for that reason any more, so the field is GONE rather
+    // than kept at a permanent zero that a later reader would misread as
+    // evidence the loss had been fixed.
     let referenceEvents = 0;
-    let unscopedReferences = 0;
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       if (!referencedKey(event)) continue;
-      if (sessionOf(event)) referenceEvents += 1;
-      // Names a finding but cannot be scoped to one injection. `sessionId` is
-      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
-      // is the expected loss rather than an edge case -- counted here so it is
-      // visible instead of silently deflating the numerator.
-      else unscopedReferences += 1;
+      referenceEvents += 1;
     }
 
     // The tool calls that DID receive findings, keyed the way
@@ -292,7 +329,7 @@ export function referenceRate(dir, { events = null } = {}) {
       unattributable,
       unattributableWithInjectedToolCall,
       referenceEvents,
-      unscopedReferences,
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
     };
   } catch {
     return empty;
@@ -300,11 +337,18 @@ export function referenceRate(dir, { events = null } = {}) {
 }
 
 /**
- * One line for the audit, or nothing at all.
+ * One or two lines for the audit, or nothing at all.
  *
  * Says which of the three things is true -- a measured rate, a live channel
  * with no opportunities yet, or no channel at all -- rather than printing a
  * figure and letting the reader assume the first.
+ *
+ * AND IT CARRIES THE CAVEATS, because this is the only place a human meets the
+ * number. A rate attributed on (finding key, time order) can cross-attribute
+ * between two concurrent sessions on one repository, and a windowed read can
+ * understate the denominator. Both are stated beside the figure they qualify.
+ * Putting them only in a task report would be publishing a clean number and
+ * filing the asterisk somewhere nobody quoting it will look.
  */
 export function referenceNote(dir, { events = null } = {}) {
   const r = referenceRate(dir, { events });
@@ -317,6 +361,11 @@ export function referenceNote(dir, { events = null } = {}) {
   }
   return (
     `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
-    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded. ` +
+    'Matched on finding key and time order, so concurrent sessions on this ' +
+    'repository can cross-attribute' +
+    (r.windowed
+      ? '; and the event log was truncated, so the denominator can understate.'
+      : '.')
   );
 }

--- a/integrations/windsurf/hooks/lib/usage.mjs
+++ b/integrations/windsurf/hooks/lib/usage.mjs
@@ -1,0 +1,322 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/usage.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 1 -- did the model actually go back and use what we injected?
+ *
+ * The cheap behavioural label. One question, answered from the event log alone:
+ * after we put a finding in front of the model, did the model later ASK FOR
+ * THAT FINDING BY NAME?
+ *
+ * WHY EXPLICIT REFERENCE, AND NOT READ-SUPPRESSION. Read-suppression -- "the
+ * file was not re-read, so the finding must have helped" -- is Layer 2's
+ * estimand, measured causally by withholding a finding and comparing. Layer 1
+ * exists to be calibrated AGAINST that. If both layers derived from
+ * suppression, the calibration would compare two spellings of one quantity,
+ * report a strong correlation, and mean nothing. So Layer 1 is deliberately
+ * built on a signal Layer 2 does not touch: an explicit `query` naming the
+ * finding key.
+ *
+ * WHAT THIS DOES NOT DO. It does not invent a join. `recordToolOutcome`
+ * already joins each post-tool result back to the injection that preceded it,
+ * recording `injectionId`, `findingIds` and a `joinMethod` of `tool-call-id`,
+ * `episode-anchor` or `none` -- preferring an exact tool-call id, which is
+ * strictly better evidence than the `(sessionId, findingKey)` approximation an
+ * earlier draft of this plan proposed. This module consumes that join and adds
+ * none of its own. `inject.mjs` needed no change: it has written `findingIds`
+ * at every call site all along.
+ *
+ * WHAT `unknown` IS FOR, and it is the whole reason this file is careful. An
+ * injection whose session simply stopped afterwards is not a miss. Nothing
+ * happened, so nothing can be concluded, and counting it against the finding
+ * would make the metric read worse the more often sessions end -- a number
+ * that moves with session length rather than with usefulness. `unknown` is
+ * therefore EXCLUDED from the denominator rather than scored zero, and
+ * outcomes the join could not attribute at all are reported as
+ * `unattributable` rather than folded into either arm.
+ *
+ * AND WHY THE RATE CAN BE `null`. This project has already shipped two metrics
+ * whose only producer was their own test suite. A rate of 0% that actually
+ * means "no data" is worse than a refusal, because it is a number and numbers
+ * get quoted. So `rate` is null unless there is a denominator AND the
+ * reference channel produced at least one usable event in the window. "Nothing
+ * was referenced" and "nothing could be measured" are different answers and
+ * this module gives different answers for them.
+ */
+import { readMetrics } from './metrics.mjs';
+
+/**
+ * The events that name a finding, and it is ONE kind, not the two the plan
+ * assumed.
+ *
+ * The brief said "a later `query` or `expand` event". Checked against the code
+ * and against every metrics log on this machine, `expand` does not qualify and
+ * cannot be made to:
+ *
+ *   - `recordExpansion` writes `{ ref, tool, shape, asked, sessionId }`. `ref`
+ *     is a TRUNCATION CAPTURE id (a 16-hex digest of captured tool output),
+ *     not a finding key, and `asked` is free text naming a section of that
+ *     output. Neither is a graph key, and no code path ever puts one there.
+ *   - measured: 64 live `expand` events exist on this machine and all 64 carry
+ *     `sessionId: null`, so they could not be scoped to an injection even if
+ *     they did name one.
+ *
+ * Keying the classifier on `expand` would therefore have added a branch that
+ * can never fire -- a metric with no producer, which is the exact defect this
+ * whole effort exists to close. So it is excluded, deliberately and with the
+ * measurement recorded, rather than included for symmetry with the brief.
+ */
+const REFERENCE_KINDS = new Set(['query']);
+
+/**
+ * What counts as the session having CONTINUED past the injection.
+ *
+ * The distinction between `not-referenced` and `unknown` rests entirely on
+ * this, so the set is explicit rather than "any later event". These are the
+ * kinds a tool call produces: if one of them follows the injection in the same
+ * session, the model had the opportunity to ask and did not. If none does, the
+ * session ended and there was no opportunity.
+ *
+ * `inject` is in the set because a later injection means a later tool call
+ * happened. `forecast`, `mcp-client` and `mcp-tool` are NOT: they are written
+ * by session bookkeeping rather than by the model doing something, and
+ * treating them as opportunity would convert `unknown` rows into misses on
+ * bookkeeping alone.
+ */
+const ACTIVITY_KINDS = new Set([
+  'tool-outcome',
+  'read',
+  'query',
+  'expand',
+  'substitute',
+  'inject',
+]);
+
+/** A usable session id: a non-empty string. `null == null` is not a match. */
+const sessionOf = (event) => {
+  const id = event?.sessionId;
+  return typeof id === 'string' && id ? id : null;
+};
+
+/** The finding key a reference event names, or null if it names none. */
+const referencedKey = (event) => {
+  const key = event?.key;
+  return typeof key === 'string' && key ? key : null;
+};
+
+/** Ordering by the caller's timestamp, with log order breaking ties. */
+function inTimeOrder(events) {
+  return events
+    .map((event, index) => ({ event, index }))
+    .sort(
+      (a, b) =>
+        (a.event.at || 0) - (b.event.at || 0) || a.index - b.index
+    )
+    .map((row) => row.event);
+}
+
+/**
+ * One row per (injection, finding) pair, labelled.
+ *
+ * Per injection rather than per finding: the same finding injected twice is two
+ * separate opportunities, and collapsing them would let one reference excuse
+ * every later injection of that key.
+ *
+ * FAILS OPEN. A malformed log yields an empty classification, never a throw:
+ * this runs on report paths that must not break a tool call.
+ */
+export function classify(dir, { events = null } = {}) {
+  let rows = [];
+  try {
+    const all = inTimeOrder(events || readMetrics(dir));
+
+    // Every reference, keyed on the finding it names. Only references carrying
+    // a session id are usable -- see `unscopedReferences` in `referenceRate`
+    // for the ones this drops and why they are counted rather than credited.
+    const references = new Map();
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      const key = referencedKey(event);
+      const session = sessionOf(event);
+      if (!key || !session) continue;
+      if (!references.has(key)) references.set(key, []);
+      references.get(key).push({ at: event.at || 0, session });
+    }
+
+    // Which injections the existing outcome join could attribute. An outcome
+    // carrying our injectionId is proof the tool call completed, which is
+    // opportunity even when the session id is missing from the log.
+    const attributed = new Set();
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) continue;
+      attributed.add(String(event.injectionId));
+    }
+
+    // Activity per session, so "did anything follow?" is one lookup rather
+    // than a scan per injection.
+    const activity = new Map();
+    for (const event of all) {
+      if (!ACTIVITY_KINDS.has(event.kind)) continue;
+      const session = sessionOf(event);
+      if (!session) continue;
+      if (!activity.has(session)) activity.set(session, []);
+      activity.get(session).push(event.at || 0);
+    }
+
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+      if (!keys.length) continue;
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const at = event.at || 0;
+      const session = sessionOf(event);
+      // STRICTLY AFTER. A query that PRECEDED the injection is the model
+      // asking on its own initiative; crediting it would let the metric take
+      // the credit for a lookup it had nothing to do with.
+      const followed = (times) => times.some((t) => t > at);
+      const continued =
+        (injectionId && attributed.has(injectionId)) ||
+        (session ? followed(activity.get(session) || []) : false);
+
+      for (const raw of keys) {
+        const findingKey = String(raw);
+        const hits = references.get(findingKey) || [];
+        const referenced = session
+          ? hits.some((hit) => hit.session === session && hit.at > at)
+          : false;
+        rows.push({
+          findingKey,
+          injectionId,
+          label: referenced
+            ? 'referenced'
+            : continued
+              ? 'not-referenced'
+              : 'unknown',
+        });
+      }
+    }
+  } catch {
+    rows = [];
+  }
+  return rows;
+}
+
+/**
+ * The rate, with everything needed to tell a real 0 from an absent one.
+ *
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
+ * `unattributable` and `unscopedReferences` are reported beside it, never
+ * inside it.
+ */
+export function referenceRate(dir, { events = null } = {}) {
+  const empty = {
+    referenced: 0,
+    notReferenced: 0,
+    unknown: 0,
+    denominator: 0,
+    rate: null,
+    unattributable: 0,
+    unattributableWithInjectedToolCall: 0,
+    referenceEvents: 0,
+    unscopedReferences: 0,
+  };
+  try {
+    const all = events || readMetrics(dir);
+    const rows = classify(dir, { events: all });
+    const count = (label) => rows.filter((row) => row.label === label).length;
+    const referenced = count('referenced');
+    const notReferenced = count('not-referenced');
+    const denominator = referenced + notReferenced;
+
+    // Usable reference events in the window: the numerator's producer. If this
+    // is zero the channel never fired, and a 0% rate would be measuring the
+    // absence of a producer rather than the uselessness of findings.
+    let referenceEvents = 0;
+    let unscopedReferences = 0;
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      if (!referencedKey(event)) continue;
+      if (sessionOf(event)) referenceEvents += 1;
+      // Names a finding but cannot be scoped to one injection. `sessionId` is
+      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
+      // is the expected loss rather than an edge case -- counted here so it is
+      // visible instead of silently deflating the numerator.
+      else unscopedReferences += 1;
+    }
+
+    // The tool calls that DID receive findings, keyed the way
+    // `recordToolOutcome` keys its own primary join: the tool-call id. An
+    // unattributable outcome for one of these is a join that FAILED. An
+    // unattributable outcome for any other tool call had nothing to join to.
+    //
+    // KEYED ON THE TOOL CALL, NOT THE EPISODE, and the first draft of this
+    // got it wrong in a way worth recording because it is the exact
+    // measurement-bias class this plan hunts. `episodeId` equals the SESSION
+    // id, so "unattributable outcomes in an episode that had an injection"
+    // scored all 2,559 tool calls of a session in which ONE injection
+    // happened. It would have published 2,559 join failures where the true
+    // number is zero -- correct code, lying number, and biased pessimistic
+    // rather than flattering, which is no better.
+    const injectedToolCalls = new Set();
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      if (!Array.isArray(event.findingIds) || !event.findingIds.length)
+        continue;
+      if (event.toolCallId) injectedToolCalls.add(String(event.toolCallId));
+    }
+    let unattributable = 0;
+    let unattributableWithInjectedToolCall = 0;
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome' || event.joinMethod !== 'none')
+        continue;
+      unattributable += 1;
+      // BOTH FIGURES, because the raw one alone lies in the pessimistic
+      // direction. Measured on this machine: 2,991 of 2,992 live outcomes
+      // report `joinMethod: 'none'`, and every one of them because NO
+      // INJECTION EXISTED for that tool call -- the graph holds one finding.
+      // Quoting only the raw count would read as a join that fails 99.97% of
+      // the time, which is a different and false claim.
+      if (event.toolCallId && injectedToolCalls.has(String(event.toolCallId)))
+        unattributableWithInjectedToolCall += 1;
+    }
+
+    return {
+      referenced,
+      notReferenced,
+      unknown: count('unknown'),
+      denominator,
+      rate:
+        denominator > 0 && referenceEvents > 0
+          ? referenced / denominator
+          : null,
+      unattributable,
+      unattributableWithInjectedToolCall,
+      referenceEvents,
+      unscopedReferences,
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/**
+ * One line for the audit, or nothing at all.
+ *
+ * Says which of the three things is true -- a measured rate, a live channel
+ * with no opportunities yet, or no channel at all -- rather than printing a
+ * figure and letting the reader assume the first.
+ */
+export function referenceNote(dir, { events = null } = {}) {
+  const r = referenceRate(dir, { events });
+  if (!r.denominator && !r.unknown && !r.referenceEvents) return null;
+  if (r.rate == null) {
+    const why = !r.referenceEvents
+      ? 'no finding was ever queried by key in this window'
+      : `no injection had a chance to be referenced yet (${r.unknown} unknown)`;
+    return `Injected findings referenced later: not measurable -- ${why}.`;
+  }
+  return (
+    `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+  );
+}

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -103,6 +103,44 @@ const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
 
 /**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because FOUR readers depend on it -- mutation accounting,
+ * success classification, output capture and exit-code capture -- and clients
+ * disagree on the envelope name and on nothing else. Letting each reader name
+ * its own subset is exactly how both classifiers came to miss MCP's failure
+ * flag: `toolSucceeded` listed four envelopes and `mutationSucceeded` listed
+ * three, and neither list mentioned `isError` at all.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/**
+ * Did an MCP result declare itself an error?
+ *
+ * `isError` is the ONLY failure signal an MCP result carries -- there is no
+ * `error` field and no `status` -- and `src/server/index.ts` sets it in seven
+ * places. Shared by both classifiers so they cannot disagree about what a
+ * failed call from this project's own tools looks like.
+ *
+ * `=== true` EXACTLY. A client using the key for anything else must not have
+ * its successful calls silently reclassified, and `isError: false` is a
+ * successful MCP call, not a missing verdict.
+ */
+function reportedMcpError(raw) {
+  return [...responseEnvelopes(raw), raw].some(
+    (envelope) => envelope?.isError === true
+  );
+}
+
+/**
  * A post-tool event is not universally proof of success. Some clients split
  * success and failure into distinct events; others expose a result status.
  * Keep mutation accounting conservative so a failed edit cannot arm Stop.
@@ -112,6 +150,19 @@ export function mutationSucceeded(clientName, raw) {
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
     return false;
+  // BEFORE the status read, the explicit-success read AND the client
+  // allowlist, because all three would otherwise pass a failed MCP write. The
+  // allowlist is the one that actually bit: it returns true for claude-code,
+  // codex, qwen, opencode, kilo and windsurf on any post-tool event with no
+  // error and no status, which is precisely the shape of a failed smart_write.
+  //
+  // WHY THIS IS THE SAME BUG AS THE ONE IN `toolSucceeded` AND NOT A COSMETIC
+  // ECHO OF IT: this function gates edit counting and harvest pressure, so
+  // counting a failed write to THE OPTIMIZER'S OWN TOOLS as a mutation
+  // inflates "the optimizer successfully edited a file". Different consumers
+  // from the effectiveness figures, same direction of bias -- toward
+  // flattering the thing being measured.
+  if (reportedMcpError(raw)) return false;
 
   const status =
     raw?.tool_response?.status ??
@@ -145,24 +196,6 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * Spelled out ONCE because three readers depend on it -- success
- * classification, output capture and exit-code capture -- and clients disagree
- * on the envelope name and on nothing else. Letting each reader name its own
- * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
-}
-
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
@@ -181,8 +214,7 @@ export function toolSucceeded(raw) {
   // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
   // optimizer's favour. A measurement that flatters the thing being measured
   // is worse than no measurement.
-  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
-    return false;
+  if (reportedMcpError(raw)) return false;
   const status =
     raw?.tool_response?.status ??
     raw?.toolResponse?.status ??

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -957,10 +957,12 @@ async function runHook(clientName, event, invocation) {
       // accumulates structure and no verdicts at all. These detectors read only
       // what is already on disk and send nothing anywhere.
       //
-      // The COUNT is recorded rather than the candidates: how many findings a
-      // session's own evidence supports is the number that says whether this is
-      // working, and it is measurable before anything is stored. Storage is the
-      // caller's next step, under a budget.
+      // COUNTS are recorded rather than the candidates, and BOTH counts: how
+      // many findings a session's own evidence supports, and how many of them
+      // survived the storage budget and the anchor discipline. The gap between
+      // the two is the number that says whether the bound is doing anything --
+      // one figure alone cannot distinguish "nothing to derive" from "derived
+      // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
       const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
       const dir = wikiDir(projectRoot);
@@ -976,6 +978,7 @@ async function runHook(clientName, event, invocation) {
         sessionId,
         candidates: derived.candidates.length,
         observations: derived.observations.length,
+        written: derived.written.length,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -172,6 +172,136 @@ export function toolSucceeded(raw) {
   return true;
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * The same family `toolSucceeded` reads above, hoisted so the three readers
+ * cannot drift apart. Clients disagree on the envelope name and on nothing
+ * else, so this is the one place that disagreement is spelled out.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
+/** A non-empty string, or null.  Blank output is the same as none. */
+function nonEmpty(value) {
+  const text = String(value ?? '');
+  return text.trim() ? text : null;
+}
+
+/**
+ * The human-readable result text inside one envelope, or null.
+ *
+ * RETURNS NULL RATHER THAN GUESSING. An envelope shape nobody here has seen
+ * produces no capture at all, which costs one finding. Stringifying it instead
+ * would put `[object Object]` or a wall of JSON metadata into a claim that gets
+ * injected into model context -- a wrong observation, which is strictly worse
+ * than a missing one.
+ */
+function resultText(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'string') return nonEmpty(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return null;
+
+  // MCP content blocks, which is how THIS PROJECT'S OWN tools now arrive:
+  // `normalizeTool` resolves `mcp__<server>__smart_edit`, so smart_edit and
+  // smart_write reach the post-tool path for the first time and their results
+  // are `{ content: [{ type: 'text', text }], isError }` rather than a shell
+  // result. Both the bare array and the wrapping object are accepted because
+  // hosts differ on whether they hand the hook the result or its content.
+  if (Array.isArray(value)) {
+    const blocks = value
+      .map((block) =>
+        typeof block === 'string' ? block : nonEmpty(block?.text)
+      )
+      .filter(Boolean);
+    return blocks.length ? nonEmpty(blocks.join('\n')) : null;
+  }
+  if (typeof value !== 'object') return null;
+
+  // STDERR FIRST, and not because that is the order it was produced in. The
+  // cap can only ever cut the tail, and the diagnostic that explains a failure
+  // is almost always on stderr while the volume is almost always on stdout --
+  // so appending stderr would let a 3 MB build log push the one line worth
+  // capturing out of the window.
+  const streams = [nonEmpty(value.stderr), nonEmpty(value.stdout)].filter(
+    Boolean
+  );
+  if (streams.length) return streams.join('\n');
+
+  if (Array.isArray(value.content)) {
+    const inner = resultText(value.content);
+    if (inner) return inner;
+  }
+
+  const error = value.error;
+  if (error) {
+    const message =
+      typeof error === 'string' ? error : nonEmpty(error.message ?? error.msg);
+    if (message) return message;
+  }
+
+  return (
+    nonEmpty(value.output) ??
+    nonEmpty(value.text) ??
+    nonEmpty(value.message) ??
+    (typeof value.result === 'string' ? nonEmpty(value.result) : null)
+  );
+}
+
+/**
+ * The result text of a completed tool call, or null when the client reports
+ * none.  Redaction and the size cap are NOT applied here -- they belong at the
+ * `recordToolOutcome` boundary, which is the only place every caller passes.
+ */
+export function outputFrom(raw) {
+  for (const envelope of responseEnvelopes(raw)) {
+    const text = resultText(envelope);
+    if (text) return text;
+  }
+  return resultText(raw?.output) ?? resultText(raw?.stdout) ?? null;
+}
+
+/**
+ * Key names that mean "process exit code" and nothing else.
+ *
+ * `code` is deliberately ABSENT. JSON-RPC errors (`code: -32602`), Node errno
+ * objects (`code: 'ENOENT'`) and HTTP wrappers all reuse that name, so reading
+ * it would record a confident exit code for calls that never had one. A null
+ * here is honest; a -32602 claiming to be an exit status is not.
+ */
+const EXIT_KEYS = [
+  'exit_code',
+  'exitCode',
+  'exit',
+  'exit_status',
+  'exitStatus',
+  'return_code',
+  'returncode',
+];
+
+/** The numeric exit code a client reported, or null when it reported none. */
+export function exitFrom(raw) {
+  for (const envelope of [...responseEnvelopes(raw), raw]) {
+    if (!envelope || typeof envelope !== 'object') continue;
+    for (const key of EXIT_KEYS) {
+      const value = envelope[key];
+      if (Number.isInteger(value)) return value;
+      // A client that serializes the code as a digit string still reported it.
+      // Bounded so a hash or an id cannot be mistaken for a status.
+      if (typeof value === 'string' && /^-?\d{1,5}$/.test(value.trim()))
+        return Number(value.trim());
+    }
+  }
+  return null;
+}
+
 function contextOutput(client, eventName, additionalContext) {
   if (client.contextStyle === 'top-level') return { additionalContext };
   if (client.contextStyle === 'cline') {
@@ -890,6 +1020,11 @@ async function runHook(clientName, event, invocation) {
         anchor,
         toolName: payload.tool_name,
         success: toolSucceeded(raw),
+        // The two fields a boolean cannot carry: which KIND of failure this
+        // was. Read through the same normalisers as `success`, never off `raw`
+        // at this call site.
+        output: outputFrom(raw),
+        exit: exitFrom(raw),
         durationMs:
           Number(
             raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -145,11 +145,43 @@ export function mutationSucceeded(clientName, raw) {
   );
 }
 
+/**
+ * The response envelopes a completed tool call can arrive in.
+ *
+ * Spelled out ONCE because three readers depend on it -- success
+ * classification, output capture and exit-code capture -- and clients disagree
+ * on the envelope name and on nothing else. Letting each reader name its own
+ * subset is how `toolSucceeded` came to miss MCP's failure flag entirely.
+ */
+function responseEnvelopes(raw) {
+  return [
+    raw?.tool_response,
+    raw?.toolResponse,
+    raw?.tool_result,
+    raw?.toolResult,
+    raw?.postToolUse,
+  ].filter((envelope) => envelope !== undefined && envelope !== null);
+}
+
 /** Conservative success classification for any completed tool call. */
 export function toolSucceeded(raw) {
   if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
     return false;
   if (raw?.postToolUse?.success === false || raw?.success === false)
+    return false;
+  // MCP'S OWN FAILURE FLAG, which this function did not read for as long as it
+  // existed. It did not matter while `normalizeTool` dropped MCP names before
+  // any accounting ran; it matters now that `mcp__<server>__smart_edit` and
+  // `smart_write` reach the post-tool path, because an MCP result carries no
+  // `error` field and no `status` -- only `isError` -- so a failed smart_edit
+  // fell through to the optimistic `return true` below.
+  //
+  // WHY THIS IS A MEASUREMENT BUG AND NOT A COSMETIC ONE: this boolean feeds
+  // episode outcomes and effectiveness accounting, so recording every failed
+  // call to THE OPTIMIZER'S OWN TOOLS as a success biased all of it in the
+  // optimizer's favour. A measurement that flatters the thing being measured
+  // is worse than no measurement.
+  if ([...responseEnvelopes(raw), raw].some((e) => e?.isError === true))
     return false;
   const status =
     raw?.tool_response?.status ??
@@ -170,23 +202,6 @@ export function toolSucceeded(raw) {
   // that its output proved the task.  `success` here is deliberately scoped to
   // the tool call; task correctness comes only from an eval grader.
   return true;
-}
-
-/**
- * The response envelopes a completed tool call can arrive in.
- *
- * The same family `toolSucceeded` reads above, hoisted so the three readers
- * cannot drift apart. Clients disagree on the envelope name and on nothing
- * else, so this is the one place that disagreement is spelled out.
- */
-function responseEnvelopes(raw) {
-  return [
-    raw?.tool_response,
-    raw?.toolResponse,
-    raw?.tool_result,
-    raw?.toolResult,
-    raw?.postToolUse,
-  ].filter((envelope) => envelope !== undefined && envelope !== null);
 }
 
 /** A non-empty string, or null.  Blank output is the same as none. */

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -58,6 +58,7 @@ import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { briefing } from './remedy.mjs';
 import { stableText, transcriptFor } from './cache.mjs';
+import { scoreRefreshes } from './keepwarm.mjs';
 import { cachedRoutingBriefing } from './routing.mjs';
 import {
   forCommand,
@@ -1010,6 +1011,26 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE KEEP-WARM FEEDBACK ARM, at the boundary where a turn has just
+      // ended -- which is the only place the arrival question can be answered.
+      // Every refresh whose TTL has since elapsed is scored here as used or
+      // unused; anything the log cannot settle is left unscored rather than
+      // recorded as a miss, because an absent signal is not a miss.
+      //
+      // Nothing in this repository issues a refresh today -- cache_audit only
+      // recommends one -- so this scores nothing, and what it costs while
+      // dormant is one readBalance: median 70 ms on this machine's 3.5 MB log,
+      // against derive's 71-111 ms a few lines below on the same path. The
+      // firehose is read for ARRIVALS only if an unscored refresh exists, so
+      // the dormant case never pays for that. The moment an issuer exists, the
+      // decision starts learning with no second wiring change.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      scoreRefreshes(dir);
+    } catch {
+      // A refresh that cannot be scored costs a measurement, not a session.
     }
     try {
       // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -40,11 +40,13 @@ import {
   touchedFiles,
 } from './decide.mjs';
 import {
+  record,
   recordRead,
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
 } from './metrics.mjs';
+import { derive } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -948,6 +950,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // ZERO-COST DERIVATION, on every client, with no credential. The semantic
+      // harvest below needs an API key, so on a machine without one the graph
+      // accumulates structure and no verdicts at all. These detectors read only
+      // what is already on disk and send nothing anywhere.
+      //
+      // The COUNT is recorded rather than the candidates: how many findings a
+      // session's own evidence supports is the number that says whether this is
+      // working, and it is measurable before anything is stored. Storage is the
+      // caller's next step, under a budget.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      const dir = wikiDir(projectRoot);
+      const derived = derive(dir, {
+        sessionId,
+        projectRoot,
+        transcriptPath: agentScope,
+        // The hook payload's own identity, not a value a model typed.
+        authoritativeSessionId: sessionId,
+      });
+      record(dir, {
+        kind: 'derive',
+        sessionId,
+        candidates: derived.candidates.length,
+        observations: derived.observations.length,
+      });
+    } catch {
+      // A detector failing must never cost a user the end of their session.
     }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -72,7 +72,8 @@ import {
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
-import { isArchived } from './transcript.mjs';
+import { archive, isArchived } from './transcript.mjs';
+import { harvestMode } from './harvest.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
@@ -577,6 +578,65 @@ function emit(object) {
   process.stdout.write(serialized);
 }
 
+/**
+ * What will and will not extract findings after this session, in one sentence.
+ *
+ * THE STATE WAS ONLY EVER LEGIBLE FROM THE DOCTOR, and the doctor is a place
+ * someone visits after they already suspect something is wrong. A user watching
+ * a graph fill with structural nodes and no verdicts has no reason to suspect
+ * anything, which is the failure this project has now measured twice.
+ *
+ * IT IS ADDRESSED TO THE MODEL, NOT ONLY TO THE READER, which is why it earns a
+ * place in the prefix rather than a systemMessage. "Nothing else will write this
+ * down in words" changes what the model does with a conclusion it is holding;
+ * "here is a configuration variable" would not.
+ *
+ * CACHE-SAFE: derived from configuration, so it differs between sessions only
+ * when the configuration does -- the same standard the rest of this block is
+ * held to, and it carries no digits for `stableText` to reject.
+ *
+ * A local endpoint is named FIRST in the off case on purpose. It is the option
+ * that costs nothing and sends nothing, and it was the one buried deepest.
+ */
+function extractionNotice() {
+  switch (harvestMode()) {
+    case 'local':
+      return (
+        '\n\nA local model endpoint is configured, so semantic extraction also runs after this ' +
+        'session -- free and private, with nothing leaving this machine.'
+      );
+    case 'remote':
+      return (
+        '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
+        'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
+    case 'off:mode':
+      // The whole optimizer is off and this text is not emitted anyway. Saying
+      // anything here would be noise stacked on an explicit choice.
+      return '';
+    case 'off:opted-out':
+      // A DELIBERATE CHOICE, SO NO PITCH. The consequence is stated because the
+      // model needs it; the setting that would reverse it is not, because
+      // arguing with a configured decision on every session is how a notice
+      // stops being read. doctor.mjs draws the same line for the same reason.
+      return (
+        '\n\nFallback extraction is off by configuration, so a conclusion you do not record is ' +
+        'not written down in words anywhere. Findings are still derived locally from exit codes, ' +
+        'red-to-green transitions and corrections.'
+      );
+    default:
+      // off:no-key, and any mode a future harvest adds: no extractor is running
+      // and nobody chose that, so the free option is worth naming.
+      return (
+        '\n\nNo separate extractor will run after this session, so a conclusion you do not record ' +
+        'is not written down in words anywhere. Findings are still derived locally from exit ' +
+        'codes, red-to-green transitions and corrections. Pointing ' +
+        'TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model adds semantic extraction, free and ' +
+        'private.'
+      );
+  }
+}
+
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
 export function policyText(
   canDeny,
@@ -635,7 +695,7 @@ export function policyText(
     .filter(Boolean)
     .join(' ');
   const recording = tools.has('wiki_write')
-    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.`
+    ? `\n\n## Record what you work out\n\nCall wiki_write when you establish something durable about this project, while\nyou still hold the context. Every claim needs at least one anchor -- a real file\npath, or path#symbol -- because an unanchored claim can never be checked against\nthe code again and would be served as current forever; unanchored writes are\nrefused.\n\nWorth recording: a decision and why the alternative was rejected, a failure and\nwhat actually caused it, a command that turned out to be the one that works.\nNot worth recording: what the code plainly says. Every wiki_write must include\nthe concrete evidence, when it applies, a calibrated confidence label, its\nscope, and what would invalidate it. Prefer the thing someone had to work out,\nbecause that exists nowhere in the source tree.${extractionNotice()}`
     : '\n\nStructural graph capture remains active through lifecycle hooks. Durable semantic MCP writes are not requested because the writer schema is not proven available.';
 
   return `# Token optimization is active\n\nLive graph capture is active through the lifecycle adapter.\n\n${connection}${routing}${enforcement}${utilities ? `\n\n${utilities}` : ''}${recording}${projectBriefing()}`;
@@ -950,6 +1010,27 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Evidence is best effort and must never stop a session from finishing.
+    }
+    try {
+      // THE ARCHIVE, WRITTEN BEFORE ANYTHING READS IT.
+      //
+      // This was lost rather than retired. `plugin/hooks/stop-harvest.mjs` called
+      // `archive()` at Stop, and #300 replaced that entry in `hooks.json` with the
+      // generated `stop.mjs`, which routes here -- so on Claude Code no session has
+      // been archived since. Nothing failed loudly: `readArchive` simply returns an
+      // empty list, so `derive`'s correction detector fell through to the live
+      // transcript (present only for a client that reports one) and `lessons.mjs`
+      // lost the only corpus it can verify a verbatim quote against, which is the
+      // single test that grants a feedback finding human origin.
+      //
+      // BEFORE `derive`, deliberately: the correction detector reads the archive
+      // first and treats the live transcript as the fallback, and the archive is
+      // the copy that survives into later sessions.
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      if (agentScope) archive(dir, agentScope, { sessionId });
+    } catch {
+      // The archive is a record, not a result. A session still ends.
     }
     try {
       // ZERO-COST DERIVATION, on every client, with no credential. The semantic

--- a/plugin/hooks/lib/audit.mjs
+++ b/plugin/hooks/lib/audit.mjs
@@ -32,6 +32,7 @@
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
+import { looNote } from './loo.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -401,6 +402,16 @@ export function renderAudit(
   // project with no injections and no queries gains no line at all.
   const reference = referenceNote(dir);
   if (reference) body.push('', reference);
+
+  // WHAT ONE FINDING IS CAUSALLY WORTH (Layer 2).
+  //
+  // The same reasoning as above, and the same refusal: `looNote` returns null
+  // until the leave-one-out experiment has collected an observation, and says
+  // NOT MEASURABLE YET rather than printing a mean until it clears the floor.
+  // A causal number is the most quotable thing this project can produce, so it
+  // is the one that most needs to be absent when it is not earned.
+  const causal = looNote(dir);
+  if (causal) body.push('', causal);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/plugin/hooks/lib/audit.mjs
+++ b/plugin/hooks/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { referenceNote } from './usage.mjs';
 import { looNote } from './loo.mjs';
+import { calibrationNote } from './crosslayer.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -244,9 +245,15 @@ export function renderAudit(
     lines.push(text);
   }
 
+  // SCOPED TO THE QUEUE, because that is all it ever described. The bare
+  // sentence "Nothing addressable found." was printed directly above a Layer 1
+  // reference note and a published Layer 2 causal verdict -- so a reader was
+  // told nothing had been found immediately before being shown a finding. The
+  // headline is about the remediation queue and nothing else, and saying so
+  // costs four words and removes a false negative shown to a human.
   const head = shown.length
     ? ['What to do next, most expensive first:', ...lines]
-    : ['Nothing addressable found.'];
+    : ['Nothing addressable found in the remediation queue.'];
 
   const body = [...head];
 
@@ -412,6 +419,16 @@ export function renderAudit(
   // is the one that most needs to be absent when it is not earned.
   const causal = looNote(dir);
   if (causal) body.push('', causal);
+
+  // WHETHER LAYER 1'S CHEAP LABEL PREDICTS LAYER 2'S EXPENSIVE EFFECT.
+  //
+  // The reason this is printed rather than kept for a dashboard: the reference
+  // rate is the number a reader is most likely to quote as a saving, and it is
+  // not one until this comparison says so. `calibrationNote` returns null while
+  // both layers are silent, and otherwise prints the refusal -- naming which
+  // input was insufficient -- rather than a gap of zero.
+  const calibrated = calibrationNote(dir);
+  if (calibrated) body.push('', calibrated);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/plugin/hooks/lib/audit.mjs
+++ b/plugin/hooks/lib/audit.mjs
@@ -61,6 +61,28 @@ export function declines(dir, { events = readMetrics(dir) } = {}) {
   return counts;
 }
 
+/**
+ * What the local Stop-time derivation path produced in the visible event log.
+ *
+ * The producer records all three counts because any one of them alone is
+ * ambiguous: zero stored can mean no evidence, no candidates, or a binding
+ * storage/anchor filter. This reader keeps those states distinct and prevents
+ * the telemetry itself from becoming an unobserved cost.
+ */
+export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
+  const runs = events.filter((event) => event.kind === 'derive');
+  if (!runs.length) return null;
+
+  const sum = (field) =>
+    runs.reduce((total, event) => total + Math.max(0, Number(event[field]) || 0), 0);
+  const candidates = sum('candidates');
+  const observations = sum('observations');
+  const written = sum('written');
+  return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
+    `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
+    `across ${runs.length.toLocaleString()} Stop run(s).`;
+}
+
 const idOf = (finding) =>
   finding.remedy
     ? `${finding.remedy.type}:${finding.remedy.anchor || finding.remedy.file || (finding.remedy.anchors || []).join(',')}`
@@ -399,6 +421,15 @@ export function renderAudit(
       );
     }
   }
+
+  // WHAT THE DEFAULT, LOCAL DERIVATION PATH ACTUALLY PRODUCED.
+  //
+  // This event used to have a producer and no reader. Keep its three states
+  // together: evidence seen, candidates derived, and findings that survived
+  // selection/storage. A lone stored count would turn every earlier refusal
+  // into an apparent "nothing found" result.
+  const derived = derivationNote(dir);
+  if (derived) body.push('', derived);
 
   // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
   //

--- a/plugin/hooks/lib/audit.mjs
+++ b/plugin/hooks/lib/audit.mjs
@@ -31,6 +31,7 @@
  */
 
 import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
+import { referenceNote } from './usage.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -390,6 +391,16 @@ export function renderAudit(
       );
     }
   }
+
+  // WHETHER THE FINDINGS WE INJECTED GOT USED (Layer 1).
+  //
+  // Printed here because this is the report that already asks "did the advice
+  // change anything", and because a measurement with no reader is how this
+  // project shipped two metrics whose only consumer was their own test suite.
+  // `referenceNote` returns null when it has nothing honest to say, so a
+  // project with no injections and no queries gains no line at all.
+  const reference = referenceNote(dir);
+  if (reference) body.push('', reference);
 
   const addressable = queue.reduce(
     (sum, item) => sum + (item.costPerSession || 0),

--- a/plugin/hooks/lib/consolidate.mjs
+++ b/plugin/hooks/lib/consolidate.mjs
@@ -142,7 +142,8 @@ const ALWAYS_KEEP = new Set(['failure', 'decision']);
  * Chooses what to promote into the graph, under a token budget.
  *
  * @param {object} graph      Loaded wiki graph, for reuse probability.
- * @param {Array}  candidates Extracted conclusions, each { type, summary, anchors, evidence, at }.
+ * @param {Array}  candidates Extracted conclusions, each { type, claim (or summary),
+ *                              anchors, evidence, at }.
  * @param {object} options    budget: tokens available for promoted findings.
  */
 export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}) {
@@ -221,4 +222,3 @@ export function aggregateConsolidation(findings) {
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
-

--- a/plugin/hooks/lib/crosslayer.mjs
+++ b/plugin/hooks/lib/crosslayer.mjs
@@ -1,0 +1,351 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/crosslayer.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The calibration loop: does Layer 1's LABEL predict Layer 2's EFFECT?
+ *
+ * Layer 1 (`usage.mjs`) classifies an injected finding by whether the model
+ * later NAMED it. Layer 2 (`loo.mjs`) measures, by leave-one-out, how many
+ * tokens of reading a finding actually SUPPRESSED. Those are two different
+ * quantities, and the whole point of putting them side by side is that the
+ * cheap one (a label, available on every injection) might stand in for the
+ * expensive one (a causal effect, costing three withheld sessions per finding).
+ *
+ * WHY THIS IS A REAL QUESTION AND NOT A TAUTOLOGY. Task 7 established the
+ * independence three ways -- statically (`loo.mjs` contains no `query` or
+ * `reference`; `usage.mjs` contains no `tokens`, `cost` or `bytes`),
+ * behaviourally in both directions, and by naming the one overlap that does
+ * exist (`recordToolOutcome`'s join, which supplies ATTRIBUTABILITY to both and
+ * the measured quantity to neither). This module is built to preserve that:
+ *
+ *   - from Layer 1 it takes ONLY the categorical label per finding key. No
+ *     rate, no count, no magnitude -- Layer 1 has no magnitude to give.
+ *   - from Layer 2 it takes ONLY the effect magnitude per finding key.
+ *   - the join is the finding key, which is a graph identity and not a
+ *     measurement.
+ *
+ * If a magnitude common to both ever entered, this would correlate a quantity
+ * with itself and report a strong result that means nothing. Two tests pin the
+ * separation from opposite sides: flipping the labels while holding the effects
+ * fixed must move the gap, and changing Layer 1's rate WITHOUT changing any
+ * label must leave the gap byte-identical.
+ *
+ * MEASURED UTILITY RANKS A FINDING. IT MUST NEVER RAISE ITS CONFIDENCE.
+ * A confidently WRONG finding suppresses reads better than a hedged true one,
+ * so utility alone optimises directly against "wrong findings are worse than
+ * none". The plan called for a `mayPromote` gate over
+ * `hasOutstandingContradiction` here. There is nothing to gate: every write of
+ * `confidence` in `hooks-core` happens at CREATION (a per-producer constant in
+ * `derive.mjs` / `lessons.mjs` / `harvest.mjs`, or a human's own number in
+ * `curate.mjs`), and no code path updates a stored finding's confidence
+ * afterwards. `assessFindings` in `utility.mjs` READS confidence into an
+ * ephemeral `netUtility` used for ordering and writes nothing back. So a gate
+ * here would be unreachable, and an unreachable gate is the exact defect class
+ * this work exists to close. `hasOutstandingContradiction` already has its
+ * real consumer -- `staleness.mjs` calls it as the dispute gate on serve.
+ * What is enforceable is the invariant itself, and it is: this module never
+ * writes to the graph, and `tests/hooks/calibration-loop.test.mjs` asserts that
+ * neither it nor either layer under it can move a stored confidence.
+ *
+ * NOTHING HERE IS PRICED. A calibration verdict, a holdout estimate and a
+ * consolidation ratio are all estimates; currency belongs only on a measured
+ * counterfactual, and `balanceSheet`'s `measuredCounterfactual` is the one
+ * section in the sheet below that qualifies.
+ */
+
+import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
+import { classify, referenceRate } from './usage.mjs';
+import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Distinct findings needed in EACH arm before a gap is reported at all.
+ *
+ * Two findings per arm is a difference of two numbers; the comparison would be
+ * dominated by whichever finding happened to sit on a big file. Three is still
+ * small, and the refusal says so rather than implying the gap is solid.
+ */
+export const MIN_FINDINGS_PER_ARM = 3;
+
+/**
+ * The smallest gap that may be PUBLISHED, in tokens per touch.
+ *
+ * Not an effect-size convention: it is tied to the unit the verdict prints. The
+ * published sentence rounds the gap to whole tokens, so a gap of 1e-13 -- which
+ * is what two arms of equal means produce once floating point has had its say --
+ * would publish as "referenced findings suppress 0 more tokens/touch". That is a
+ * calibration claim resting on arithmetic noise, and it leans the only direction
+ * a measurement of this project by this project must never lean.
+ */
+export const MIN_GAP_TOKENS = 1;
+
+/**
+ * The per-finding Layer 1 label, folded from per-injection rows.
+ *
+ * ANY reference wins. `classify` emits one row per (injection, finding) because
+ * one reference must not excuse every later injection -- that is the right unit
+ * for a RATE. For a label the question is different: did the model ever name
+ * this finding? A finding referenced once and ignored nine times is a finding
+ * the model reads, and averaging it into `not-referenced` would put it in the
+ * arm whose mean effect it is meant to predict.
+ *
+ * `unknown` rows are dropped rather than defaulted, exactly as Layer 1 drops
+ * them from its own denominator.
+ */
+export function labelsByFinding(rows) {
+  const labels = new Map();
+  for (const row of rows || []) {
+    const key = row?.findingKey;
+    if (typeof key !== 'string' || !key) continue;
+    if (row.label === 'referenced') labels.set(key, 'referenced');
+    else if (row.label === 'not-referenced' && !labels.has(key))
+      labels.set(key, 'not-referenced');
+  }
+  return labels;
+}
+
+const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * Does Layer 1's label predict Layer 2's effect?
+ *
+ * Returns `publishable`, a `verdict` in English, and `gap` ONLY when a gap was
+ * actually computed. There is no `gap: 0` for the unmeasured case, and that is
+ * deliberate: a permanent zero reads as "measured, and the two agree", which is
+ * the opposite of "nothing was measured". Task 7 deleted a field rather than
+ * zero it for the same reason.
+ *
+ * FAILS OPEN. This runs on report paths that must not break a tool call.
+ */
+export function calibration(dir, options = {}) {
+  const refuse = (verdict, extra = {}) => ({
+    publishable: false,
+    verdict,
+    ...extra,
+  });
+
+  try {
+    // ONE READ for both layers, so the two arms of the comparison cannot cover
+    // different spans of the log. `referenceRate` reports `windowed: false`
+    // when the caller supplies events -- correctly, since the bounds are then
+    // the caller's -- so the truncation flag is taken here, from the read that
+    // actually set it, and republished.
+    const supplied = options.events || null;
+    const events = supplied || readMetrics(dir);
+    const truncation = supplied ? null : readTruncation();
+    const truncated = Boolean(
+      truncation && (truncation.byBytes || truncation.byEvents)
+    );
+
+    const layer1 = referenceRate(dir, { events });
+    const labels = labelsByFinding(classify(dir, { events }));
+
+    const obs = observations(dir, { ...options, events });
+    const rows = effects(dir, { ...options, events, obs });
+
+    // ONE POLICY VERSION. Layer 2 refuses to pool arms across serving
+    // policies; a calibration that pooled them would undo that guard one level
+    // up. Rows from any other policy are excluded and counted.
+    const policy = servingPolicyVersion();
+    const inPolicy = rows.filter((row) => row.policy === policy);
+
+    const layer2 = {
+      rows: rows.length,
+      inPolicy: inPolicy.length,
+      published: rows.filter((row) => row.published).length,
+      observations: obs.rows.length,
+      policy,
+    };
+    const l1 = {
+      referenced: layer1.referenced,
+      notReferenced: layer1.notReferenced,
+      unknown: layer1.unknown,
+      denominator: layer1.denominator,
+      rate: layer1.rate,
+      referenceEvents: layer1.referenceEvents,
+    };
+
+    const excluded = { layer1Unknown: layer1.unknown, unlabelled: 0, noEffect: 0 };
+    const arms = { referenced: [], notReferenced: [] };
+    for (const row of inPolicy) {
+      // THE SHRUNK ESTIMATE, not the raw one. Shrinkage pulls every finding
+      // toward the population mean, so it pulls the GAP toward zero -- the
+      // bias runs against publishing, which is the only direction a
+      // measurement of this project by this project may lean.
+      if (row.shrunk === null || !Number.isFinite(row.shrunk)) {
+        excluded.noEffect += 1;
+        continue;
+      }
+      const label = labels.get(row.findingKey);
+      if (label === 'referenced') arms.referenced.push(row.shrunk);
+      else if (label === 'not-referenced') arms.notReferenced.push(row.shrunk);
+      else excluded.unlabelled += 1;
+    }
+
+    const context = { layer1: l1, layer2, arms: { referenced: arms.referenced.length, notReferenced: arms.notReferenced.length }, excluded, windowed: truncated };
+    const caveat = truncated
+      ? ' The event log was truncated, so both sides can understate.'
+      : '';
+
+    // WHICH INPUT WAS INSUFFICIENT, named. "Not enough data" tells a reader
+    // nothing about which half of the loop to go and fix.
+    const l1Silent = layer1.rate === null;
+    const l2Silent = layer2.observations === 0;
+    if (l1Silent || l2Silent) {
+      const why = [];
+      if (l1Silent)
+        why.push(
+          `Layer 1 has ${layer1.denominator} classifiable observation(s) and ` +
+            `${layer1.referenceEvents} reference event(s), so it publishes no rate`
+        );
+      if (l2Silent)
+        why.push(
+          `Layer 2 has ${layer2.observations} observation(s), so it publishes no effect`
+        );
+      return refuse(
+        `not calibrated: ${why.join('; and ')}. No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+    }
+
+    // A POLICY CHANGE RESETS THE CALIBRATION, and says so rather than reporting
+    // an empty arm. Layer 2 refuses to pool arms across serving policies, so
+    // rows generated under an older one cannot answer a question about how the
+    // graph serves findings today -- but "0 findings per arm" would send a
+    // reader hunting for missing observations that are right there in the log.
+    if (rows.length > 0 && inPolicy.length === 0)
+      return refuse(
+        `not calibrated: all ${rows.length} Layer 2 effect row(s) were measured under a different serving ` +
+          `policy than the current ${policy}, and arms are never pooled across policies. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (layer2.published === 0)
+      return refuse(
+        `not calibrated: Layer 2 has ${layer2.observations} observation(s) but no published effect at q=0.1, ` +
+          'so its per-finding numbers are noise and a difference between two means of them would be too. ' +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    if (
+      arms.referenced.length < MIN_FINDINGS_PER_ARM ||
+      arms.notReferenced.length < MIN_FINDINGS_PER_ARM
+    )
+      return refuse(
+        `not calibrated: ${arms.referenced.length} referenced and ${arms.notReferenced.length} not-referenced ` +
+          `finding(s) carry a Layer 2 effect, below the floor of ${MIN_FINDINGS_PER_ARM} per arm. ` +
+          `No gap is reported, which is not the same as a gap of zero.${caveat}`,
+        context
+      );
+
+    const referencedMean = mean(arms.referenced);
+    const notReferencedMean = mean(arms.notReferenced);
+    const gap = referencedMean - notReferencedMean;
+    const measured = { ...context, gap, referencedMean, notReferencedMean };
+
+    if (!(gap >= MIN_GAP_TOKENS))
+      return refuse(
+        `uncalibrated: Layer 1's "referenced" label does not predict a larger Layer 2 effect ` +
+          `(referenced ${Math.round(referencedMean).toLocaleString()} vs not-referenced ` +
+          `${Math.round(notReferencedMean).toLocaleString()} tokens/touch, gap ${Math.round(gap).toLocaleString()}). ` +
+          `Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
+    return {
+      publishable: true,
+      verdict:
+        `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
+      ...measured,
+    };
+  } catch {
+    return refuse(
+      'not calibrated: the calibration inputs could not be read. No gap is reported, which is not the same as a gap of zero.'
+    );
+  }
+}
+
+/**
+ * What the graph cost to build against what it carries -- AN ESTIMATE, and
+ * never priced.
+ *
+ * `consolidationRatio` is the per-finding form and the aggregate is the fold.
+ * Both need `derivedCost`, which `expand.promote` persists onto the finding
+ * node it creates (`src/server/disclosure.ts` is its caller) and which
+ * `harvest-write.mjs` does not yet carry through -- so a graph built only by
+ * the harvest reports nothing here rather than a ratio of one.
+ */
+export function consolidation(dir, { graph = null } = {}) {
+  try {
+    const g = graph || load(dir);
+    const findings = [...g.nodes.values()].filter(
+      (node) => node.kind === 'finding' && !node.retired
+    );
+    const rated = [];
+    for (const finding of findings) {
+      const ratio = consolidationRatio(finding);
+      if (ratio === null) continue;
+      rated.push({ key: finding.key, ratio, derivedCost: finding.derivedCost });
+    }
+    const aggregate = aggregateConsolidation(findings);
+    return {
+      what: 'cost to derive against cost to carry',
+      // SAID IN THE DATA, not only in the prose above it, because this is the
+      // field a dashboard will read and a dashboard will not read a comment.
+      basis: 'estimate',
+      priced: false,
+      findings: findings.length,
+      withDerivedCost: rated.length,
+      aggregate,
+      best: rated.sort((a, b) => b.ratio - a.ratio).slice(0, 5),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The balance sheet with the graph's own three measurements attached.
+ *
+ * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
+ * imports, so it cannot import them back. This is where the two meet, and it
+ * is the shape `get_optimization_report` serves.
+ */
+export function graphBalanceSheet(dir, options = {}) {
+  const sheet = balanceSheet(dir);
+  const cal = calibration(dir, options);
+  const { layer1 = null, layer2 = null } = cal;
+  return {
+    ...sheet,
+    layer1,
+    layer2,
+    calibration: cal,
+    consolidation: consolidation(dir, options),
+  };
+}
+
+/**
+ * One audit line, or null when there is nothing honest to say.
+ *
+ * Silent when NEITHER layer has produced anything: a reader of a graph that has
+ * never injected a finding is owed no paragraph about a loop that has not
+ * started. The moment either side speaks, the refusal is worth printing --
+ * because at that point a reader could otherwise take Layer 1's rate for a
+ * saving, which is precisely what this loop exists to stop.
+ */
+export function calibrationNote(dir, options = {}) {
+  try {
+    const result = calibration(dir, options);
+    const l1 = result.layer1;
+    const l2 = result.layer2;
+    if (!l1 || !l2) return null;
+    if (l1.denominator === 0 && l2.observations === 0) return null;
+    return `Layer 1 against Layer 2: ${result.verdict}`;
+  } catch {
+    return null;
+  }
+}

--- a/plugin/hooks/lib/crosslayer.mjs
+++ b/plugin/hooks/lib/crosslayer.mjs
@@ -54,7 +54,13 @@
 
 import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
-import { effects, observations, servingPolicyVersion } from './loo.mjs';
+import {
+  effects,
+  observations,
+  servingPolicyVersion,
+  permutationP,
+  FDR_Q,
+} from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
 import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
@@ -106,6 +112,32 @@ export function labelsByFinding(rows) {
 }
 
 const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/**
+ * A deterministic, label-symmetric permutation test for the headline gap.
+ *
+ * Layer 2 only publishes a per-finding row after a two-sided permutation test.
+ * The calibration headline summarises those rows, so a positive difference of
+ * arm means must clear the same evidential bar rather than being promoted just
+ * because it points in this project's favour.
+ *
+ * Sorting within each arm and then sorting the two arms makes the sampled path
+ * invariant to event order and to swapping the labels. The seed is derived
+ * from that canonical data instead of shared globally, so two different
+ * datasets do not reuse one arbitrary sequence of sampled relabellings.
+ */
+export function calibrationP(referenced, notReferenced) {
+  const arms = [referenced, notReferenced]
+    .map((values) => [...values].sort((a, b) => a - b))
+    .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  const encoded = JSON.stringify(arms);
+  let seed = 2166136261;
+  for (const char of encoded) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return permutationP(arms[0], arms[1], { seed: seed >>> 0 });
+}
 
 /**
  * Does Layer 1's label predict Layer 2's effect?
@@ -244,7 +276,16 @@ export function calibration(dir, options = {}) {
     const referencedMean = mean(arms.referenced);
     const notReferencedMean = mean(arms.notReferenced);
     const gap = referencedMean - notReferencedMean;
-    const measured = { ...context, gap, referencedMean, notReferencedMean };
+    const p = calibrationP(arms.referenced, arms.notReferenced);
+    const measured = {
+      ...context,
+      gap,
+      referencedMean,
+      notReferencedMean,
+      p,
+      alpha: FDR_Q,
+      test: 'two-sided permutation',
+    };
 
     if (!(gap >= MIN_GAP_TOKENS))
       return refuse(
@@ -255,11 +296,20 @@ export function calibration(dir, options = {}) {
         measured
       );
 
+    if (p === null || p > FDR_Q)
+      return refuse(
+        `not calibrated: the positive Layer 1/Layer 2 gap is not statistically resolved by the ` +
+          `two-sided permutation test (p=${p === null ? 'unavailable' : p.toFixed(3)}, ` +
+          `alpha=${FDR_Q.toFixed(3)}). Do not quote the reference rate as a saving.${caveat}`,
+        measured
+      );
+
     return {
       publishable: true,
       verdict:
         `calibrated: referenced findings suppress ${Math.round(gap).toLocaleString()} more tokens/touch ` +
-        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, shrunk estimates). ` +
+        `than unreferenced ones (${arms.referenced.length} vs ${arms.notReferenced.length} findings, ` +
+        `shrunk estimates, two-sided permutation p=${p.toFixed(3)}). ` +
         `The reference rate is a usable proxy for causal value at this sample size.${caveat}`,
       ...measured,
     };

--- a/plugin/hooks/lib/crosslayer.mjs
+++ b/plugin/hooks/lib/crosslayer.mjs
@@ -56,6 +56,7 @@ import { readMetrics, readTruncation, balanceSheet } from './metrics.mjs';
 import { classify, referenceRate } from './usage.mjs';
 import { effects, observations, servingPolicyVersion } from './loo.mjs';
 import { consolidationRatio, aggregateConsolidation } from './consolidate.mjs';
+import { recallProbe } from './recall.mjs';
 import { load } from './wiki.mjs';
 
 /**
@@ -309,11 +310,19 @@ export function consolidation(dir, { graph = null } = {}) {
 }
 
 /**
- * The balance sheet with the graph's own three measurements attached.
+ * The balance sheet with the graph's own measurements attached.
  *
  * `balanceSheet` lives in `metrics.mjs`, which every one of these modules
  * imports, so it cannot import them back. This is where the two meet, and it
  * is the shape `get_optimization_report` serves.
+ *
+ * `recall` joins them as an OFFLINE PROBE, and that label travels in the data
+ * (`recall.basis`) as well as in the rendered line. It is not an observation of
+ * anything a session did: it deletes an anchor edge in memory and re-runs the
+ * real retrieval primitives over the graph as it stands right now. `recall.mjs`
+ * imports only `wiki.mjs` and `lexical.mjs`, neither of which imports anything
+ * in this direction, so no cycle -- the same reason `calibration` had to live
+ * here rather than in `metrics.mjs`.
  */
 export function graphBalanceSheet(dir, options = {}) {
   const sheet = balanceSheet(dir);
@@ -325,6 +334,7 @@ export function graphBalanceSheet(dir, options = {}) {
     layer2,
     calibration: cal,
     consolidation: consolidation(dir, options),
+    recall: recallProbe(dir, options),
   };
 }
 

--- a/plugin/hooks/lib/derive.mjs
+++ b/plugin/hooks/lib/derive.mjs
@@ -23,13 +23,21 @@
  * the observation supports no claim at all are refused rather than downgraded
  * (see `attemptKey` and the identical-text guard below).
  *
- * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
- * budget, belongs to the caller.
+ * WHAT IS STORED IS BOUNDED. Candidates go through `selectForConsolidation`
+ * before `writeHarvested`, so a long session cannot spend the whole retrieval
+ * budget of every later session on one afternoon's exit codes. Nothing enters
+ * the graph unbudgeted, and nothing enters it wearing a human origin.
  */
 
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
 import { readArchive, readTurns } from './transcript.mjs';
 import { redact } from './redact.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { load } from './wiki.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -106,6 +114,92 @@ const triggerFor = (command) =>
   attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
 
 /**
+ * Literal root-level files that define how a project is BUILT, RUN and TESTED,
+ * best first. A `command` claim is a claim about this project's commands, and
+ * this is the file those commands are declared in.
+ */
+const PROJECT_MARKERS = [
+  'package.json', 'pyproject.toml', 'Cargo.toml', 'go.mod', 'pom.xml',
+  'build.gradle.kts', 'build.gradle', 'build.sbt', 'mix.exs', 'composer.json',
+  'Gemfile', 'Package.swift', 'CMakeLists.txt', 'Makefile', 'Taskfile.yml',
+  'requirements.txt', 'setup.py', 'deno.json', 'bun.lockb',
+];
+
+/** .NET has no single literal marker; the solution or project file is one. */
+const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
+
+/**
+ * A REAL FILE to anchor a derived claim to, inside the project root.
+ *
+ * WHY NOT THE PROJECT ROOT ITSELF, which is what the extraction step reaches
+ * for and what `promoteToShared` uses in the shared tier. Because
+ * `writeHarvested` resolves every anchor through `indexFile`, `indexFile` reads
+ * the path, and reading a DIRECTORY returns null -- so a candidate anchored to
+ * `projectRoot` resolves to nothing, is refused as unanchorable, and the whole
+ * pipeline stores zero findings while reporting a healthy candidate count.
+ * Verified directly: `indexFile(dir, dir)` returns null. That refusal is
+ * correct and must not be weakened -- an anchor that cannot be indexed is an
+ * anchor that can never be invalidated -- so the anchor has to be a file.
+ *
+ * STALENESS DOES NOT MISFIRE ON THIS. `command`, `failure` and `feedback` are
+ * all outside `CONTENT_DEPENDENT` (staleness.mjs), so the anchor is a RETRIEVAL
+ * AND EXISTENCE hook rather than a contents claim: editing the manifest does
+ * not mark these findings stale. staleness.mjs names this exact case in its own
+ * comment -- "a claim about `npm test` anchored to package.json" -- and calls
+ * missing that invalidation the better error.
+ *
+ * A project with no recognisable marker gets the root back, which will not
+ * resolve, so its candidates are derived and then refused rather than stored
+ * against a fabricated anchor. That is the fail-open direction: no finding
+ * beats a finding anchored to something that is not what the claim is about.
+ */
+export function projectAnchor(projectRoot) {
+  if (!projectRoot) return null;
+  let entries;
+  try {
+    entries = readdirSync(projectRoot);
+  } catch {
+    return projectRoot;
+  }
+  const present = new Set(entries);
+  for (const marker of PROJECT_MARKERS) {
+    if (!present.has(marker)) continue;
+    const path = join(projectRoot, marker);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // A marker that cannot be stat'ed is not a marker.
+    }
+  }
+  // Sorted so two sessions in the same repository pick the SAME solution file:
+  // readdir order is not guaranteed stable across hosts, and an anchor that
+  // varies by host splits one finding into two nodes.
+  for (const entry of [...entries].sort()) {
+    if (!DOTNET_MARKER.test(entry)) continue;
+    const path = join(projectRoot, entry);
+    try {
+      if (statSync(path).isFile()) return path;
+    } catch {
+      // Same.
+    }
+  }
+  return projectRoot;
+}
+
+/**
+ * Tokens of claim text one session may add to the graph.
+ *
+ * SCALED TO THE RETRIEVAL BUDGET IT COMPETES FOR, not picked round. A single
+ * command's injection budget is 500 tokens (`TOKEN_OPTIMIZER_TOUCH_BUDGET`),
+ * and everything stored here is competing for that budget on every later
+ * command, forever. Two touch-budgets per session is the bound: enough for a
+ * few dozen real claims, and short of one session's exit codes crowding out
+ * every finding a human or a model ever wrote.
+ */
+const storageBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_DERIVE_BUDGET) || 1000;
+
+/**
  * Derives finding candidates from one project's local evidence.
  *
  * @param {string} dir wiki directory.
@@ -118,11 +212,18 @@ const triggerFor = (command) =>
  *   and is refused by `writeHarvested` anyway, so emitting one would only spend
  *   the caller's budget on junk.
  * @param {string|null} options.authoritativeSessionId the session id as the HOOK
- *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
- *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
- *   edge -- `taskForAnchors` returns null without one, so an unverified string
- *   would silently produce no edge. Threaded rather than defaulted from
- *   `sessionId`: defaulting would promote any caller's string to trusted.
+ *   PAYLOAD reported it, never a value a model typed. Passed straight to
+ *   `writeHarvested`, which needs it to resolve the `answers` edge --
+ *   `taskForAnchors` returns null without one, so an unverified string would
+ *   silently produce no edge. Threaded rather than defaulted from `sessionId`:
+ *   defaulting would promote any caller's string to trusted. Also returned, so a
+ *   caller can see what it handed over.
+ * @returns {object} `{ candidates, observations, written, selected, dropped,
+ *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
+ *   everything derived; `written` is the subset of keys the graph actually
+ *   holds, which is smaller for three independent reasons -- the budget, the
+ *   anchor discipline, and the duplicate collapse that returns an EXISTING key
+ *   when a later session derives the same claim again.
  */
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
@@ -152,6 +253,11 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // ONE anchor for the whole run, so every candidate from this session points at
+  // the same node and the duplicate collapse in `writeHarvested` can recognise
+  // the same lesson across sessions.
+  const anchorPath = projectAnchor(projectRoot);
 
   const seen = new Set();
   const add = (candidate) => {
@@ -246,7 +352,7 @@ export function derive(dir, options = {}) {
               `observed in one session: \`${failed.command}\` failed` +
                 `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
                 `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
-                'an intervening edit or a flaky run explains the same pair.',
+                'an intervening edit or an unrelated environment change explains the same pair.',
               { max: EVIDENCE_MAX }
             ),
             applicability: 'when about to run this command in this project',
@@ -255,7 +361,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the failing form later succeeds unchanged'],
             trigger: triggerFor(outcome.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: outcome.at || Date.now(),
@@ -280,7 +386,7 @@ export function derive(dir, options = {}) {
             scope: 'project',
             invalidators: ['the same command later succeeds unchanged'],
             trigger: triggerFor(failed.command),
-            anchors: [projectRoot],
+            anchors: [anchorPath],
             derivedBy,
             sessionId,
             at: failed.at || Date.now(),
@@ -330,7 +436,7 @@ export function derive(dir, options = {}) {
           confidenceLabel: labelFor(CONFIDENCE.correction),
           scope: 'project',
           invalidators: ['the user later asks for the corrected behaviour'],
-          anchors: [projectRoot],
+          anchors: [anchorPath],
           derivedBy: 'correction',
           sessionId,
           at: Date.parse(turn.at || '') || Date.now(),
@@ -379,6 +485,48 @@ export function derive(dir, options = {}) {
     }
   } catch {
     // One detector, never the session.
+  }
+
+  // ---- storage, under a budget -------------------------------------------
+  //
+  // NOTHING ENTERS THE GRAPH UNBUDGETED. `selectForConsolidation` existed for
+  // exactly this and had no caller, which meant that until now nothing bounded
+  // what a session could add. It admits `failure` and `decision` on a FLOOR
+  // before ranking -- a dead end exists nowhere else and is small, and cheap to
+  // find is not cheap to find again -- then fills the remainder by
+  // cost x irrecoverability x reuse-probability.
+  //
+  // ORIGIN_HARVESTED, EXPLICITLY, never ORIGIN_HUMAN. These are machine
+  // derivations; `curate.mjs` states the reason in its own header -- "a
+  // hand-written assertion and a machine guess look identical three months
+  // later, which quietly destroys the reader's ability to calibrate trust".
+  // `writeHarvested` would refuse a batch-wide human origin anyway, and a
+  // candidate here carries neither `origin` nor `quote`, so it cannot earn one
+  // per finding either. That is deliberate: whether a turn was a correction at
+  // all is a lexical guess, and the standing-rules layer selects on human
+  // origin to inject on EVERY turn.
+  try {
+    if (result.candidates.length) {
+      const selected = selectForConsolidation(load(dir), result.candidates, {
+        budget: storageBudget(),
+      });
+      result.selected = selected.kept.length;
+      result.dropped = selected.dropped;
+      result.selectedTokens = selected.tokens;
+      result.written = writeHarvested(dir, selected.kept, {
+        sessionId,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        // The hook payload's own identity, passed through untouched. Without it
+        // `taskForAnchors` returns null and the `answers` edge never fires --
+        // which is the state a default install has been in, because its only
+        // other producer is credential-gated.
+        authoritativeSessionId,
+      });
+    }
+  } catch {
+    // Storage is the last step and the session is already over. A graph write
+    // that fails must not turn a completed session into a hook error.
   }
 
   return result;

--- a/plugin/hooks/lib/derive.mjs
+++ b/plugin/hooks/lib/derive.mjs
@@ -139,17 +139,19 @@ const quotable = (command) => {
  * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
  * found across 163 transcripts on this machine it refuses 2 and keeps 6.
  *
- * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
- * building the key, so the claim is about `npm test` rather than about the `cd`.
- * That changes `attemptKey` for every client and every finding already derived
- * from it, so it belongs in its own change with its own comparison.
+ * `commandBody` below now skips a leading `cd <path> &&`, so those two are
+ * recovered and this guard is left holding only the keys that reached a
+ * separator which is NOT a directory change -- `git fetch && <anything>`, a
+ * pipeline, a `;`-joined pair. Those still name no single attempt.
  */
 const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
 
 /**
  * Did `attemptKey` actually capture a command, or only how one was chained?
  *
- * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart --
+ * which now means AFTER `commandBody` has removed any leading `cd`, so this no
+ * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
 const hasAttemptIdentity = (command) =>
@@ -177,6 +179,81 @@ const CORRECTION_OPENER =
   /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
 
 /**
+ * A leading directory change, stripped before the key is built.
+ *
+ * THE MEASURED CASE, AND ONLY THE MEASURED CASE. `attemptKey` spends up to
+ * three non-flag tokens on identity and the habit on this machine is
+ * `cd <absolute path> && <the real command>`, which spends all three on `cd`,
+ * the path and the separator. This repository's own corpus: 1,400 of 2,243
+ * command outcomes open with a `cd`, and the single key
+ * `cd c:/users/.../token-optimizer-mcp &&` covered 547 distinct command lines.
+ * A `cd` says WHERE a command ran; it says nothing about WHAT ran, so it cannot
+ * be part of the identity of an attempt.
+ *
+ * THE SEPARATOR SET IS THE ONE THAT WAS OBSERVED: `&&` (1,147), a newline (204)
+ * and `;` (38) after a leading `cd`. All three mean "then run this". `||` is
+ * DELIBERATELY EXCLUDED even though it costs one line to add: `cd x || echo
+ * failed` puts an error branch after the separator, not the next step, so
+ * stripping there would key the attempt on a failure handler. It occurred zero
+ * times.
+ *
+ * AND NOTHING WIDER, each refusal for a reason from the same corpus:
+ *
+ *   Environment assignments (`FOO=bar cmd`) DO carry information about what
+ *   ran. The one true instance here is
+ *   `TOKEN_OPTIMIZER_HOLDOUT=1 node ... jest.js ...`, and the holdout arm is a
+ *   genuinely different attempt from the same command without it. The other 20
+ *   are shell variable assignments joined by `;` -- statements, not prefixes --
+ *   whose value is usually a 120-character path that would be stripped down to
+ *   nothing useful.
+ *
+ *   `time`, `env`, `nice`, `sudo`, `bash -c`, `pushd`, `Set-Location`: ZERO
+ *   occurrences in 2,243 commands. Code for an unmeasured prefix is a way to
+ *   over-strip that no evidence asked for, and over-stripping merges commands
+ *   that genuinely differ -- the same bug in the other direction. `bash -c` is
+ *   worse than unmeasured: the command sits inside a quoted string, so stripping
+ *   the wrapper leaves a key beginning with a quote character.
+ *
+ *   `cd /d C:\path &&` and `cd "C:/a b" &&` need no extra rule -- the match runs
+ *   to the separator rather than counting tokens, so flags and quoted paths
+ *   containing spaces are consumed for free. Neither appears here, so neither is
+ *   claimed as tested behaviour beyond its unit test.
+ *
+ * A `cd` with NO separator is left alone: `cd <path>` on its own ran no command,
+ * and its key is as meaningless afterwards as before -- there is nothing to
+ * recover. Stripping is repeated up to `MAX_DIR_PREFIXES` times so
+ * `cd a && cd b && cmd` reaches `cmd`; the bound exists only so a pathological
+ * line cannot loop, since each pass must consume a whole `cd ... <sep>`.
+ *
+ * APPLIED IDENTICALLY TO BOTH SOURCES because it is applied INSIDE `attemptKey`,
+ * which is the single function both the event path and the transcript reader's
+ * output pass through. The 120-character anchor cap that makes the two agree on
+ * 266 of 266 keys is untouched and still applied on both sides before this runs.
+ */
+const DIR_PREFIX = /^\s*cd\s[^\r\n;&|]*?(?:&&|;|\r?\n)\s*/i;
+const MAX_DIR_PREFIXES = 4;
+
+/**
+ * The command text with any leading directory change removed.
+ *
+ * Used for the key AND for the identical-text refusal, which is the half that
+ * keeps this from becoming a licence to pair more loosely: without it,
+ * `cd repo && npm test` failing and `npm test` succeeding would emit
+ * "`npm test` succeeded where `cd repo && npm test` failed" at 0.90 -- two
+ * spellings of one attempt, dressed up as a difference that mattered. The
+ * claim itself still quotes the RAW command, because that is what ran.
+ */
+export function commandBody(command) {
+  let text = String(command || '');
+  for (let i = 0; i < MAX_DIR_PREFIXES; i++) {
+    const stripped = text.replace(DIR_PREFIX, '');
+    if (stripped === text) break;
+    text = stripped;
+  }
+  return text;
+}
+
+/**
  * The prefix that makes two invocations "the same attempt".
  *
  * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
@@ -194,7 +271,7 @@ const CORRECTION_OPENER =
  * ships a false claim into model context.
  */
 export function attemptKey(command) {
-  return String(command || '')
+  return commandBody(command)
     .trim()
     .split(/\s+/)
     .filter((token) => token && !token.startsWith('-'))
@@ -494,7 +571,14 @@ export function derive(dir, options = {}) {
           // is real and supports NEITHER claim, so nothing is emitted. This is
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
-          if (failed.command === outcome.command) continue;
+          // COMPARED WITH THE DIRECTORY CHANGE REMOVED, for the same reason
+          // the key is. `cd repo && npm test` and `npm test` are one attempt
+          // spelled two ways; before `commandBody` they landed in different
+          // groups and never met, and letting them meet without widening this
+          // guard would emit "`npm test` succeeded where `cd repo && npm test`
+          // failed" at 0.90 -- a difference in the claim that is not a
+          // difference in what ran. Same for two `cd`s to different paths.
+          if (commandBody(failed.command) === commandBody(outcome.command)) continue;
 
           // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
           // client both sides of almost every pair are truncated multi-line
@@ -502,10 +586,12 @@ export function derive(dir, options = {}) {
           // spending the retrieval budget of every later session.
           if (!quotable(failed.command) || !quotable(outcome.command)) continue;
 
-          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
-          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
-          // command lines in this repository alone, and any pair drawn from that
-          // group is a false claim about both halves.
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`. The
+          // `cd <path> &&` case that grouped 547 unrelated command lines in this
+          // repository is now handled earlier by `commandBody`; what is left
+          // here is every OTHER separator -- `git fetch && <anything>`, a
+          // pipeline, a `;`-joined pair -- where the key still names no single
+          // attempt and any pair drawn from it is false about both halves.
           if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =

--- a/plugin/hooks/lib/derive.mjs
+++ b/plugin/hooks/lib/derive.mjs
@@ -1,0 +1,385 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/derive.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Findings from data we already hold, with no model call.
+ *
+ * WHY THIS EXISTS. The semantic harvest is on by default but its real gate is a
+ * credential: `harvestMode()` returns `off:no-key` on any machine without one,
+ * which is CI, corporate laptops, and every subscription-only login. This
+ * repository's own graph is the evidence -- 2,965 symbol nodes, 904 file nodes,
+ * 128 task nodes and ONE finding -- because the structural layer accumulates
+ * from ordinary tool traffic while every verdict needed an API key this machine
+ * does not have.
+ *
+ * Everything here is derived from outcomes, transitions and corrections that are
+ * ALREADY RECORDED LOCALLY. Nothing is sent anywhere, nothing is billed, so
+ * there is nothing to consent to and this runs by default. It is the only
+ * finding producer on a machine without a key.
+ *
+ * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
+ * second command fixed the first -- an intervening edit, a dependency install or
+ * a flaky test explains it just as well. So each detector carries a confidence
+ * ceiling, the claim text says only what was OBSERVED, and the two shapes where
+ * the observation supports no claim at all are refused rather than downgraded
+ * (see `attemptKey` and the identical-text guard below).
+ *
+ * THIS MODULE WRITES NOTHING. It returns candidates; storing them, under a
+ * budget, belongs to the caller.
+ */
+
+import { readMetrics, rereadsByAnchor } from './metrics.mjs';
+import { readArchive, readTurns } from './transcript.mjs';
+import { redact } from './redact.mjs';
+
+/**
+ * Ceilings, ordered by how much the evidence actually supports.
+ *
+ * A command that succeeded where a DIFFERENT command failed is close to a direct
+ * observation. A test or build going red-to-green is weaker, because the usual
+ * cause is the code changing between the two runs rather than anything about the
+ * command. A correction is a lexical guess about what a human meant. Churn
+ * describes our own reading behaviour and says nothing about the code at all.
+ */
+export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+
+/** Claim text cap. A finding is one sentence; a paragraph is evidence. */
+const CLAIM_MAX = 300;
+const EVIDENCE_MAX = 400;
+
+/** Bounded so a pathological log cannot turn session end into real work. */
+const MAX_CANDIDATES = 200;
+
+/**
+ * Commands whose red-to-green transition is usually explained by the CODE
+ * changing rather than by the command. They get the lower ceiling.
+ */
+const CODE_SENSITIVE = /\b(test|tests|jest|vitest|pytest|mocha|build|compile|tsc|lint|typecheck)\b/i;
+
+/**
+ * Openers that mark a user turn as a correction rather than an instruction.
+ *
+ * DELIBERATELY NARROW, and anchored to the START of the turn. The model-based
+ * extractor in `lessons.mjs` can read intent; this cannot, so it only claims the
+ * shapes where the first few words carry the whole signal. Recall is poor by
+ * design: a missed correction costs one finding, a false one puts words in the
+ * user's mouth at 0.6 confidence.
+ */
+const CORRECTION_OPENER =
+  /^\s*(?:no+[,.!\s]|nope\b|wrong\b|stop\b|don'?t\b|do not\b|never\b|revert\b|undo\b|that'?s (?:not|wrong)\b|you (?:broke|were told|didn'?t|did not|ignored)\b|i (?:said|told you|already said)\b|as i said\b|why did you\b)/i;
+
+/**
+ * The prefix that makes two invocations "the same attempt".
+ *
+ * UP TO THREE NON-FLAG TOKENS, and both halves of that were found by working
+ * through what the alternatives do to real command lines:
+ *
+ *   Two tokens conflates `npm run build` with `npm run test`, and the pair then
+ *   produces "`npm run test` works where `npm run build` failed" -- a claim that
+ *   is simply false.
+ *
+ *   Counting flags splits `deploy` from `deploy --retry`, which is the single
+ *   most useful pair this detector can find, into two groups that never meet.
+ *
+ * Conservative in the remaining direction: `npm run build:prod` and
+ * `npm run build` do not pair. A missed pair costs one finding; a wrong pair
+ * ships a false claim into model context.
+ */
+export function attemptKey(command) {
+  return String(command || '')
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'))
+    .slice(0, 3)
+    .join(' ')
+    .toLowerCase();
+}
+
+/** Normalised claim text, so the same lesson derived twice is one candidate. */
+const claimKey = (type, claim) =>
+  `${type}|${String(claim).toLowerCase().replace(/\s+/g, ' ').trim()}`;
+
+/** 0.95 is reserved for verified; everything here is inference. */
+const labelFor = (confidence) => (confidence >= 0.75 ? 'probable' : 'speculative');
+
+/** A literal command prefix, safe to hand to `safeTrigger`. */
+const triggerFor = (command) =>
+  attemptKey(command).replace(/[.*+?^${}()|[\]\\]/g, '\\$&').slice(0, 120) || undefined;
+
+/**
+ * Derives finding candidates from one project's local evidence.
+ *
+ * @param {string} dir wiki directory.
+ * @param {object} options
+ * @param {string|null} options.sessionId session this ran for, for provenance.
+ * @param {string|null} options.transcriptPath live transcript, read only when the
+ *   archive holds nothing for this session yet.
+ * @param {string|null} options.projectRoot the anchor every derived claim gets.
+ *   Without it nothing is derived: an unanchored finding cannot be invalidated
+ *   and is refused by `writeHarvested` anyway, so emitting one would only spend
+ *   the caller's budget on junk.
+ * @param {string|null} options.authoritativeSessionId the session id as the HOOK
+ *   PAYLOAD reported it, never a value a model typed. Returned untouched for the
+ *   caller to pass to `writeHarvested`, which needs it to resolve the `answers`
+ *   edge -- `taskForAnchors` returns null without one, so an unverified string
+ *   would silently produce no edge. Threaded rather than defaulted from
+ *   `sessionId`: defaulting would promote any caller's string to trusted.
+ */
+export function derive(dir, options = {}) {
+  // `options || {}` rather than a destructuring default. A default only fires on
+  // `undefined`, so a caller passing an explicitly null options object -- which
+  // is what a hook does when it has nothing to say -- threw a TypeError out of
+  // the parameter list itself, before any of the try/catch below could fail open.
+  const {
+    sessionId = null,
+    transcriptPath = null,
+    projectRoot = null,
+    authoritativeSessionId = null,
+  } = options || {};
+
+  const result = {
+    candidates: [],
+    observations: [],
+    written: [],
+    sessionId,
+    authoritativeSessionId,
+  };
+
+  let events;
+  try {
+    events = readMetrics(dir);
+  } catch {
+    // Session end must cost nothing. No evidence is not an error.
+    return result;
+  }
+  if (!Array.isArray(events)) return result;
+
+  const seen = new Set();
+  const add = (candidate) => {
+    if (result.candidates.length >= MAX_CANDIDATES) return;
+    const key = claimKey(candidate.type, candidate.claim);
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.candidates.push(candidate);
+  };
+
+  // ---- 1 & 2: a failed attempt followed by a succeeding one ---------------
+  //
+  // The event is `tool-outcome` and THE COMMAND TEXT IS IN `anchor`: there is no
+  // separate command field, because the anchor of a command surface IS the
+  // command. It is capped at 120 characters at the boundary, so a very long
+  // command line is compared and quoted truncated.
+  try {
+    if (projectRoot) {
+      const outcomes = events
+        .filter(
+          (e) =>
+            e &&
+            e.kind === 'tool-outcome' &&
+            e.surface === 'command' &&
+            typeof e.anchor === 'string' &&
+            e.anchor.trim()
+        )
+        .map((e) => ({
+          command: e.anchor.trim(),
+          output: typeof e.output === 'string' ? e.output : '',
+          exit: Number.isInteger(e.exit) ? e.exit : null,
+          at: e.at ?? 0,
+          // `success` FIRST, `exit` only as a refinement. MCP tools report no
+          // numeric code at all, so a classifier keyed on `exit !== 0` would be
+          // inert for most clients -- and `exit` is null rather than 0 precisely
+          // so that absence is not read as a clean exit.
+          failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
+        }))
+        .sort((a, b) => a.at - b.at);
+
+      const byAttempt = new Map();
+      for (const outcome of outcomes) {
+        const key = attemptKey(outcome.command);
+        if (!key) continue;
+        if (!byAttempt.has(key)) byAttempt.set(key, []);
+        byAttempt.get(key).push(outcome);
+      }
+
+      for (const run of byAttempt.values()) {
+        // The NEAREST preceding failure, not the first one in the session. With
+        // `find` over the whole run, a command that failed at 09:00 and
+        // succeeded at 17:00 after nine unrelated attempts is reported as one
+        // story.
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          // One pair per failure: a command that succeeds twice afterwards has
+          // not taught two lessons.
+          lastFailure = null;
+
+          // THE GUARD THAT REMOVES THE LARGEST JUNK CLASS. The commonest shape
+          // in a coding session is `npm run build` failing, the code being
+          // fixed, and `npm run build` succeeding -- identical text. From that
+          // pair the two available claims are "`npm run build` works where
+          // `npm run build` failed", which is incoherent, and "`npm run build`
+          // fails", which the same evidence has just disproved. The observation
+          // is real and supports NEITHER claim, so nothing is emitted. This is
+          // not a confidence question; a ceiling cannot rescue a claim whose
+          // content is wrong.
+          if (failed.command === outcome.command) continue;
+
+          const codeSensitive =
+            CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);
+          const confidence = codeSensitive ? CONFIDENCE.test : CONFIDENCE.command;
+          const derivedBy = codeSensitive ? 'test-transition' : 'command-transition';
+
+          // "SUCCEEDED WHERE", NOT "FIXES". What is observed is two outcomes in
+          // order on the same attempt; that the difference in the command line
+          // CAUSED the difference in outcome is not observed and is not claimed.
+          add({
+            type: 'command',
+            claim: redact(
+              `\`${outcome.command}\` succeeded in this project where \`${failed.command}\` failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded. The two outcomes are ordered, not proven causal: ` +
+                'an intervening edit or a flaky run explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: 'when about to run this command in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the failing form later succeeds unchanged'],
+            trigger: triggerFor(outcome.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+
+          // The error text, only when there is error text. Without it the claim
+          // degrades to "`X` failed with:" and nothing after the colon, which
+          // carries no information and still costs budget.
+          const firstLine = failed.output.split('\n').find((line) => line.trim()) || '';
+          if (firstLine.trim().length < 8) continue;
+          add({
+            type: 'failure',
+            claim: redact(`\`${failed.command}\` failed with: ${firstLine.trim()}`, {
+              max: CLAIM_MAX,
+            }),
+            evidence: redact(`captured output of the failing run:\n${failed.output}`, {
+              max: EVIDENCE_MAX,
+            }),
+            applicability: 'when this command is about to be run in this project',
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: ['the same command later succeeds unchanged'],
+            trigger: triggerFor(failed.command),
+            anchors: [projectRoot],
+            derivedBy,
+            sessionId,
+            at: failed.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 3: user corrections ------------------------------------------------
+  //
+  // A `feedback` finding -- the one type whose source is a person saying the
+  // agent was wrong. The MODEL-BASED extractor for this lives in `lessons.mjs`
+  // and needs the credential this module exists to do without, so here the
+  // signal is lexical: the opening words of the user's own turn.
+  //
+  // ORIGIN IS NOT PROMOTED. `writeHarvested` grants ORIGIN_HUMAN to a finding
+  // carrying a verified verbatim quote, and the standing-rules layer selects on
+  // that origin to inject a claim on EVERY turn. The quote here would be
+  // verbatim -- it is copied out of the archive -- but whether the turn was a
+  // correction at all is a guess, and a guess must not buy always-on injection.
+  // So no `origin` and no `quote` field: this stays harvested provenance.
+  try {
+    if (projectRoot) {
+      let turns = readArchive(dir, sessionId);
+      // The archive is written by the Stop hook too, and the order of the two is
+      // not this module's to assume, so fall back to the live transcript.
+      if (!turns.length && transcriptPath) turns = readTurns(transcriptPath);
+
+      for (const turn of turns) {
+        if (!turn || turn.role !== 'user') continue;
+        const text = String(turn.text || '').trim();
+        // Long turns are new instructions with a complaint somewhere inside
+        // them; truncating one into a claim would misquote the user.
+        if (text.length < 12 || text.length > 300) continue;
+        if (!CORRECTION_OPENER.test(text)) continue;
+        add({
+          type: 'feedback',
+          claim: redact(text, { max: CLAIM_MAX }),
+          evidence: redact(`the user opened a turn with a correction: "${text}"`, {
+            max: EVIDENCE_MAX,
+          }),
+          applicability: 'when working in this project, before repeating what was corrected',
+          confidence: CONFIDENCE.correction,
+          confidenceLabel: labelFor(CONFIDENCE.correction),
+          scope: 'project',
+          invalidators: ['the user later asks for the corrected behaviour'],
+          anchors: [projectRoot],
+          derivedBy: 'correction',
+          sessionId,
+          at: Date.parse(turn.at || '') || Date.now(),
+        });
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  // ---- 4: re-read churn ---------------------------------------------------
+  //
+  // NOT A FINDING, AND THAT IS THE DECISION RATHER THAN AN OMISSION.
+  //
+  // Churn is a claim about OUR OWN reading behaviour: "this file was read three
+  // times unchanged". Every finding type available is a claim about the work --
+  // `map` describes how an area of the codebase is laid out, and is
+  // content-dependent, so a churn claim filed as `map` would be checked for
+  // staleness against contents it makes no claim about and flip stale on the
+  // first edit to a file it never described. Worse, the anchors it would take
+  // are by construction the HOTTEST files in the project, which are exactly the
+  // files that already carry real findings, so a 0.4-confidence row saying
+  // nothing actionable would sit in the injection budget beside them and render
+  // on the same reads. Nothing a future agent could DO differently follows from
+  // it: it does not say what the file contains, so it cannot substitute for
+  // reading it.
+  //
+  // The signal is still worth having -- as the measurement it already is.
+  // `rereadWaste` reports it on the balance sheet, `rereadsByAnchor` names the
+  // offenders, and this returns those rows as OBSERVATIONS: computed, carried,
+  // and deliberately not competing for context. Three detectors produce
+  // findings; the fourth produces a number.
+  try {
+    for (const row of rereadsByAnchor(events).slice(0, 3)) {
+      if (!row.anchor || row.wasteful < 2) continue;
+      result.observations.push({
+        kind: 'churn',
+        anchor: row.anchor,
+        repeats: row.repeats,
+        wasteful: row.wasteful,
+        tokens: row.tokens,
+        confidence: CONFIDENCE.churn,
+        derivedBy: 'churn',
+        note: `re-read ${row.repeats} times, ${row.wasteful} of them unchanged`,
+      });
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
+  return result;
+}

--- a/plugin/hooks/lib/derive.mjs
+++ b/plugin/hooks/lib/derive.mjs
@@ -16,6 +16,13 @@
  * there is nothing to consent to and this runs by default. It is the only
  * finding producer on a machine without a key.
  *
+ * THREE SOURCES, NOT TWO. `tool-outcome` events, the transcript archive, and --
+ * since the transition detectors were measured to have no input at all on the
+ * primary client -- the raw transcript's FAILED tool results, which is the only
+ * place a Claude Code failure is recorded (`failedResultsFromTranscript` in
+ * transcript.mjs, and the note above `quotable` for what that measurement
+ * actually yielded).
+ *
  * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
  * second command fixed the first -- an intervening edit, a dependency install or
  * a flaky test explains it just as well. So each detector carries a confidence
@@ -32,7 +39,11 @@
 import { readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { readMetrics, rereadsByAnchor } from './metrics.mjs';
-import { readArchive, readTurns } from './transcript.mjs';
+import {
+  readArchive,
+  readTurns,
+  failedResultsFromTranscript,
+} from './transcript.mjs';
 import { redact } from './redact.mjs';
 import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
@@ -56,6 +67,96 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * The anchor cap a command surface is stored under, restated here as a TEST.
+ *
+ * `recordToolOutcome` truncates `anchor` to 120 characters, so a command at or
+ * over that length reached this module already cut -- and `quotable` below
+ * refuses to build a claim out of the fragment.
+ */
+const COMMAND_ANCHOR_MAX = 120;
+
+/**
+ * Can this command text be QUOTED in a claim a reader could act on?
+ *
+ * THE SECOND REFUSAL OF ITS KIND, and it exists because measurement forced it.
+ * Wiring the transcript reader gave the transition detectors their first real
+ * input on this client and immediately produced four candidates at 0.9
+ * confidence whose claim text read:
+ *
+ *   `cd /c/Users/.../token-optimizer-mcp\ncat >> docs/superpowers/plans/2026-` succeeded
+ *   in this project where `cd /c/Users/.../token-optimizer-mcp\ncat > /tmp/probe3.mjs
+ *   <<'EOF'\nimport { readdirSync, readFileSync, sta` failed
+ *
+ * -- two truncated fragments of throwaway shell scripts, grouped together only
+ * because `attemptKey`'s three tokens were spent on `cd`, the absolute path, and
+ * the verb. Then measured properly across three real transcripts: **0 of 83**
+ * captured command failures are single-line and inside the cap. 65% of this
+ * project's 2,178 successful command outcomes are not either. On this client a
+ * "command" is usually a whole shell script, so the attempt identity the
+ * transition detectors are built on does not fit most of the traffic.
+ *
+ * This is the same judgement as the identical-text guard below rather than a
+ * confidence question: a claim whose subject is a truncated fragment of a
+ * program is not a weaker claim, it is not a claim. A raised cap would not
+ * rescue it -- quoting the whole 500-character heredoc is no more actionable.
+ *
+ * What survives is exactly what the detector was designed for: `npm test`,
+ * `dotnet build X`, `deploy --retry` -- a repeatable command someone could run
+ * again. This machine captured none failing, which is why the honest yield here
+ * is zero and why that is reported rather than dressed up.
+ *
+ * Applied to BOTH sources. Where the evidence arrived from has no bearing on
+ * whether the resulting sentence says anything, and a rule that let events
+ * through would ship the junk on the ten clients that do report failures.
+ */
+const quotable = (command) => {
+  const text = String(command || '');
+  return (
+    text.trim().length > 0 &&
+    !/[\r\n]/.test(text) &&
+    text.length < COMMAND_ANCHOR_MAX
+  );
+};
+
+/**
+ * Tokens that separate one command from the next rather than naming one.
+ *
+ * MEASURED, LIKE EVERY OTHER REFUSAL HERE. `attemptKey` spends up to three
+ * non-flag tokens on identity, and the habit on this machine is
+ * `cd <absolute path> && <the real command>` -- which spends all three on `cd`,
+ * the path and `&&`, so the real command never enters the key. This project's
+ * own evidence: the single key `cd c:/users/.../token-optimizer-mcp &&` covers
+ * **539 distinct command lines**. One quotable failure in that group would pair
+ * with an arbitrary unrelated success and claim "`cd repo && grep -n ...`
+ * succeeded where `cd repo && git merge ...` failed", which is false about both.
+ *
+ * A KEY THAT REACHED A SEPARATOR NEVER REACHED A COMMAND, so there is no attempt
+ * to compare and nothing to claim -- the same judgement as the identical-text
+ * guard rather than a lower ceiling. Narrow on purpose: `2>&1` and `/F` are not
+ * separators and do not trip this, so `cat commitlint.config.mjs 2>&1` and
+ * `taskkill /F /PID 1 2>&1` keep their identity. Of the 8 quotable failures
+ * found across 163 transcripts on this machine it refuses 2 and keeps 6.
+ *
+ * The fix that would RECOVER those two is to skip a leading `cd <path> &&` when
+ * building the key, so the claim is about `npm test` rather than about the `cd`.
+ * That changes `attemptKey` for every client and every finding already derived
+ * from it, so it belongs in its own change with its own comparison.
+ */
+const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
+
+/**
+ * Did `attemptKey` actually capture a command, or only how one was chained?
+ *
+ * Read off the SAME key `attemptKey` produces, so the two cannot drift apart.
+ * One check per pair is enough: both halves share the key by construction.
+ */
+const hasAttemptIdentity = (command) =>
+  attemptKey(command)
+    .split(' ')
+    .filter(Boolean)
+    .every((token) => !COMMAND_SEPARATORS.has(token));
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -274,6 +375,17 @@ export function derive(dir, options = {}) {
   // separate command field, because the anchor of a command surface IS the
   // command. It is capped at 120 characters at the boundary, so a very long
   // command line is compared and quoted truncated.
+  //
+  // TWO SOURCES OF FAILURE, ONE PAIRING LOOP. Claude Code never fires
+  // PostToolUse for a failed tool call -- 2,238 of 2,238 live `tool-outcome`
+  // events on the measuring machine carry `success: true`, and a deliberately
+  // failing command produced no event at all -- so on the primary client these
+  // two detectors had NO INPUT WHATSOEVER while working normally on the ten
+  // adapter clients. `failedResultsFromTranscript` supplies the missing half
+  // from the only place it exists. The successes still come from events only:
+  // a transcript failure that pairs with nothing stays unclaimed, which is also
+  // what keeps a failure from ANOTHER project's directory out of this project's
+  // graph -- a candidate cannot be emitted without a success recorded HERE.
   try {
     if (projectRoot) {
       const outcomes = events
@@ -290,6 +402,9 @@ export function derive(dir, options = {}) {
           output: typeof e.output === 'string' ? e.output : '',
           exit: Number.isInteger(e.exit) ? e.exit : null,
           at: e.at ?? 0,
+          // Carried purely so the transcript merge below can recognise the same
+          // tool call arriving from the other source.
+          toolCallId: e.toolCallId ? String(e.toolCallId) : null,
           // `success` FIRST, `exit` only as a refinement. MCP tools report no
           // numeric code at all, so a classifier keyed on `exit !== 0` would be
           // inert for most clients -- and `exit` is null rather than 0 precisely
@@ -297,6 +412,53 @@ export function derive(dir, options = {}) {
           failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0),
         }))
         .sort((a, b) => a.at - b.at);
+
+      // DEDUPLICATED ON `toolCallId`, which is the SAME STRING in both sources:
+      // `episodeMeta` reads `raw.tool_use_id` into `toolCallId`, and that is the
+      // transcript's `tool_use_id` verbatim -- verified against live evidence
+      // (`toolu_01L4Nwr...` in metrics.jsonl, the same ids in the transcript).
+      // So on the ten clients that DO report failures, the event copy wins and
+      // the transcript copy is dropped before grouping. Without this the two
+      // copies of one failure would sit in the same run and the second of them
+      // would be paired against the first as a failed-then-succeeded story about
+      // itself.
+      //
+      // The fallback covers a client that reports a failure with no call id:
+      // identical command text within two seconds is one failure recorded twice,
+      // not two failures, because nothing re-runs a command that fast.
+      const eventIds = new Set(
+        outcomes.map((o) => o.toolCallId).filter(Boolean)
+      );
+      const eventFailures = outcomes.filter((o) => o.failed);
+      const alreadyRecorded = (failure) => {
+        if (failure.toolCallId && eventIds.has(failure.toolCallId)) return true;
+        return eventFailures.some(
+          (o) =>
+            o.command === failure.command &&
+            Math.abs((o.at || 0) - (failure.at || 0)) <= 2000
+        );
+      };
+
+      let transcriptFailures = [];
+      try {
+        transcriptFailures = failedResultsFromTranscript(transcriptPath).filter(
+          (failure) => failure.command.trim() && !alreadyRecorded(failure)
+        );
+      } catch {
+        // The reader is an extra source, never a reason the detector stops.
+      }
+      for (const failure of transcriptFailures) {
+        outcomes.push({
+          command: failure.command.trim(),
+          output: failure.output,
+          exit: failure.exit,
+          at: failure.at,
+          toolCallId: failure.toolCallId,
+          // Read from `Exit code N`, which is the only shape the reader admits.
+          failed: true,
+        });
+      }
+      if (transcriptFailures.length) outcomes.sort((a, b) => a.at - b.at);
 
       const byAttempt = new Map();
       for (const outcome of outcomes) {
@@ -333,6 +495,18 @@ export function derive(dir, options = {}) {
           // not a confidence question; a ceiling cannot rescue a claim whose
           // content is wrong.
           if (failed.command === outcome.command) continue;
+
+          // NOTHING QUOTABLE, NOTHING CLAIMED. See `quotable` above: on this
+          // client both sides of almost every pair are truncated multi-line
+          // shell scripts, and a claim quoting a fragment of one is noise
+          // spending the retrieval budget of every later session.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          // AND THE KEY HAS TO NAME A COMMAND. See `hasAttemptIdentity`: a key
+          // that ran out of tokens on `cd <path> &&` groups 539 unrelated
+          // command lines in this repository alone, and any pair drawn from that
+          // group is a false claim about both halves.
+          if (!hasAttemptIdentity(outcome.command)) continue;
 
           const codeSensitive =
             CODE_SENSITIVE.test(outcome.command) || CODE_SENSITIVE.test(failed.command);

--- a/plugin/hooks/lib/doctor.mjs
+++ b/plugin/hooks/lib/doctor.mjs
@@ -197,7 +197,8 @@ function hooksDirFor({ hooksDir, install, root }) {
  * identical from outside: a graph that fills with structural nodes either way.
  *
  * Measured on a real 5.4.0 install: 484 symbol, 286 file and 122 task nodes and
- * ZERO findings, because harvestMode() was 'off:not-opted-in'. Fifteen checks
+ * ZERO findings, because harvestMode() then returned an opt-in refusal (the mode has
+ * since been renamed: it is 'off:no-key' now, and opting in is no longer the gate). Fifteen checks
  * passed and none mentioned harvest. stop-harvest.mjs names this exact gap --
  * "nothing in doctor, audit or waste mentions harvest, so a user sees a graph
  * filling with structural nodes and no findings and has no way to learn why" --
@@ -221,9 +222,15 @@ export function probeHarvest() {
   // optimizer is off" is noise, which is why stop-harvest maps it to no notice.
   if (mode === 'off:mode') return [];
 
+  // SAID PLAINLY, because this is the configuration a user would choose if they
+  // knew it existed and the previous wording buried it in machinery. A local
+  // endpoint is the only setting under which the semantic harvest runs with no
+  // credential, no billing and no digest leaving the machine -- so the two facts
+  // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
     return [ok('finding extraction is available',
-      'active-model wiki_write is primary; local endpoint also enables fallback extraction')];
+      'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
+      'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
@@ -233,10 +240,19 @@ export function probeHarvest() {
 
   // No second-model credential is required for the primary path. The Codex/agent session that
   // already paid to derive the conclusion is the extractor and wiki_write is local.
+  // NAME THE TRADE, not just the missing variable. This is the default state on
+  // every machine without a credential, so it is the text most users will read,
+  // and "unavailable" alone tells them neither what they are missing nor that
+  // the free option exists. Local findings still accumulate: derive.mjs reads
+  // exit codes, red-to-green transitions, corrections and churn out of evidence
+  // already on disk and sends nothing anywhere.
   if (mode === 'off:no-key') {
     return [ok('finding extraction is available',
-      'active model records durable conclusions through local wiki_write; no separate-model ' +
-      'credential is configured, so fallback transcript extraction is unavailable')];
+      'active model records durable conclusions through local wiki_write, and derive runs at ' +
+      'session end with no credential. No separate-model credential is configured, so fallback ' +
+      'transcript extraction is unavailable: point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local ' +
+      'model to run it free and private, or set TOKEN_OPTIMIZER_API_KEY to run it from a bounded ' +
+      'digest of paths, commands, prompts and conclusions -- never file contents')];
   }
 
   // off:opted-out -- a deliberate choice, reported as one. Nagging about a setting somebody chose

--- a/plugin/hooks/lib/inject.mjs
+++ b/plugin/hooks/lib/inject.mjs
@@ -1134,10 +1134,25 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // injected more than the budget allowed and recorded fewer tokens than it
   // spent -- in a block whose entire justification is that it is tightly
   // bounded and measured against the control arm.
+  // THE LAST LINE IS HOW THE NEXT RULE GETS HERE, and it is one line because
+  // this block is charged on every session forever. A rule reaches this list
+  // only by being pinned or by being a person's verified correction, and both
+  // start as a `wiki_write` -- so a model reading a set of standing rules with
+  // no idea how they were produced has no way to add to it. Stated at the point
+  // of the evidence rather than as a separate always-on block: the reader is
+  // already looking at the output of the mechanism being described.
+  //
+  // THE COLD GRAPH IS COVERED ELSEWHERE, deliberately. Nothing here renders
+  // until at least one rule qualifies, which is the property the always-on
+  // budget depends on, so this line cannot be the first-session nudge --
+  // `policyText`'s "Record what you work out" section is, and it is emitted at
+  // SessionStart whether or not the graph holds anything.
   const HEADING =
     '# Standing rules for this project' +
     '\n\nEstablished in previous sessions and expected to hold. ' +
-    'These are not suggestions.\n\n';
+    'These are not suggestions.\n\n' +
+    'Record what you work out with wiki_write and a real file anchor; ' +
+    'that is how a rule reaches this list.\n\n';
   const noticeFor = (n) =>
     n
       ? `\n(${n} further standing rule${n === 1 ? '' : 's'} did not fit this budget; ` +

--- a/plugin/hooks/lib/inject.mjs
+++ b/plugin/hooks/lib/inject.mjs
@@ -35,6 +35,7 @@ import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
 import { cacheOrdered } from './cache.mjs';
+import { withheldFor, exploreOrder, servingPolicyVersion, LOO_ENABLED } from './loo.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -311,8 +312,38 @@ export function forTouch(
     });
     for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
   }
-  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  // LAYER 2 EXPLORATION, BEFORE the budget decides.
+  //
+  // `assessed.eligible` arrives in net-utility order and `fit` keeps that order
+  // until the budget runs out -- so the ranking decides which findings are ever
+  // served, which decides which ever accumulate observations, which decides
+  // their utility. A tenth of touches therefore promote the least-served
+  // candidate first. This is the only place it can go: after `fit` the choice
+  // has already been made.
+  const ordered = exploreOrder(assessed.eligible, dir, { sessionId, anchor: filePath });
+  const { kept, spent } = fit(ordered.map((item) => item.finding), budget);
   if (!kept.length) return null;
+
+  // LAYER 2 WITHHOLDING, AFTER the budget decides, which is the only ordering
+  // that produces a leave-one-out rather than a substitution: withholding first
+  // would let the next-ranked finding take the freed tokens, so the withheld
+  // arm would differ from the served arm by two findings instead of one and the
+  // effect would belong to neither.
+  //
+  // `holdout` is passed so the two experiments cannot compose into "withhold
+  // everything and call it a leave-one-out": that arm already serves nothing.
+  const withheld = withheldFor(kept.map((finding) => finding.key), sessionId, graph, dir, {
+    surface: 'file',
+    anchor: filePath,
+    holdout,
+  });
+  const delivered = withheld ? kept.filter((finding) => finding.key !== withheld) : kept;
+  // RE-PRICED, because `fit` priced what it KEPT and this delivers less. Using
+  // `spent` would bill the injection-cost side of the balance sheet for text
+  // the model never received.
+  const deliveredSpent = withheld
+    ? delivered.reduce((sum, finding) => sum + estimate(render(finding)), 0)
+    : spent;
 
   record(dir, {
     kind: 'inject',
@@ -321,15 +352,20 @@ export function forTouch(
     surface: 'file',
     anchor: filePath,
     holdout,
-    tokens: holdout ? 0 : spent,
-    deliveredTokens: holdout ? 0 : spent,
+    tokens: holdout ? 0 : deliveredSpent,
+    deliveredTokens: holdout ? 0 : deliveredSpent,
     shadowTokens: spent,
-    count: holdout ? 0 : kept.length,
+    count: holdout ? 0 : delivered.length,
     candidateCount: kept.length,
-    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    findingIds: holdout ? [] : delivered.map((finding) => finding.key),
     shadowFindingIds: kept.map((finding) => finding.key),
-    stale: kept.some((f) => f.stale),
+    stale: delivered.some((f) => f.stale),
     sessionId,
+    // ON EVERY RECORD, not only the withheld ones. A served observation needs
+    // the policy version as much as a withheld one does, or `effects` cannot
+    // keep the two arms of one comparison inside one policy.
+    ...(LOO_ENABLED() ? { looPolicy: servingPolicyVersion() } : {}),
+    ...(withheld ? { loo: withheld } : {}),
   });
 
   // MARKED SEEN IN BOTH ARMS, for the same reason as the command path: a file
@@ -339,11 +375,16 @@ export function forTouch(
   // grow faster purely from repetition.
   //
   // This is the identical defect that was fixed in `forCommand` and not here.
+  //
+  // THE WITHHELD KEY IS MARKED TOO, and that is load-bearing rather than tidy:
+  // an unmarked one would be a candidate again on the next touch of this file,
+  // where the one-per-touch tiebreak could serve it -- flipping its arm inside
+  // the very session the arm hash exists to pin it for.
   for (const f of kept) alreadyInjected.add(f.key);
 
-  if (holdout || !kept.length) return null;
+  if (holdout || !delivered.length) return null;
 
-  return `Known about ${filePath} (from previous sessions):\n${kept.map(render).join('\n')}`;
+  return `Known about ${filePath} (from previous sessions):\n${delivered.map(render).join('\n')}`;
 }
 
 /**

--- a/plugin/hooks/lib/keepwarm.mjs
+++ b/plugin/hooks/lib/keepwarm.mjs
@@ -30,6 +30,15 @@ import { record, readMetrics, readBalance } from './metrics.mjs';
 import { WRITE_MULTIPLIER, READ_MULTIPLIER } from './cache.mjs';
 
 /**
+ * The shortest gap that counts as a NEW turn rather than a burst inside one.
+ *
+ * Shared by the gap distribution and by the hit test, because they have to
+ * agree about what a turn is. Two copies of this number would let the decision
+ * be fitted to one definition of a turn and scored against another.
+ */
+export const TURN_GAP_MS = 250;
+
+/**
  * TTL tiers, with what a WRITE costs at each.
  *
  * A five-minute entry is written at 1.25x a plain input token; the one-hour
@@ -85,7 +94,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
     for (let i = 1; i < session.length; i++) {
       const gap = session[i] - session[i - 1];
       // A burst of events inside one turn is not a gap between turns.
-      if (gap > 250) gaps.push(gap);
+      if (gap > TURN_GAP_MS) gaps.push(gap);
     }
   }
   if (gaps.length < 6) return null;
@@ -105,10 +114,91 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
 }
 
 /**
+ * Refreshes to observe at a tier before the observation may bound the decision.
+ *
+ * THE SAME NUMBER THE BACKSTOP DEMANDS, deliberately. The decision and the
+ * tripwire read the same ledger, so letting them disagree about when there is
+ * enough evidence would mean one of them acting on a sample the other calls too
+ * small. Below the floor the decision keeps its expected-value answer, so a
+ * single unlucky miss changes nothing at all.
+ *
+ * NOT A CONFIDENCE INTERVAL, and the reason is arithmetic rather than taste. A
+ * Wilson 95% upper bound at ten refreshes and zero hits is 0.28 -- so a policy
+ * that missed ten times out of ten would still be recommended, which is exactly
+ * the case the loop exists to catch. The point estimate is safe here because of
+ * the bound below: an observation may only ever LOWER the modelled probability,
+ * so sampling noise cannot manufacture a refresh, and the tripwire's realised
+ * ledger is a second guard underneath.
+ */
+export const OBSERVATION_FLOOR = TRIPWIRE_MIN;
+
+/**
+ * The measured hit rate per tier, from recorded outcomes.
+ *
+ * Tiers below the floor are ABSENT rather than present with a small n, because
+ * a rate carrying no weight is the thing most likely to be used as though it
+ * did.
+ */
+export function observedHitRates(outcomes = []) {
+  const byTier = new Map();
+  for (const event of outcomes) {
+    if (event?.kind !== 'keepwarm' || event.action !== 'outcome') continue;
+    const name = TIERS.some((t) => t.name === event.tier) ? event.tier : TIERS[0].name;
+    const row = byTier.get(name) || { refreshes: 0, hits: 0 };
+    row.refreshes += 1;
+    if (event.hit) row.hits += 1;
+    byTier.set(name, row);
+  }
+
+  const qualified = new Map();
+  for (const [name, row] of byTier) {
+    if (row.refreshes < OBSERVATION_FLOOR) continue;
+    qualified.set(name, { ...row, rate: row.hits / row.refreshes });
+  }
+  return qualified;
+}
+
+/**
+ * What the refreshes at this tier actually did, if enough of them have.
+ *
+ * Tolerates being handed anything -- null, a plain object, a Map -- because the
+ * callers are two public functions whose options object is assembled by other
+ * people's code.
+ */
+function observationsFor(observed, tierName) {
+  const row = observed instanceof Map ? observed.get(tierName) : null;
+  return row && Number.isFinite(row.rate) ? row : null;
+}
+
+/**
+ * The modelled probability, BOUNDED BY what was observed and never raised by it.
+ *
+ * The asymmetry is the whole point and runs against this project's interest. A
+ * recorded `hit` says only that a turn arrived before the entry expired; it
+ * cannot say the refresh is what kept the entry alive, because a turn arriving
+ * one minute after a five-minute ping would have found the entry warm anyway.
+ * So the observed rate is an UPPER bound on a refresh's value, and substituting
+ * it for the model would flatter keep-warm badly: on the machine this was
+ * written on, the modelled ping probability is 0.2% and the observable
+ * before-expiry rate is 99.5%, so the substitution would recommend refreshing
+ * forever. A low rate, by contrast, is real evidence against: if turns do not
+ * even arrive inside the TTL, the refresh certainly bought nothing.
+ */
+function bounded(modelled, seen) {
+  return seen ? Math.min(modelled, seen.rate) : modelled;
+}
+
+/**
  * Should we refresh this prefix now?
  *
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
+ *
+ * `observed` is passed IN rather than read from disk here: this function is
+ * pure, its purity is what lets the tests build a distribution by hand, and
+ * `shouldKeepWarm` has already read the outcome log for the tripwire -- so
+ * threading the reader in here would be a second read of the same file and a
+ * second place for the window discipline to be got wrong.
  */
 export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
@@ -125,42 +215,30 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
   const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
-
-  // MEASURED BEATS MODELLED, once there is enough of it.
-  //
-  // The module header already commits to this -- "an expected-value decision is
-  // only as good as the distribution it was fitted to, and distributions
-  // shift" -- and the tripwire underneath was the only thing acting on it, as
-  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
-  // entirely" there was nothing, because the observed hit rate was never
-  // computed: both recording halves had no call site, so ten refreshes that
-  // bought nothing would keep recommending refresh right up to the moment the
-  // tripwire cut the whole feature off.
-  //
-  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
-  // handful of samples would swing the decision harder than the distribution
-  // they replace.
-  const probability = observed ? observed.rate : modelled;
+  const seen = observationsFor(observed, tier.name);
+  const probability = bounded(modelled, seen);
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
-  const basis = observed
-    ? `measured over ${observed.observations} refreshes`
-    : 'modelled from the gap distribution';
+  const note = seen && probability < modelled
+    ? `; bounded by ${seen.refreshes} observed refreshes, ` +
+      `${Math.round(seen.rate * 100)}% used before expiry`
+    : '';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
     modelledProbability: modelled,
-    basis,
+    observedHitRate: seen ? seen.rate : null,
+    observedRefreshes: seen ? seen.refreshes : 0,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
-    reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
+    reason: (ev > 0
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
-        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+        `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`) + note,
   };
 }
 
@@ -171,7 +249,12 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed
  * long enough that the short tier keeps missing. Returns null when neither tier
  * pays, which is a real answer and the one a default-on product never gives.
  */
-export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS }) {
+export function ttlTier({
+  prefixTokens,
+  gaps,
+  turnsPerSession = DEFAULT_TURNS,
+  observed = null,
+}) {
   if (!prefixTokens || !gaps) return null;
 
   // Expected cost of a turn under each tier, as a multiple of what the prefix
@@ -179,7 +262,16 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   // again; and the FIRST write is amortised over the session, which is what
   // stops the expensive tier from looking free whenever gaps are short.
   const costOf = (tier) => {
-    const hit = gaps.probabilityWithin(tier.ms);
+    // THE SAME QUANTITY THE OUTCOMES RECORD, which is what makes the
+    // observation admissible here at all. `hit` is P(a turn arrives before the
+    // entry expires) and `recordRefreshOutcome`'s `hit` is exactly that event,
+    // measured -- unlike keepWarmDecision, whose probability is the narrower
+    // ping window and for which the same observation is only an upper bound.
+    // Bounded rather than replaced even so: a sample drawn only from moments we
+    // CHOSE to refresh is not a sample of gaps, and its bias runs our way.
+    const modelled = gaps.probabilityWithin(tier.ms);
+    const seen = observationsFor(observed, tier.name);
+    const hit = bounded(modelled, seen);
     const perTurn = hit * READ_MULTIPLIER + (1 - hit) * tier.writeMultiplier;
     // THE SUPPLIED VALUE, not only the computed one. Math.max(1, NaN) is NaN -- Math.max
     // propagates it rather than clamping -- so perTurn became NaN, the `perTurn >= 1` guard below
@@ -192,6 +284,8 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     return {
       tier,
       hit,
+      seen,
+      boundedByObservation: Boolean(seen) && hit < modelled,
       perTurn: (tier.writeMultiplier + (turns - 1) * perTurn) / turns,
     };
   };
@@ -208,99 +302,53 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
     action: 'refresh',
     tier: best.tier.name,
     hitProbability: best.hit,
+    observedHitRate: best.seen ? best.seen.rate : null,
+    observedRefreshes: best.seen ? best.seen.refreshes : 0,
     expectedCostPerTurn: Number(best.perTurn.toFixed(3)),
     expectedValue: Math.round((1 - best.perTurn) * prefixTokens),
     reason: `${Math.round(best.hit * 100)}% of gaps land inside ${best.tier.name}; ` +
-      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached`,
+      `expected cost ${best.perTurn.toFixed(2)}x per turn against 1.00x uncached` +
+      (best.boundedByObservation
+        ? `, bounded by ${best.seen.refreshes} observed refreshes ` +
+          `(${Math.round(best.seen.rate * 100)}% used before expiry)`
+        : ''),
   };
 }
 
-/** Observations of a tier before its measured hit rate may override the model. */
-export const OBSERVATION_FLOOR = 5;
-
-/** Records a refresh so its outcome can be scored. */
-export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
-  record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
-}
-
 /**
- * Scores every refresh whose window has since resolved.
+ * Records a refresh so its outcome can be scored.
  *
- * THE MISSING HALF, and it was missing because nobody could see where the
- * signal would come from. `recordRefreshOutcome` needs to know whether a real
- * turn arrived before the entry expired -- and that is not a thing anyone has
- * to instrument, because the event log already records when every turn
- * happened. The answer was in the data the whole time.
+ * `sessionId` IS REQUIRED FOR THE REFRESH TO BE SCOREABLE, and is not defaulted
+ * to anything. The hit test asks whether a turn of THIS conversation arrived
+ * before expiry; pooling arrivals across sessions would let a second concurrent
+ * session's turn pay for this one's ping, which manufactures hits. A refresh
+ * recorded without one is kept in the ledger and reported as unattributable
+ * rather than guessed at.
  *
- * For each unscored refresh at time T on a tier with TTL `ms`:
- *
- *   - a later event within `ms`            -> HIT, observed
- *   - a later event after `ms`             -> MISS, observed
- *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
- *                                             demonstrably closed unused
- *   - no later event, window still open    -> NOTHING RECORDED
- *
- * That last line is the important one and it is Plan 2's own instruction: "if
- * no signal is available for a tier, record nothing rather than guessing
- * `hit: false`". A refresh whose window has not closed yet is not a miss, and
- * scoring it as one would drive the tripwire negative on the newest and least
- * informative records.
- *
- * DRAINED AT READ TIME, which is the pattern this codebase already uses for
- * staleness: the producer cannot know the outcome at the moment it acts, so the
- * next reader resolves what has become knowable since.
+ * Returns the stored record, whose `id` is what `scoreRefreshes` pairs the
+ * outcome to, so an issuer can hold onto it.
  */
-export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
-  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
-  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
-  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
-
-  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
-  // so everything past the number already scored is outstanding. Pairing by
-  // timestamp instead would double-count two refreshes recorded in the same
-  // millisecond, which is reachable: a tool run twice in a loop.
-  const outstanding = refreshes.slice(scored);
-  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
-
-  let recorded = 0;
-  for (const refresh of outstanding) {
-    const at = Number(refresh.at) || 0;
-    if (!at) continue;
-    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
-    const next = timeline.find((t) => t > at);
-
-    let hit;
-    if (next !== undefined) hit = next - at <= tierSpec.ms;
-    else if (now - at > tierSpec.ms) hit = false;
-    else continue; // window still open: not yet knowable
-
-    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
-    recorded += 1;
-  }
-  return { outstanding: outstanding.length, recorded };
-}
-
-/**
- * The measured hit rate for a tier, or null below the observation floor.
- *
- * Null rather than a small-sample number, because the caller substitutes it for
- * a modelled probability and three observations would swing the decision harder
- * than the model they replace.
- */
-export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
-  const relevant = outcomes.filter(
-    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
-  );
-  if (relevant.length < OBSERVATION_FLOOR) return null;
-  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
+export function recordRefresh(dir, { tier, prefixTokens, expectedValue, sessionId, at }) {
+  return record(dir, {
+    kind: 'keepwarm',
+    action: 'refresh',
+    tier,
+    prefixTokens,
+    expectedValue,
+    sessionId,
+    at,
+  });
 }
 
 /**
  * Records whether the refresh was used.
  *
  * `hit` means a real turn arrived before expiry, so the write bought a read.
+ * `refreshId` names the refresh this scores, so the same one cannot be scored
+ * twice -- once per turn for the rest of the session, which is what an
+ * unpaired outcome would become.
  */
-export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
+export function recordRefreshOutcome(dir, { tier, prefixTokens, hit, refreshId = null }) {
   const tierSpec = TIERS.find((t) => t.name === tier) || TIERS[0];
   // THE SAME LEDGER keepWarmDecision BUYS THE REFRESH WITH. That function is explicit that a
   // refresh is a PING, which READS the prefix -- costOfPing = prefixTokens * READ_MULTIPLIER --
@@ -317,7 +365,125 @@ export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
   const realised = hit
     ? prefixTokens * (tierSpec.writeMultiplier - READ_MULTIPLIER) - prefixTokens * READ_MULTIPLIER
     : -prefixTokens * READ_MULTIPLIER;
-  record(dir, { kind: 'keepwarm', action: 'outcome', tier, prefixTokens, hit: Boolean(hit), realised: Math.round(realised) });
+  record(dir, {
+    kind: 'keepwarm',
+    action: 'outcome',
+    tier,
+    prefixTokens,
+    hit: Boolean(hit),
+    refreshId,
+    realised: Math.round(realised),
+  });
+}
+
+/**
+ * Scores every recorded refresh whose window has closed -- and NOTHING ELSE.
+ *
+ * This is the arm that was missing. `recordRefresh` and `recordRefreshOutcome`
+ * were both correct and both called by nothing, so the decision spent money on
+ * refreshes and could never find out whether one bought a read.
+ *
+ * THE SIGNAL IS REAL, not invented. `gapDistribution` already treats this log's
+ * timestamps as turn arrivals -- that is the distribution the whole decision is
+ * fitted to -- so the same log answers the outcome question directly: a refresh
+ * at tier `5m` was used if a turn of the same session arrived within five
+ * minutes of it. Four cases refuse to answer rather than guess, and every one
+ * of them refuses in the direction that costs this project its own good news:
+ *
+ *   - `pending`: the window has not closed yet. A hit could be scored the
+ *     instant it arrives while a miss must wait out the whole TTL, so scoring
+ *     early would mean the recorded hits are always complete and the recorded
+ *     misses always lagging -- right-censoring, biased upward, invisible in any
+ *     test. So a hit waits exactly as long as a miss.
+ *   - `uncovered`: the arrival log no longer reaches back to the refresh, so
+ *     absence of an arrival is absence of evidence. RECORDING `hit: false` HERE
+ *     WOULD BE THE INVENTION THIS IS FORBIDDEN TO MAKE: an absent signal is not
+ *     a miss, and treating it as one biases every rate downward and would
+ *     eventually switch keep-warm off on no evidence at all.
+ *   - `unattributable`: the refresh names no session, so no arrival can be
+ *     shown to belong to it.
+ *   - already scored: an outcome already names this refresh.
+ *
+ * The firehose is READ LAZILY, and only when there is something to score. On a
+ * machine where nothing issues refreshes -- which is every machine today, since
+ * nothing in this repository issues one -- the whole cost is the outcome-log
+ * read: median 70 ms on a 3.5 MB log, of which readBalance is 49 ms, because
+ * that reader also scans the firehose tail for pre-split records.
+ */
+export function scoreRefreshes(dir, {
+  refreshes = readBalance(dir),
+  arrivals = null,
+  now = Date.now(),
+} = {}) {
+  const summary = { scored: 0, hits: 0, pending: 0, uncovered: 0, unattributable: 0 };
+  const keepwarm = refreshes.filter((event) => event?.kind === 'keepwarm');
+  const alreadyScored = new Set(
+    keepwarm
+      .filter((event) => event.action === 'outcome' && event.refreshId)
+      .map((event) => event.refreshId)
+  );
+  const unscored = keepwarm.filter(
+    (event) =>
+      event.action === 'refresh' &&
+      Number.isFinite(event.at) &&
+      event.id &&
+      !alreadyScored.has(event.id)
+  );
+
+  // A refresh with no id cannot be paired, so scoring it would write a fresh
+  // outcome on every turn forever. Reported, not silently dropped.
+  summary.unattributable += keepwarm.filter(
+    (event) => event.action === 'refresh' && (!event.id || !Number.isFinite(event.at))
+  ).length;
+
+  if (!unscored.length) return summary;
+
+  const events = (arrivals ? arrivals() : readMetrics(dir)).filter((event) =>
+    Number.isFinite(event?.at)
+  );
+  // Coverage is judged over EVERY event, including our own bookkeeping: the
+  // refresh's own copy in the firehose is what proves the window is still
+  // inside the read. Arrivals are judged over everything else, because a record
+  // keep-warm wrote about itself is not a turn -- and counting one would
+  // manufacture a hit out of the act of measuring.
+  const earliest = events.reduce((min, event) => Math.min(min, event.at), Infinity);
+  const turns = events.filter((event) => event.kind !== 'keepwarm');
+
+  for (const refresh of unscored) {
+    const tier = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    if (now - refresh.at < tier.ms) {
+      summary.pending += 1;
+      continue;
+    }
+    const session = refresh.sessionId;
+    if (!session) {
+      summary.unattributable += 1;
+      continue;
+    }
+    if (!(earliest <= refresh.at)) {
+      summary.uncovered += 1;
+      continue;
+    }
+
+    const opens = refresh.at + TURN_GAP_MS;
+    const closes = refresh.at + tier.ms;
+    const hit = turns.some(
+      (event) =>
+        (event.sessionId ?? event.episodeId) === session &&
+        event.at > opens &&
+        event.at <= closes
+    );
+    recordRefreshOutcome(dir, {
+      tier: refresh.tier,
+      prefixTokens: refresh.prefixTokens,
+      hit,
+      refreshId: refresh.id,
+    });
+    summary.scored += 1;
+    if (hit) summary.hits += 1;
+  }
+
+  return summary;
 }
 
 /**
@@ -372,23 +538,15 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
-  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
-  // becomes evidence now, so the decision below and the tripwire above both see
-  // the most that is currently knowable -- the same read-time drain the
-  // staleness path uses, and for the same reason: the producer cannot know the
-  // outcome at the moment it acts.
-  try {
-    scoreOutstandingRefreshes(dir, { events, outcomes });
-    outcomes = readBalance(dir);
-  } catch {
-    /* scoring is evidence, never a reason to refuse a decision */
-  }
-
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
+  // THE SAME ARRAY THE TRIPWIRE JUST READ, so closing the loop costs no extra
+  // I/O -- and so the decision and its backstop cannot be looking at different
+  // evidence about the same refreshes.
+  const observed = observedHitRates(outcomes);
   const gaps = gapDistribution(dir, { events });
-  const best = ttlTier({ prefixTokens, gaps });
+  const best = ttlTier({ prefixTokens, gaps, observed });
   if (!best) {
     // THE TWO MODELS ANSWER DIFFERENT QUESTIONS, so they may legitimately disagree. ttlTier asks
     // whether holding a cache beats not caching at all; keepWarmDecision asks whether ONE ping
@@ -397,11 +555,7 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({
-      prefixTokens,
-      gaps,
-      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
-    });
+    const decision = keepWarmDecision({ prefixTokens, gaps, observed });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/plugin/hooks/lib/loo.mjs
+++ b/plugin/hooks/lib/loo.mjs
@@ -1,0 +1,788 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/loo.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 2 -- what one finding is actually worth, measured by withholding it.
+ *
+ * Layer 1 asks whether the model went back and named a finding. This asks the
+ * harder question and answers it causally: WITHHOLD ONE FINDING while serving
+ * every other finding for the same touch, and compare what the session spent
+ * READING that anchor afterwards. Nobody in this space measures per-item value
+ * this way in production; the state of the art is an offline evaluation set.
+ * That is also why this file is more refusal than statistics -- a causal claim
+ * from four observations is worse than no claim, because it is a number and
+ * numbers get quoted.
+ *
+ * THE ESTIMAND IS READ-SUPPRESSION, and it is deliberately DISJOINT from Layer
+ * 1. Layer 1 keys on an explicit `query` naming a finding key. This keys on
+ * `read` events against the injection's anchor. Neither signal appears in the
+ * other's arithmetic: no `query` event is consulted here, and `usage.mjs`
+ * consults no `read` event. Task 8 calibrates one against the other, and if
+ * both derived from the same channel that calibration would report a strong
+ * correlation between two spellings of one quantity and mean nothing.
+ *
+ * IT INVENTS NO JOIN. `recordToolOutcome` already joins each post-tool result
+ * back to the injection that preceded it, recording `injectionId`,
+ * `findingIds` and a `joinMethod` of `tool-call-id` / `episode-anchor` /
+ * `none`. Every observation here is GATED on that join: an injection with no
+ * joined outcome is unattributable and enters neither arm, exactly as Layer 1
+ * treats `joinMethod: 'none'`. An earlier draft of this plan proposed a fresh
+ * `(sessionId, findingKey)` join; it was rejected and is not here.
+ *
+ * WHAT IT COSTS THE USER, because an experiment that degrades a turn owes an
+ * accounting. One withheld finding means the model may re-derive what it was
+ * told last time, and the worst case is one read of that anchor: measured on
+ * this machine, a median read is 3,769 tokens and the 90th percentile is
+ * 14,082. Five guards bound that exposure, and they are the reason the numbers
+ * below are as small as they are:
+ *
+ *   1. only on a FILE touch, because a command injection has no anchor a read
+ *      event can be joined to -- withholding there would cost a user a finding
+ *      and buy no observation at all (see `buildReport`, which excludes command
+ *      injections from the holdout balance for the same reason);
+ *   2. never when fewer than two findings were kept, so "leave one out" always
+ *      leaves something in -- otherwise it degenerates into `inHoldout`, which
+ *      withholds EVERY finding for an anchor and is a different experiment;
+ *   3. never in the same breath as `inHoldout`: if that arm already withheld
+ *      everything, there is nothing to leave out and a Layer 2 arm recorded
+ *      there would be a fabricated observation;
+ *   4. at most ONE finding per touch, or the effect is attributable to neither;
+ *   5. at most ONE withheld finding per SESSION, so the worst case a user can
+ *      experience is a single re-read -- not one per file they open.
+ *
+ * AND IT NEVER OVERRIDES A PERSON. A `pinned` or `origin: 'human'` finding is
+ * an explicit human decision to keep something in front of the model.
+ * Withholding it to run an experiment would overrule that decision for the
+ * convenience of the measurement, so those findings are exempt: they are
+ * always served, they get no causal score, and `looNote` says so rather than
+ * leaving a reader to wonder why they are missing from the table.
+ */
+
+import { createHash } from 'node:crypto';
+import { readEvidence, readMetrics, readTruncation, isFixtureAnchor } from './metrics.mjs';
+import { retrievalPolicy } from './utility.mjs';
+import { ORIGIN_HUMAN } from './curate.mjs';
+import { canonicalPath } from './paths.mjs';
+import { load } from './wiki.mjs';
+
+/**
+ * Injections of a finding before it may enter the experiment.
+ *
+ * A finding nobody has served yet has no established value to measure the
+ * absence of, and withholding it would be measuring the cold start rather than
+ * the finding. Four is also what makes the ratio below reachable: at a quarter
+ * of (key, session) pairs armed, a key needs roughly a dozen enrolled
+ * injections before it can reach a verdict at all.
+ */
+export const MIN_PRIOR_INJECTIONS = 4;
+
+/** The observation floor. Below this there is no verdict -- and NOT a zero. */
+export const MIN_SERVED = 6;
+export const MIN_WITHHELD = 3;
+
+/** Benjamini-Hochberg false-discovery rate for published verdicts. */
+export const FDR_Q = 0.1;
+
+/**
+ * Exploration rate.
+ *
+ * Without this, utility feeds the ranking, the ranking feeds injection
+ * frequency, injection frequency feeds the observation count, and a low score
+ * becomes self-fulfilling: the finding is never served often enough to earn a
+ * better one. A tenth of touches therefore ignore the utility order and
+ * promote the LEAST-served candidate instead.
+ */
+export const EPSILON = 0.1;
+
+/**
+ * The share of (finding, session) pairs assigned to the withheld arm.
+ *
+ * Chosen against the floors rather than picked: MIN_SERVED / MIN_WITHHELD is
+ * 2:1, so a quarter withheld reaches both floors at about the same time while
+ * leaving three touches in four undamaged.
+ */
+export const WITHHOLD_FRACTION = 0.25;
+
+/**
+ * Withheld findings allowed per session. ONE.
+ *
+ * The per-touch cap alone bounds nothing across a session: a session that
+ * opens twelve files with enrolled findings could have withheld twelve. This
+ * makes the worst case a user can experience one re-read, at the price of a
+ * mild confound that is stated rather than hidden -- when the cap binds, the
+ * other armed findings in that session are served, so the served arm is
+ * slightly enriched by sessions that touch many enrolled findings.
+ */
+export const MAX_WITHHELD_PER_SESSION = 1;
+
+/**
+ * Fallback shrinkage weight when the between-finding variance cannot be
+ * estimated (fewer than two findings with both arms, or no dispersion at all).
+ *
+ * MIN_SERVED + MIN_WITHHELD, deliberately: a finding's own data outweighs the
+ * population prior only once it has reached the publication floor.
+ */
+export const SHRINKAGE_K = MIN_SERVED + MIN_WITHHELD;
+
+/** Bounds on the estimated shrinkage weight, so a degenerate variance ratio cannot run away. */
+const K_MIN = 1;
+const K_MAX = 100;
+
+/**
+ * Bumped BY HAND when the serving code changes in a way that could move a
+ * finding's measured effect. It is the part of the policy version a hash of the
+ * configuration cannot see.
+ */
+export const LOO_POLICY_GENERATION = 1;
+
+/** Permutation budget before the exact null distribution is sampled instead of enumerated. */
+const MAX_EXACT_PERMUTATIONS = 20_000;
+const SAMPLED_PERMUTATIONS = 10_000;
+
+/**
+ * On by default, off by `TOKEN_OPTIMIZER_LOO=off`.
+ *
+ * Read per call rather than at module load, for the reason `holdoutFraction`
+ * gives: a long-lived process started before the setting changed would
+ * otherwise honour the old value forever with no way to tell.
+ */
+export function LOO_ENABLED() {
+  return String(process.env.TOKEN_OPTIMIZER_LOO || '').trim().toLowerCase() !== 'off';
+}
+
+/**
+ * The serving policy an observation was collected under.
+ *
+ * WHY EVERY OBSERVATION CARRIES ONE. An effect is only meaningful against a
+ * fixed policy. Halve the touch budget or move the minimum net utility and the
+ * same finding is served in different company, at a different rank, against a
+ * different counterfactual -- so pooling observations from before and after
+ * that change would average two different experiments and call the result
+ * causal. `effects()` therefore groups by (finding, policy) and never across.
+ *
+ * IT IS DELIBERATELY ABSENT FROM THE ARM HASH. Including it would reassign
+ * arms the moment a setting changed, which is precisely the mid-session flip
+ * the arm hash exists to prevent. Configuration decides which experiment an
+ * observation belongs to; it must never decide which arm.
+ */
+export function servingPolicyVersion() {
+  const policy = retrievalPolicy();
+  const parts = [
+    `g${LOO_POLICY_GENERATION}`,
+    `touch=${Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500}`,
+    `benefit=${policy.baseBenefitTokens}`,
+    `minutility=${policy.minimumNetUtility}`,
+    `cooldown=${policy.cooldownMs}`,
+    `quarantine=${policy.quarantineHarmCount}`,
+    `holdout=${process.env.TOKEN_OPTIMIZER_HOLDOUT ?? 'default'}`,
+    `withhold=${WITHHOLD_FRACTION}`,
+    `prior=${MIN_PRIOR_INJECTIONS}`,
+    `epsilon=${EPSILON}`,
+  ];
+  const digest = createHash('sha256').update(parts.join('|')).digest('hex');
+  return `${LOO_POLICY_GENERATION}-${digest.slice(0, 8)}`;
+}
+
+/**
+ * A stable number in [0, 1) from a string.
+ *
+ * SHA-256 rather than SHA-1 for the same reason `inHoldout` uses it: this is a
+ * bucketing hash and nothing here is secret, but arguing that a CodeQL finding
+ * is benign is a worse habit than paying a cost that rounds to nothing.
+ */
+function bucket(text) {
+  return createHash('sha256').update(String(text)).digest().readUInt32BE(0) / 4_294_967_296;
+}
+
+/**
+ * The arm of one finding in one session.
+ *
+ * Keyed on (findingKey, sessionId) AND NOTHING ELSE, so a finding cannot
+ * change arms partway through a session: not when the candidate set changes,
+ * not when the budget changes, not when the graph grows. The measurement is a
+ * comparison between sessions, and an arm that flips inside one contaminates
+ * both sides of it.
+ */
+function armed(findingKey, sessionId) {
+  return bucket(`loo-arm:${findingKey}:${sessionId}`) < WITHHOLD_FRACTION;
+}
+
+/** Deterministic tiebreak among armed candidates: lowest bucket, then key order. */
+function armRank(findingKey, sessionId) {
+  return bucket(`loo-rank:${findingKey}:${sessionId}`);
+}
+
+/** The graph node for a finding key, or null. Keys are unique per graph. */
+function findingNode(graph, key) {
+  const nodes = graph?.nodes;
+  if (!nodes || typeof nodes.values !== 'function') return null;
+  for (const node of nodes.values()) {
+    if (node?.kind === 'finding' && node.key === key) return node;
+    // A fixture graph may omit `kind`; key identity is what this needs.
+    if (node?.key === key && node.kind === undefined) return node;
+  }
+  return null;
+}
+
+/**
+ * May this finding ever be withheld?
+ *
+ * FAILS CLOSED ON AN UNKNOWN KEY, which is the opposite of how the rest of
+ * this module fails. Everywhere else a missing input costs a measurement; here
+ * it could cost a human their explicit decision, because a key whose node
+ * cannot be read is a key whose `pinned` and `origin` cannot be checked.
+ */
+function withholdable(graph, key) {
+  const node = findingNode(graph, key);
+  if (!node) return false;
+  if (node.pinned) return false;
+  if (node.origin === ORIGIN_HUMAN) return false;
+  if (node.retired) return false;
+  return true;
+}
+
+/** Prior SERVED injections per finding key, and withheld injections per session. */
+function history(dir, { evidence = null } = {}) {
+  const priorServed = new Map();
+  const withheldPerSession = new Map();
+  const events = evidence || readEvidence(dir);
+  for (const event of events) {
+    if (event.kind !== 'inject') continue;
+    if (typeof event.loo === 'string' && event.loo) {
+      const session = typeof event.sessionId === 'string' ? event.sessionId : '';
+      withheldPerSession.set(session, (withheldPerSession.get(session) || 0) + 1);
+    }
+    if (event.holdout) continue;
+    const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+    for (const raw of keys) {
+      const key = String(raw);
+      priorServed.set(key, (priorServed.get(key) || 0) + 1);
+    }
+  }
+  return { priorServed, withheldPerSession };
+}
+
+/**
+ * Which single finding to withhold from this touch, or null.
+ *
+ * Called from `forTouch` AFTER `fit` has decided what would have been served,
+ * which is the only ordering that produces a true leave-one-out. Withholding
+ * BEFORE the budget runs would let a lower-ranked finding take the freed
+ * tokens, so the withheld arm would receive different company as well as one
+ * fewer finding, and the comparison would confound the two.
+ *
+ * @param {string[]} findingKeys keys that would otherwise be delivered
+ * @param {string} sessionId the session, which pins the arm
+ * @param {object} graph the loaded graph, for `pinned` / `origin`
+ * @param {string|null} dir graph directory, for the injection history
+ */
+export function withheldFor(findingKeys, sessionId, graph, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return null;
+
+    // Every guard that needs no I/O runs first: this is the PreToolUse path,
+    // and on a project with one finding per anchor the answer is null before
+    // anything is read.
+    const keys = [...new Set((findingKeys || []).map((k) => String(k)).filter(Boolean))];
+    if (keys.length < 2) return null;
+    if (!sessionId || typeof sessionId !== 'string') return null;
+
+    // FILE SURFACE ONLY. A command injection's anchor is the command text, and
+    // no read event will ever match it -- so both arms would score zero
+    // downstream and the finding would be scored on nothing.
+    const { surface = 'file', anchor = '', holdout = false } = options;
+    if (surface !== 'file' || !anchor) return null;
+    // The all-findings holdout already withheld everything for this anchor.
+    if (holdout) return null;
+
+    const eligible = keys.filter((key) => withholdable(graph, key));
+    if (!eligible.length) return null;
+
+    const { priorServed, withheldPerSession } = history(dir, options);
+    if ((withheldPerSession.get(sessionId) || 0) >= MAX_WITHHELD_PER_SESSION) return null;
+
+    const enrolled = eligible.filter(
+      (key) => (priorServed.get(key) || 0) >= MIN_PRIOR_INJECTIONS
+    );
+    if (!enrolled.length) return null;
+
+    const candidates = enrolled.filter((key) => armed(key, sessionId));
+    if (!candidates.length) return null;
+
+    // AT MOST ONE. Sorted deterministically so the same touch always yields the
+    // same choice; the findings that lose the tiebreak are SERVED, and the
+    // observation records what actually happened rather than what the arm hash
+    // intended.
+    candidates.sort(
+      (a, b) => armRank(a, sessionId) - armRank(b, sessionId) || (a < b ? -1 : a > b ? 1 : 0)
+    );
+    return candidates[0];
+  } catch {
+    // An experiment must never break a tool call. Failing open here means
+    // serving everything, which is the undegraded behaviour.
+    return null;
+  }
+}
+
+/**
+ * Reorders candidates so exploration can break the feedback loop.
+ *
+ * A tenth of touches -- deterministic in (session, anchor), not random, so the
+ * same touch behaves the same way twice -- promote the LEAST-served candidate
+ * ahead of the utility order, giving it a chance to survive `fit` and accrue
+ * the observations it needs to earn a score. The other nine tenths are
+ * untouched.
+ *
+ * @param {Array<{finding:{key:string}}>} items assessed candidates, best first
+ */
+export function exploreOrder(items, dir, options = {}) {
+  try {
+    if (!LOO_ENABLED()) return items;
+    const list = Array.isArray(items) ? items : [];
+    if (list.length < 2) return list;
+    const { sessionId = '', anchor = '' } = options;
+    if (bucket(`loo-explore:${sessionId}:${anchor}`) >= EPSILON) return list;
+
+    const keyOf = (item) => String(item?.finding?.key ?? item?.key ?? '');
+    const { priorServed } = history(dir, options);
+    let promoted = 0;
+    for (let i = 1; i < list.length; i += 1) {
+      const a = priorServed.get(keyOf(list[i])) || 0;
+      const b = priorServed.get(keyOf(list[promoted])) || 0;
+      if (a < b || (a === b && keyOf(list[i]) < keyOf(list[promoted]))) promoted = i;
+    }
+    if (promoted === 0) return list;
+    return [list[promoted], ...list.filter((_, i) => i !== promoted)];
+  } catch {
+    return Array.isArray(items) ? items : [];
+  }
+}
+
+const mean = (values) =>
+  values.length ? values.reduce((sum, v) => sum + v, 0) / values.length : 0;
+
+/** Sample variance (n-1). Zero for a single observation: dispersion is unknown, not large. */
+function variance(values) {
+  if (values.length < 2) return 0;
+  const m = mean(values);
+  return values.reduce((sum, v) => sum + (v - m) * (v - m), 0) / (values.length - 1);
+}
+
+/**
+ * Every attributable Layer 2 observation, one per (injection, finding, arm).
+ *
+ * THREE THINGS ARE REPORTED SEPARATELY RATHER THAN FOLDED IN, because each of
+ * them would otherwise turn an absence into a zero:
+ *
+ *   `unattributable`  the outcome join could not attach a tool call to the
+ *                     injection, so nothing is known about what followed it.
+ *   `excluded`        the injection could never produce a read-join at all
+ *                     (command surface, session-start, fixture anchor) or was
+ *                     already in the all-findings holdout.
+ *   `costObservations` how many observations saw a non-zero read cost. If this
+ *                     is zero, "withholding changed nothing" and "the read
+ *                     channel never fired" are the same picture, and only one
+ *                     of them is a finding about findings.
+ */
+export function observations(dir, { events = null, evidence = null } = {}) {
+  const empty = {
+    rows: [],
+    unattributable: 0,
+    unattributableOutcomes: 0,
+    excluded: { command: 0, holdout: 0, fixture: 0, unanchored: 0 },
+    injections: 0,
+    withheldInjections: 0,
+    costObservations: 0,
+    policies: [],
+    windowed: false,
+  };
+  try {
+    const causal = evidence || readEvidence(dir);
+    const all = events || readMetrics(dir);
+    // OUT OF BAND and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` describes the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
+
+    // THE JOIN THIS MODULE CONSUMES AND DOES NOT REPLACE.
+    const joined = new Set();
+    let unattributableOutcomes = 0;
+    for (const event of causal) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) {
+        unattributableOutcomes += 1;
+        continue;
+      }
+      joined.add(String(event.injectionId));
+    }
+
+    // Read cost, grouped the way `buildReport` groups it: (session, anchor),
+    // canonicalised on both sides so two spellings of one file are one anchor.
+    // A mismatch here would make every read invisible and report a clean zero
+    // effect in both arms -- correct code, absent measurement.
+    const reads = new Map();
+    for (const event of all) {
+      if (event.kind !== 'read' || !event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      if (!reads.has(key)) reads.set(key, []);
+      reads.get(key).push(event);
+    }
+
+    const injects = causal
+      .filter((event) => event.kind === 'inject')
+      .map((event, index) => ({ event, index }))
+      .sort((a, b) => (a.event.at || 0) - (b.event.at || 0) || a.index - b.index)
+      .map((row) => row.event);
+
+    // How many injections share each (session, anchor), so a key's read total
+    // is SPLIT between them rather than charged in full to each -- the same
+    // correction `buildReport` applies, and for the same reason: without it the
+    // arm means scale with injections-per-anchor instead of per-touch cost.
+    const perKey = new Map();
+    for (const event of injects) {
+      if (!event.anchor) continue;
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      perKey.set(key, (perKey.get(key) || 0) + 1);
+    }
+
+    const rows = [];
+    const excluded = { command: 0, holdout: 0, fixture: 0, unanchored: 0 };
+    const priorServed = new Map();
+    const policies = new Set();
+    let unattributable = 0;
+    let considered = 0;
+    let withheldInjections = 0;
+
+    for (const event of injects) {
+      const served = (Array.isArray(event.findingIds) ? event.findingIds : []).map(String);
+      const withheldKey = typeof event.loo === 'string' && event.loo ? event.loo : null;
+      const bump = () => {
+        for (const key of served) priorServed.set(key, (priorServed.get(key) || 0) + 1);
+      };
+
+      const isCommand =
+        event.surface === 'command' ||
+        event.trigger === 'command' ||
+        event.surface === 'session-start';
+      if (isCommand) {
+        excluded.command += 1;
+        bump();
+        continue;
+      }
+      if (!event.anchor) {
+        excluded.unanchored += 1;
+        bump();
+        continue;
+      }
+      if (isFixtureAnchor(event.anchor)) {
+        excluded.fixture += 1;
+        bump();
+        continue;
+      }
+      if (event.holdout) {
+        excluded.holdout += 1;
+        bump();
+        continue;
+      }
+
+      considered += 1;
+      if (withheldKey) withheldInjections += 1;
+      const policy = typeof event.looPolicy === 'string' && event.looPolicy
+        ? event.looPolicy
+        : 'unversioned';
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const attributable = Boolean(injectionId && joined.has(injectionId));
+
+      // DOWNSTREAM MEANS AFTER, STRICTLY. The read that triggered the touch is
+      // not caused by the advice; it happened before the advice existed.
+      const key = `${event.sessionId || ''}|${canonicalPath(event.anchor)}`;
+      const at = event.at || 0;
+      const total = (reads.get(key) || []).reduce(
+        (sum, read) => sum + ((read.at || 0) > at ? read.tokens || 0 : 0),
+        0
+      );
+      const cost = total / Math.max(1, perKey.get(key) || 1);
+
+      const observe = (findingKey, arm) => {
+        // ENROLMENT IS RE-DERIVED FROM THE LOG rather than trusted from the
+        // serving decision. It is the one field an old or hand-written record
+        // could contradict, and a served observation from before a finding was
+        // enrolled would compare an established finding against its own cold
+        // start.
+        //
+        // CHECKED BEFORE ATTRIBUTABILITY, so `unattributable` counts only
+        // observations the experiment actually wanted. Counting the rest there
+        // would report a join failure for every finding that was never in the
+        // experiment to begin with -- the same shape as the 2,559-row
+        // measurement-bias defect Layer 1 found in its own first draft.
+        if ((priorServed.get(findingKey) || 0) < MIN_PRIOR_INJECTIONS) return;
+        if (!attributable) {
+          unattributable += 1;
+          return;
+        }
+        policies.add(policy);
+        rows.push({ findingKey, arm, cost, policy, injectionId, anchor: event.anchor });
+      };
+
+      if (withheldKey) observe(withheldKey, 'withheld');
+      for (const findingKey of served) observe(findingKey, 'served');
+      bump();
+    }
+
+    return {
+      rows,
+      unattributable,
+      unattributableOutcomes,
+      excluded,
+      injections: considered,
+      withheldInjections,
+      costObservations: rows.filter((row) => row.cost > 0).length,
+      policies: [...policies].sort(),
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
+function permutationP(servedCosts, withheldCosts) {
+  const pooled = [...servedCosts, ...withheldCosts];
+  const n = pooled.length;
+  const k = withheldCosts.length;
+  if (!k || k === n) return null;
+  const observed = Math.abs(mean(withheldCosts) - mean(servedCosts));
+  const total = pooled.reduce((sum, v) => sum + v, 0);
+  // Mean difference from the withheld-arm sum alone: the served sum is the
+  // complement, so one number decides the statistic.
+  const diffFrom = (withheldSum) =>
+    Math.abs(withheldSum / k - (total - withheldSum) / (n - k));
+
+  const choose = (a, b) => {
+    let out = 1;
+    for (let i = 1; i <= b; i += 1) out = (out * (a - b + i)) / i;
+    return out;
+  };
+
+  const tolerance = 1e-9;
+  if (choose(n, k) <= MAX_EXACT_PERMUTATIONS) {
+    let extreme = 0;
+    let count = 0;
+    const walk = (start, chosen, sum) => {
+      if (chosen === k) {
+        count += 1;
+        if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+        return;
+      }
+      for (let i = start; i <= n - (k - chosen); i += 1) walk(i + 1, chosen + 1, sum + pooled[i]);
+    };
+    walk(0, 0, 0);
+    return count ? extreme / count : null;
+  }
+
+  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
+  // the same p-value and a verdict cannot flicker between two audit runs.
+  let state = 0x9e3779b9;
+  const random = () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4_294_967_296;
+  };
+  let extreme = 0;
+  const order = [...pooled];
+  for (let round = 0; round < SAMPLED_PERMUTATIONS; round += 1) {
+    for (let i = order.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(random() * (i + 1));
+      [order[i], order[j]] = [order[j], order[i]];
+    }
+    let sum = 0;
+    for (let i = 0; i < k; i += 1) sum += order[i];
+    if (diffFrom(sum) >= observed - tolerance) extreme += 1;
+  }
+  return (extreme + 1) / (SAMPLED_PERMUTATIONS + 1);
+}
+
+/**
+ * The per-finding causal effect, shrunk, and whether it may be published.
+ *
+ * `raw` is `mean(withheld) - mean(served)`: POSITIVE means the session read the
+ * anchor more when the finding was withheld, which is the finding earning its
+ * place. `shrunk` is the number a reader should use.
+ *
+ * EMPIRICAL BAYES, and both halves of it come from the data. The prior mean is
+ * the population effect across findings; the weight `k` is the ratio of
+ * within-finding noise to between-finding spread, so a population where every
+ * finding behaves alike shrinks hard and one where they genuinely differ
+ * shrinks little. `SHRINKAGE_K` is the fallback when that spread cannot be
+ * estimated at all. Two observations therefore cannot post a wild score.
+ *
+ * PUBLICATION IS NOT THE SAME QUESTION as having an estimate. A row is
+ * published only if it clears the observation floor AND its permutation
+ * p-value survives Benjamini-Hochberg at q = 0.10 across every candidate row.
+ * Everything else gets `published: false` -- which is not a zero effect, and
+ * `looNote` says which of the two it is. An all-zero-cost population needs no
+ * separate guard: p is exactly 1 there, so nothing can publish anyway.
+ *
+ * NEVER POOLED ACROSS POLICY VERSIONS: rows are keyed on (findingKey, policy).
+ */
+export function effects(dir, options = {}) {
+  try {
+    // `obs` is accepted so `looNote` can read the logs once for both.
+    const obs = options.obs || observations(dir, options);
+    const groups = new Map();
+    for (const row of obs.rows) {
+      const id = JSON.stringify([row.findingKey, row.policy]);
+      if (!groups.has(id))
+        groups.set(id, { findingKey: row.findingKey, policy: row.policy, served: [], withheld: [] });
+      groups.get(id)[row.arm === 'withheld' ? 'withheld' : 'served'].push(row.cost);
+    }
+
+    const raws = [];
+    const withinVars = [];
+    for (const group of groups.values()) {
+      if (!group.served.length || !group.withheld.length) continue;
+      raws.push(mean(group.withheld) - mean(group.served));
+      withinVars.push(
+        variance(group.withheld) / group.withheld.length +
+          variance(group.served) / group.served.length
+      );
+    }
+    const prior = raws.length ? mean(raws) : 0;
+    const within = withinVars.length ? mean(withinVars) : 0;
+    const between = raws.length > 1 ? Math.max(0, variance(raws) - within) : 0;
+    const weight =
+      between > 0 && within > 0
+        ? Math.min(K_MAX, Math.max(K_MIN, within / between))
+        : SHRINKAGE_K;
+
+    const rows = [...groups.values()]
+      .map((group) => {
+        const served = group.served.length;
+        const withheld = group.withheld.length;
+        const both = served > 0 && withheld > 0;
+        const raw = both ? mean(group.withheld) - mean(group.served) : null;
+        const n = served + withheld;
+        const shrunk = raw === null ? null : (n * raw + weight * prior) / (n + weight);
+        const eligible = served >= MIN_SERVED && withheld >= MIN_WITHHELD;
+        return {
+          findingKey: group.findingKey,
+          policy: group.policy,
+          served,
+          withheld,
+          servedMean: mean(group.served),
+          withheldMean: mean(group.withheld),
+          raw,
+          shrunk,
+          p: eligible ? permutationP(group.served, group.withheld) : null,
+          published: false,
+        };
+      })
+      .sort((a, b) =>
+        a.findingKey < b.findingKey ? -1 : a.findingKey > b.findingKey ? 1 : a.policy < b.policy ? -1 : 1
+      );
+
+    // BENJAMINI-HOCHBERG at q = 0.10 over every row that cleared the floor.
+    // One finding tested in isolation would publish at p < 0.10; a hundred
+    // would publish ten false ones, and this module's whole claim is that its
+    // numbers can be quoted.
+    //
+    // THERE IS NO SEPARATE "WAS ANY READ COST OBSERVED" GATE HERE, and its
+    // absence is deliberate rather than an omission. One was written, and
+    // mutation testing showed it could not change a single verdict: if every
+    // observation has zero cost then both arm means are zero, the permutation
+    // statistic is zero for every relabelling, and p is exactly 1 -- which no
+    // BH threshold can pass. The guard was unfalsifiable, and an unfalsifiable
+    // guard is worse than none because it reads as protection nobody can test.
+    // `costObservations` survives as what it can honestly be: a DISCLOSURE, so
+    // `looNote` can say the read channel never fired instead of letting a
+    // reader take an arithmetic zero for a measured one.
+    const candidates = rows
+      .filter((row) => row.p !== null)
+      .sort((a, b) => a.p - b.p);
+    const m = candidates.length;
+    let cutoff = 0;
+    for (let i = 0; i < m; i += 1) {
+      if (candidates[i].p <= ((i + 1) / m) * FDR_Q) cutoff = i + 1;
+    }
+    for (let i = 0; i < cutoff; i += 1) candidates[i].published = true;
+
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * One or two lines for the audit, or nothing at all.
+ *
+ * THE REFUSAL IS THE PRODUCT HERE. On a machine with two injections in sixteen
+ * thousand events, the only honest output is that nothing is measurable yet,
+ * and this says so with the counts that make it checkable rather than printing
+ * a mean of nothing. It returns `null` when Layer 2 has not collected a single
+ * observation, so an idle experiment costs the reader no line at all -- the
+ * same standard `referenceNote` holds itself to.
+ */
+export function looNote(dir, options = {}) {
+  try {
+    const obs = options.obs || observations(dir, options);
+    const rows = effects(dir, { ...options, obs });
+    if (!obs.rows.length && !obs.withheldInjections) return null;
+
+    let graph = options.graph;
+    if (graph === undefined) {
+      try {
+        graph = load(dir);
+      } catch {
+        graph = null;
+      }
+    }
+    let exempt = 0;
+    if (graph?.nodes?.values) {
+      for (const node of graph.nodes.values()) {
+        if (node?.kind !== 'finding' || node.retired) continue;
+        if (node.pinned || node.origin === ORIGIN_HUMAN) exempt += 1;
+      }
+    }
+
+    const published = rows.filter((row) => row.published);
+    const head = published.length
+      ? `Per-finding causal value (leave-one-out): ${published.length} of ${rows.length} ` +
+        `findings show a verdict at q=${FDR_Q}` +
+        published
+          .slice(0, 3)
+          .map(
+            (row) =>
+              `; ${row.findingKey} saves ~${Math.round(row.shrunk)} tokens/touch ` +
+              `(${row.served} served, ${row.withheld} withheld, p=${row.p.toFixed(3)})`
+          )
+          .join('') +
+        '.'
+      : `Per-finding causal value (leave-one-out): NOT MEASURABLE YET -- ` +
+        `${obs.rows.length} attributable observations across ${rows.length} findings, ` +
+        `${obs.withheldInjections} withheld touches; the floor is ${MIN_SERVED} served ` +
+        `and ${MIN_WITHHELD} withheld per finding` +
+        (obs.costObservations ? '' : ', and no read cost has been observed in either arm') +
+        '. No effect is reported, which is not the same as an effect of zero.';
+
+    const caveats = [];
+    if (obs.unattributable)
+      caveats.push(
+        `${obs.unattributable} observations were unattributable (no joined tool outcome) and are in neither arm`
+      );
+    if (exempt)
+      caveats.push(
+        `${exempt} pinned or human-origin findings are exempt from withholding and get no causal score`
+      );
+    if (obs.policies.length > 1)
+      caveats.push(
+        `observations span ${obs.policies.length} serving-policy versions and are never pooled across them`
+      );
+    if (obs.windowed)
+      caveats.push('the read log was truncated, so downstream cost can understate');
+    return caveats.length ? `${head} ${caveats.join('; ')}.` : head;
+  } catch {
+    return null;
+  }
+}

--- a/plugin/hooks/lib/loo.mjs
+++ b/plugin/hooks/lib/loo.mjs
@@ -545,8 +545,22 @@ export function observations(dir, { events = null, evidence = null } = {}) {
   }
 }
 
-/** Enumerates or samples arm relabellings and returns a two-sided p-value. */
-function permutationP(servedCosts, withheldCosts) {
+/**
+ * Enumerates or samples arm relabellings and returns a two-sided p-value.
+ *
+ * EXPORTED so the cross-layer headline can be held to the same standard as the
+ * per-finding rows it summarises. `crosslayer.mjs` runs this over the two ARMS
+ * of shrunk effect estimates; the statistic, the enumerate-or-sample switch and the
+ * tolerance are therefore shared rather than reimplemented, and there is one
+ * place where "two-sided" is decided.
+ *
+ * `seed` exists for that caller. The default reproduces the fixed seed this
+ * function has always used, so Layer 2's own p-values are byte-identical; the
+ * cross-layer caller passes a seed DERIVED FROM ITS DATA, because a verdict
+ * printed to a human must not depend on `Math.random()` or on which module
+ * happened to call first.
+ */
+export function permutationP(servedCosts, withheldCosts, { seed = 0x9e3779b9 } = {}) {
   const pooled = [...servedCosts, ...withheldCosts];
   const n = pooled.length;
   const k = withheldCosts.length;
@@ -580,9 +594,10 @@ function permutationP(servedCosts, withheldCosts) {
     return count ? extreme / count : null;
   }
 
-  // Mulberry32 off a fixed seed: reproducible, so the same data always yields
-  // the same p-value and a verdict cannot flicker between two audit runs.
-  let state = 0x9e3779b9;
+  // Mulberry32 off the caller's seed: reproducible, so the same data always
+  // yields the same p-value and a verdict cannot flicker between two audit
+  // runs.
+  let state = seed | 0;
   const random = () => {
     state = (state + 0x6d2b79f5) | 0;
     let t = state;

--- a/plugin/hooks/lib/metrics.mjs
+++ b/plugin/hooks/lib/metrics.mjs
@@ -31,6 +31,7 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { createHash, randomBytes } from 'node:crypto';
+import { redact } from './redact.mjs';
 
 /**
  * Read per call, not once at module load.
@@ -517,6 +518,15 @@ export function readEvidence(dir) {
 }
 
 /**
+ * The captured-output budget, in characters.
+ *
+ * Small enough that a 3 MB test log cannot bloat the evidence log or a single
+ * injected claim, large enough to hold the stack trace or compiler diagnostic
+ * that makes a failure finding worth anything.
+ */
+const OUTPUT_MAX_BYTES = 4096;
+
+/**
  * Joins a post-tool result to the most recent matching injection.  The exact
  * tool-call id wins; clients that omit it fall back to episode + surface +
  * anchor, in timestamp order, and the report states the weaker join method.
@@ -545,10 +555,31 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
+  // text is INJECTED into model context and EXPORTED to markdown, so the
+  // boundary is the only place that can guarantee it: a second caller added
+  // later would otherwise have to remember, and the one that forgot would leak
+  // a secret into two more places than the terminal it came from. `undefined`
+  // rather than `''` when nothing was captured, so JSON.stringify omits the
+  // key entirely and an absent capture is distinguishable from an empty one.
+  const output =
+    outcome.output === undefined || outcome.output === null
+      ? undefined
+      : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
+  // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric
+  // code at all, and 0 is the success value -- defaulting to it would claim
+  // every unreported call exited cleanly, which is a fabricated observation
+  // rather than a missing one.
+  const exit = Number.isInteger(outcome.exit) ? outcome.exit : null;
+
   return record(dir, {
     kind: 'tool-outcome',
     ...outcome,
     anchor,
+    // AFTER the spread, so a caller cannot smuggle raw text past the boundary
+    // by setting the field itself.
+    output,
+    exit,
     injectionId: injection?.injectionId || null,
     findingIds: injection?.findingIds || [],
     joinMethod,

--- a/plugin/hooks/lib/metrics.mjs
+++ b/plugin/hooks/lib/metrics.mjs
@@ -555,6 +555,22 @@ export function recordToolOutcome(dir, outcome) {
       : 'episode-anchor'
     : 'none';
 
+  // FAILURES ONLY, and that is a deliberate override of the original plan.
+  // The plan predates MCP tool names reaching this path, so it never
+  // considered that a SUCCESSFUL `smart_read` would deposit 4 KB of file
+  // content into the evidence log on every call -- the log would grow with
+  // file text and the privacy surface would be every file the session opened.
+  //
+  // Nothing downstream loses anything. A failure claim quotes the error text;
+  // a "this command works" claim needs only the fact that it worked, which
+  // `success` and `exit` already carry. So the stored text narrows to text
+  // that is already an error message.
+  //
+  // GATED ON `success === true`, not on `!== false`: an outcome that never
+  // said whether it worked is unclassified, not successful, and dropping its
+  // text would lose exactly the failures a client too terse to report status
+  // produces.
+  const captureOutput = outcome.success !== true;
   // REDACTED AND CAPPED HERE, not at the call site. A claim built from this
   // text is INJECTED into model context and EXPORTED to markdown, so the
   // boundary is the only place that can guarantee it: a second caller added
@@ -563,7 +579,7 @@ export function recordToolOutcome(dir, outcome) {
   // rather than `''` when nothing was captured, so JSON.stringify omits the
   // key entirely and an absent capture is distinguishable from an empty one.
   const output =
-    outcome.output === undefined || outcome.output === null
+    !captureOutput || outcome.output === undefined || outcome.output === null
       ? undefined
       : redact(String(outcome.output), { max: OUTPUT_MAX_BYTES });
   // NULL RATHER THAN 0 when nothing is reported. Most clients supply no numeric

--- a/plugin/hooks/lib/metrics.mjs
+++ b/plugin/hooks/lib/metrics.mjs
@@ -663,6 +663,89 @@ export function isFixtureAnchor(anchor) {
  * Fixture anchors are excluded from both.
  */
 /**
+ * Re-reads grouped by anchor -- the one place that decides what "wasteful" means.
+ *
+ * `rereadWaste` needed only the totals, so the grouping lived inside it and the
+ * per-anchor rows were thrown away. `derive.mjs`'s churn detector needs the
+ * rows, and re-deriving them there would put TWO definitions of "a repeat read
+ * of an unchanged file is waste" in the codebase, free to drift apart -- the
+ * exact divergence `npm run sync:hooks` exists to prevent between hooks-core and
+ * its generated copies. So the grouping lives here and both consumers read it.
+ *
+ * A re-read is only a re-read INSIDE ONE SESSION: grouping is keyed on
+ * session + canonical anchor, and rows are then merged per anchor so a file
+ * re-read across three sessions reports as one anchor with the sum of its
+ * repeats rather than three rows the caller has to add up. Merging cannot move
+ * the totals -- a sum of sums -- which is what makes it safe for `rereadWaste`.
+ *
+ * `tokens` is the WASTEFUL token count, not the total: it is the only one of the
+ * three that names something recoverable, and a row whose headline number
+ * included legitimate re-reads would overstate exactly the way the first
+ * version of this measurement did.
+ *
+ * @returns {Array<{anchor: string, repeats: number, wasteful: number,
+ *   tokens: number, legitimate: number, legitimateTokens: number,
+ *   undecidable: number, undecidableTokens: number}>} descending by `wasteful`,
+ *   then by `repeats`.
+ */
+export function rereadsByAnchor(events = [], { includeFixtures = false } = {}) {
+  const groups = new Map();
+  for (const e of events) {
+    if (!e || e.kind !== 'read' || !e.anchor) continue;
+    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
+    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(e);
+  }
+
+  const rows = new Map();
+  for (const list of groups.values()) {
+    if (list.length < 2) continue;
+    list.sort((a, b) => (a.at || 0) - (b.at || 0));
+
+    const anchorKey = canonicalKeyish(list[0].anchor);
+    let row = rows.get(anchorKey);
+    if (!row) {
+      row = {
+        anchor: list[0].anchor,
+        repeats: 0,
+        wasteful: 0,
+        tokens: 0,
+        legitimate: 0,
+        legitimateTokens: 0,
+        undecidable: 0,
+        undecidableTokens: 0,
+      };
+      rows.set(anchorKey, row);
+    }
+
+    for (let i = 1; i < list.length; i++) {
+      const prev = list[i - 1];
+      const cur = list[i];
+      const tokens = cur.tokens || 0;
+      row.repeats += 1;
+      // THE JUDGEMENT, in one place. A repeat read of a file that CHANGED is
+      // correct behaviour, not waste; a read written before fingerprints
+      // existed cannot be judged at all and says so.
+      if (!prev.fp || !cur.fp) {
+        row.undecidable += 1;
+        row.undecidableTokens += tokens;
+      } else if (prev.fp === cur.fp) {
+        row.wasteful += 1;
+        row.tokens += tokens;
+      } else {
+        row.legitimate += 1;
+        row.legitimateTokens += tokens;
+      }
+    }
+  }
+
+  return [...rows.values()].sort(
+    (a, b) => b.wasteful - a.wasteful || b.repeats - a.repeats
+  );
+}
+
+/**
  * Re-read waste, split into what is KNOWN and what is not.
  *
  * The question is narrow on purpose: how often does one session read the same
@@ -677,6 +760,9 @@ export function isFixtureAnchor(anchor) {
  * `undecidable` is reported rather than hidden. Reads written before the
  * fingerprint existed cannot be classified, and a measurement that quietly
  * counted them either way would be inventing its own answer.
+ *
+ * The aggregate fields are UNCHANGED -- `balanceSheet` reads them -- and are now
+ * a fold over `rereadsByAnchor`'s rows. `worst` is purely additive.
  */
 export function rereadWaste(
   dir,
@@ -685,14 +771,7 @@ export function rereadWaste(
   // excludes by design, making the real path untestable.
   { events = readMetrics(dir), includeFixtures = false } = {}
 ) {
-  const groups = new Map();
-  for (const e of events) {
-    if (e.kind !== 'read' || !e.anchor) continue;
-    if (!includeFixtures && isFixtureAnchor(e.anchor)) continue;
-    const key = `${e.sessionId || ''}|${canonicalKeyish(e.anchor)}`;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key).push(e);
-  }
+  const rows = rereadsByAnchor(events, { includeFixtures });
 
   const out = {
     repeats: 0,
@@ -704,29 +783,21 @@ export function rereadWaste(
     undecidableTokens: 0,
   };
 
-  for (const list of groups.values()) {
-    if (list.length < 2) continue;
-    list.sort((a, b) => (a.at || 0) - (b.at || 0));
-    for (let i = 1; i < list.length; i++) {
-      const prev = list[i - 1];
-      const cur = list[i];
-      const tokens = cur.tokens || 0;
-      out.repeats += 1;
-      if (!prev.fp || !cur.fp) {
-        out.undecidable += 1;
-        out.undecidableTokens += tokens;
-      } else if (prev.fp === cur.fp) {
-        out.wasteful += 1;
-        out.wastefulTokens += tokens;
-      } else {
-        out.legitimate += 1;
-        out.legitimateTokens += tokens;
-      }
-    }
+  for (const row of rows) {
+    out.repeats += row.repeats;
+    out.wasteful += row.wasteful;
+    out.wastefulTokens += row.tokens;
+    out.legitimate += row.legitimate;
+    out.legitimateTokens += row.legitimateTokens;
+    out.undecidable += row.undecidable;
+    out.undecidableTokens += row.undecidableTokens;
   }
 
   const decided = out.wasteful + out.legitimate;
   out.coverage = out.repeats ? decided / out.repeats : null;
+  // The offenders behind the totals, bounded: a report needs the handful worth
+  // acting on, not one row per file the session touched twice.
+  out.worst = rows.slice(0, 10);
   return out;
 }
 

--- a/plugin/hooks/lib/recall.mjs
+++ b/plugin/hooks/lib/recall.mjs
@@ -1,0 +1,390 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/recall.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Does retrieval FIND a finding, or does it only find what it was told where
+ * to look?
+ *
+ * `docs/WIKI_GRAPH.md` says embeddings get added "if measurement shows real
+ * recall loss". Nothing measured recall, so the no-embeddings stance was
+ * unfalsifiable -- a claim with no observation that could contradict it. This
+ * module is the observation.
+ *
+ * ---------------------------------------------------------------------------
+ * THE TAUTOLOGY THIS DELIBERATELY DOES NOT SHIP, AND WHY IT IS RECORDED HERE
+ * ---------------------------------------------------------------------------
+ * The obvious probe -- for each finding, take its anchors and ask whether
+ * `findingsFor` returns it from each -- CANNOT FAIL. `findingsFor(graph, A)`
+ * walks `derived_from` edges backwards into A, and the edge F -> A is the very
+ * thing that makes A an anchor of F. So F is in the result by CONSTRUCTION, not
+ * by retrieval quality, for every graph, forever. Its rate is 1.0 always, and a
+ * permanent 1.0 published as a recall rate reads to a human as "retrieval is
+ * perfect, embeddings unnecessary" -- one unfalsifiable claim swapped for
+ * another, leaning the one direction a measurement of this project by this
+ * project must never lean.
+ *
+ * That check is still worth running -- if it ever fails, traversal is broken
+ * rather than merely lossy -- so it is kept, and reported as `integrity` with
+ * its own `what` string saying it is not a recall rate. It is NEVER `rate`.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT IS MEASURED INSTEAD: LEAVE-ONE-EDGE-OUT
+ * ---------------------------------------------------------------------------
+ * For each active finding F and each anchor A of F, delete the edge F -> A and
+ * ask whether touching A would STILL surface F. Two independent arms, both of
+ * which can genuinely miss, which is what makes this a measurement:
+ *
+ *   Arm A -- TRAVERSAL FROM THE NEIGHBOURHOOD. Run the real `findingsFor` over
+ *   the edge-deleted graph from A itself and from A's `contains` parents. This
+ *   hits only when F has some OTHER structural route in: a second anchor on the
+ *   same file, or an anchor on a sibling symbol under the same parent. A's
+ *   `contains` children need no separate call because `findingsFor` expands
+ *   them itself -- calling the parent therefore covers every sibling, which is
+ *   why the neighbour list is `[A, ...parents(A)]` and not a hop-counted
+ *   frontier. The REAL primitive is used rather than an equivalent inlined
+ *   here, because a probe that reimplements the thing it measures drifts from
+ *   it and then measures itself.
+ *
+ *   Arm B -- BM25 FROM THE ANCHOR'S OWN KEY. Rank the whole active corpus with
+ *   `lexical.rank`, querying with A's key -- the file path or symbol name the
+ *   user actually touched -- and hit if F comes back inside `limit`.
+ *
+ * WHY ARM B IS NOT QUERIED WITH THE FINDING'S OWN CLAIM. The plan's literal
+ * form was "the finding's claim terms against the rest of the corpus", and both
+ * readings of it are degenerate. Querying F's claim against a corpus that
+ * INCLUDES F is the tautology again: BM25 scores a document against its own
+ * text, so F wins its own query every time. Querying F's claim against a corpus
+ * that EXCLUDES F cannot return F at all, so a "hit" would mean some DIFFERENT
+ * finding matched -- that is redundancy of storage, not recall of F, and it
+ * would score a graph better for holding duplicates. The anchor's key is the
+ * one query text that is available offline, is not derived from F, and matches
+ * the production question: a session touches a file, and the only lexical
+ * handle on it is its own path. It misses exactly when a finding's claim never
+ * names the code it is about, which is the recall gap embeddings are supposed
+ * to close.
+ *
+ * ---------------------------------------------------------------------------
+ * REFUSALS -- four, and each costs this project its own good news
+ * ---------------------------------------------------------------------------
+ *  1. TOO FEW OBSERVATIONS -> `rate: null` with a reason. See `MIN_PROBED`.
+ *  2. A CORPUS NO LARGER THAN THE RETRIEVAL LIMIT -> `rate: null`. Arm B is
+ *     recall@`limit`, and below the limit NO FINDING IS EVER CUT FOR BUDGET:
+ *     every document scoring above zero is returned, so the arm measures
+ *     whether a token matched, which is a strictly weaker bar than the one
+ *     production applies when `forTouch` fills a token budget from a ranked
+ *     list. A probe more permissive than the system it measures can only
+ *     overstate recall, so the rate is withheld in that band and the counts are
+ *     published instead. It bites between `MIN_PROBED` and `limit` findings --
+ *     on this machine's project graph, whose one finding had both anchor edges
+ *     "recovered" that way, the observation-count refusal fires first.
+ *  3. NO ANCHOR NODE -> the pair is UNPROBEABLE, not a miss. Reported and
+ *     excluded from the denominator; see `probeEdge`.
+ *  4. STRICT AGGREGATION -> a finding counts as retrieved only if EVERY one of
+ *     its probeable anchor edges is recoverable. A finding reachable from one
+ *     anchor and lost from another is a miss, with the losing anchor named.
+ *     This biases the rate DOWN, which is the safe direction here.
+ *
+ * FAILS OPEN. It runs on a report path; a graph it cannot read must cost a
+ * section, not the report.
+ */
+
+import { load, findingsFor } from './wiki.mjs';
+import { rank } from './lexical.mjs';
+
+/**
+ * Distinct findings that must be probeable before a RATE is published at all.
+ *
+ * NOT AN EFFECT-SIZE CONVENTION -- it is a resolution argument. A proportion
+ * over n observations has a resolution of 1/n, so below ten findings the
+ * published figure moves in steps coarser than ten percentage points, and the
+ * two extremes a small graph actually produces (`1.0` and `0.0`) are the two a
+ * reader is most likely to mistake for a finding about retrieval. At n = 10 and
+ * zero misses the exact binomial 95% upper bound on the true miss rate is still
+ * 1 - 0.05^(1/10) = 0.26, so even a clean sweep here bounds recall loss only
+ * below about a quarter -- which is why the refusal reason says what the number
+ * would and would not have supported rather than just naming the floor.
+ *
+ * THE FLOOR IS ON DISTINCT FINDINGS, NOT ANCHOR EDGES. Two anchors of one
+ * finding are two edges of the same claim, not two independent observations;
+ * counting them would let a single multi-anchored finding unlock a rate.
+ */
+export const MIN_PROBED = 10;
+
+/**
+ * The most findings probed in one call.
+ *
+ * Each probed anchor edge costs a graph-sized edge filter plus one or two real
+ * `findingsFor` walks plus one BM25 pass over the corpus, and this runs on the
+ * on-demand report path. The cap is deterministic (findings sorted by key) and
+ * `truncated` says when it bit, so a large graph gets a smaller, honestly
+ * labelled sample rather than a slow report.
+ */
+export const MAX_FINDINGS = 200;
+
+/** Active findings only. A retired claim is withdrawn; recalling it is not a win. */
+function activeFindings(graph) {
+  return [...graph.nodes.values()]
+    .filter((node) => node && node.kind === 'finding' && !node.retired)
+    .sort((a, b) => String(a.key || '').localeCompare(String(b.key || '')));
+}
+
+/** The `contains` parents of every node, indexed once for the whole probe. */
+function parentIndex(graph) {
+  const parents = new Map();
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contains') continue;
+    const list = parents.get(edge.to);
+    if (list) list.push(edge.from);
+    else parents.set(edge.to, [edge.from]);
+  }
+  return parents;
+}
+
+/** The anchors of one finding: the targets of its own `derived_from` edges. */
+function anchorsOf(graph, findingId) {
+  const out = new Set();
+  for (const edge of graph.edges) {
+    if (edge.edge === 'derived_from' && edge.from === findingId) out.add(edge.to);
+  }
+  return [...out];
+}
+
+/**
+ * The graph minus exactly one anchor edge.
+ *
+ * `nodes` is shared rather than copied: nothing here mutates it, and a
+ * 2,600-node Map copied once per anchor edge is the difference between a probe
+ * and a stall.
+ */
+function withoutAnchorEdge(graph, findingId, anchorId) {
+  return {
+    nodes: graph.nodes,
+    edges: graph.edges.filter(
+      (edge) =>
+        !(
+          edge.edge === 'derived_from' &&
+          edge.from === findingId &&
+          edge.to === anchorId
+        )
+    ),
+  };
+}
+
+/**
+ * One anchor edge, hidden, then asked after. Returns `recovered` with the arm
+ * that found it, or a reason -- and `probeable: false` when the question could
+ * not be put at all.
+ */
+function probeEdge(graph, parents, finding, anchorId, corpus, limit) {
+  const hidden = withoutAnchorEdge(graph, finding.id, anchorId);
+
+  // Arm A. `findingsFor` expands `contains` children itself, so the parent call
+  // covers every sibling of the anchor.
+  const neighbours = [anchorId, ...(parents.get(anchorId) || [])];
+  for (const neighbour of neighbours) {
+    const got = findingsFor(hidden, neighbour, { limit });
+    if (got.some((node) => node.id === finding.id)) {
+      return { recovered: true, arm: 'traversal', anchorId };
+    }
+  }
+
+  // Arm B needs a query, and the query is the anchor's own key. A dangling
+  // anchor edge -- an edge whose target node was never indexed, which
+  // `expand.promote` produces -- leaves nothing to query with. That is a
+  // question that could not be asked, NOT an observed miss: scoring it a miss
+  // would manufacture a recall loss out of a graph-integrity defect.
+  const anchor = graph.nodes.get(anchorId);
+  const key = anchor && typeof anchor.key === 'string' ? anchor.key : '';
+  if (!key) {
+    return {
+      recovered: false,
+      probeable: false,
+      anchorId,
+      reason: `anchor ${anchorId} has no node in the graph, so there is no anchor key to query BM25 with`,
+    };
+  }
+
+  const hits = rank(key, corpus, { limit });
+  if (hits.some((hit) => hit.finding && hit.finding.id === finding.id)) {
+    return { recovered: true, arm: 'lexical', anchorId };
+  }
+
+  return {
+    recovered: false,
+    probeable: true,
+    anchorId,
+    reason: `no neighbouring anchor reaches it and BM25 over ${key} does not rank it in the top ${limit}`,
+  };
+}
+
+/**
+ * The probe. An OFFLINE measurement over the graph as it stands -- it reads,
+ * ranks and traverses, and writes nothing.
+ */
+export function recallProbe(
+  dir,
+  {
+    limit = 20,
+    graph = null,
+    minProbed = MIN_PROBED,
+    maxFindings = MAX_FINDINGS,
+  } = {}
+) {
+  const refuse = (reason) => ({
+    basis: 'offline probe over the current graph',
+    probed: 0,
+    retrieved: 0,
+    rate: null,
+    reason,
+    misses: [],
+    unprobeable: [],
+  });
+
+  let g;
+  try {
+    g = graph || load(dir);
+  } catch {
+    return refuse('the graph could not be read, so recall was not measured.');
+  }
+
+  try {
+    const all = activeFindings(g);
+    const truncated = all.length > maxFindings;
+    const findings = truncated ? all.slice(0, maxFindings) : all;
+    const parents = parentIndex(g);
+    // The corpus BM25 ranks over is the ACTIVE graph, uncapped: the sample is
+    // which findings are probed, not what they compete against. Every reported
+    // figure below reads `corpus.length` rather than `all.length`, so the
+    // published size IS the ranking corpus rather than a parallel claim about
+    // it. The distinction is not pedantry: a mutation that shrank the ranking
+    // corpus to the probed sample -- making retrieval easier, in this project's
+    // favour -- SURVIVED the first mutation run precisely because the reported
+    // number came from the other variable and could not move.
+    const corpus = all;
+
+    const misses = [];
+    const unprobeable = [];
+    const integrityFailures = [];
+    let probed = 0;
+    let retrieved = 0;
+    let integrityOk = 0;
+    let probedEdges = 0;
+    let recoveredEdges = 0;
+    const byArm = { traversal: 0, lexical: 0 };
+
+    for (const finding of findings) {
+      const anchors = anchorsOf(g, finding.id);
+
+      // INTEGRITY, run on the UNTOUCHED graph: the by-construction check. Its
+      // only honest use is as a smoke test, and it is reported as one.
+      if (!anchors.length) {
+        integrityFailures.push({
+          key: finding.key,
+          reason:
+            'active finding with no anchor -- writeHarvested refuses to create one',
+        });
+      } else if (
+        anchors.every((anchorId) =>
+          findingsFor(g, anchorId, { limit }).some((node) => node.id === finding.id)
+        )
+      ) {
+        integrityOk += 1;
+      } else {
+        integrityFailures.push({
+          key: finding.key,
+          reason: `not returned by findingsFor from one of its own anchors at limit ${limit}`,
+        });
+      }
+
+      // An unanchored finding is a definite miss, not an unaskable question:
+      // nothing traverses to it and there is no anchor key to query from, so
+      // the anchor-driven path that serves findings on a file touch can never
+      // surface it. Only an explicit wiki_query naming its own terms would.
+      if (!anchors.length) {
+        probed += 1;
+        misses.push({
+          key: finding.key,
+          reason:
+            'no anchor: nothing traverses to it and there is no anchor key to query with, so only an explicit wiki_query of its own terms would surface it',
+        });
+        continue;
+      }
+
+      const results = anchors.map((anchorId) =>
+        probeEdge(g, parents, finding, anchorId, corpus, limit)
+      );
+      const askable = results.filter((result) => result.probeable !== false);
+      probedEdges += askable.length;
+      recoveredEdges += askable.filter((result) => result.recovered).length;
+      for (const result of askable) {
+        if (result.recovered) byArm[result.arm] += 1;
+      }
+
+      if (!askable.length) {
+        unprobeable.push({ key: finding.key, reason: results[0].reason });
+        continue;
+      }
+
+      probed += 1;
+      const lost = askable.filter((result) => !result.recovered);
+      if (!lost.length) retrieved += 1;
+      else misses.push({ key: finding.key, reason: lost[0].reason });
+    }
+
+    const integrity = {
+      what:
+        'BY CONSTRUCTION: a finding is returned by findingsFor from its own anchor because that edge is what makes it an anchor. Expected 1 for every graph. NOT a recall rate.',
+      probed: findings.length,
+      retrieved: integrityOk,
+      rate: findings.length ? integrityOk / findings.length : null,
+      ok: integrityFailures.length === 0,
+      failures: integrityFailures,
+    };
+
+    // Arm B is recall@`limit`. Over a corpus of at most `limit` findings nothing
+    // is ever cut for budget, so the arm asks only whether a token matched --
+    // weaker than the bar production applies under a token budget, and a probe
+    // more permissive than the system it measures can only overstate recall.
+    const discriminating = corpus.length > limit;
+
+    const common = {
+      basis: 'offline probe over the current graph',
+      probed,
+      retrieved,
+      misses,
+      unprobeable,
+      probedEdges,
+      recoveredEdges,
+      byArm,
+      corpus: corpus.length,
+      discriminating,
+      truncated,
+      minProbed,
+      integrity,
+    };
+
+    if (probed < minProbed) {
+      return {
+        ...common,
+        rate: null,
+        reason:
+          probed === 0
+            ? `no probeable finding: ${unprobeable.length} of ${findings.length} active finding(s) have no anchor node to query from, so recall was not measured. No rate is reported, which is not the same as a rate of zero.`
+            : `${probed} probeable finding(s), below the floor of ${minProbed}: a proportion over ${probed} has a resolution of ${Math.round(
+                100 / probed
+              )} percentage points, so no rate is published. ${retrieved} of ${probed} were recovered without their own anchor edge, which is a count and not a rate.`,
+      };
+    }
+
+    if (!discriminating) {
+      return {
+        ...common,
+        rate: null,
+        reason: `the active corpus holds ${corpus.length} finding(s) and the retrieval limit is ${limit}, so nothing is ever cut for budget and the lexical arm asks only whether a token matched -- a weaker bar than production applies. No rate is published off a probe more permissive than the system it measures; ${retrieved} of ${probed} were recovered, which is a count and not a rate.`,
+      };
+    }
+
+    return { ...common, rate: retrieved / probed, reason: null };
+  } catch {
+    return refuse('the probe failed, so recall was not measured.');
+  }
+}

--- a/plugin/hooks/lib/redact.mjs
+++ b/plugin/hooks/lib/redact.mjs
@@ -1,0 +1,30 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/redact.mjs. Regenerate with `npm run sync:hooks`.
+// hooks-core/redact.mjs
+/**
+ * Redaction for anything derived from captured output.
+ *
+ * WHY THIS IS MANDATORY RATHER THAN PRUDENT. derive.mjs builds claims out of
+ * command stderr. A claim is INJECTED into model context and EXPORTED to
+ * markdown, so a secret that reaches a claim reaches two more places than the
+ * terminal it came from. Pattern matching is imperfect and that is stated in the
+ * spec, but "imperfect" beats "absent" by a wide margin here.
+ */
+
+const PATTERNS = [
+  // Bearer / API-key shaped tokens.
+  [/\b(bearer\s+)[A-Za-z0-9._~+/-]{12,}/gi, '$1[redacted]'],
+  [/\b(sk|pk|ghp|gho|github_pat|xox[baprs])[-_][A-Za-z0-9._-]{10,}/gi, '[redacted]'],
+  // KEY=value where the key name suggests a secret.
+  [/\b([A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|APIKEY|API_KEY|PRIVATE_KEY|CREDENTIAL)[A-Z0-9_]*)\s*[=:]\s*\S+/g, '$1=[redacted]'],
+  // Credentials inside a URL.
+  [/\b([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+):[^\s@]+@/gi, '$1:[redacted]@'],
+  // PEM blocks.
+  [/-----BEGIN[^-]*PRIVATE KEY-----[\s\S]*?-----END[^-]*PRIVATE KEY-----/g, '[redacted key]'],
+];
+
+export function redact(text, { max = 400 } = {}) {
+  let out = String(text ?? '');
+  for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
+}

--- a/plugin/hooks/lib/redact.mjs
+++ b/plugin/hooks/lib/redact.mjs
@@ -24,7 +24,21 @@ const PATTERNS = [
 ];
 
 export function redact(text, { max = 400 } = {}) {
+  // `?? ''` matters even though String(null)/String(undefined) never throw:
+  // without it a missing value becomes the literal 4-11 character string
+  // "null"/"undefined" -- a garbage claim that silently reaches the graph
+  // and model context instead of surfacing as an error.
   let out = String(text ?? '');
   for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  // Redact BEFORE truncating, never the reverse. Several patterns above rely
+  // on a minimum-length quantifier (e.g. `{10,}`, `{12,}`) plus a prefix.
+  // Truncating first can cut a match down to fewer characters than that
+  // quantifier requires, so the shortened fragment no longer satisfies the
+  // pattern and a live partial secret would pass through in cleartext. By
+  // redacting the full, untruncated string first, every pattern always sees
+  // the complete secret and removes it before any character budget is
+  // spent; the cap below can then only ever cut into already-redacted text
+  // (a label, or the "[redacted]" placeholder itself), never into raw
+  // secret bytes.
   return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
 }

--- a/plugin/hooks/lib/transcript.mjs
+++ b/plugin/hooks/lib/transcript.mjs
@@ -19,9 +19,11 @@
  */
 
 import {
-  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, unlinkSync,
+  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync,
+  unlinkSync, openSync, readSync, closeSync,
 } from 'node:fs';
 import { join } from 'node:path';
+import { redact } from './redact.mjs';
 
 /** Where a project's transcripts live, under the graph it belongs to. */
 export const transcriptDir = (dir) => join(dir, 'transcripts');
@@ -210,4 +212,204 @@ export function readArchive(dir, sessionId) {
   } catch {
     return [];
   }
+}
+
+/**
+ * How much of a transcript's TAIL is scanned for failed tool results.
+ *
+ * A transcript is the largest file this project reads: the three real ones on
+ * the measuring machine are 5.8 MB, 22 MB and 45 MB. `archive()` above already
+ * reads the whole thing once at Stop, so an unbounded second pass doubles the
+ * most expensive read on the session-end path for evidence that is, by
+ * construction, mostly old. The tail is the right half to keep for the same
+ * reason `buildFeedbackDigest` keeps the end: what a session learned is
+ * concentrated where the work went wrong, which is later rather than sooner.
+ */
+const FAILED_SCAN_BYTES = () =>
+  Number(process.env.TOKEN_OPTIMIZER_TRANSCRIPT_SCAN_BYTES) || 8 * 1024 * 1024;
+
+/** Failed results kept, most recent first. The pairing detector needs a handful. */
+const FAILED_MAX = 50;
+
+/** Same 4 KB cap `recordToolOutcome` applies to `output`, for the same reason. */
+const FAILED_OUTPUT_MAX = 4096;
+
+/**
+ * The same 120-character truncation `recordToolOutcome` applies to `anchor`.
+ *
+ * ONE COMMAND MUST PRODUCE ONE KEY FROM EITHER SOURCE. A `tool-outcome` stores
+ * the command as `String(tool_input.command).slice(0, 120)`, and `attemptKey`
+ * reads up to three non-flag tokens off whatever it is handed. A long first
+ * token -- a quoted grep pattern, an absolute Windows path, a heredoc -- is cut
+ * by that cap INSIDE those three tokens, so the untruncated transcript copy of
+ * the same command lands in a DIFFERENT group. Measured against one real
+ * session's own evidence: 266 commands present in both sources, and truncating
+ * here made 266 of 266 keys agree where the untruncated text agreed on only
+ * 240.
+ *
+ * WHAT THAT ACTUALLY BUYS, stated precisely rather than generously. `derive`
+ * refuses to build a claim out of a command at or over the cap at all (see
+ * `quotable` there), so agreement on a TRUNCATED key never produces a finding
+ * on its own. It buys two things that still matter: a transcript failure lands
+ * in the same run as the event outcomes of the same command, so the
+ * nearest-preceding-failure rule sees the real sequence rather than a sparse
+ * one; and the no-call-id fallback in `derive`'s deduplication compares command
+ * TEXT against an already-truncated anchor, which cannot match unless this side
+ * is truncated identically.
+ */
+const ANCHOR_MAX = 120;
+
+/**
+ * A tool result that reports a command that RAN and exited non-zero.
+ *
+ * A POSITIVE ALLOWLIST, and the measurement is why. Claude Code sets
+ * `is_error: true` on every kind of unhappy tool result, and across three real
+ * transcripts 214 of them fell into four shapes:
+ *
+ *   83  `Exit code N` + stderr    -- a command ran and failed. THIS ONE.
+ *   109 hook and policy denials   -- overwhelmingly THIS optimizer's own
+ *                                    PreToolUse text ("Recursive shell searches
+ *                                    return unbounded output. Call the
+ *                                    token-optimizer MCP tool smart_grep
+ *                                    instead"), plus `Remove-Item on system
+ *                                    path` blocks.
+ *   18  `<tool_use_error>...`     -- protocol errors: `String to replace not
+ *                                    found`, `File has not been read yet`,
+ *                                    `Blocked: ...`.
+ *   4   a person declined the call.
+ *
+ * Only the first shape is a command failing. In every other shape THE COMMAND
+ * NEVER RAN, so "`X` failed with: ..." would be a false claim about X, and a
+ * later success would pair with a failure that never happened. The 109 are the
+ * dangerous ones: ingesting them would have this tool derive findings from its
+ * own advice, at 0.9 confidence, and serve them back as observations about the
+ * project -- a self-referential loop that also inflates its own finding count.
+ * That is the measurement-bias class this plan tracks, and a denylist would
+ * have let every future denial string through by default.
+ */
+const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
+
+/** Reads at most `bytes` from the END of a file, without loading the rest. */
+function readTail(path, bytes) {
+  let fd;
+  try {
+    const size = statSync(path).size;
+    const length = Math.min(size, bytes);
+    if (!length) return '';
+    fd = openSync(path, 'r');
+    const buffer = Buffer.allocUnsafe(length);
+    readSync(fd, buffer, 0, length, size - length);
+    const text = buffer.toString('utf8');
+    // A tail almost never starts on a line boundary, and half a JSON object is
+    // not a parse failure worth reporting -- it is a partial record. Drop it.
+    return length < size ? text.slice(text.indexOf('\n') + 1) : text;
+  } catch {
+    return '';
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+}
+
+/**
+ * The failed COMMAND results a transcript holds, which no hook event carries.
+ *
+ * WHY THIS READER EXISTS. Claude Code never fires PostToolUse for a failed tool
+ * call: a deliberately failing command produced no event at all, and 2,238 of
+ * 2,238 live `tool-outcome` events on the measuring machine carry
+ * `success: true`. So `derive.mjs`'s two strongest detectors -- command
+ * failed-then-succeeded at 0.90 and test/build red-to-green at 0.85 -- have no
+ * input whatsoever on the primary client, while working normally on the ten
+ * adapter clients. The failures exist; they exist only here.
+ *
+ * WHY NOT THE ARCHIVE, which the plan for this reader assumed. `readTurns`
+ * DROPS tool results by design -- that is where whole file contents would enter
+ * the record -- so `readArchive` returns no failure, ever, and an extractor over
+ * archived turns would find nothing however well it was written. Making the
+ * archive carry them would also push command stderr into `buildFeedbackDigest`,
+ * which is the one code path in this project that sends anything to a model
+ * endpoint. So this reads the transcript and STORES NOTHING NEW: read-only, no
+ * capture path, no new event kind, and no widening of what leaves the machine.
+ *
+ * REDACTED HERE, at this boundary, exactly as `recordToolOutcome` redacts
+ * `output`. Transcript text has never passed a redaction boundary -- that one
+ * never saw it -- and everything returned from here is destined for a claim that
+ * is injected into model context and exported to markdown.
+ *
+ * @returns {Array<{command: string, output: string, exit: number|null,
+ *   at: number, toolCallId: string|null}>} in transcript order, so a caller can
+ *   sort it beside `tool-outcome` events without re-ordering.
+ */
+export function failedResultsFromTranscript(transcriptPath, options = {}) {
+  const { max = FAILED_MAX, scanBytes = FAILED_SCAN_BYTES() } = options || {};
+  if (!transcriptPath) return [];
+  const text = readTail(transcriptPath, scanBytes);
+  if (!text) return [];
+
+  // tool_use_id -> the command that was attempted. The join is EXACT and it is
+  // the only one available: the result block carries no command of its own, and
+  // the id is the same string `episodeMeta` reads into `toolCallId`, so the same
+  // key also deduplicates against events on clients that do report failures.
+  const commands = new Map();
+  const failures = [];
+
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const message = entry.message || entry;
+    const role = message.role || entry.type;
+    const content = message.content;
+    if (!Array.isArray(content)) continue;
+
+    if (role === 'assistant') {
+      for (const block of content) {
+        if (!block || block.type !== 'tool_use' || !block.id) continue;
+        const command = block.input?.command;
+        if (typeof command !== 'string' || !command.trim()) continue;
+        commands.set(String(block.id), command.slice(0, ANCHOR_MAX));
+      }
+      continue;
+    }
+
+    if (role !== 'user') continue;
+    for (const block of content) {
+      if (!block || block.type !== 'tool_result' || block.is_error !== true) continue;
+      // Only a STRING result can be an exit-code report; every failed Claude
+      // Code result observed was one, and a structured body is a shape this
+      // classifier has not measured, so it is refused rather than guessed at.
+      if (typeof block.content !== 'string') continue;
+      const match = EXIT_CODE_RESULT.exec(block.content);
+      if (!match) continue;
+      const command = commands.get(String(block.tool_use_id || ''));
+      // No command means no claim. The result says something failed; without
+      // the text of what failed there is nothing to say about it, and nothing
+      // to group it with.
+      if (!command) continue;
+      failures.push({
+        command,
+        // The exit line itself is stripped: `exit` carries it structurally, and
+        // leaving it in makes every failure claim read "failed with: Exit code 1".
+        output: redact(block.content.slice(match[0].length).trim(), {
+          max: FAILED_OUTPUT_MAX,
+        }),
+        exit: Number(match[1]),
+        at: Date.parse(entry.timestamp || '') || 0,
+        toolCallId: block.tool_use_id ? String(block.tool_use_id) : null,
+      });
+    }
+  }
+
+  // The MOST RECENT `max`, keeping chronological order. A session that failed
+  // two hundred times teaches its last lessons, not its first.
+  return failures.slice(-max);
 }

--- a/plugin/hooks/lib/usage.mjs
+++ b/plugin/hooks/lib/usage.mjs
@@ -42,7 +42,7 @@
  * was referenced" and "nothing could be measured" are different answers and
  * this module gives different answers for them.
  */
-import { readMetrics } from './metrics.mjs';
+import { readMetrics, readTruncation } from './metrics.mjs';
 
 /**
  * The events that name a finding, and it is ONE kind, not the two the plan
@@ -129,17 +129,30 @@ export function classify(dir, { events = null } = {}) {
   try {
     const all = inTimeOrder(events || readMetrics(dir));
 
-    // Every reference, keyed on the finding it names. Only references carrying
-    // a session id are usable -- see `unscopedReferences` in `referenceRate`
-    // for the ones this drops and why they are counted rather than credited.
+    // Every reference, keyed on the finding it names and on nothing else.
+    //
+    // NOT SCOPED BY SESSION, and that is a deliberate reversal. Scoping needs
+    // the query's `sessionId`, which `wiki_query` takes as an OPTIONAL input
+    // the model has to volunteer (`options.sessionId ?? null`) -- so the
+    // numerator depended on the model choosing to identify itself, and an
+    // unverifiable model-supplied id is not evidence. Plan 1 settled that for
+    // the `answers` edge and it settles it here: stop depending on the field
+    // rather than hope for cooperation. The finding key is the specific part
+    // anyway; a key is a graph identity, not a guess.
+    //
+    // THE COST, disclosed here and in `referenceNote` because a reader of the
+    // number has to see it: TWO CONCURRENT SESSIONS ON ONE REPOSITORY CAN
+    // CROSS-ATTRIBUTE. Session A's injection of K plus session B's later query
+    // for K reads as a reference. Nothing in the log can separate them once the
+    // session id is gone, so the exposure is real and is stated rather than
+    // priced.
     const references = new Map();
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       const key = referencedKey(event);
-      const session = sessionOf(event);
-      if (!key || !session) continue;
+      if (!key) continue;
       if (!references.has(key)) references.set(key, []);
-      references.get(key).push({ at: event.at || 0, session });
+      references.get(key).push(event.at || 0);
     }
 
     // Which injections the existing outcome join could attribute. An outcome
@@ -170,9 +183,8 @@ export function classify(dir, { events = null } = {}) {
       const injectionId = event.injectionId ? String(event.injectionId) : null;
       const at = event.at || 0;
       const session = sessionOf(event);
-      // STRICTLY AFTER. A query that PRECEDED the injection is the model
-      // asking on its own initiative; crediting it would let the metric take
-      // the credit for a lookup it had nothing to do with.
+      // STRICTLY AFTER here too: activity that predates the injection is not
+      // an opportunity to have used it.
       const followed = (times) => times.some((t) => t > at);
       const continued =
         (injectionId && attributed.has(injectionId)) ||
@@ -181,9 +193,11 @@ export function classify(dir, { events = null } = {}) {
       for (const raw of keys) {
         const findingKey = String(raw);
         const hits = references.get(findingKey) || [];
-        const referenced = session
-          ? hits.some((hit) => hit.session === session && hit.at > at)
-          : false;
+        // TIME ORDER IS THE ONLY REMAINING GUARD, so it carries the whole
+        // weight of the attribution: a query that PRECEDED the injection is
+        // the model asking on its own initiative, and crediting it would let
+        // the metric take the credit for a lookup it had nothing to do with.
+        const referenced = hits.some((hitAt) => hitAt > at);
         rows.push({
           findingKey,
           injectionId,
@@ -204,9 +218,27 @@ export function classify(dir, { events = null } = {}) {
 /**
  * The rate, with everything needed to tell a real 0 from an absent one.
  *
- * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
- * `unattributable` and `unscopedReferences` are reported beside it, never
- * inside it.
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown` and
+ * `unattributable` are reported beside it, never inside it.
+ *
+ * `windowed` SAYS WHETHER THE DENOMINATOR CAN UNDERSTATE, and it is not
+ * decoration. `readMetrics` reads a 2 MB / 5,000-event TAIL of the firehose,
+ * and injections are rare enough on a real project to age out of it: measured
+ * on this repository, both `inject` events sit at lines 502 and 883 of 6,871
+ * and have scrolled away behind ~6,000 later `read` and `tool-outcome` rows,
+ * so the windowed denominator is 0 where the whole-file truth is 1.
+ *
+ * IT IS REPORTED RATHER THAN FIXED, deliberately. `inject` already gets
+ * unwindowed access through `BALANCE_KINDS` / `EVIDENCE_KINDS`, but `query`
+ * does not -- and reading only the INJECTION arm unwindowed would be worse
+ * than the windowing: every old injection would enter the denominator with no
+ * chance of a matching query in the window and score `not-referenced`,
+ * manufacturing a pessimistic rate out of the asymmetry. Making the query arm
+ * unwindowed means adding `query` to `EVIDENCE_KINDS`, which two other
+ * consumers read, and this project's own standard says a shared-classifier
+ * change needs a per-consumer verdict comparison. So the honest move is to
+ * publish the flag: a caller that needs the unwindowed truth passes its own
+ * `events`, which is exactly what the live measurement in the task report did.
  */
 export function referenceRate(dir, { events = null } = {}) {
   const empty = {
@@ -218,10 +250,15 @@ export function referenceRate(dir, { events = null } = {}) {
     unattributable: 0,
     unattributableWithInjectedToolCall: 0,
     referenceEvents: 0,
-    unscopedReferences: 0,
+    windowed: false,
   };
   try {
     const all = events || readMetrics(dir);
+    // OUT OF BAND, and read IMMEDIATELY after the only read that sets it --
+    // `readTruncation` reports on the last `readAll`, so anything between the
+    // two could overwrite it. False when the caller supplied its own events:
+    // the read was theirs and its bounds are not ours to claim.
+    const truncation = events ? null : readTruncation();
     const rows = classify(dir, { events: all });
     const count = (label) => rows.filter((row) => row.label === label).length;
     const referenced = count('referenced');
@@ -231,17 +268,17 @@ export function referenceRate(dir, { events = null } = {}) {
     // Usable reference events in the window: the numerator's producer. If this
     // is zero the channel never fired, and a 0% rate would be measuring the
     // absence of a producer rather than the uselessness of findings.
+    //
+    // NO SESSION REQUIREMENT, matching the attribution above. The former
+    // `unscopedReferences` counted queries dropped for want of a session id;
+    // nothing is dropped for that reason any more, so the field is GONE rather
+    // than kept at a permanent zero that a later reader would misread as
+    // evidence the loss had been fixed.
     let referenceEvents = 0;
-    let unscopedReferences = 0;
     for (const event of all) {
       if (!REFERENCE_KINDS.has(event.kind)) continue;
       if (!referencedKey(event)) continue;
-      if (sessionOf(event)) referenceEvents += 1;
-      // Names a finding but cannot be scoped to one injection. `sessionId` is
-      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
-      // is the expected loss rather than an edge case -- counted here so it is
-      // visible instead of silently deflating the numerator.
-      else unscopedReferences += 1;
+      referenceEvents += 1;
     }
 
     // The tool calls that DID receive findings, keyed the way
@@ -292,7 +329,7 @@ export function referenceRate(dir, { events = null } = {}) {
       unattributable,
       unattributableWithInjectedToolCall,
       referenceEvents,
-      unscopedReferences,
+      windowed: Boolean(truncation?.byBytes || truncation?.byEvents),
     };
   } catch {
     return empty;
@@ -300,11 +337,18 @@ export function referenceRate(dir, { events = null } = {}) {
 }
 
 /**
- * One line for the audit, or nothing at all.
+ * One or two lines for the audit, or nothing at all.
  *
  * Says which of the three things is true -- a measured rate, a live channel
  * with no opportunities yet, or no channel at all -- rather than printing a
  * figure and letting the reader assume the first.
+ *
+ * AND IT CARRIES THE CAVEATS, because this is the only place a human meets the
+ * number. A rate attributed on (finding key, time order) can cross-attribute
+ * between two concurrent sessions on one repository, and a windowed read can
+ * understate the denominator. Both are stated beside the figure they qualify.
+ * Putting them only in a task report would be publishing a clean number and
+ * filing the asterisk somewhere nobody quoting it will look.
  */
 export function referenceNote(dir, { events = null } = {}) {
   const r = referenceRate(dir, { events });
@@ -317,6 +361,11 @@ export function referenceNote(dir, { events = null } = {}) {
   }
   return (
     `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
-    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded. ` +
+    'Matched on finding key and time order, so concurrent sessions on this ' +
+    'repository can cross-attribute' +
+    (r.windowed
+      ? '; and the event log was truncated, so the denominator can understate.'
+      : '.')
   );
 }

--- a/plugin/hooks/lib/usage.mjs
+++ b/plugin/hooks/lib/usage.mjs
@@ -1,0 +1,322 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/usage.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * LAYER 1 -- did the model actually go back and use what we injected?
+ *
+ * The cheap behavioural label. One question, answered from the event log alone:
+ * after we put a finding in front of the model, did the model later ASK FOR
+ * THAT FINDING BY NAME?
+ *
+ * WHY EXPLICIT REFERENCE, AND NOT READ-SUPPRESSION. Read-suppression -- "the
+ * file was not re-read, so the finding must have helped" -- is Layer 2's
+ * estimand, measured causally by withholding a finding and comparing. Layer 1
+ * exists to be calibrated AGAINST that. If both layers derived from
+ * suppression, the calibration would compare two spellings of one quantity,
+ * report a strong correlation, and mean nothing. So Layer 1 is deliberately
+ * built on a signal Layer 2 does not touch: an explicit `query` naming the
+ * finding key.
+ *
+ * WHAT THIS DOES NOT DO. It does not invent a join. `recordToolOutcome`
+ * already joins each post-tool result back to the injection that preceded it,
+ * recording `injectionId`, `findingIds` and a `joinMethod` of `tool-call-id`,
+ * `episode-anchor` or `none` -- preferring an exact tool-call id, which is
+ * strictly better evidence than the `(sessionId, findingKey)` approximation an
+ * earlier draft of this plan proposed. This module consumes that join and adds
+ * none of its own. `inject.mjs` needed no change: it has written `findingIds`
+ * at every call site all along.
+ *
+ * WHAT `unknown` IS FOR, and it is the whole reason this file is careful. An
+ * injection whose session simply stopped afterwards is not a miss. Nothing
+ * happened, so nothing can be concluded, and counting it against the finding
+ * would make the metric read worse the more often sessions end -- a number
+ * that moves with session length rather than with usefulness. `unknown` is
+ * therefore EXCLUDED from the denominator rather than scored zero, and
+ * outcomes the join could not attribute at all are reported as
+ * `unattributable` rather than folded into either arm.
+ *
+ * AND WHY THE RATE CAN BE `null`. This project has already shipped two metrics
+ * whose only producer was their own test suite. A rate of 0% that actually
+ * means "no data" is worse than a refusal, because it is a number and numbers
+ * get quoted. So `rate` is null unless there is a denominator AND the
+ * reference channel produced at least one usable event in the window. "Nothing
+ * was referenced" and "nothing could be measured" are different answers and
+ * this module gives different answers for them.
+ */
+import { readMetrics } from './metrics.mjs';
+
+/**
+ * The events that name a finding, and it is ONE kind, not the two the plan
+ * assumed.
+ *
+ * The brief said "a later `query` or `expand` event". Checked against the code
+ * and against every metrics log on this machine, `expand` does not qualify and
+ * cannot be made to:
+ *
+ *   - `recordExpansion` writes `{ ref, tool, shape, asked, sessionId }`. `ref`
+ *     is a TRUNCATION CAPTURE id (a 16-hex digest of captured tool output),
+ *     not a finding key, and `asked` is free text naming a section of that
+ *     output. Neither is a graph key, and no code path ever puts one there.
+ *   - measured: 64 live `expand` events exist on this machine and all 64 carry
+ *     `sessionId: null`, so they could not be scoped to an injection even if
+ *     they did name one.
+ *
+ * Keying the classifier on `expand` would therefore have added a branch that
+ * can never fire -- a metric with no producer, which is the exact defect this
+ * whole effort exists to close. So it is excluded, deliberately and with the
+ * measurement recorded, rather than included for symmetry with the brief.
+ */
+const REFERENCE_KINDS = new Set(['query']);
+
+/**
+ * What counts as the session having CONTINUED past the injection.
+ *
+ * The distinction between `not-referenced` and `unknown` rests entirely on
+ * this, so the set is explicit rather than "any later event". These are the
+ * kinds a tool call produces: if one of them follows the injection in the same
+ * session, the model had the opportunity to ask and did not. If none does, the
+ * session ended and there was no opportunity.
+ *
+ * `inject` is in the set because a later injection means a later tool call
+ * happened. `forecast`, `mcp-client` and `mcp-tool` are NOT: they are written
+ * by session bookkeeping rather than by the model doing something, and
+ * treating them as opportunity would convert `unknown` rows into misses on
+ * bookkeeping alone.
+ */
+const ACTIVITY_KINDS = new Set([
+  'tool-outcome',
+  'read',
+  'query',
+  'expand',
+  'substitute',
+  'inject',
+]);
+
+/** A usable session id: a non-empty string. `null == null` is not a match. */
+const sessionOf = (event) => {
+  const id = event?.sessionId;
+  return typeof id === 'string' && id ? id : null;
+};
+
+/** The finding key a reference event names, or null if it names none. */
+const referencedKey = (event) => {
+  const key = event?.key;
+  return typeof key === 'string' && key ? key : null;
+};
+
+/** Ordering by the caller's timestamp, with log order breaking ties. */
+function inTimeOrder(events) {
+  return events
+    .map((event, index) => ({ event, index }))
+    .sort(
+      (a, b) =>
+        (a.event.at || 0) - (b.event.at || 0) || a.index - b.index
+    )
+    .map((row) => row.event);
+}
+
+/**
+ * One row per (injection, finding) pair, labelled.
+ *
+ * Per injection rather than per finding: the same finding injected twice is two
+ * separate opportunities, and collapsing them would let one reference excuse
+ * every later injection of that key.
+ *
+ * FAILS OPEN. A malformed log yields an empty classification, never a throw:
+ * this runs on report paths that must not break a tool call.
+ */
+export function classify(dir, { events = null } = {}) {
+  let rows = [];
+  try {
+    const all = inTimeOrder(events || readMetrics(dir));
+
+    // Every reference, keyed on the finding it names. Only references carrying
+    // a session id are usable -- see `unscopedReferences` in `referenceRate`
+    // for the ones this drops and why they are counted rather than credited.
+    const references = new Map();
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      const key = referencedKey(event);
+      const session = sessionOf(event);
+      if (!key || !session) continue;
+      if (!references.has(key)) references.set(key, []);
+      references.get(key).push({ at: event.at || 0, session });
+    }
+
+    // Which injections the existing outcome join could attribute. An outcome
+    // carrying our injectionId is proof the tool call completed, which is
+    // opportunity even when the session id is missing from the log.
+    const attributed = new Set();
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome') continue;
+      if (event.joinMethod === 'none' || !event.injectionId) continue;
+      attributed.add(String(event.injectionId));
+    }
+
+    // Activity per session, so "did anything follow?" is one lookup rather
+    // than a scan per injection.
+    const activity = new Map();
+    for (const event of all) {
+      if (!ACTIVITY_KINDS.has(event.kind)) continue;
+      const session = sessionOf(event);
+      if (!session) continue;
+      if (!activity.has(session)) activity.set(session, []);
+      activity.get(session).push(event.at || 0);
+    }
+
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      const keys = Array.isArray(event.findingIds) ? event.findingIds : [];
+      if (!keys.length) continue;
+      const injectionId = event.injectionId ? String(event.injectionId) : null;
+      const at = event.at || 0;
+      const session = sessionOf(event);
+      // STRICTLY AFTER. A query that PRECEDED the injection is the model
+      // asking on its own initiative; crediting it would let the metric take
+      // the credit for a lookup it had nothing to do with.
+      const followed = (times) => times.some((t) => t > at);
+      const continued =
+        (injectionId && attributed.has(injectionId)) ||
+        (session ? followed(activity.get(session) || []) : false);
+
+      for (const raw of keys) {
+        const findingKey = String(raw);
+        const hits = references.get(findingKey) || [];
+        const referenced = session
+          ? hits.some((hit) => hit.session === session && hit.at > at)
+          : false;
+        rows.push({
+          findingKey,
+          injectionId,
+          label: referenced
+            ? 'referenced'
+            : continued
+              ? 'not-referenced'
+              : 'unknown',
+        });
+      }
+    }
+  } catch {
+    rows = [];
+  }
+  return rows;
+}
+
+/**
+ * The rate, with everything needed to tell a real 0 from an absent one.
+ *
+ * `denominator` counts only `referenced` + `not-referenced`. `unknown`,
+ * `unattributable` and `unscopedReferences` are reported beside it, never
+ * inside it.
+ */
+export function referenceRate(dir, { events = null } = {}) {
+  const empty = {
+    referenced: 0,
+    notReferenced: 0,
+    unknown: 0,
+    denominator: 0,
+    rate: null,
+    unattributable: 0,
+    unattributableWithInjectedToolCall: 0,
+    referenceEvents: 0,
+    unscopedReferences: 0,
+  };
+  try {
+    const all = events || readMetrics(dir);
+    const rows = classify(dir, { events: all });
+    const count = (label) => rows.filter((row) => row.label === label).length;
+    const referenced = count('referenced');
+    const notReferenced = count('not-referenced');
+    const denominator = referenced + notReferenced;
+
+    // Usable reference events in the window: the numerator's producer. If this
+    // is zero the channel never fired, and a 0% rate would be measuring the
+    // absence of a producer rather than the uselessness of findings.
+    let referenceEvents = 0;
+    let unscopedReferences = 0;
+    for (const event of all) {
+      if (!REFERENCE_KINDS.has(event.kind)) continue;
+      if (!referencedKey(event)) continue;
+      if (sessionOf(event)) referenceEvents += 1;
+      // Names a finding but cannot be scoped to one injection. `sessionId` is
+      // an OPTIONAL input the caller of wiki_query has to volunteer, so this
+      // is the expected loss rather than an edge case -- counted here so it is
+      // visible instead of silently deflating the numerator.
+      else unscopedReferences += 1;
+    }
+
+    // The tool calls that DID receive findings, keyed the way
+    // `recordToolOutcome` keys its own primary join: the tool-call id. An
+    // unattributable outcome for one of these is a join that FAILED. An
+    // unattributable outcome for any other tool call had nothing to join to.
+    //
+    // KEYED ON THE TOOL CALL, NOT THE EPISODE, and the first draft of this
+    // got it wrong in a way worth recording because it is the exact
+    // measurement-bias class this plan hunts. `episodeId` equals the SESSION
+    // id, so "unattributable outcomes in an episode that had an injection"
+    // scored all 2,559 tool calls of a session in which ONE injection
+    // happened. It would have published 2,559 join failures where the true
+    // number is zero -- correct code, lying number, and biased pessimistic
+    // rather than flattering, which is no better.
+    const injectedToolCalls = new Set();
+    for (const event of all) {
+      if (event.kind !== 'inject') continue;
+      if (!Array.isArray(event.findingIds) || !event.findingIds.length)
+        continue;
+      if (event.toolCallId) injectedToolCalls.add(String(event.toolCallId));
+    }
+    let unattributable = 0;
+    let unattributableWithInjectedToolCall = 0;
+    for (const event of all) {
+      if (event.kind !== 'tool-outcome' || event.joinMethod !== 'none')
+        continue;
+      unattributable += 1;
+      // BOTH FIGURES, because the raw one alone lies in the pessimistic
+      // direction. Measured on this machine: 2,991 of 2,992 live outcomes
+      // report `joinMethod: 'none'`, and every one of them because NO
+      // INJECTION EXISTED for that tool call -- the graph holds one finding.
+      // Quoting only the raw count would read as a join that fails 99.97% of
+      // the time, which is a different and false claim.
+      if (event.toolCallId && injectedToolCalls.has(String(event.toolCallId)))
+        unattributableWithInjectedToolCall += 1;
+    }
+
+    return {
+      referenced,
+      notReferenced,
+      unknown: count('unknown'),
+      denominator,
+      rate:
+        denominator > 0 && referenceEvents > 0
+          ? referenced / denominator
+          : null,
+      unattributable,
+      unattributableWithInjectedToolCall,
+      referenceEvents,
+      unscopedReferences,
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/**
+ * One line for the audit, or nothing at all.
+ *
+ * Says which of the three things is true -- a measured rate, a live channel
+ * with no opportunities yet, or no channel at all -- rather than printing a
+ * figure and letting the reader assume the first.
+ */
+export function referenceNote(dir, { events = null } = {}) {
+  const r = referenceRate(dir, { events });
+  if (!r.denominator && !r.unknown && !r.referenceEvents) return null;
+  if (r.rate == null) {
+    const why = !r.referenceEvents
+      ? 'no finding was ever queried by key in this window'
+      : `no injection had a chance to be referenced yet (${r.unknown} unknown)`;
+    return `Injected findings referenced later: not measurable -- ${why}.`;
+  }
+  return (
+    `Injected findings referenced later: ${r.referenced}/${r.denominator} ` +
+    `(${Math.round(r.rate * 100)}%); ${r.unknown} unknown, excluded.`
+  );
+}

--- a/src/server/cache-tool.ts
+++ b/src/server/cache-tool.ts
@@ -136,32 +136,6 @@ export async function cacheAudit(): Promise<{
   });
   lines.push('', `Keep-warm: ${decision.action} -- ${decision.reason}`);
 
-  // AND THE DECISION IS RECORDED, which is what closes the loop.
-  //
-  // `recordRefresh` and `recordRefreshOutcome` had no call site anywhere, so
-  // `tripwire` could never reach the ten outcomes it demands before it is
-  // allowed an opinion -- it returned "only 0/10 refreshes observed" for the
-  // life of the project, and `keepWarmDecision` could never learn that its
-  // modelled hit rate was wrong. A backstop that cannot reach its own threshold
-  // is not a backstop.
-  //
-  // WHAT IS RECORDED IS THE ADVICE, and the ledger means exactly that: this
-  // tool advises, the user acts. `scoreOutstandingRefreshes` then reads the
-  // event log to see whether a turn actually arrived inside the window this
-  // advice predicted, so what accumulates is "was the recommendation right",
-  // which is the question the tripwire and the decision both need answered.
-  if (decision.action === 'refresh') {
-    try {
-      mods.keepwarm.recordRefresh(dir, {
-        tier: decision.tier,
-        prefixTokens: health?.prefixTokens,
-        expectedValue: decision.expectedValue,
-      });
-    } catch {
-      /* the ledger is evidence, never a reason to fail the report */
-    }
-  }
-
   const trip = mods.keepwarm.tripwire(dir);
   if (trip.tripped) lines.push(`  tripwire: ${trip.reason}`);
   else if (trip.observed > 0) {

--- a/src/tools/analytics/get-optimization-report.ts
+++ b/src/tools/analytics/get-optimization-report.ts
@@ -251,7 +251,9 @@ function renderGraph(
         ? `${num(l1.referenced)}/${num(
             l1.denominator
           )} injected findings referenced later${
-            l1.rate === null ? ', no rate published' : ` (${pct(l1.rate * 100)})`
+            l1.rate === null
+              ? ', no rate published'
+              : ` (${pct(l1.rate * 100)})`
           }`
         : 'unavailable'
     }`

--- a/src/tools/analytics/get-optimization-report.ts
+++ b/src/tools/analytics/get-optimization-report.ts
@@ -17,6 +17,11 @@ import {
 } from '../../analytics/savings-classification.js';
 import { priceTokenUsage } from '../../analytics/provider-pricing.js';
 import type { AnalyticsEntry } from '../../analytics/analytics-types.js';
+import path from 'path';
+import { dirname } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const here = dirname(fileURLToPath(import.meta.url));
 
 export const GET_OPTIMIZATION_REPORT_TOOL_DEFINITION = {
   name: 'get_optimization_report',
@@ -134,6 +139,140 @@ function renderTable(
   return `${title}\n${header}\n${lines.join('\n')}\n${extra}`;
 }
 
+/** Resolves hooks-core relative to the built output, which lives in dist/tools/analytics. */
+function coreUrl(name: string): string {
+  return pathToFileURL(path.join(here, '..', '..', '..', 'hooks-core', name))
+    .href;
+}
+
+interface GraphPricing {
+  dollars: (n: number) => number | null;
+  money: (a: number | null) => string;
+  priceNote: () => string;
+}
+
+/**
+ * The graph's own balance sheet, or nothing.
+ *
+ * FAILS OPEN, like every other hooks-core bridge in this codebase: the savings
+ * report is what a user runs when something already looks wrong, so a missing
+ * graph module must cost them a section rather than the report.
+ */
+async function graphSection(): Promise<{
+  sheet: Record<string, unknown>;
+  lines: string[];
+} | null> {
+  try {
+    const [cross, wiki, pricing] = await Promise.all([
+      import(coreUrl('crosslayer.mjs')),
+      import(coreUrl('wiki.mjs')),
+      import(coreUrl('pricing.mjs')),
+    ]);
+    const dir = wiki.wikiDir(process.cwd());
+    const sheet = cross.graphBalanceSheet(dir);
+    return { sheet, lines: renderGraph(sheet, pricing as GraphPricing) };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The graph block, with CURRENCY ON EXACTLY ONE LINE.
+ *
+ * The rule is the project's own: a dollar figure may appear beside a MEASURED
+ * COUNTERFACTUAL -- a substitution whose control arm's cost was recorded -- and
+ * nowhere else. The holdout estimate, the consolidation ratio and the
+ * calibration verdict are estimates, and pricing an estimate makes a headline
+ * saving larger for free, which is exactly the measurement-bias class this work
+ * exists to close. Each of those lines says "estimate" and carries no currency,
+ * which a test checks by reading the rendered text rather than by trusting this
+ * comment.
+ */
+function renderGraph(
+  sheet: Record<string, any>,
+  pricing: GraphPricing
+): string[] {
+  const lines: string[] = ['▸ Graph balance sheet'];
+  const mc = sheet.measuredCounterfactual || {};
+  const avoided = Number(mc.tokensAvoidedNet || 0);
+  // The ONE priced line: a substitution whose control arm was measured.
+  lines.push(
+    `  measured counterfactual : ${num(avoided)} tokens avoided net over ${num(
+      Number(mc.substitutions || 0)
+    )} substitution(s), ${num(
+      Number(mc.withheld || 0)
+    )} withheld; ${pricing.money(pricing.dollars(avoided))}`
+  );
+
+  const ec = sheet.estimatedCausal || {};
+  lines.push(
+    `  estimated causal        : ${num(
+      Number(ec.tokensAvoided || 0)
+    )} tokens from ${num(Number(ec.treated || 0))} treated and ${num(
+      Number(ec.holdouts || 0)
+    )} holdout injection(s) -- estimate, deliberately not priced`
+  );
+
+  const con = sheet.consolidation;
+  lines.push(
+    con && con.withDerivedCost
+      ? `  consolidation           : ${num(con.withDerivedCost)} of ${num(
+          con.findings
+        )} finding(s) carry a derivation cost, ${(
+          con.aggregate?.ratio || 0
+        ).toFixed(
+          1
+        )}x cost-to-derive over cost-to-carry -- estimate, deliberately not priced`
+      : '  consolidation           : no finding carries a derivation cost yet -- estimate, deliberately not priced'
+  );
+
+  const waste = sheet.waste || {};
+  // THE UNDECIDABLE COUNT TRAVELS WITH THE FIGURE. `rereadWaste` splits repeats
+  // into confirmed waste, legitimate re-reads of a CHANGED file, and repeats
+  // written before fingerprints existed -- and its own docstring says the third
+  // group is reported rather than hidden, because a reader has to know the
+  // classification is incomplete. Printing only the confirmed number is
+  // conservative, but silently conservative is still a number without its
+  // error bar.
+  lines.push(
+    `  re-read waste           : ${num(
+      Number(waste.wastefulTokens || 0)
+    )} tokens over ${num(
+      Number(waste.wasteful || 0)
+    )} unchanged repeat read(s), ${num(
+      Number(waste.undecidable || 0)
+    )} repeat(s) unclassifiable`
+  );
+
+  const l1 = sheet.layer1;
+  lines.push(
+    `  Layer 1 (reference)     : ${
+      l1
+        ? `${num(l1.referenced)}/${num(
+            l1.denominator
+          )} injected findings referenced later${
+            l1.rate === null ? ', no rate published' : ` (${pct(l1.rate * 100)})`
+          }`
+        : 'unavailable'
+    }`
+  );
+  const l2 = sheet.layer2;
+  lines.push(
+    `  Layer 2 (suppression)   : ${
+      l2
+        ? `${num(l2.observations)} observation(s), ${num(
+            l2.published
+          )} published effect(s)`
+        : 'unavailable'
+    }`
+  );
+  lines.push(
+    `  calibration             : ${sheet.calibration?.verdict || 'unavailable'}`
+  );
+  lines.push(`  ${pricing.priceNote()}`);
+  return lines;
+}
+
 export function getOptimizationReportTool(analyticsManager: AnalyticsManager) {
   return async (args: {
     startDate?: string;
@@ -195,6 +334,7 @@ export function getOptimizationReportTool(analyticsManager: AnalyticsManager) {
         : `${args.startDate || 'all time'} → ${args.endDate || 'present'}`;
 
       const cost = directPrice(scopedEntries);
+      const graph = await graphSection();
 
       const formatted = [
         '╔══ Token Optimizer — Verified Savings Report ══╗',
@@ -214,6 +354,7 @@ export function getOptimizationReportTool(analyticsManager: AnalyticsManager) {
         renderTable('▸ By action (tool)', byAction, topN),
         renderTable('▸ By hook phase', hook.byHook, topN),
         renderTable('▸ By MCP server', server.byServer, topN),
+        ...(graph ? graph.lines : []),
       ].join('\n');
 
       return JSON.stringify(
@@ -235,6 +376,7 @@ export function getOptimizationReportTool(analyticsManager: AnalyticsManager) {
             legacyPolicy:
               'rows without versioned comparable-baseline provenance are excluded',
           },
+          graph: graph ? graph.sheet : null,
           byAction,
           byHook: hook.byHook,
           byServer: server.byServer,

--- a/src/tools/analytics/get-optimization-report.ts
+++ b/src/tools/analytics/get-optimization-report.ts
@@ -269,6 +269,24 @@ function renderGraph(
   lines.push(
     `  calibration             : ${sheet.calibration?.verdict || 'unavailable'}`
   );
+
+  // AN OFFLINE PROBE, AND THE LINE SAYS SO. It observes nothing a session did:
+  // it deletes each anchor edge in memory and re-runs traversal and BM25 over
+  // the graph as it stands. `rate` is deliberately absent more often than
+  // present -- the by-construction check that always returns 1.0 is reported as
+  // `integrity` and is never printed as a recall rate.
+  const recall = sheet.recall;
+  lines.push(
+    `  recall (offline probe)  : ${
+      recall
+        ? recall.rate === null
+          ? `no rate -- ${recall.reason}`
+          : `${pct(recall.rate * 100)} of ${num(
+              recall.probed
+            )} finding(s) recovered without their own anchor edge -- offline probe over the current graph`
+        : 'unavailable'
+    }`
+  );
   lines.push(`  ${pricing.priceNote()}`);
   return lines;
 }

--- a/tests/hooks/audit.test.mjs
+++ b/tests/hooks/audit.test.mjs
@@ -463,3 +463,16 @@ describe('the standing-context panel', () => {
     );
   });
 });
+
+describe('the local derivation metric has a reader', () => {
+  test('keeps evidence, candidates, and stored findings distinct in the audit', () => {
+    expect(renderAudit(dir, []).text).not.toMatch(/Local derivation:/);
+
+    record(dir, { kind: 'derive', observations: 7, candidates: 3, written: 2 });
+    record(dir, { kind: 'derive', observations: 5, candidates: 2, written: 1 });
+
+    expect(renderAudit(dir, []).text).toMatch(
+      /Local derivation: 5 candidate\(s\) from 12 observation\(s\); 3 stored across 2 Stop run\(s\)\./
+    );
+  });
+});

--- a/tests/hooks/cache.test.mjs
+++ b/tests/hooks/cache.test.mjs
@@ -51,7 +51,6 @@ beforeEach(() => {
   workspace = mkdtempSync(join(tmpdir(), 'cache-'));
   dir = join(workspace, '.token-optimizer', 'wiki');
 });
-
 afterEach(() => rmSync(workspace, { recursive: true, force: true }));
 
 /** A transcript in the client's own format. */

--- a/tests/hooks/cache.test.mjs
+++ b/tests/hooks/cache.test.mjs
@@ -32,11 +32,12 @@ import {
   shouldKeepWarm,
   recordRefresh,
   recordRefreshOutcome,
-  scoreOutstandingRefreshes,
-  observedHitRate,
-  OBSERVATION_FLOOR,
+  scoreRefreshes,
+  observedHitRates,
   TIERS,
   TRIPWIRE_MIN,
+  OBSERVATION_FLOOR,
+  TURN_GAP_MS,
 } from '../../hooks-core/keepwarm.mjs';
 import { record, readMetrics, readBalance } from '../../hooks-core/metrics.mjs';
 import { policyText } from '../../hooks-core/adapter.mjs';
@@ -317,6 +318,308 @@ describe('the tripwire stays underneath the expected-value decision', () => {
     }
     expect(tripwire(dir).tripped).toBe(false);
     expect(tripwire(dir).realised).toBeGreaterThan(0);
+  });
+});
+
+describe('a refresh finds out whether it bought anything', () => {
+  /** A refresh recorded at a chosen moment, as an issuer would record it. */
+  const issue = (at, extra = {}) =>
+    recordRefresh(dir, {
+      tier: '5m',
+      prefixTokens: 20_000,
+      expectedValue: 1,
+      sessionId: 's1',
+      at,
+      ...extra,
+    });
+
+  /** A turn, through the real producer, so both logs see it. */
+  const turn = (at, sessionId = 's1') => record(dir, { kind: 'read', at, sessionId });
+
+  const outcomes = () =>
+    readBalance(dir).filter((e) => e.kind === 'keepwarm' && e.action === 'outcome');
+
+  test('a turn arriving before expiry is recorded as a hit', () => {
+    const at = Date.now() - 10 * 60 * 1000;
+    issue(at);
+    turn(at + 60_000);
+
+    const summary = scoreRefreshes(dir);
+    expect([summary.scored, summary.hits]).toEqual([1, 1]);
+    expect(outcomes().map((o) => [o.hit, o.tier])).toEqual([[true, '5m']]);
+  });
+
+  test('a window that closed with no turn in it is a real miss', () => {
+    const at = Date.now() - 10 * 60 * 1000;
+    issue(at);
+    // Six minutes later: the 5m entry had already lapsed, so this arrival is
+    // evidence the window closed unused rather than evidence of a hit.
+    turn(at + 6 * 60 * 1000);
+
+    const summary = scoreRefreshes(dir);
+    expect([summary.scored, summary.hits]).toEqual([1, 0]);
+    expect(outcomes().map((o) => o.hit)).toEqual([false]);
+  });
+
+  test('a hit is not scored before its window closes, or hits would be counted first', () => {
+    // RIGHT-CENSORING, which is the way this measurement flatters itself.
+    // Scoring a hit the moment it arrives while a miss has to wait out the
+    // whole TTL means that at any instant the recorded hits are complete and
+    // the recorded misses are not.
+    const at = Date.now() - 60_000;
+    issue(at);
+    turn(at + 10_000);
+
+    const summary = scoreRefreshes(dir);
+    expect([summary.scored, summary.pending]).toEqual([0, 1]);
+    expect(outcomes()).toEqual([]);
+  });
+
+  test('a refresh with no arrival evidence records nothing rather than a miss', () => {
+    const at = Date.now() - 10 * 60 * 1000;
+    issue(at);
+
+    // The firehose window has moved past the period an answer would need. An
+    // absent signal is not a miss: counting it as one biases every rate
+    // downward and would eventually switch keep-warm off on no evidence.
+    const summary = scoreRefreshes(dir, {
+      arrivals: () => [{ kind: 'read', at: Date.now(), sessionId: 's1' }],
+    });
+    expect([summary.scored, summary.uncovered]).toEqual([0, 1]);
+    expect(outcomes()).toEqual([]);
+  });
+
+  test('a refresh naming no session is not scored, because no arrival belongs to it', () => {
+    const at = Date.now() - 10 * 60 * 1000;
+    issue(at, { sessionId: null });
+    turn(at + 60_000);
+
+    const summary = scoreRefreshes(dir);
+    expect([summary.scored, summary.unattributable]).toEqual([0, 1]);
+    expect(outcomes()).toEqual([]);
+  });
+
+  test('a refresh that cannot be paired is not scored, or it would be scored forever', () => {
+    // No id, so no outcome could ever name it -- and an outcome that names
+    // nothing is one more row on the ledger at the end of every turn, forever.
+    // Everything else about this refresh is scoreable: the window has closed,
+    // the arrival log covers it, and a turn did arrive inside it.
+    const at = Date.now() - 10 * 60 * 1000;
+    const summary = scoreRefreshes(dir, {
+      refreshes: [
+        {
+          kind: 'keepwarm',
+          action: 'refresh',
+          tier: '5m',
+          prefixTokens: 20_000,
+          sessionId: 's1',
+          at,
+        },
+      ],
+      arrivals: () => [
+        { kind: 'keepwarm', action: 'refresh', at, sessionId: 's1' },
+        { kind: 'read', at: at + 60_000, sessionId: 's1' },
+      ],
+    });
+    expect([summary.scored, summary.unattributable]).toEqual([0, 1]);
+  });
+
+  test('each refresh is scored once, not once per turn', () => {
+    const at = Date.now() - 10 * 60 * 1000;
+    issue(at);
+    turn(at + 60_000);
+
+    scoreRefreshes(dir);
+    expect(scoreRefreshes(dir).scored).toBe(0);
+    expect(outcomes()).toHaveLength(1);
+  });
+
+  test('the firehose is not read when there is no refresh to score', () => {
+    // The dormant cost of this loop is one small file, not a 2 MB tail read on
+    // every turn of every session on a machine that never refreshes anything.
+    turn(Date.now() - 60_000);
+    let reads = 0;
+    const summary = scoreRefreshes(dir, {
+      arrivals: () => {
+        reads += 1;
+        return [];
+      },
+    });
+    expect([reads, summary.scored, summary.pending]).toEqual([0, 0, 0]);
+  });
+
+  test("keep-warm's own bookkeeping does not count as a turn arrival", () => {
+    const at = Date.now() - 10 * 60 * 1000;
+    issue(at);
+    const summary = scoreRefreshes(dir, {
+      arrivals: () => [
+        { kind: 'keepwarm', action: 'refresh', at, sessionId: 's1' },
+        { kind: 'keepwarm', action: 'outcome', at: at + 60_000, sessionId: 's1' },
+      ],
+    });
+    expect([summary.scored, summary.hits]).toEqual([1, 0]);
+  });
+
+  test('a burst inside the same turn is not an arrival', () => {
+    const at = Date.now() - 10 * 60 * 1000;
+    issue(at);
+    turn(at + TURN_GAP_MS - 50);
+    turn(at + 6 * 60 * 1000);
+    expect(scoreRefreshes(dir).hits).toBe(0);
+  });
+
+  test('the window is the tier the refresh was bought at', () => {
+    const at = Date.now() - 2 * 60 * 60 * 1000;
+    issue(at, { tier: '1h' });
+    turn(at + 30 * 60 * 1000);
+    const summary = scoreRefreshes(dir);
+    expect([summary.scored, summary.hits]).toEqual([1, 1]);
+  });
+
+  test('the Stop hook scores refreshes, so the loop has a live call site', () => {
+    // THE HALF THAT WAS MISSING. Both recorders were correct, tested and called
+    // by nothing, so the decision could never learn. Spawned rather than
+    // imported: an in-process call proves the function works, not that anything
+    // runs it.
+    const project = mkdtempSync(join(tmpdir(), 'kw-stop-'));
+    mkdirSync(join(project, '.git'), { recursive: true });
+    try {
+      const at = Date.now() - 10 * 60 * 1000;
+      issue(at);
+      turn(at + 60_000);
+
+      const r = spawnSync(
+        process.execPath,
+        [join(process.cwd(), 'plugin', 'hooks', 'stop.mjs')],
+        {
+          input: JSON.stringify({ cwd: project, session_id: 'stop-session' }),
+          encoding: 'utf8',
+          timeout: 30_000,
+          env: {
+            ...process.env,
+            TOKEN_OPTIMIZER_WIKI_DIR: dir,
+            TOKEN_OPTIMIZER_SHARED_DIR: dir,
+            TOKEN_OPTIMIZER_STATE_DIR: join(project, '.state'),
+            TOKEN_OPTIMIZER_PROJECT_REGISTRY: join(project, 'projects.jsonl'),
+            CLAUDE_PROJECT_DIR: project,
+          },
+        }
+      );
+      expect(r.status).toBe(0);
+      expect(outcomes().map((o) => o.hit)).toEqual([true]);
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('the keep-warm decision reads what the refreshes actually did', () => {
+  /** Turns `gapMs` apart, through the real producer. */
+  const seedTurns = (gapMs, count = 20) => {
+    const base = Date.now() - count * gapMs;
+    for (let i = 0; i < count; i++) record(dir, { kind: 'read', at: base + i * gapMs });
+  };
+
+  const seedOutcomes = (hits, misses, tier = '5m') => {
+    for (let i = 0; i < hits + misses; i++)
+      recordRefreshOutcome(dir, { tier, prefixTokens: 20_000, hit: i < hits });
+  };
+
+  const observed = () => observedHitRates(readBalance(dir));
+
+  test('ten refreshes that never bought a read stop it recommending one', () => {
+    // Gaps just past the TTL: the ping model says refresh, and until now
+    // nothing could contradict it.
+    seedTurns(7 * 60 * 1000);
+    const gaps = gapDistribution(dir);
+    expect(keepWarmDecision({ prefixTokens: 20_000, gaps }).action).toBe('refresh');
+
+    seedOutcomes(0, OBSERVATION_FLOOR);
+    const decision = keepWarmDecision({ prefixTokens: 20_000, gaps, observed: observed() });
+    expect(decision.action).toBe('skip');
+    expect(decision.observedHitRate).toBe(0);
+    expect(decision.reason).toMatch(/10 observed refreshes/);
+  });
+
+  test('an observed hit rate may lower the modelled probability and never raise it', () => {
+    // Every gap inside the TTL, so a ping buys nothing: the entry was warm
+    // anyway. A recorded `hit` only says a turn arrived before expiry -- it
+    // cannot say the ping is what kept the entry alive, so it is an UPPER bound
+    // on the ping's value and must never be substituted for the model.
+    seedTurns(30_000);
+    const gaps = gapDistribution(dir);
+    const plain = keepWarmDecision({ prefixTokens: 20_000, gaps });
+    expect(plain.action).toBe('skip');
+
+    seedOutcomes(OBSERVATION_FLOOR, 0);
+    const withObservations = keepWarmDecision({
+      prefixTokens: 20_000,
+      gaps,
+      observed: observed(),
+    });
+    expect(withObservations.action).toBe('skip');
+    expect(withObservations.probability).toBe(plain.probability);
+  });
+
+  test('a perfect observed record cannot make a tier that never pays pay', () => {
+    seedTurns(6 * 60 * 60 * 1000);
+    seedOutcomes(OBSERVATION_FLOOR, 0);
+    expect(
+      ttlTier({ prefixTokens: 20_000, gaps: gapDistribution(dir), observed: observed() })
+    ).toBeNull();
+  });
+
+  test('an observed hit rate moves the tier chooser off the tier that missed', () => {
+    seedTurns(30_000);
+    expect(ttlTier({ prefixTokens: 20_000, gaps: gapDistribution(dir) }).tier).toBe('5m');
+
+    seedOutcomes(2, OBSERVATION_FLOOR - 2);
+    const best = ttlTier({
+      prefixTokens: 20_000,
+      gaps: gapDistribution(dir),
+      observed: observed(),
+    });
+    // Observations bind the tier they were measured at, and only that tier.
+    expect(best.tier).toBe('1h');
+  });
+
+  test('when every tier has missed, no tier pays and it says so', () => {
+    seedTurns(30_000);
+    seedOutcomes(0, OBSERVATION_FLOOR, '5m');
+    seedOutcomes(0, OBSERVATION_FLOOR, '1h');
+    expect(
+      ttlTier({ prefixTokens: 20_000, gaps: gapDistribution(dir), observed: observed() })
+    ).toBeNull();
+  });
+
+  test('a single unlucky miss cannot switch keep-warm off', () => {
+    seedTurns(30_000);
+    seedOutcomes(0, 1);
+    expect(observed().size).toBe(0);
+    expect(shouldKeepWarm(dir, { prefixTokens: 20_000 }).action).toBe('refresh');
+  });
+
+  test('the floor is the same evidence the backstop demands', () => {
+    seedOutcomes(0, OBSERVATION_FLOOR - 1);
+    expect(observed().size).toBe(0);
+    seedOutcomes(0, 1);
+    expect(observed().get('5m')).toEqual({ refreshes: 10, hits: 0, rate: 0 });
+    expect(OBSERVATION_FLOOR).toBe(TRIPWIRE_MIN);
+  });
+
+  test('the shipped decision reads the observations without the tripwire doing it', () => {
+    seedTurns(30_000);
+    expect(shouldKeepWarm(dir, { prefixTokens: 20_000 }).action).toBe('refresh');
+
+    // Two used in ten at each tier. The realised ledger is still POSITIVE, so
+    // the backstop has no opinion: if the verdict moves, the decision moved it.
+    seedOutcomes(2, OBSERVATION_FLOOR - 2, '5m');
+    seedOutcomes(2, OBSERVATION_FLOOR - 2, '1h');
+    expect(tripwire(dir).tripped).toBe(false);
+
+    const out = shouldKeepWarm(dir, { prefixTokens: 20_000 });
+    expect(out.action).toBe('skip');
+    expect(out.trippedWire).toBeUndefined();
   });
 });
 
@@ -731,112 +1034,3 @@ describe('SessionStart context is assembled in cache order', () => {
   });
 });
 
-describe('the keep-warm loop actually closes', () => {
-  // `recordRefresh` and `recordRefreshOutcome` had no call site anywhere, so
-  // `tripwire` returned "only 0/10 refreshes observed" for the life of the
-  // project and `keepWarmDecision` could never learn that its modelled hit rate
-  // was wrong. The missing piece was never a new sensor: the event log already
-  // records when every turn happened, so whether a refresh's window was used is
-  // recoverable from data that was there the whole time.
-  let graph;
-
-  beforeEach(() => {
-    graph = mkdtempSync(join(tmpdir(), 'kw-loop-'));
-  });
-
-  afterEach(() => {
-    rmSync(graph, { recursive: true, force: true });
-  });
-
-  const fiveMinutes = TIERS[0].ms;
-
-  test('a turn inside the window scores as a hit', () => {
-    const at = 1_000_000;
-    recordRefresh(graph, { tier: '5m', prefixTokens: 20000, expectedValue: 1 });
-    const refreshes = readBalance(graph).filter((e) => e.action === 'refresh');
-    // Drive the timeline explicitly rather than depending on wall-clock.
-    const events = [{ kind: 'read', at: refreshes[0].at + fiveMinutes / 2 }];
-
-    const { recorded } = scoreOutstandingRefreshes(graph, { events, now: at + fiveMinutes * 10 });
-    expect(recorded).toBe(1);
-    const outcome = readBalance(graph).find((e) => e.action === 'outcome');
-    expect(outcome.hit).toBe(true);
-  });
-
-  test('a turn after the window scores as a miss', () => {
-    recordRefresh(graph, { tier: '5m', prefixTokens: 20000, expectedValue: 1 });
-    const refreshAt = readBalance(graph).find((e) => e.action === 'refresh').at;
-    const events = [{ kind: 'read', at: refreshAt + fiveMinutes * 3 }];
-
-    scoreOutstandingRefreshes(graph, { events, now: refreshAt + fiveMinutes * 10 });
-    expect(readBalance(graph).find((e) => e.action === 'outcome').hit).toBe(false);
-  });
-
-  test('a window that has not closed yet records NOTHING, rather than guessing a miss', () => {
-    // Plan 2's own instruction, and the important one: scoring an open window
-    // as a miss would drive the tripwire negative on the newest and least
-    // informative records.
-    recordRefresh(graph, { tier: '5m', prefixTokens: 20000, expectedValue: 1 });
-    const refreshAt = readBalance(graph).find((e) => e.action === 'refresh').at;
-
-    const { recorded, outstanding } = scoreOutstandingRefreshes(graph, {
-      events: [],
-      now: refreshAt + fiveMinutes / 2,
-    });
-    expect(outstanding).toBe(1);
-    expect(recorded).toBe(0);
-    expect(readBalance(graph).some((e) => e.action === 'outcome')).toBe(false);
-  });
-
-  test('a closed window with no turn at all is an observed miss', () => {
-    recordRefresh(graph, { tier: '5m', prefixTokens: 20000, expectedValue: 1 });
-    const refreshAt = readBalance(graph).find((e) => e.action === 'refresh').at;
-
-    scoreOutstandingRefreshes(graph, { events: [], now: refreshAt + fiveMinutes * 2 });
-    expect(readBalance(graph).find((e) => e.action === 'outcome').hit).toBe(false);
-  });
-
-  test('scoring is idempotent, so a second drain does not double-count', () => {
-    recordRefresh(graph, { tier: '5m', prefixTokens: 20000, expectedValue: 1 });
-    const refreshAt = readBalance(graph).find((e) => e.action === 'refresh').at;
-    const opts = { events: [], now: refreshAt + fiveMinutes * 2 };
-
-    scoreOutstandingRefreshes(graph, opts);
-    const second = scoreOutstandingRefreshes(graph, { ...opts, outcomes: readBalance(graph) });
-    expect(second.recorded).toBe(0);
-    expect(readBalance(graph).filter((e) => e.action === 'outcome')).toHaveLength(1);
-  });
-
-  test('the observed hit rate stays null below the floor, then reports', () => {
-    for (let i = 0; i < OBSERVATION_FLOOR - 1; i++) {
-      recordRefreshOutcome(graph, { tier: '5m', prefixTokens: 20000, hit: false });
-    }
-    expect(observedHitRate(graph, { tier: '5m' })).toBeNull();
-
-    recordRefreshOutcome(graph, { tier: '5m', prefixTokens: 20000, hit: false });
-    const observed = observedHitRate(graph, { tier: '5m' });
-    expect(observed.observations).toBe(OBSERVATION_FLOOR);
-    expect(observed.rate).toBe(0);
-  });
-
-  test('an observed hit rate of zero overturns a model that says refresh', () => {
-    // THE POINT OF THE WHOLE LOOP. Before this, refreshes that bought nothing
-    // kept being recommended right up to the moment the tripwire cut the entire
-    // feature off -- there was nothing between "the model says yes" and "stop".
-    const gaps = { probabilityWithin: (ms) => (ms > TIERS[0].ms ? 1 : 0) };
-    const modelled = keepWarmDecision({ prefixTokens: 20000, gaps });
-    expect(modelled.action).toBe('refresh');
-    expect(modelled.basis).toMatch(/modelled/);
-
-    const learned = keepWarmDecision({
-      prefixTokens: 20000,
-      gaps,
-      observed: { observations: 10, rate: 0 },
-    });
-    expect(learned.action).toBe('skip');
-    expect(learned.basis).toMatch(/measured over 10/);
-    // The model's own number is still reported, so the disagreement is visible
-    // rather than silently overwritten.
-    expect(learned.modelledProbability).toBe(1);
-  });
-});

--- a/tests/hooks/cache.test.mjs
+++ b/tests/hooks/cache.test.mjs
@@ -1032,4 +1032,3 @@ describe('SessionStart context is assembled in cache order', () => {
     }
   });
 });
-

--- a/tests/hooks/calibration-loop.test.mjs
+++ b/tests/hooks/calibration-loop.test.mjs
@@ -1,0 +1,503 @@
+/**
+ * The calibration loop -- does Layer 1's cheap LABEL predict Layer 2's
+ * expensive EFFECT?
+ *
+ * FIXTURES ARE BUILT WITH THE REAL PRODUCERS, following `loo.test.mjs`: `record`
+ * writes the `inject` and `read` rows, `recordToolOutcome` performs the real
+ * (episodeId, toolCallId) join, and Layer 1's reference channel is driven by
+ * real `query` events. Nothing here hand-writes an event shape that production
+ * does not write.
+ *
+ * TWO THINGS THIS FILE IS WATCHING FOR, both of which are the reason it exists:
+ *
+ *   1. A CALIBRATION THAT PUBLISHES WHEN IT CANNOT. Every refusal below asserts
+ *      the ABSENCE of a `gap` field, not `gap === 0`. A permanent zero reads as
+ *      "measured, and the two agree", which is the opposite of "nothing was
+ *      measured" -- and it is the shape that would let this project quote a
+ *      reference rate as a saving.
+ *   2. CIRCULARITY. The whole comparison is worthless if a quantity common to
+ *      both layers leaks in. Two tests pin it from opposite sides: flipping the
+ *      LABELS while holding the effects fixed must flip the gap, and moving
+ *      Layer 1's RATE without moving any label must leave the gap identical.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  record,
+  recordToolOutcome,
+  readMetrics,
+  readTruncation,
+} from '../../hooks-core/metrics.mjs';
+import { referenceRate } from '../../hooks-core/usage.mjs';
+import {
+  servingPolicyVersion,
+  MIN_PRIOR_INJECTIONS,
+  MIN_SERVED,
+  MIN_WITHHELD,
+} from '../../hooks-core/loo.mjs';
+import {
+  calibration,
+  calibrationNote,
+  consolidation,
+  graphBalanceSheet,
+  labelsByFinding,
+  MIN_FINDINGS_PER_ARM,
+  MIN_GAP_TOKENS,
+} from '../../hooks-core/crosslayer.mjs';
+import { renderAudit } from '../../hooks-core/audit.mjs';
+import { putNode, load } from '../../hooks-core/wiki.mjs';
+import { contradict, hasOutstandingContradiction } from '../../hooks-core/curate.mjs';
+
+let workspace;
+let dir;
+let clock;
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), 'cal-'));
+  dir = join(workspace, 'wiki');
+  clock = 1;
+  // Pinned, because `servingPolicyVersion()` hashes it: the fixtures must be
+  // written under the same policy the assertions compute.
+  process.env.TOKEN_OPTIMIZER_HOLDOUT = '0';
+  delete process.env.TOKEN_OPTIMIZER_LOO;
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+  delete process.env.TOKEN_OPTIMIZER_HOLDOUT;
+  delete process.env.TOKEN_OPTIMIZER_LOO;
+});
+
+const POLICY = () => servingPolicyVersion();
+
+/** One injection, written by the real recorder. */
+function inject({ keys, session, loo = null, anchor, policy }) {
+  clock += 10;
+  const toolCallId = `tc-${clock}`;
+  return record(dir, {
+    kind: 'inject',
+    episodeId: session,
+    sessionId: session,
+    toolCallId,
+    surface: 'file',
+    anchor,
+    holdout: false,
+    tokens: 10,
+    deliveredTokens: 10,
+    shadowTokens: 10,
+    count: keys.length,
+    candidateCount: keys.length,
+    findingIds: keys,
+    shadowFindingIds: keys,
+    stale: false,
+    looPolicy: policy,
+    ...(loo ? { loo } : {}),
+    at: clock,
+  });
+}
+
+/** The post-tool result that makes the injection attributable, via the real join. */
+const outcome = (event) =>
+  recordToolOutcome(dir, {
+    episodeId: event.episodeId,
+    sessionId: event.sessionId,
+    toolCallId: event.toolCallId,
+    surface: event.surface,
+    anchor: event.anchor,
+    toolName: 'Read',
+    success: true,
+    at: (event.at || 0) + 1,
+  });
+
+/** `n` touches, one session each, each with its joined outcome and a later read. */
+function touches(n, { keys, loo = null, cost = 0, tag, anchor, policy = null }) {
+  for (let i = 0; i < n; i += 1) {
+    const session = `${tag}-${i}`;
+    const event = inject({ keys, session, loo, anchor, policy: policy || POLICY() });
+    outcome(event);
+    if (cost)
+      record(dir, {
+        kind: 'read',
+        anchor,
+        sessionId: session,
+        tokens: cost,
+        at: (event.at || 0) + 5,
+      });
+  }
+}
+
+/** One finding node, by key, from the graph on disk. */
+const findingNode = (key) =>
+  [...load(dir).nodes.values()].find((n) => n.kind === 'finding' && n.key === key);
+
+/** A `query` naming a finding key -- Layer 1's only reference producer. */
+const query = (key, at) =>
+  record(dir, { kind: 'query', operation: 'get', key, sessionId: 'q', at });
+
+/**
+ * `n` findings, each with a served and a withheld arm, and an effect of its own.
+ *
+ * `effectFor(i)` is the extra read cost the WITHHELD arm carries, so a positive
+ * value means the finding suppressed that much reading. Each finding gets its
+ * own anchor and its own pad key, so one finding's arms cannot borrow another's
+ * read total through the (session, anchor) split.
+ */
+function findings(n, { effectFor, withheldCount = MIN_WITHHELD, policy = null } = {}) {
+  for (let i = 0; i < n; i += 1) {
+    const keys = [`f${i}`, `p${i}`];
+    const anchor = `src/f${i}.ts`;
+    touches(MIN_PRIOR_INJECTIONS, { keys, tag: `w${i}`, anchor, policy });
+    touches(MIN_SERVED, { keys, tag: `s${i}`, cost: 100, anchor, policy });
+    touches(withheldCount, {
+      keys: [`p${i}`],
+      loo: `f${i}`,
+      tag: `x${i}`,
+      cost: 100 + effectFor(i),
+      anchor,
+      policy,
+    });
+  }
+}
+
+/** Names f0..f2 in a later `query`, so Layer 1 labels exactly those referenced. */
+function referenceFirstThree(offset = 0) {
+  for (let i = 0; i < 3; i += 1) query(`f${i + offset}`, 10_000 + i);
+}
+
+/** Six findings where the REFERENCED ones show no read-suppression at all. */
+function dirWhereReferencedFindingsShowNoEffect() {
+  findings(6, { effectFor: (i) => (i < 3 ? 0 : 4900) });
+  referenceFirstThree();
+}
+
+/** Six findings where the REFERENCED ones are the ones that suppress reads. */
+function dirWhereReferencedFindingsShowEffect() {
+  findings(6, { effectFor: (i) => (i < 3 ? 4900 : 0) });
+  referenceFirstThree();
+}
+
+describe('the calibration loop', () => {
+  it('refuses to publish Layer 1 when its label does not predict Layer 2', () => {
+    dirWhereReferencedFindingsShowNoEffect();
+    const result = calibration(dir);
+    expect(result.publishable).toBe(false);
+    expect(result.verdict).toMatch(/does not predict|uncalibrated/i);
+    // MEASURED, so a gap exists and is reported: this is a refusal on the
+    // evidence, not for want of it.
+    expect(result.gap).toBeLessThan(0);
+    expect(result.arms).toEqual({ referenced: 3, notReferenced: 3 });
+  });
+
+  it('publishes when referenced findings show a larger causal effect', () => {
+    dirWhereReferencedFindingsShowEffect();
+    const result = calibration(dir);
+    expect(result.publishable).toBe(true);
+    expect(result.gap).toBeGreaterThan(0);
+    expect(result.verdict).toMatch(/calibrated: referenced findings suppress/);
+  });
+
+  it('refuses with NO gap field when Layer 1 has published no rate', () => {
+    // Layer 2 is fully populated; nothing ever named a finding.
+    findings(6, { effectFor: (i) => (i < 3 ? 4900 : 0) });
+    const result = calibration(dir);
+    expect(result.publishable).toBe(false);
+    // Layer 1 has rows -- 138 of them -- and every one is `not-referenced`
+    // because its numerator's producer never fired. A 0% rate there would be
+    // measuring the absence of a producer, so Layer 1 publishes no rate and the
+    // refusal quotes both halves of why.
+    expect(result.verdict).toMatch(
+      /Layer 1 has \d+ classifiable observation\(s\) and 0 reference event\(s\), so it publishes no rate/
+    );
+    expect(result.layer1.rate).toBeNull();
+    // A PERMANENT ZERO WOULD READ AS "measured, and they agree". Task 7 removed
+    // a field rather than zero it for exactly this reason.
+    expect('gap' in result).toBe(false);
+    expect(result.verdict).toMatch(/not the same as a gap of zero/);
+  });
+
+  it('refuses with NO gap field when Layer 2 has no observations', () => {
+    // Layer 1 has a real rate; the leave-one-out has never run.
+    const anchor = 'src/only.ts';
+    touches(2, { keys: ['f0', 'p0'], tag: 'l1', anchor });
+    query('f0', 9_000);
+    const result = calibration(dir);
+    expect(result.layer1.rate).not.toBeNull();
+    expect(result.publishable).toBe(false);
+    expect(result.verdict).toMatch(/Layer 2 has 0 observation/);
+    expect('gap' in result).toBe(false);
+  });
+
+  it('names BOTH sides when both are silent, and reports no gap', () => {
+    const result = calibration(dir);
+    expect(result.publishable).toBe(false);
+    expect(result.verdict).toMatch(/Layer 1 has 0 classifiable observation/);
+    expect(result.verdict).toMatch(/Layer 2 has 0 observation/);
+    expect('gap' in result).toBe(false);
+  });
+
+  it('refuses when Layer 2 has observations but no published effect', () => {
+    // One withheld observation short of the floor: every row still carries an
+    // estimate, so a mean of them exists -- and is noise.
+    findings(6, {
+      effectFor: (i) => (i < 3 ? 4900 : 0),
+      withheldCount: MIN_WITHHELD - 1,
+    });
+    referenceFirstThree();
+    const result = calibration(dir);
+    expect(result.layer2.observations).toBeGreaterThan(0);
+    expect(result.layer2.published).toBe(0);
+    expect(result.publishable).toBe(false);
+    expect(result.verdict).toMatch(/no published effect/);
+    expect('gap' in result).toBe(false);
+  });
+
+  it('refuses when an arm is below the per-arm floor', () => {
+    findings(4, { effectFor: (i) => (i < 3 ? 4900 : 0) });
+    // Only two findings are ever named, so the referenced arm holds two.
+    query('f0', 10_000);
+    query('f1', 10_001);
+    const result = calibration(dir);
+    expect(result.arms.referenced).toBe(2);
+    expect(result.publishable).toBe(false);
+    expect(result.verdict).toMatch(
+      new RegExp(`below the floor of ${MIN_FINDINGS_PER_ARM} per arm`)
+    );
+    expect('gap' in result).toBe(false);
+  });
+
+  it('refuses a gap that only floating point can see', () => {
+    // Both arms carry the SAME mean effect, spread differently across findings,
+    // so one finding in each arm publishes and the gap is zero up to arithmetic
+    // noise. Publishing that would print "suppress 0 more tokens/touch".
+    findings(6, { effectFor: (i) => (i === 0 || i === 3 ? 4900 : 0) });
+    referenceFirstThree();
+    const result = calibration(dir);
+    expect(result.layer2.published).toBeGreaterThan(0);
+    expect(Math.abs(result.gap)).toBeLessThan(MIN_GAP_TOKENS);
+    expect(result.publishable).toBe(false);
+    expect(result.verdict).toMatch(/does not predict/);
+  });
+
+  it('refuses rather than pooling arms measured under another serving policy', () => {
+    findings(6, { effectFor: (i) => (i < 3 ? 4900 : 0), policy: 'some-older-policy' });
+    referenceFirstThree();
+    const result = calibration(dir);
+    expect(result.layer2.rows).toBeGreaterThan(0);
+    expect(result.layer2.inPolicy).toBe(0);
+    expect(result.verdict).toMatch(/different serving policy/);
+    expect('gap' in result).toBe(false);
+  });
+});
+
+describe('independence of the two layers', () => {
+  it('flips the gap when the LABELS move and the effects do not', () => {
+    // Identical Layer 2 data in both dirs; only which findings were named
+    // changes. If the gap did not move, Layer 1's label is not an input.
+    findings(6, { effectFor: (i) => (i < 3 ? 4900 : 0) });
+    referenceFirstThree(0);
+    const naming012 = calibration(dir);
+
+    const second = mkdtempSync(join(tmpdir(), 'cal2-'));
+    const saved = dir;
+    dir = join(second, 'wiki');
+    clock = 1;
+    findings(6, { effectFor: (i) => (i < 3 ? 4900 : 0) });
+    referenceFirstThree(3);
+    const naming345 = calibration(dir);
+    dir = saved;
+    rmSync(second, { recursive: true, force: true });
+
+    expect(naming012.gap).toBeGreaterThan(0);
+    expect(naming345.gap).toBeLessThan(0);
+    expect(naming012.gap).toBeCloseTo(-naming345.gap, 6);
+  });
+
+  it('leaves the gap identical when Layer 1s RATE moves and no label does', () => {
+    dirWhereReferencedFindingsShowEffect();
+    const before = calibration(dir);
+    const rateBefore = referenceRate(dir).rate;
+
+    // Five more references, all naming a pad key that carries no Layer 2
+    // effect. Layer 1's rate moves; no finding with an effect changes label.
+    for (let i = 0; i < 5; i += 1) query('p0', 20_000 + i);
+
+    const after = calibration(dir);
+    expect(referenceRate(dir).rate).not.toBeCloseTo(rateBefore, 6);
+    // BYTE-IDENTICAL. Any Layer 1 magnitude feeding the gap would move it.
+    expect(after.gap).toBe(before.gap);
+    expect(after.referencedMean).toBe(before.referencedMean);
+    expect(after.notReferencedMean).toBe(before.notReferencedMean);
+  });
+
+  it('does not claim a truncated window when the caller supplied its own events', () => {
+    // The bounds of a caller's read are the caller's to describe. Claiming
+    // truncation over someone else's array would attach a caveat to a figure
+    // that does not carry the risk it warns about.
+    // A GENUINELY TRUNCATED READ FIRST, in another graph, so `readTruncation()`
+    // is armed. Without this the assertion below holds whether the flag is
+    // consulted or not, which is the vacuous version of it.
+    const noisy = join(workspace, 'noisy');
+    mkdirSync(noisy, { recursive: true });
+    writeFileSync(
+      join(noisy, 'metrics.jsonl'),
+      Array.from({ length: 5_100 }, (_, i) =>
+        JSON.stringify({ kind: 'read', at: i })
+      )
+        .map((line) => line + String.fromCharCode(10))
+        .join('')
+    );
+    readMetrics(noisy);
+    expect(readTruncation().byEvents).toBe(true);
+
+    const events = [
+      { kind: 'inject', findingIds: ['k1'], injectionId: 'i', sessionId: 's', at: 1 },
+      { kind: 'query', operation: 'get', key: 'k1', sessionId: 's', at: 2 },
+    ];
+    const result = calibration(dir, { events });
+    expect(result.windowed).toBe(false);
+    expect(result.verdict).not.toMatch(/truncated/);
+  });
+
+  it('takes only the label from Layer 1: any reference makes a finding referenced', () => {
+    // BOTH ORDERS. `classify` emits rows in time order, so a finding injected
+    // AGAIN after the model named it has a `referenced` row followed by a
+    // `not-referenced` one -- and a fold that let the later row win would put a
+    // finding the model demonstrably reads into the arm it is meant to predict.
+    const rows = [
+      { findingKey: 'a', label: 'not-referenced' },
+      { findingKey: 'a', label: 'referenced' },
+      { findingKey: 'd', label: 'referenced' },
+      { findingKey: 'd', label: 'not-referenced' },
+      { findingKey: 'b', label: 'unknown' },
+      { findingKey: 'c', label: 'not-referenced' },
+    ];
+    const labels = labelsByFinding(rows);
+    expect(labels.get('a')).toBe('referenced');
+    expect(labels.get('d')).toBe('referenced');
+    expect(labels.get('c')).toBe('not-referenced');
+    // `unknown` is dropped rather than defaulted into an arm.
+    expect(labels.has('b')).toBe(false);
+  });
+});
+
+describe('measured utility ranks a finding and never raises its confidence', () => {
+  /**
+   * THE GATE THE PLAN ASKED FOR DOES NOT EXIST, AND MUST NOT BE INVENTED.
+   *
+   * Step 6 called for `mayPromote(graph, key)` over
+   * `hasOutstandingContradiction`. There is no promotion path to gate: every
+   * write of `confidence` in `hooks-core` happens at CREATION, and nothing
+   * updates a stored finding's confidence afterwards. An unreachable gate is
+   * the defect class this plan exists to close, so what is asserted here is the
+   * invariant itself -- from both directions.
+   */
+  it('does not change a contradicted findings confidence when its measured effect is large', () => {
+    putNode(dir, { kind: 'finding', key: 'f0', claim: 'suppressor', confidence: 0.6 });
+    putNode(dir, { kind: 'finding', key: 'rebuttal', claim: 'rebuttal', confidence: 0.9 });
+    expect(
+      contradict(dir, { key: 'f0', byKey: 'rebuttal', reason: 're-derived differently' })
+    ).toBe(true);
+    const before = findingNode('f0');
+    expect(hasOutstandingContradiction(load(dir), 'f0')).toBe(true);
+
+    // A large measured win for that exact key, then every reader of it.
+    findings(6, { effectFor: () => 4900 });
+    for (let i = 0; i < 3; i += 1) query(`f${i}`, 10_000 + i);
+    const effect = calibration(dir).layer2;
+    expect(effect.observations).toBeGreaterThan(0);
+    graphBalanceSheet(dir);
+    calibrationNote(dir);
+    renderAudit(dir, []);
+
+    // UNCHANGED. Utility ranked it; nothing promoted it.
+    expect(findingNode('f0').confidence).toBe(before.confidence);
+  });
+
+  it('never writes confidence from any module that measures utility', () => {
+    // STRUCTURAL, in the spirit of the reachability guard: utility RANKS, and a
+    // module that measures it must not be able to promote what it measured.
+    for (const file of ['crosslayer.mjs', 'loo.mjs', 'usage.mjs']) {
+      const text = readFileSync(new URL(`../../hooks-core/${file}`, import.meta.url), 'utf8')
+        // Comments name `confidence` on purpose; only code counts.
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/^\s*\/\/.*$/gm, '');
+      expect([file, /confidence/.test(text)]).toEqual([file, false]);
+    }
+  });
+});
+
+describe('the consolidation section', () => {
+  it('reports nothing rather than a ratio when no finding carries a derivation cost', () => {
+    putNode(dir, { kind: 'finding', key: 'nocost', claim: 'no cost recorded', confidence: 0.9 });
+    const out = consolidation(dir);
+    expect(out.withDerivedCost).toBe(0);
+    expect(out.aggregate).toBeNull();
+    expect(out.best).toEqual([]);
+    // ALWAYS LABELLED AN ESTIMATE, in the data and not only in a comment.
+    expect(out.basis).toBe('estimate');
+    expect(out.priced).toBe(false);
+  });
+
+  it('reports the per-finding ratio for a finding that does carry one', () => {
+    putNode(dir, {
+      kind: 'finding',
+      key: 'expand:one',
+      claim: 'x'.repeat(200), // 50 tokens to carry
+      derivedCost: 5_000,
+      confidence: 0.7,
+    });
+    const out = consolidation(dir);
+    expect(out.withDerivedCost).toBe(1);
+    expect(out.best[0].key).toBe('expand:one');
+    expect(out.best[0].ratio).toBeCloseTo(100, 6);
+    expect(out.aggregate.ratio).toBeCloseTo(100, 6);
+  });
+});
+
+describe('the balance sheet the report serves', () => {
+  it('carries layer1, layer2, calibration and consolidation beside the measured lines', () => {
+    dirWhereReferencedFindingsShowEffect();
+    const sheet = graphBalanceSheet(dir);
+    expect(sheet.measuredCounterfactual).toBeDefined();
+    expect(sheet.estimatedCausal).toBeDefined();
+    expect(sheet.layer1).not.toBeNull();
+    expect(sheet.layer2).not.toBeNull();
+    expect(sheet.layer2.published).toBeGreaterThan(0);
+    expect(sheet.calibration.publishable).toBe(true);
+    expect(sheet.consolidation.basis).toBe('estimate');
+  });
+});
+
+describe('the audit is the note the human reads', () => {
+  it('says nothing at all while both layers are silent', () => {
+    expect(calibrationNote(dir)).toBeNull();
+    expect(renderAudit(dir, []).text).not.toMatch(/Layer 1 against Layer 2/);
+  });
+
+  it('prints the refusal once one side has spoken', () => {
+    const anchor = 'src/only.ts';
+    touches(2, { keys: ['f0', 'p0'], tag: 'l1', anchor });
+    query('f0', 9_000);
+    const note = calibrationNote(dir);
+    expect(note).toMatch(/Layer 1 against Layer 2: not calibrated/);
+    expect(note).toMatch(/Layer 2 has 0 observation/);
+  });
+
+  it('reaches a human through renderAudit, which is its production reader', () => {
+    dirWhereReferencedFindingsShowEffect();
+    const text = renderAudit(dir, []).text;
+    expect(text).toMatch(/Layer 1 against Layer 2: calibrated/);
+  });
+
+  it('does not headline "Nothing addressable found." above a real verdict', () => {
+    dirWhereReferencedFindingsShowEffect();
+    const text = renderAudit(dir, []).text;
+    // The queue is empty and a causal verdict is printed below it. The old
+    // headline told the reader nothing was found immediately above a finding.
+    expect(text).toContain('Nothing addressable found in the remediation queue.');
+    expect(text).not.toContain('Nothing addressable found.');
+    expect(text).toMatch(/Layer 1 against Layer 2/);
+  });
+});

--- a/tests/hooks/calibration-loop.test.mjs
+++ b/tests/hooks/calibration-loop.test.mjs
@@ -36,9 +36,12 @@ import {
   MIN_PRIOR_INJECTIONS,
   MIN_SERVED,
   MIN_WITHHELD,
+  FDR_Q,
+  permutationP,
 } from '../../hooks-core/loo.mjs';
 import {
   calibration,
+  calibrationP,
   calibrationNote,
   consolidation,
   graphBalanceSheet,
@@ -195,7 +198,25 @@ describe('the calibration loop', () => {
     const result = calibration(dir);
     expect(result.publishable).toBe(true);
     expect(result.gap).toBeGreaterThan(0);
+    expect(result.p).toBeCloseTo(FDR_Q, 12);
     expect(result.verdict).toMatch(/calibrated: referenced findings suppress/);
+    expect(result.verdict).toMatch(/two-sided permutation p=0\.100/);
+  });
+
+  it('refuses a positive gap that does not survive a two-sided permutation test', () => {
+    // Three individually real effects, but split 2:1 and 1:2 between the two
+    // label arms. Their means differ in the favourable direction purely because
+    // six findings admit a noisy partition; the cross-layer headline must not
+    // promote that positive gap into a calibration claim.
+    findings(6, { effectFor: (i) => ([4900, 0, 4900, 0, 4900, 0][i]) });
+    referenceFirstThree();
+    const result = calibration(dir);
+    expect(result.layer2.published).toBeGreaterThan(0);
+    expect(result.gap).toBeGreaterThan(MIN_GAP_TOKENS);
+    expect(result.p).toBeCloseTo(1, 12);
+    expect(result.publishable).toBe(false);
+    expect(result.verdict).toMatch(/two-sided permutation/i);
+    expect(result.verdict).toMatch(/not statistically resolved/i);
   });
 
   it('refuses with NO gap field when Layer 1 has published no rate', () => {
@@ -214,6 +235,7 @@ describe('the calibration loop', () => {
     // A PERMANENT ZERO WOULD READ AS "measured, and they agree". Task 7 removed
     // a field rather than zero it for exactly this reason.
     expect('gap' in result).toBe(false);
+    expect('p' in result).toBe(false);
     expect(result.verdict).toMatch(/not the same as a gap of zero/);
   });
 
@@ -227,6 +249,7 @@ describe('the calibration loop', () => {
     expect(result.publishable).toBe(false);
     expect(result.verdict).toMatch(/Layer 2 has 0 observation/);
     expect('gap' in result).toBe(false);
+    expect('p' in result).toBe(false);
   });
 
   it('names BOTH sides when both are silent, and reports no gap', () => {
@@ -288,6 +311,30 @@ describe('the calibration loop', () => {
     expect(result.layer2.inPolicy).toBe(0);
     expect(result.verdict).toMatch(/different serving policy/);
     expect('gap' in result).toBe(false);
+  });
+});
+
+describe('the cross-layer permutation statistic', () => {
+  it('is invariant to event order and to swapping the semantic labels on the sampled path', () => {
+    const referenced = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const notReferenced = [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+    const expected = calibrationP(referenced, notReferenced);
+    expect(calibrationP([...referenced].reverse(), [...notReferenced].reverse())).toBe(expected);
+    expect(calibrationP(notReferenced, referenced)).toBe(expected);
+
+    // Independent oracle for the caller contract: canonicalise both arms,
+    // derive FNV-1a from the data, and prove the result is not the shared fixed
+    // sequence Layer 2 keeps for backward compatibility.
+    const arms = [referenced, notReferenced]
+      .map((values) => [...values].sort((a, b) => a - b))
+      .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+    let seed = 2166136261;
+    for (const char of JSON.stringify(arms)) {
+      seed ^= char.charCodeAt(0);
+      seed = Math.imul(seed, 16777619);
+    }
+    expect(expected).toBe(permutationP(arms[0], arms[1], { seed: seed >>> 0 }));
+    expect(expected).not.toBe(permutationP(arms[0], arms[1]));
   });
 });
 

--- a/tests/hooks/capture-results.test.mjs
+++ b/tests/hooks/capture-results.test.mjs
@@ -1,0 +1,225 @@
+/**
+ * What a tool call actually SAID, not merely whether it worked.
+ *
+ * `recordToolOutcome` has carried a `success` boolean since the pipeline
+ * landed. A boolean cannot tell a compile error from a test failure from a
+ * denied permission, and those are three different findings -- so the failure
+ * findings that carry the most value had nothing to be built out of. This suite
+ * pins the two additions that fix that, and pins them AT THE BOUNDARY:
+ * redaction and the size cap live inside `recordToolOutcome`, because a claim
+ * built from this text is injected into model context and exported to markdown,
+ * and a second caller added later must not be able to skip them.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  readEvidence,
+  recordToolOutcome,
+  record,
+} from '../../hooks-core/metrics.mjs';
+import { outputFrom, exitFrom } from '../../hooks-core/adapter.mjs';
+
+let dir;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'res-'));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+const outcome = (extra) =>
+  recordToolOutcome(dir, {
+    surface: 'command',
+    anchor: 'npm test',
+    toolName: 'Bash',
+    success: false,
+    ...extra,
+  });
+const latest = () =>
+  readEvidence(dir)
+    .filter((e) => e.kind === 'tool-outcome')
+    .pop();
+
+describe('tool-outcome carries output and exit', () => {
+  it('records the output and the exit code alongside success', () => {
+    outcome({ output: 'FAIL x.test.ts', exit: 1 });
+    expect(latest().success).toBe(false);
+    expect(latest().exit).toBe(1);
+    expect(latest().output).toContain('FAIL');
+  });
+
+  it('redacts secrets out of captured output', () => {
+    outcome({ output: 'API_TOKEN=abcdef123456 failed', exit: 1 });
+    expect(latest().output).not.toContain('abcdef123456');
+  });
+
+  it('caps output so a huge log is never stored whole', () => {
+    outcome({ output: 'x'.repeat(100000), exit: 0 });
+    expect(latest().output.length).toBeLessThanOrEqual(4096);
+  });
+
+  it('leaves exit null when the client reports no code, rather than guessing 0', () => {
+    outcome({ output: 'denied' });
+    expect(latest().exit).toBeNull();
+  });
+
+  it('leaves exit null for a non-integer code rather than coercing it', () => {
+    // 'ENOENT' and 1.5 are both "no code was reported" as far as a finding is
+    // concerned; coercing either would fabricate an observation.
+    outcome({ output: 'x', exit: 'ENOENT' });
+    expect(latest().exit).toBeNull();
+  });
+
+  it('keeps a reported exit of 0 distinguishable from an unreported one', () => {
+    // The whole point of the null: 0 must mean "the client said zero".
+    outcome({ output: 'ok', exit: 0, success: true });
+    expect(latest().exit).toBe(0);
+  });
+
+  it('omits output entirely when nothing was captured', () => {
+    // Not '' and not the string "undefined": an absent capture has to stay
+    // distinguishable from an empty one, or a finding is built from nothing.
+    outcome({ exit: 1 });
+    expect(latest().output).toBeUndefined();
+    expect(JSON.stringify(latest())).not.toContain('undefined');
+  });
+
+  it('redacts before capping, so truncation cannot expose a secret tail', () => {
+    // CONSTRUCTED SO ONLY THE ORDER CAN DECIDE IT, and so only ONE redaction
+    // pattern is in play (the `ghp_` prefix rule, which needs 10+ trailing
+    // characters). The token starts 11 characters before the 4096 cap, so
+    // capping FIRST leaves `ghp_abcdefg` -- seven trailing characters, below
+    // the quantifier, no match, and a live secret fragment in cleartext.
+    // Redacting first sees the whole 24-character token and removes it.
+    outcome({
+      output: `${'x'.repeat(4084)} ghp_abcdefghijklmnopqrst`,
+      exit: 1,
+    });
+    expect(latest().output).not.toContain('ghp_abcdef');
+  });
+
+  it('does not disturb the injection join the pipeline already performs', () => {
+    outcome({ output: 'x', exit: 1 });
+    expect(latest().joinMethod).toBeDefined();
+  });
+
+  it('still joins an outcome to its injection by tool call id', () => {
+    // The join is the load-bearing part of this event and predates this task;
+    // adding two fields must leave it exactly as it was.
+    record(dir, {
+      kind: 'inject',
+      episodeId: 'ep-1',
+      toolCallId: 'call-7',
+      surface: 'command',
+      anchor: 'npm test',
+      findingIds: ['f-1'],
+    });
+    recordToolOutcome(dir, {
+      episodeId: 'ep-1',
+      toolCallId: 'call-7',
+      surface: 'command',
+      anchor: 'npm test',
+      toolName: 'Bash',
+      success: false,
+      output: 'FAIL',
+      exit: 1,
+    });
+    expect(latest().joinMethod).toBe('tool-call-id');
+    expect(latest().findingIds).toEqual(['f-1']);
+    expect(latest().injectionId).toBeTruthy();
+  });
+});
+
+describe('outputFrom reads the same response family as toolSucceeded', () => {
+  it('captures a shell result from the stdout and stderr streams', () => {
+    const text = outputFrom({
+      tool_response: { stdout: 'ran 4 tests', stderr: 'FAIL x.test.ts' },
+    });
+    expect(text).toContain('FAIL x.test.ts');
+    expect(text).toContain('ran 4 tests');
+  });
+
+  it('puts stderr ahead of stdout so the cap cannot cut the diagnostic away', () => {
+    const text = outputFrom({
+      tool_response: { stdout: 'a'.repeat(50), stderr: 'the reason' },
+    });
+    expect(text.indexOf('the reason')).toBeLessThan(text.indexOf('aaaa'));
+  });
+
+  it('reads the camelCase and tool_result envelopes too', () => {
+    expect(outputFrom({ toolResponse: { stderr: 'boom' } })).toBe('boom');
+    expect(outputFrom({ tool_result: 'plain text result' })).toBe(
+      'plain text result'
+    );
+  });
+
+  it("captures this project's own MCP tools, whose results are content blocks", () => {
+    // normalizeTool now resolves mcp__<server>__smart_edit, so smart_edit and
+    // smart_write reach the post-tool path for the first time. Their result is
+    // an MCP envelope, not a shell result.
+    const text = outputFrom({
+      tool_response: {
+        content: [{ type: 'text', text: '{"success": false, "error": "no match"}' }],
+        isError: true,
+      },
+    });
+    expect(text).toContain('no match');
+  });
+
+  it('accepts a bare content array, which some hosts hand the hook directly', () => {
+    expect(outputFrom({ tool_response: [{ type: 'text', text: 'block' }] })).toBe(
+      'block'
+    );
+  });
+
+  it('captures an error message when that is all the client reports', () => {
+    expect(outputFrom({ tool_response: { error: 'permission denied' } })).toBe(
+      'permission denied'
+    );
+    expect(
+      outputFrom({ toolResponse: { error: { message: 'denied by hook' } } })
+    ).toBe('denied by hook');
+  });
+
+  it('returns null rather than stringifying a shape it does not understand', () => {
+    // A wall of JSON metadata or "[object Object]" in an injected claim is a
+    // WRONG observation; no capture is merely a missing one.
+    expect(
+      outputFrom({ tool_response: { filePath: '/a.ts', structuredPatch: [{}] } })
+    ).toBeNull();
+    expect(outputFrom({})).toBeNull();
+    expect(outputFrom(undefined)).toBeNull();
+  });
+
+  it('treats blank output as no output', () => {
+    expect(outputFrom({ tool_response: { stdout: '   ', stderr: '' } })).toBeNull();
+  });
+});
+
+describe('exitFrom reports only a real exit code', () => {
+  it('reads the code a client supplies, including zero', () => {
+    expect(exitFrom({ tool_response: { exit_code: 2 } })).toBe(2);
+    expect(exitFrom({ toolResponse: { exitCode: 0 } })).toBe(0);
+    expect(exitFrom({ tool_result: { returncode: 137 } })).toBe(137);
+  });
+
+  it('accepts a code serialized as a digit string', () => {
+    expect(exitFrom({ tool_response: { exit_code: '1' } })).toBe(1);
+  });
+
+  it('returns null when no client reported a code', () => {
+    expect(exitFrom({ tool_response: { stdout: 'fine' } })).toBeNull();
+    expect(exitFrom({})).toBeNull();
+  });
+
+  it('ignores `code`, which JSON-RPC and errno both reuse', () => {
+    // -32602 is an RPC error, ENOENT is an errno; recording either as an exit
+    // status would be a confident lie about a call that never had one.
+    expect(exitFrom({ tool_response: { code: -32602 } })).toBeNull();
+    expect(exitFrom({ tool_response: { code: 'ENOENT' } })).toBeNull();
+  });
+
+  it('ignores a long digit string, which is an id rather than a status', () => {
+    expect(exitFrom({ tool_response: { exit_code: '1755123456789' } })).toBeNull();
+  });
+});

--- a/tests/hooks/capture-results.test.mjs
+++ b/tests/hooks/capture-results.test.mjs
@@ -19,7 +19,11 @@ import {
   recordToolOutcome,
   record,
 } from '../../hooks-core/metrics.mjs';
-import { outputFrom, exitFrom } from '../../hooks-core/adapter.mjs';
+import {
+  outputFrom,
+  exitFrom,
+  toolSucceeded,
+} from '../../hooks-core/adapter.mjs';
 
 let dir;
 beforeEach(() => {
@@ -54,7 +58,10 @@ describe('tool-outcome carries output and exit', () => {
   });
 
   it('caps output so a huge log is never stored whole', () => {
-    outcome({ output: 'x'.repeat(100000), exit: 0 });
+    // A FAILING call, because capture is now failure-only. The cap still has
+    // to hold: a 100 KB build log is exactly the failure whose text is worth
+    // having, and exactly the one that must not be stored whole.
+    outcome({ output: 'x'.repeat(100000), exit: 1 });
     expect(latest().output.length).toBeLessThanOrEqual(4096);
   });
 
@@ -72,8 +79,27 @@ describe('tool-outcome carries output and exit', () => {
 
   it('keeps a reported exit of 0 distinguishable from an unreported one', () => {
     // The whole point of the null: 0 must mean "the client said zero".
-    outcome({ output: 'ok', exit: 0, success: true });
+    outcome({ exit: 0, success: true });
     expect(latest().exit).toBe(0);
+  });
+
+  it('records no output at all for a call that succeeded', () => {
+    // OVERRIDES THE ORIGINAL PLAN. A successful smart_read would otherwise
+    // deposit 4 KB of file content per call: the evidence log would grow with
+    // file text and the privacy surface would be every file the session read.
+    // `success` and `exit` already carry everything a "this works" claim needs.
+    outcome({ output: 'FILE BODY LINE ONE', exit: 0, success: true });
+    expect(latest().success).toBe(true);
+    expect(latest().output).toBeUndefined();
+    expect(JSON.stringify(latest())).not.toContain('FILE BODY');
+  });
+
+  it('still captures output when the outcome never said whether it worked', () => {
+    // Unclassified is not successful. A client too terse to report status
+    // still produces failures, and dropping their text would lose exactly the
+    // ones worth having.
+    outcome({ output: 'segfault', exit: null, success: undefined });
+    expect(latest().output).toBe('segfault');
   });
 
   it('omits output entirely when nothing was captured', () => {
@@ -127,6 +153,43 @@ describe('tool-outcome carries output and exit', () => {
     expect(latest().joinMethod).toBe('tool-call-id');
     expect(latest().findingIds).toEqual(['f-1']);
     expect(latest().injectionId).toBeTruthy();
+  });
+});
+
+describe("toolSucceeded reads MCP's own failure flag", () => {
+  it('classifies an MCP isError result as a failure', () => {
+    // The only failure signal an MCP result carries: no `error` field, no
+    // `status`. Missing it recorded every failed smart_edit as a success and
+    // biased effectiveness accounting in the optimizer's own favour.
+    expect(
+      toolSucceeded({
+        tool_response: {
+          content: [{ type: 'text', text: '{"success": false}' }],
+          isError: true,
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('reads isError in every envelope, and at the top level', () => {
+    expect(toolSucceeded({ toolResponse: { isError: true } })).toBe(false);
+    expect(toolSucceeded({ tool_result: { isError: true } })).toBe(false);
+    expect(toolSucceeded({ isError: true })).toBe(false);
+  });
+
+  it('leaves a successful MCP result classified as a success', () => {
+    // isError absent, and isError:false, both mean the call worked. Only
+    // `true` may flip the verdict, or every MCP call becomes a failure.
+    expect(
+      toolSucceeded({ tool_response: { content: [{ type: 'text', text: 'ok' }] } })
+    ).toBe(true);
+    expect(toolSucceeded({ tool_response: { isError: false } })).toBe(true);
+  });
+
+  it('does not treat a truthy non-boolean isError as a verdict', () => {
+    // Exact `=== true` only: a client using the key for something else must
+    // not have its successful calls silently recorded as failures.
+    expect(toolSucceeded({ tool_response: { isError: 'no' } })).toBe(true);
   });
 });
 

--- a/tests/hooks/capture-results.test.mjs
+++ b/tests/hooks/capture-results.test.mjs
@@ -23,6 +23,7 @@ import {
   outputFrom,
   exitFrom,
   toolSucceeded,
+  mutationSucceeded,
 } from '../../hooks-core/adapter.mjs';
 
 let dir;
@@ -190,6 +191,95 @@ describe("toolSucceeded reads MCP's own failure flag", () => {
     // Exact `=== true` only: a client using the key for something else must
     // not have its successful calls silently recorded as failures.
     expect(toolSucceeded({ tool_response: { isError: 'no' } })).toBe(true);
+  });
+});
+
+describe("mutationSucceeded reads MCP's own failure flag too", () => {
+  // The six clients whose lifecycle contract makes the allowlist return true
+  // for any error-free, status-free post-tool event. That allowlist is what a
+  // failed smart_write used to slip through.
+  const ALLOWLISTED = [
+    'claude-code',
+    'codex',
+    'qwen',
+    'opencode',
+    'kilo',
+    'windsurf',
+  ];
+  const failedWrite = {
+    tool_response: {
+      content: [{ type: 'text', text: '{"success": false, "error": "read-only"}' }],
+      isError: true,
+    },
+  };
+
+  it('stops counting a failed MCP write as a mutation on every allowlisted client', () => {
+    for (const client of ALLOWLISTED)
+      expect(mutationSucceeded(client, failedWrite)).toBe(false);
+  });
+
+  it('overrides gemini, whose rule passes any tool_response at all', () => {
+    expect(mutationSucceeded('gemini', failedWrite)).toBe(false);
+  });
+
+  it('outranks an explicit success flag, because mutation accounting is conservative', () => {
+    // A failed edit must not arm Stop even if the envelope also claims success.
+    expect(
+      mutationSucceeded('claude-code', { ...failedWrite, success: true })
+    ).toBe(false);
+  });
+
+  it('outranks a positive status, for the same reason', () => {
+    expect(
+      mutationSucceeded('claude-code', {
+        tool_response: { status: 'ok', isError: true },
+      })
+    ).toBe(false);
+  });
+
+  it('reads isError in every envelope for mutation accounting too', () => {
+    expect(mutationSucceeded('codex', { toolResponse: { isError: true } })).toBe(
+      false
+    );
+    expect(mutationSucceeded('codex', { tool_result: { isError: true } })).toBe(
+      false
+    );
+    expect(mutationSucceeded('codex', { toolResult: { isError: true } })).toBe(
+      false
+    );
+    expect(mutationSucceeded('codex', { isError: true })).toBe(false);
+  });
+
+  it('still counts a successful MCP write, and a plain successful edit', () => {
+    // The gate must not turn every mutation into a non-mutation: that would
+    // silently stop all edit counting and harvest pressure.
+    expect(
+      mutationSucceeded('claude-code', {
+        tool_response: { content: [{ type: 'text', text: '{"success": true}' }] },
+      })
+    ).toBe(true);
+    expect(
+      mutationSucceeded('claude-code', {
+        tool_response: { content: [{ type: 'text', text: 'ok' }], isError: false },
+      })
+    ).toBe(true);
+    expect(
+      mutationSucceeded('claude-code', { tool_response: { status: 'ok' } })
+    ).toBe(true);
+  });
+
+  it('does not treat a truthy non-boolean isError as a mutation failure', () => {
+    expect(
+      mutationSucceeded('claude-code', { tool_response: { isError: 'no' } })
+    ).toBe(true);
+  });
+
+  it('leaves an unlisted client uncounted, as it was', () => {
+    // Regression guard on the pre-existing conservatism: adding the isError
+    // gate must not accidentally make a client count that never did.
+    expect(mutationSucceeded('cursor', { tool_response: { stdout: 'ok' } })).toBe(
+      false
+    );
   });
 });
 

--- a/tests/hooks/consolidate.test.mjs
+++ b/tests/hooks/consolidate.test.mjs
@@ -95,11 +95,18 @@ describe('selection is derived, with a floor for dead ends', () => {
   });
 
   test('decisions are on the floor too', () => {
+    // THE TWO SUMMARIES ARE THE SAME LENGTH, and the budget holds exactly one of
+    // them. The previous fixture gave the decision a much SHORTER summary than
+    // the finding, so the finding did not fit the budget at all and the decision
+    // was kept by ranking -- the test passed with the floor deleted. Equal carry
+    // cost is what makes this a test of the floor rather than of arithmetic: on
+    // rank alone the 80,000-token finding wins every time.
     const { kept } = selectForConsolidation(graph(), [
-      { type: 'finding', summary: 'expensive thing '.repeat(6), anchors: ['/a.ts'], tokensSpent: 80_000 },
-      { type: 'decision', summary: 'chose per-host budgets', anchors: ['/a.ts'], tokensSpent: 50 },
+      { type: 'finding', summary: 'an expensive analysis of the retry path', anchors: ['/a.ts'], tokensSpent: 80_000 },
+      { type: 'decision', summary: 'chose per-host retry budgets, not one', anchors: ['/a.ts'], tokensSpent: 50 },
     ], { budget: 10 });
 
+    expect(kept).toHaveLength(1);
     expect(kept.map((k) => k.type)).toContain('decision');
   });
 
@@ -255,6 +262,33 @@ describe('scoring inputs are the ones the module claims to use', () => {
 
   test('an explicitly measured spend still wins over the evidence-size fallback', () => {
     expect(costToRederive({ summary: 'x', evidence: 'y', tokensSpent: 4242 })).toBe(4242);
+  });
+
+  test('scores the `claim` field, which is what every layer that stores a finding calls it', () => {
+    // THE MISMATCH WAS SILENT AND TOTAL. This module was written against an
+    // extractor producing `summary`; the graph node, `consolidationRatio` in this
+    // same file, and the renderer all call the text `claim`. So for a
+    // claim-shaped candidate `estimate(entry.summary)` was 0, `spent + 0 > budget`
+    // was never true, and the budget admitted EVERYTHING while reporting a tidy
+    // `tokens: 0`. A bound that cannot bind is worse than no bound.
+    const candidates = Array.from({ length: 30 }, (_, i) => ({
+      type: 'command', claim: `conclusion number ${i} with a reasonably long claim`,
+      anchors: ['/a.ts'], tokensSpent: 1000 * i,
+    }));
+    const out = selectForConsolidation(graph(), candidates, { budget: 40 });
+    expect(out.tokens).toBeGreaterThan(0);
+    expect(out.tokens).toBeLessThanOrEqual(40);
+    expect(out.kept.length).toBeLessThan(candidates.length);
+  });
+
+  test('irrecoverability reads a `claim` too, so the multiplier is not a constant', () => {
+    expect(irrecoverability({ claim: 'only fails intermittently under load' }))
+      .toBeGreaterThan(irrecoverability({ claim: 'the handler returns early' }));
+  });
+
+  test('the evidence-size fallback works off a `claim` when there is no evidence', () => {
+    expect(costToRederive({ type: 'command', claim: 'a claim with some length to it' }))
+      .toBeGreaterThan(0);
   });
 });
 

--- a/tests/hooks/derive.test.mjs
+++ b/tests/hooks/derive.test.mjs
@@ -16,7 +16,7 @@ import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { record, recordToolOutcome } from '../../hooks-core/metrics.mjs';
-import { transcriptDir, safeName } from '../../hooks-core/transcript.mjs';
+import { readArchive, transcriptDir, safeName } from '../../hooks-core/transcript.mjs';
 import { load, putNode, putEdge, nodeId } from '../../hooks-core/wiki.mjs';
 import { indexFile } from '../../hooks-core/staleness.mjs';
 import { canonicalPath } from '../../hooks-core/paths.mjs';
@@ -575,6 +575,147 @@ describe('wired at session end', () => {
       // The count, not the candidates: whether a session's own evidence
       // supports any finding at all is the number that says this is working.
       expect(derived[0].candidates).toBeGreaterThan(0);
+    } finally {
+      try {
+        rmSync(workspace, { recursive: true, force: true });
+      } catch {
+        /* windows */
+      }
+    }
+  });
+});
+
+/**
+ * The Claude Code Stop path, end to end, asserted on STORAGE.
+ *
+ * A CANDIDATE COUNT IS NOT A FINDING. The test above proves `derive` is reached
+ * from a generated client entry and records a count; it deliberately does not
+ * prove anything landed, and its own workspace has no project marker, so the
+ * anchor falls back to the directory, `indexFile` returns null, and nothing is
+ * stored. That is exactly the failure mode Task 4 found by measuring: healthy
+ * counts, empty graph. So this asserts the node in the graph.
+ *
+ * AND IT USES CLAUDE CODE'S OWN ENTRY. Claude Code is the client most users are
+ * on, and its Stop hook is a separate file from the generated ones -- so a
+ * regression that unregisters or rewrites it is invisible to a test that spawns
+ * cursor's. That is not hypothetical here: #300 replaced `stop-harvest.mjs` with
+ * `stop.mjs` in `hooks.json` and the archive call inside the old entry was lost
+ * with it, silently, for every Claude Code user.
+ */
+describe('through the Claude Code Stop hook', () => {
+  const stopHook = (workspace, wiki, payload) =>
+    spawnSync(
+      process.execPath,
+      [join(process.cwd(), 'plugin', 'hooks', 'stop.mjs')],
+      {
+        cwd: workspace,
+        env: {
+          ...process.env,
+          TOKEN_OPTIMIZER_STATE_DIR: join(workspace, '.state'),
+          TOKEN_OPTIMIZER_WIKI_DIR: wiki,
+          TOKEN_OPTIMIZER_SHARED_DIR: join(workspace, '.shared'),
+        },
+        input: JSON.stringify(payload),
+        encoding: 'utf8',
+        timeout: 60_000,
+      }
+    );
+
+  /**
+   * A workspace shaped like a real project, because every discipline in the
+   * pipeline is a real check: a VCS root (`writeHarvested` refuses an anchor
+   * with no ancestor), and a manifest (`projectAnchor` needs a FILE).
+   */
+  const project = () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'der-cc-'));
+    mkdirSync(join(workspace, '.git'), { recursive: true });
+    writeFileSync(join(workspace, 'package.json'), '{"name":"fixture"}');
+    const wiki = join(workspace, '.wiki');
+    mkdirSync(wiki, { recursive: true });
+    return { workspace, wiki };
+  };
+
+  const evidence = (wiki) =>
+    writeFileSync(
+      join(wiki, 'metrics.jsonl'),
+      [
+        { kind: 'tool-outcome', surface: 'command', anchor: 'deploy', success: false, output: 'connection refused by host', at: 1 },
+        { kind: 'tool-outcome', surface: 'command', anchor: 'deploy --retry', success: true, at: 2 },
+      ]
+        .map((event) => JSON.stringify(event))
+        .join('\n') + '\n'
+    );
+
+  it('leaves findings in the graph, not just a count in the log', () => {
+    const { workspace, wiki } = project();
+    try {
+      evidence(wiki);
+
+      const result = stopHook(workspace, wiki, {
+        session_id: 'cc-session',
+        cwd: workspace,
+      });
+      expect(result.status).toBe(0);
+
+      const findings = [...load(wiki).nodes.values()].filter(
+        (node) => node.kind === 'finding'
+      );
+      expect(findings.length).toBeGreaterThan(0);
+      // Anchored to the manifest, which is what makes them invalidatable --
+      // and what distinguishes a stored finding from one refused for having an
+      // anchor nothing can ever re-check.
+      expect(
+        load(wiki).edges.some(
+          (edge) =>
+            edge.edge === 'derived_from' &&
+            edge.to === nodeId('file', canonicalPath(join(workspace, 'package.json')))
+        )
+      ).toBe(true);
+    } finally {
+      try {
+        rmSync(workspace, { recursive: true, force: true });
+      } catch {
+        /* windows */
+      }
+    }
+  });
+
+  it('archives the session transcript, which #300 stopped doing', () => {
+    // THE ARCHIVE IS WHAT SURVIVES THE SESSION. `derive`'s correction detector
+    // reads it first and falls back to the live transcript; `lessons.mjs` can
+    // verify a verbatim quote against nothing else, and that verification is
+    // the only route to a human-origin finding. Losing it failed silently,
+    // because an empty archive and an unarchived session are the same value.
+    const { workspace, wiki } = project();
+    const transcript = join(workspace, 'session.jsonl');
+    try {
+      writeFileSync(
+        transcript,
+        [
+          { type: 'user', message: { role: 'user', content: 'add a test for the parser' } },
+          { type: 'user', message: { role: 'user', content: 'no, use npm test rather than npx jest' } },
+        ]
+          .map((row) => JSON.stringify(row))
+          .join('\n') + '\n'
+      );
+
+      const result = stopHook(workspace, wiki, {
+        session_id: 'cc-archive',
+        cwd: workspace,
+        transcript_path: transcript,
+      });
+      expect(result.status).toBe(0);
+
+      const archived = readArchive(wiki, 'cc-archive');
+      expect(archived.map((turn) => turn.text)).toContain(
+        'no, use npm test rather than npx jest'
+      );
+      // And the archive is immediately useful: the correction detector reads it
+      // in the same hook run, so the turn becomes a finding without a model.
+      const feedback = [...load(wiki).nodes.values()].filter(
+        (node) => node.kind === 'finding' && node.type === 'feedback'
+      );
+      expect(feedback.length).toBeGreaterThan(0);
     } finally {
       try {
         rmSync(workspace, { recursive: true, force: true });

--- a/tests/hooks/derive.test.mjs
+++ b/tests/hooks/derive.test.mjs
@@ -26,7 +26,13 @@ import { load, putNode, putEdge, nodeId } from '../../hooks-core/wiki.mjs';
 import { indexFile } from '../../hooks-core/staleness.mjs';
 import { canonicalPath } from '../../hooks-core/paths.mjs';
 import { ORIGIN_HARVESTED, ORIGIN_HUMAN } from '../../hooks-core/curate.mjs';
-import { derive, CONFIDENCE, attemptKey, projectAnchor } from '../../hooks-core/derive.mjs';
+import {
+  derive,
+  CONFIDENCE,
+  attemptKey,
+  commandBody,
+  projectAnchor,
+} from '../../hooks-core/derive.mjs';
 
 let dir;
 
@@ -740,6 +746,70 @@ describe('what counts as the same attempt', () => {
   it('keeps two scripts behind one runner apart', () => {
     expect(attemptKey('npm run build')).not.toBe(attemptKey('npm run test'));
   });
+
+  it('skips a leading directory change, which says where and not what', () => {
+    // THE BUG THIS FIXES, measured on this repository's own 2,243 command
+    // outcomes: 1,400 of them open with a `cd`, and the single key
+    // `cd c:/users/.../token-optimizer-mcp &&` covered 547 distinct command
+    // lines. Every one of the three tokens went to the directory change, so the
+    // key named no command at all.
+    expect(attemptKey('cd /repo && npm test')).toBe('npm test');
+    expect(attemptKey('cd /repo && npm test')).toBe(attemptKey('npm test'));
+    // And the distinctions the key is FOR still hold across the prefix: two
+    // scripts behind one runner must not merge just because both were cd'd to.
+    expect(attemptKey('cd /repo && npm run build')).not.toBe(
+      attemptKey('cd /repo && npm run test')
+    );
+  });
+
+  it('skips the three separators that were observed, and repeats', () => {
+    // `&&` (1,147), a newline (204) and `;` (38) are the separators that follow
+    // a leading `cd` in this corpus. All three mean "then run this".
+    expect(attemptKey('cd /repo && npm test')).toBe('npm test');
+    expect(attemptKey('cd /repo; npm test')).toBe('npm test');
+    expect(attemptKey('cd /repo\nnpm test')).toBe('npm test');
+    // Repeated, so a nested change still reaches the command.
+    expect(attemptKey('cd /repo && cd sub && npm test')).toBe('npm test');
+  });
+
+  it('runs to the separator rather than counting tokens', () => {
+    // A quoted path containing spaces and a `cd /d` flag would each defeat a
+    // rule that skipped a fixed number of tokens. Neither needs its own case.
+    expect(attemptKey('cd "C:/Program Files/repo" && npm test')).toBe('npm test');
+    expect(attemptKey('cd /d C:/repo && npm test')).toBe('npm test');
+  });
+
+  it('leaves a directory change with no separator alone', () => {
+    // `cd <path>` on its own ran no command, so there is nothing to recover and
+    // nothing to claim. Stripping it would leave an empty key, which would
+    // silently drop the outcome from grouping on a rule nothing measured.
+    expect(commandBody('cd /repo')).toBe('cd /repo');
+    expect(attemptKey('cd /repo')).toBe('cd /repo');
+  });
+
+  it('refuses to skip any prefix wider than the measured one', () => {
+    // OVER-STRIPPING IS THE SAME BUG IN THE OTHER DIRECTION. Each of these was
+    // considered and rejected against this corpus.
+    //
+    // An environment assignment DOES say something about what ran: the one true
+    // instance here is `TOKEN_OPTIMIZER_HOLDOUT=1 node ... jest.js ...`, and the
+    // holdout arm is a genuinely different attempt from the same command
+    // without it.
+    expect(attemptKey('TOKEN_OPTIMIZER_HOLDOUT=1 npm test')).not.toBe(attemptKey('npm test'));
+    // `time`, `env` and `bash -c` occurred ZERO times in 2,243 commands, so
+    // code for them would be an unmeasured way to over-strip.
+    expect(attemptKey('time npm test')).not.toBe(attemptKey('npm test'));
+    expect(attemptKey('bash -c "npm test"')).not.toBe(attemptKey('npm test'));
+    // `||` puts an error BRANCH after the separator, not the next step, so
+    // stripping there would key the attempt on a failure handler. Zero
+    // occurrences.
+    expect(commandBody('cd /repo || echo failed')).toBe('cd /repo || echo failed');
+    // And only a LEADING change is a preamble. A `cd` in the middle is part of
+    // what ran.
+    expect(commandBody('npm test && cd /repo && ls')).toBe('npm test && cd /repo && ls');
+    // `cdk` is not `cd`.
+    expect(attemptKey('cdk deploy --all')).toBe('cdk deploy');
+  });
 });
 
 /**
@@ -956,8 +1026,17 @@ describe('a failure that exists only in the transcript', () => {
     // SHORT ON PURPOSE. Both commands are well inside 120 characters, so the
     // length half of the rule cannot be what refuses them -- otherwise removing
     // either half leaves the other and this passes having tested neither.
+    //
+    // AND THEY STILL SHARE A KEY AFTER `commandBody`, which is why both tails
+    // are `npm run build` rather than `build` against `ship`: the leading
+    // `cd sub` is now stripped, so `build` against `ship` would land in
+    // separate groups and this would pass on a key mismatch, testing neither
+    // half.
     withManifest();
-    outcome('cd sub\nnpm run ship', { success: true, at: 2000 });
+    expect(attemptKey('cd sub\nnpm run build --json')).toBe(
+      attemptKey('cd sub\nnpm run build')
+    );
+    outcome('cd sub\nnpm run build --json', { success: true, at: 2000 });
     const path = transcriptFile([
       toolUse('toolu_1', 'cd sub\nnpm run build', '1970-01-01T00:00:01.000Z'),
       toolResult('toolu_1', 'Exit code 1\nSyntaxError: missing )', '1970-01-01T00:00:01.000Z'),
@@ -993,17 +1072,24 @@ describe('a failure that exists only in the transcript', () => {
   });
 
   it('claims nothing when the attempt key never reached a command', () => {
-    // `attemptKey` spends three non-flag tokens on identity, and the habit here
-    // is `cd <absolute path> && <the real command>` -- which spends all three on
-    // `cd`, the path and `&&`. This project's own evidence: the single key
-    // `cd c:/users/.../token-optimizer-mcp &&` covers 539 DISTINCT command
-    // lines, so a pair drawn from that group compares two unrelated commands and
-    // is false about both. Both sides here are single-line and well inside 120
-    // characters, so `quotable` cannot be what refuses them.
+    // `attemptKey` spends three non-flag tokens on identity, and a key that runs
+    // out of them on a separator names no command: the two sides are then two
+    // unrelated things that happen to be chained the same way, and any pair
+    // drawn from that group is false about both halves.
+    //
+    // THE PREFIX IS NOT A `cd` ON PURPOSE. `commandBody` now strips a leading
+    // directory change, so written as `cd repo && git merge ...` against
+    // `cd repo && grep ...` the two sides get DIFFERENT keys, never meet, and
+    // this would pass on a key mismatch with the identity rule deleted -- the
+    // one-fixture-two-mechanisms defect these plans keep hitting. `git fetch &&`
+    // is a separator-terminated key that `commandBody` deliberately leaves
+    // alone. Both sides are single-line and well inside 120 characters, so
+    // `quotable` cannot be what refuses them either.
     withManifest();
-    const failing = 'cd repo && git merge origin/master';
-    const succeeding = 'cd repo && grep -n foo lib.mjs';
+    const failing = 'git fetch && git merge origin/master';
+    const succeeding = 'git fetch && grep -n foo lib.mjs';
     expect(attemptKey(failing)).toBe(attemptKey(succeeding));
+    expect(attemptKey(failing)).toBe('git fetch &&');
     outcome(succeeding, { success: true, at: 2000 });
     const path = transcriptFile([
       toolUse('toolu_1', failing, '1970-01-01T00:00:01.000Z'),
@@ -1012,6 +1098,72 @@ describe('a failure that exists only in the transcript', () => {
 
     const derived = run({ transcriptPath: path }).candidates;
     expect(derived.filter((c) => c.type === 'command' || c.type === 'failure')).toEqual([]);
+  });
+
+  it('pairs across a leading directory change, which it could not before', () => {
+    // THE PAIR THE OLD KEY THREW AWAY. `cd <path> && <command>` is the habit on
+    // this machine -- 1,400 of 2,243 command outcomes -- and it spent all three
+    // key tokens on `cd`, the path and the separator. The failure therefore
+    // landed in a group of 547 unrelated command lines instead of beside the
+    // success of the same command, and `hasAttemptIdentity` then (correctly)
+    // refused every pair drawn from it. Measured on 164 real transcripts: of the
+    // 8 quotable command failures this machine holds, one was refused for
+    // exactly this reason and is recovered here.
+    withManifest();
+    expect(attemptKey('cd repo && deploy')).toBe(attemptKey('deploy --retry'));
+    outcome('deploy --retry', { success: true, at: 2000 });
+    const path = transcriptFile([
+      toolUse('toolu_1', 'cd repo && deploy', '1970-01-01T00:00:01.000Z'),
+      toolResult('toolu_1', 'Exit code 1\nconnection refused by host', '1970-01-01T00:00:01.000Z'),
+    ]);
+
+    const candidates = run({ transcriptPath: path }).candidates;
+    const command = candidates.find((c) => c.type === 'command');
+    // THE CLAIM QUOTES WHAT RAN, `cd` and all. The prefix is dropped from the
+    // KEY, not from the record: a reader retrying this needs the line as it was.
+    expect(command.claim).toContain(
+      '`deploy --retry` succeeded in this project where `cd repo && deploy` failed'
+    );
+    expect(command.confidence).toBe(CONFIDENCE.command);
+  });
+
+  it('claims nothing when the two sides differ only by the directory change', () => {
+    // THE REFUSAL THAT KEEPS THE BETTER KEY FROM BECOMING A LICENCE TO PAIR
+    // LOOSELY. `cd repo && npm test` and `npm test` are one attempt spelled two
+    // ways. Before `commandBody` they never met; letting them meet without
+    // widening the identical-text guard to the STRIPPED text would emit
+    // "`npm test` succeeded where `cd repo && npm test` failed" at 0.85 -- a
+    // difference in the claim that is not a difference in what ran.
+    //
+    // BOTH SIDES ARE SHORT AND SINGLE-LINE, so `quotable` cannot be what refuses
+    // them, and they share a key by construction so `hasAttemptIdentity` cannot
+    // be either.
+    withManifest();
+    expect(attemptKey('cd repo && npm test')).toBe(attemptKey('npm test'));
+    outcome('npm test', { success: true, at: 2000 });
+    const path = transcriptFile([
+      toolUse('toolu_1', 'cd repo && npm test', '1970-01-01T00:00:01.000Z'),
+      toolResult('toolu_1', 'Exit code 1\n2 failing', '1970-01-01T00:00:01.000Z'),
+    ]);
+
+    const derived = run({ transcriptPath: path }).candidates;
+    expect(derived.filter((c) => c.type === 'command')).toEqual([]);
+  });
+
+  it('claims nothing when one command was run in two different directories', () => {
+    // The same refusal from the other side: `cd a && deploy` against
+    // `cd b && deploy` is one command tried in two places, not two commands.
+    // Claiming that one directory works where the other fails is a claim about
+    // the directories, which nothing here observed.
+    withManifest();
+    outcome('cd b && deploy', { success: true, at: 2000 });
+    const path = transcriptFile([
+      toolUse('toolu_1', 'cd a && deploy', '1970-01-01T00:00:01.000Z'),
+      toolResult('toolu_1', 'Exit code 1\nconnection refused by host', '1970-01-01T00:00:01.000Z'),
+    ]);
+
+    const derived = run({ transcriptPath: path }).candidates;
+    expect(derived.filter((c) => c.type === 'command')).toEqual([]);
   });
 
   it('scans a bounded tail, so session end cannot be turned into real work', () => {

--- a/tests/hooks/derive.test.mjs
+++ b/tests/hooks/derive.test.mjs
@@ -15,8 +15,13 @@ import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from 'nod
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { record, recordToolOutcome } from '../../hooks-core/metrics.mjs';
-import { readArchive, transcriptDir, safeName } from '../../hooks-core/transcript.mjs';
+import { record, recordToolOutcome, readMetrics } from '../../hooks-core/metrics.mjs';
+import {
+  readArchive,
+  transcriptDir,
+  safeName,
+  failedResultsFromTranscript,
+} from '../../hooks-core/transcript.mjs';
 import { load, putNode, putEdge, nodeId } from '../../hooks-core/wiki.mjs';
 import { indexFile } from '../../hooks-core/staleness.mjs';
 import { canonicalPath } from '../../hooks-core/paths.mjs';
@@ -734,5 +739,328 @@ describe('what counts as the same attempt', () => {
 
   it('keeps two scripts behind one runner apart', () => {
     expect(attemptKey('npm run build')).not.toBe(attemptKey('npm run test'));
+  });
+});
+
+/**
+ * FAILED TOOL RESULTS, WHICH ARRIVE ONLY IN THE TRANSCRIPT.
+ *
+ * Claude Code never fires PostToolUse for a failed tool call -- 2,238 of 2,238
+ * live `tool-outcome` events on the measuring machine carry `success: true` --
+ * so the two strongest detectors above had NO INPUT AT ALL on the primary
+ * client. These fixtures are transcribed from real transcript lines rather than
+ * invented: `type: 'assistant'` with a `tool_use` block carrying
+ * `input.command`, then `type: 'user'` with a `tool_result` block carrying
+ * `is_error: true` and a STRING `content` beginning `Exit code N`. Three
+ * consecutive tasks on these plans shipped extractors whose fixtures did not
+ * match production, which is the specific mistake these shapes exist to avoid.
+ */
+const transcriptFile = (lines) => {
+  const path = join(dir, 'transcript.jsonl');
+  writeFileSync(path, lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+  return path;
+};
+
+/** An assistant turn issuing a tool call, exactly as Claude Code records one. */
+const toolUse = (id, command, at) => ({
+  type: 'assistant',
+  message: {
+    role: 'assistant',
+    content: [{ type: 'tool_use', id, name: 'Bash', input: { command, description: 'x' } }],
+  },
+  timestamp: at,
+});
+
+/** The result turn. `content` is a bare string; the error flag is `is_error`. */
+const toolResult = (id, content, at) => ({
+  type: 'user',
+  message: {
+    role: 'user',
+    content: [{ type: 'tool_result', content, is_error: true, tool_use_id: id }],
+  },
+  timestamp: at,
+  toolUseResult: `Error: ${content}`,
+});
+
+describe('a failure that exists only in the transcript', () => {
+  it('reads a failed Bash result the way Claude Code actually writes one', () => {
+    const path = transcriptFile([
+      toolUse('toolu_1', 'npm test', '2026-08-26T10:00:00.000Z'),
+      toolResult('toolu_1', 'Exit code 1\nFAIL src/a.test.ts', '2026-08-26T10:00:01.000Z'),
+    ]);
+
+    const failures = failedResultsFromTranscript(path);
+    expect(failures).toHaveLength(1);
+    expect(failures[0].command).toBe('npm test');
+    expect(failures[0].exit).toBe(1);
+    expect(failures[0].toolCallId).toBe('toolu_1');
+    // The exit line is stripped: `exit` carries it structurally, and leaving it
+    // in makes every failure claim read "failed with: Exit code 1".
+    expect(failures[0].output).toBe('FAIL src/a.test.ts');
+  });
+
+  it('refuses every is_error shape where the command never RAN', () => {
+    // MEASURED, NOT ASSUMED. Across three real transcripts 214 results carried
+    // `is_error: true` and only 83 were a command exiting non-zero. The other
+    // 131 are hook denials, protocol errors and human refusals -- and the
+    // largest group by far is THIS optimizer's own PreToolUse text. Ingesting
+    // those would have the tool derive 0.9-confidence findings from its own
+    // advice and serve them back as observations about the project.
+    const path = transcriptFile([
+      toolUse('a', 'grep -rn foo .', '2026-08-26T10:00:00.000Z'),
+      toolResult(
+        'a',
+        'Recursive shell searches return unbounded output. Call the token-optimizer MCP tool smart_grep instead',
+        '2026-08-26T10:00:01.000Z'
+      ),
+      toolUse('b', 'rm -rf build', '2026-08-26T10:01:00.000Z'),
+      toolResult('b', '<tool_use_error>Blocked: rm -rf build</tool_use_error>', '2026-08-26T10:01:01.000Z'),
+      toolUse('c', 'git push --force', '2026-08-26T10:02:00.000Z'),
+      toolResult(
+        'c',
+        "The user doesn't want to proceed with this tool use. The tool use was rejected",
+        '2026-08-26T10:02:01.000Z'
+      ),
+    ]);
+
+    expect(failedResultsFromTranscript(path)).toEqual([]);
+  });
+
+  it('redacts the failure output, which no capture boundary ever saw', () => {
+    // `recordToolOutcome` redacts `output` at its boundary. Transcript text has
+    // never passed one -- that boundary never saw it -- and this text is bound
+    // for a claim that is injected into model context and exported to markdown.
+    const path = transcriptFile([
+      toolUse('toolu_1', 'npm publish', '2026-08-26T10:00:00.000Z'),
+      toolResult(
+        'toolu_1',
+        'Exit code 1\nunauthorized: token ghp_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789',
+        '2026-08-26T10:00:01.000Z'
+      ),
+    ]);
+
+    const [failure] = failedResultsFromTranscript(path);
+    expect(failure.output).not.toContain('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789');
+    expect(failure.output).toContain('[redacted]');
+  });
+
+  it('produces the SAME attempt key as the event for one command', () => {
+    // THE JOIN, AND THE ONE THING THAT MAKES PAIRING POSSIBLE AT ALL. An event
+    // stores the command truncated to 120 characters; `attemptKey` reads three
+    // non-flag tokens off whatever it is handed. A long token cut by that cap
+    // yields a DIFFERENT key from the untruncated transcript copy, so the
+    // failure would land in a group of its own and never meet a success.
+    // Measured on one real session: truncating here made 266 of 266 keys agree
+    // where the untruncated text agreed on only 240.
+    const long = `node ${'x'.repeat(200)}.mjs --flag`;
+    outcome(long, { success: true, at: 2 });
+    const stored = readMetrics(dir).find((e) => e.kind === 'tool-outcome').anchor;
+    const path = transcriptFile([
+      toolUse('toolu_1', long, '2026-08-26T10:00:00.000Z'),
+      toolResult('toolu_1', 'Exit code 1\nboom', '2026-08-26T10:00:01.000Z'),
+    ]);
+
+    const [failure] = failedResultsFromTranscript(path);
+    expect(attemptKey(failure.command)).toBe(attemptKey(stored));
+  });
+
+  it('pairs a transcript failure with an event success, which is the whole point', () => {
+    withManifest();
+    outcome('deploy --retry', { success: true, at: 2000 });
+    const path = transcriptFile([
+      toolUse('toolu_1', 'deploy', '1970-01-01T00:00:01.000Z'),
+      toolResult('toolu_1', 'Exit code 1\nconnection refused by host', '1970-01-01T00:00:01.000Z'),
+    ]);
+
+    const candidates = run({ transcriptPath: path }).candidates;
+    const command = candidates.find((c) => c.type === 'command');
+    const failure = candidates.find((c) => c.type === 'failure');
+    expect(command.claim).toContain('`deploy --retry` succeeded in this project where `deploy` failed');
+    expect(command.confidence).toBe(CONFIDENCE.command);
+    expect(failure.claim).toContain('connection refused by host');
+  });
+
+  it('deduplicates one failure reported twice on the CALL ID alone', () => {
+    // On the ten clients that DO report failures, the same failure arrives from
+    // both sources. `toolCallId` is the SAME STRING in both -- `episodeMeta`
+    // reads the transcript's `tool_use_id` into it -- so the event copy wins
+    // and the transcript copy is dropped before grouping. Without that, the two
+    // copies sit in one run and the second is paired against the first as a
+    // failed-then-succeeded story about itself.
+    //
+    // THE TIMESTAMPS ARE HOURS APART ON PURPOSE. With them equal the text-and-
+    // time fallback below ALSO dedupes the pair, so disabling the id check
+    // changed nothing and this test passed while asserting nothing about the id.
+    // That is the two-mechanisms-in-one-fixture defect this plan has hit on
+    // three consecutive tasks.
+    // AND THE TWO COPIES SAY DIFFERENT THINGS, which is what makes this
+    // observable at all. A duplicated failure never produces a second PAIR --
+    // the nearest-preceding-failure rule just overwrites one with the other --
+    // so a count assertion alone passes with the deduplication removed. What
+    // changes is WHICH copy gets quoted, and the event copy is the one that
+    // passed `recordToolOutcome`'s redaction and 4 KB cap.
+    withManifest();
+    recordToolOutcome(dir, {
+      kind: 'tool-outcome',
+      surface: 'command',
+      anchor: 'deploy',
+      toolCallId: 'toolu_1',
+      success: false,
+      output: 'connection refused by host',
+      at: 1000,
+    });
+    outcome('deploy --retry', { success: true, at: 9_000_000 });
+    const path = transcriptFile([
+      toolUse('toolu_1', 'deploy', '1970-01-01T02:00:00.000Z'),
+      toolResult('toolu_1', 'Exit code 7\nDNS lookup failed', '1970-01-01T02:00:00.000Z'),
+    ]);
+
+    const candidates = run({ transcriptPath: path }).candidates;
+    const commands = candidates.filter((c) => c.type === 'command');
+    expect(commands).toHaveLength(1);
+    expect(commands[0].claim).not.toContain('`deploy` succeeded');
+    const failures = candidates.filter((c) => c.type === 'failure');
+    expect(failures).toHaveLength(1);
+    expect(failures[0].claim).toContain('connection refused by host');
+    expect(failures[0].claim).not.toContain('DNS lookup failed');
+  });
+
+  it('deduplicates on text and time when the client reported no call id', () => {
+    // The fallback, isolated the same way: no `toolCallId` on either side, so
+    // only identical command text within two seconds can collapse the pair.
+    // Nothing re-runs a command that fast, so one text at one instant is one
+    // failure recorded twice rather than two failures.
+    withManifest();
+    outcome('deploy', { success: false, output: 'connection refused by host', at: 1000 });
+    outcome('deploy --retry', { success: true, at: 9_000_000 });
+    const path = transcriptFile([
+      toolUse('toolu_1', 'deploy', '1970-01-01T00:00:01.000Z'),
+      toolResult('toolu_1', 'Exit code 1\nconnection refused by host', '1970-01-01T00:00:01.000Z'),
+    ]);
+
+    const commands = run({ transcriptPath: path }).candidates.filter((c) => c.type === 'command');
+    expect(commands).toHaveLength(1);
+    expect(commands[0].claim).not.toContain('`deploy` succeeded');
+  });
+
+  it('claims nothing about a command that spans lines, which is a script', () => {
+    // THE MEASUREMENT THAT FORCED THIS REFUSAL. Wiring the reader produced four
+    // candidates at 0.9 confidence on this session, every one of them quoting a
+    // truncated multi-line shell script -- and then 0 of 83 captured command
+    // failures across three real transcripts turned out to be single-line and
+    // inside the 120-character cap (29 of 30 in one transcript were multi-line).
+    // A claim whose subject is a fragment of a program is not a weaker claim, it
+    // is not a claim, so this sits beside the identical-text guard rather than
+    // taking a lower ceiling.
+    //
+    // SHORT ON PURPOSE. Both commands are well inside 120 characters, so the
+    // length half of the rule cannot be what refuses them -- otherwise removing
+    // either half leaves the other and this passes having tested neither.
+    withManifest();
+    outcome('cd sub\nnpm run ship', { success: true, at: 2000 });
+    const path = transcriptFile([
+      toolUse('toolu_1', 'cd sub\nnpm run build', '1970-01-01T00:00:01.000Z'),
+      toolResult('toolu_1', 'Exit code 1\nSyntaxError: missing )', '1970-01-01T00:00:01.000Z'),
+    ]);
+
+    const derived = run({ transcriptPath: path }).candidates;
+    expect(derived.filter((c) => c.type === 'command' || c.type === 'failure')).toEqual([]);
+  });
+
+  it('claims nothing about a command the 120-char anchor cap already cut', () => {
+    // The other half, isolated: one line each, both long enough that the anchor
+    // truncation reached them. A reader cannot act on a command whose text stops
+    // mid-argument, and a bigger cap would not help -- the whole script is no
+    // more actionable than its first 120 characters.
+    // THE TWO COMMANDS SHARE AN ATTEMPT KEY ON PURPOSE. Written as
+    // `node scripts/build.mjs ...` against `node scripts/ship.mjs ...` they
+    // differ in their SECOND token, so they never met in the first place and the
+    // refusal under test was never reached -- the test passed on a key mismatch
+    // and survived removing the length rule entirely.
+    withManifest();
+    const long = (reporter) =>
+      `npm run build -- --reporter=${reporter} ${'--pad=x '.repeat(20)}`.trim();
+    expect(long('json').length).toBeGreaterThan(120);
+    expect(attemptKey(long('json'))).toBe(attemptKey(long('verbose')));
+    outcome(long('json'), { success: true, at: 2000 });
+    const path = transcriptFile([
+      toolUse('toolu_1', long('verbose'), '1970-01-01T00:00:01.000Z'),
+      toolResult('toolu_1', 'Exit code 1\nENOENT', '1970-01-01T00:00:01.000Z'),
+    ]);
+
+    const derived = run({ transcriptPath: path }).candidates;
+    expect(derived.filter((c) => c.type === 'command' || c.type === 'failure')).toEqual([]);
+  });
+
+  it('claims nothing when the attempt key never reached a command', () => {
+    // `attemptKey` spends three non-flag tokens on identity, and the habit here
+    // is `cd <absolute path> && <the real command>` -- which spends all three on
+    // `cd`, the path and `&&`. This project's own evidence: the single key
+    // `cd c:/users/.../token-optimizer-mcp &&` covers 539 DISTINCT command
+    // lines, so a pair drawn from that group compares two unrelated commands and
+    // is false about both. Both sides here are single-line and well inside 120
+    // characters, so `quotable` cannot be what refuses them.
+    withManifest();
+    const failing = 'cd repo && git merge origin/master';
+    const succeeding = 'cd repo && grep -n foo lib.mjs';
+    expect(attemptKey(failing)).toBe(attemptKey(succeeding));
+    outcome(succeeding, { success: true, at: 2000 });
+    const path = transcriptFile([
+      toolUse('toolu_1', failing, '1970-01-01T00:00:01.000Z'),
+      toolResult('toolu_1', 'Exit code 1\nCONFLICT', '1970-01-01T00:00:01.000Z'),
+    ]);
+
+    const derived = run({ transcriptPath: path }).candidates;
+    expect(derived.filter((c) => c.type === 'command' || c.type === 'failure')).toEqual([]);
+  });
+
+  it('scans a bounded tail, so session end cannot be turned into real work', () => {
+    // A transcript is the largest file this project reads -- 45 MB on this
+    // machine -- and `archive()` already reads the whole thing at Stop.
+    const lines = [];
+    for (let i = 0; i < 400; i++) {
+      lines.push(toolUse(`old${i}`, `cmd${i} ${'p'.repeat(200)}`, '2026-08-26T09:00:00.000Z'));
+      lines.push(toolResult(`old${i}`, 'Exit code 1\nold failure', '2026-08-26T09:00:01.000Z'));
+    }
+    lines.push(toolUse('recent', 'npm test', '2026-08-26T10:00:00.000Z'));
+    lines.push(toolResult('recent', 'Exit code 1\nrecent failure', '2026-08-26T10:00:01.000Z'));
+    const path = transcriptFile(lines);
+
+    // `max` is raised beyond anything the file holds so the COUNT cap cannot be
+    // what bounds this: only the byte cap can. Left at its default of 50 the
+    // count cap alone kept the result under 400 and removing the byte bound
+    // changed nothing, which is the test-passes-for-the-wrong-reason shape.
+    const bounded = failedResultsFromTranscript(path, { scanBytes: 4096, max: 10_000 });
+    expect(bounded.length).toBeGreaterThan(0);
+    expect(bounded.length).toBeLessThan(20);
+    expect(bounded[bounded.length - 1].output).toBe('recent failure');
+    // The whole file, for contrast: the bound is doing the work, not the fixture.
+    expect(
+      failedResultsFromTranscript(path, { scanBytes: 50_000_000, max: 10_000 }).length
+    ).toBeGreaterThan(300);
+    // And the count cap holds independently of the byte cap.
+    expect(failedResultsFromTranscript(path, { max: 5 })).toHaveLength(5);
+  });
+
+  it('says nothing about a failure whose tool call it never saw', () => {
+    // The command is recoverable ONLY by joining `tool_use_id` back to the
+    // assistant block that issued it, and a bounded tail read routinely cuts
+    // that block off. With no command there is no subject for a claim, so the
+    // result is dropped -- a placeholder would put "`unknown` failed with: ..."
+    // into the graph at 0.9 confidence.
+    const path = transcriptFile([
+      toolResult('toolu_orphan', 'Exit code 1\nboom', '2026-08-26T10:00:01.000Z'),
+    ]);
+
+    expect(failedResultsFromTranscript(path)).toEqual([]);
+  });
+
+  it('returns nothing rather than throwing when there is no transcript to read', () => {
+    // Session end must cost nothing, and a client that reports no transcript
+    // path is the common case rather than an error.
+    expect(failedResultsFromTranscript(null)).toEqual([]);
+    expect(failedResultsFromTranscript(join(dir, 'missing.jsonl'))).toEqual([]);
+    writeFileSync(join(dir, 'junk.jsonl'), 'not json\n{"half":\n');
+    expect(failedResultsFromTranscript(join(dir, 'junk.jsonl'))).toEqual([]);
   });
 });

--- a/tests/hooks/derive.test.mjs
+++ b/tests/hooks/derive.test.mjs
@@ -1,0 +1,395 @@
+/**
+ * The zero-cost extractors -- and what they are NOT allowed to claim.
+ *
+ * The graph on this machine held 2,965 symbol nodes, 904 file nodes, 128 task
+ * nodes and ONE finding, because every path to a verdict needed an API key this
+ * machine does not have. These detectors need none. That makes them the only
+ * finding producer on a default install, which makes their PRECISION the whole
+ * question: a graph that fills with junk competes for the injection budget
+ * against the findings that are real, and is worse than an empty one.
+ *
+ * So most of what is tested here is refusal.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { record, recordToolOutcome } from '../../hooks-core/metrics.mjs';
+import { transcriptDir, safeName } from '../../hooks-core/transcript.mjs';
+import { derive, CONFIDENCE, attemptKey } from '../../hooks-core/derive.mjs';
+
+let dir;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'der-'));
+});
+
+afterEach(() => {
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* windows */
+  }
+});
+
+/**
+ * A command outcome as the boundary really writes it.
+ *
+ * THROUGH `recordToolOutcome`, NOT `record`. The command text lives in `anchor`
+ * (there is no command field), `output` is captured only when the call did not
+ * report success, and the redaction and the 4 KB cap happen at that boundary. A
+ * fixture that wrote the event by hand would be testing a shape production never
+ * produces -- which is how a detector keyed on a field nobody writes passes its
+ * own tests and derives nothing in the field.
+ */
+const outcome = (anchor, { success, output = null, exit = null, at }) =>
+  recordToolOutcome(dir, {
+    kind: 'tool-outcome',
+    surface: 'command',
+    anchor,
+    success,
+    output,
+    exit,
+    at,
+  });
+
+/** A user turn in the local archive, which is where corrections are read from. */
+const archiveTurns = (sessionId, turns) => {
+  mkdirSync(transcriptDir(dir), { recursive: true });
+  writeFileSync(
+    join(transcriptDir(dir), `${safeName(sessionId)}.jsonl`),
+    turns.map((t) => JSON.stringify(t)).join('\n') + '\n'
+  );
+};
+
+const run = (options = {}) =>
+  derive(dir, { sessionId: 's', projectRoot: dir, ...options });
+
+describe('a command that failed and then succeeded', () => {
+  it('turns a failed-then-succeeded command into a command and a failure finding', () => {
+    outcome('npm run build', { success: false, output: 'TS2345 error', exit: 1, at: 1 });
+    outcome('npm run build -- --skipLibCheck', { success: true, output: 'ok', exit: 0, at: 2 });
+
+    const types = run().candidates.map((c) => c.type);
+    expect(types).toContain('command');
+    expect(types).toContain('failure');
+  });
+
+  it('claims only what it observed -- succeeded WHERE, never fixed', () => {
+    // THE CAUSAL LIMIT, IN THE CLAIM TEXT. Two ordered outcomes on one attempt
+    // do not establish that the second command's difference caused the second
+    // outcome; an intervening edit or a flaky run explains the same pair. A
+    // claim of "fixes" would assert what no local evidence can support.
+    outcome('deploy', { success: false, output: 'connection refused by host', at: 1 });
+    outcome('deploy --retry', { success: true, output: 'ok', at: 2 });
+
+    const command = run().candidates.find((c) => c.type === 'command');
+    expect(command.claim).toContain('succeeded in this project where');
+    expect(command.claim).not.toMatch(/\bfix(es|ed)?\b/i);
+    expect(command.evidence).toContain('not proven causal');
+  });
+
+  it('derives nothing when the same command text failed and then succeeded', () => {
+    // THE COMMONEST SHAPE IN A CODING SESSION, and the one that supports no
+    // claim at all: build fails, code is fixed, build passes. "`npm test`
+    // succeeded where `npm test` failed" is incoherent, and "`npm test` fails"
+    // has just been disproved by the same pair. Both would be junk with a
+    // confidence number attached, and a ceiling cannot rescue a claim whose
+    // CONTENT is wrong.
+    outcome('npm test', { success: false, output: 'FAIL src/a.test.ts', exit: 1, at: 1 });
+    outcome('npm test', { success: true, output: 'ok', exit: 0, at: 2 });
+
+    expect(run().candidates).toEqual([]);
+  });
+
+  it('classifies failure from `success`, not from an exit code no MCP tool reports', () => {
+    // `exit` is null unless the client reported an integer, and MCP tools never
+    // do. A detector keyed on `exit !== 0` would be inert for most clients.
+    outcome('deploy', { success: false, output: 'connection refused by host', at: 1 });
+    outcome('deploy --retry', { success: true, at: 2 });
+
+    const candidates = run().candidates;
+    expect(candidates.map((c) => c.type)).toContain('command');
+    expect(candidates.every((c) => c.evidence.includes('exit'))).toBe(false);
+  });
+
+  it('pairs the NEAREST preceding failure, not the first of the session', () => {
+    outcome('deploy', { success: false, output: 'dns failure on first host', at: 1 });
+    outcome('deploy --wait', { success: false, output: 'timed out waiting for lock', at: 2 });
+    outcome('deploy --retry', { success: true, at: 3 });
+
+    const command = run().candidates.find((c) => c.type === 'command');
+    expect(command.claim).toContain('`deploy --wait` failed');
+  });
+
+  it('drops the failure finding when the client captured no error text', () => {
+    // "`deploy` failed with:" and nothing after the colon is a finding that
+    // carries no information and still costs injection budget.
+    outcome('deploy', { success: false, output: null, at: 1 });
+    outcome('deploy --retry', { success: true, at: 2 });
+
+    expect(run().candidates.map((c) => c.type)).toEqual(['command']);
+  });
+
+  it('does not pair two different scripts behind the same runner', () => {
+    // `npm run build` and `npm run test` are not the same attempt, and pairing
+    // them would produce "`npm run test` succeeded where `npm run build`
+    // failed" -- a claim that is simply false.
+    outcome('npm run build', { success: false, output: 'TS2345 in src/a.ts', at: 1 });
+    outcome('npm run test', { success: true, at: 2 });
+
+    expect(run().candidates).toEqual([]);
+  });
+
+  it('caps a code-sensitive transition lower than a command one', () => {
+    // A test or build going red-to-green is usually explained by the code
+    // changing between the runs, not by the command line.
+    outcome('deploy', { success: false, output: 'connection refused by host', at: 1 });
+    outcome('deploy --retry', { success: true, at: 2 });
+    outcome('npm run build', { success: false, output: 'TS2345 in src/a.ts', at: 3 });
+    outcome('npm run build --force', { success: true, at: 4 });
+
+    const byDerivation = new Map(
+      run().candidates.map((c) => [c.derivedBy, c.confidence])
+    );
+    expect(byDerivation.get('command-transition')).toBe(CONFIDENCE.command);
+    expect(byDerivation.get('test-transition')).toBe(CONFIDENCE.test);
+  });
+});
+
+describe('user corrections, without a model', () => {
+  it('derives a feedback finding from a correcting turn in the local archive', () => {
+    archiveTurns('s', [
+      { role: 'user', text: 'add a test for the parser' },
+      { role: 'assistant', text: 'done', tools: [] },
+      { role: 'user', text: 'no, use npm test rather than npx jest' },
+    ]);
+
+    const feedback = run().candidates.filter((c) => c.type === 'feedback');
+    expect(feedback.length).toBe(1);
+    expect(feedback[0].claim).toBe('no, use npm test rather than npx jest');
+    expect(feedback[0].confidence).toBe(CONFIDENCE.correction);
+  });
+
+  it('never promotes a guessed correction to human origin', () => {
+    // `writeHarvested` grants ORIGIN_HUMAN to a finding carrying a verbatim
+    // quote, and the standing layer injects human-origin claims on EVERY turn.
+    // The quote here is genuinely verbatim, but whether the turn was a
+    // correction at all is a lexical guess, and a guess must not buy always-on
+    // injection.
+    archiveTurns('s', [{ role: 'user', text: "don't commit straight to master" }]);
+
+    const [feedback] = run().candidates.filter((c) => c.type === 'feedback');
+    expect(feedback.origin).toBeUndefined();
+    expect(feedback.quote).toBeUndefined();
+  });
+
+  it('ignores an ordinary instruction, which is most of a transcript', () => {
+    archiveTurns('s', [
+      { role: 'user', text: 'please refactor the parser into two functions' },
+    ]);
+
+    expect(run().candidates).toEqual([]);
+  });
+});
+
+describe('re-read churn', () => {
+  it('reports churn as an observation and never as a finding', () => {
+    // It describes OUR OWN reading behaviour, not the code. Filed as a `map` it
+    // would take the hottest files in the project as anchors -- the ones that
+    // already carry real findings -- and compete with them for the injection
+    // budget while saying nothing a future agent could act on.
+    for (const at of [1, 2, 3]) {
+      record(dir, { kind: 'read', anchor: '/src/hot.ts', sessionId: 's', fp: 'x', tokens: 100, at });
+    }
+
+    const { candidates, observations } = run();
+    expect(candidates).toEqual([]);
+    expect(observations.map((o) => o.kind)).toEqual(['churn']);
+    expect(observations[0]).toMatchObject({
+      anchor: '/src/hot.ts',
+      repeats: 2,
+      wasteful: 2,
+      confidence: CONFIDENCE.churn,
+    });
+  });
+
+  it('reports nothing for a file that was re-read because it CHANGED', () => {
+    // Re-reading a file you have just edited is correct behaviour. Counting it
+    // is how the first version of this measurement turned 213,651 confirmed
+    // tokens into a 14.6M headline, and an observation that cannot tell the two
+    // apart is the same defect one layer up.
+    record(dir, { kind: 'read', anchor: '/src/edited.ts', sessionId: 's', fp: 'a', tokens: 100, at: 1 });
+    record(dir, { kind: 'read', anchor: '/src/edited.ts', sessionId: 's', fp: 'b', tokens: 100, at: 2 });
+    record(dir, { kind: 'read', anchor: '/src/edited.ts', sessionId: 's', fp: 'c', tokens: 100, at: 3 });
+
+    expect(run().observations).toEqual([]);
+  });
+});
+
+describe('the contract the caller relies on', () => {
+  it('caps confidence per detector so a heuristic cannot outrank an observation', () => {
+    expect(CONFIDENCE.command).toBeGreaterThan(CONFIDENCE.test);
+    expect(CONFIDENCE.test).toBeGreaterThan(CONFIDENCE.correction);
+    expect(CONFIDENCE.correction).toBeGreaterThan(CONFIDENCE.churn);
+  });
+
+  it('carries no secret from captured output into a derived claim', () => {
+    // END TO END, and honest about WHERE the guarantee comes from: captured
+    // output is redacted at the `recordToolOutcome` boundary, so by the time a
+    // detector sees it the secret is already gone. Mutating derive's own
+    // `redact` away does NOT break this test, which is exactly why the two
+    // below exist -- this one would otherwise read as proof of a guard it does
+    // not exercise.
+    outcome('deploy', { success: false, output: 'API_TOKEN=abcdef123456', at: 1 });
+    outcome('deploy --retry', { success: true, output: 'ok', at: 2 });
+
+    const { candidates } = run();
+    // The pair must actually have been detected, or this asserts nothing.
+    expect(candidates.map((c) => c.type)).toContain('failure');
+    expect(JSON.stringify(candidates)).not.toContain('abcdef123456');
+  });
+
+  it('redacts a secret in the COMMAND TEXT, which no boundary redacts', () => {
+    // `recordToolOutcome` redacts `output`. It does NOT redact `anchor`, and the
+    // anchor IS the command -- so a token passed on a command line reaches the
+    // claim through a path nothing upstream cleans. A claim is injected into
+    // model context and exported to markdown, two more places than the terminal
+    // it came from.
+    outcome('deploy --key=sk-abcdef1234567890', { success: false, output: 'nope, denied', at: 1 });
+    outcome('deploy --retry', { success: true, at: 2 });
+
+    const { candidates } = run();
+    expect(candidates.map((c) => c.type)).toContain('command');
+    expect(JSON.stringify(candidates)).not.toContain('sk-abcdef1234567890');
+  });
+
+  it('redacts a secret a user pasted into a correcting turn', () => {
+    // The archive is never transmitted, but a claim derived FROM it is injected
+    // and exported. Nothing redacts the archive on the way in.
+    archiveTurns('s', [
+      { role: 'user', text: 'no, use AWS_SECRET_ACCESS_KEY=abcdef123456 instead' },
+    ]);
+
+    const { candidates } = run();
+    expect(candidates.map((c) => c.type)).toContain('feedback');
+    expect(JSON.stringify(candidates)).not.toContain('abcdef123456');
+  });
+
+  it('writes nothing, and stores nothing, on its own', () => {
+    // Selection and storage belong to the caller, under a budget.
+    outcome('deploy', { success: false, output: 'connection refused by host', at: 1 });
+    outcome('deploy --retry', { success: true, at: 2 });
+
+    expect(run().written).toEqual([]);
+  });
+
+  it('threads the authoritative session id back untouched', () => {
+    // `writeHarvested` needs it to resolve the `answers` edge: `taskForAnchors`
+    // returns null without one, so an unverified string produces no edge at all.
+    // It is never defaulted from `sessionId`, which would promote any caller's
+    // string to trusted.
+    expect(run({ authoritativeSessionId: 'hook-payload-id' }).authoritativeSessionId)
+      .toBe('hook-payload-id');
+    expect(run().authoritativeSessionId).toBeNull();
+  });
+
+  it('derives nothing without a project root to anchor to', () => {
+    // An unanchored finding cannot be invalidated and is refused downstream, so
+    // emitting one would only spend the caller's budget on junk.
+    outcome('deploy', { success: false, output: 'connection refused by host', at: 1 });
+    outcome('deploy --retry', { success: true, at: 2 });
+
+    expect(derive(dir, { sessionId: 's' }).candidates).toEqual([]);
+  });
+
+  it('derives one candidate for a lesson observed twice', () => {
+    outcome('deploy', { success: false, output: 'connection refused by host', at: 1 });
+    outcome('deploy --retry', { success: true, at: 2 });
+    outcome('deploy', { success: false, output: 'connection refused by host', at: 3 });
+    outcome('deploy --retry', { success: true, at: 4 });
+
+    expect(run().candidates.filter((c) => c.type === 'command').length).toBe(1);
+  });
+
+  it('writes nothing when there is nothing to derive', () => {
+    expect(run().candidates).toEqual([]);
+  });
+
+  it('never throws, because it runs at session end', () => {
+    record(dir, { kind: 'tool-outcome', surface: 'command', anchor: null, success: null, output: null, at: 1 });
+    record(dir, { kind: 'read', anchor: null, at: 2 });
+    expect(() => run()).not.toThrow();
+    expect(() => derive(null, null)).not.toThrow();
+    expect(() => derive(dir)).not.toThrow();
+  });
+});
+
+describe('wired at session end', () => {
+  it('runs from a real client Stop hook, not just from its own test', () => {
+    // THE DEFECT THIS PROJECT HAS SHIPPED TWICE is correct code nothing calls:
+    // `forTouch` had 27 passing tests and no production call site, and the
+    // semantic harvest before it had the same shape. `derive` is the only
+    // finding producer on a machine without a credential, so being reachable is
+    // not a lint detail here -- unwired, the graph stays at one finding.
+    const workspace = mkdtempSync(join(tmpdir(), 'der-stop-'));
+    const wiki = join(workspace, '.wiki');
+    mkdirSync(wiki, { recursive: true });
+    try {
+      writeFileSync(
+        join(wiki, 'metrics.jsonl'),
+        [
+          { kind: 'tool-outcome', surface: 'command', anchor: 'deploy', success: false, output: 'connection refused by host', at: 1 },
+          { kind: 'tool-outcome', surface: 'command', anchor: 'deploy --retry', success: true, at: 2 },
+        ]
+          .map((e) => JSON.stringify(e))
+          .join('\n') + '\n'
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [join(process.cwd(), 'integrations', 'cursor', 'hooks', 'stop.mjs')],
+        {
+          cwd: workspace,
+          env: {
+            ...process.env,
+            TOKEN_OPTIMIZER_STATE_DIR: join(workspace, '.state'),
+            TOKEN_OPTIMIZER_WIKI_DIR: wiki,
+            TOKEN_OPTIMIZER_SHARED_DIR: join(workspace, '.shared'),
+          },
+          input: JSON.stringify({ session_id: 'stop-session', cwd: workspace }),
+          encoding: 'utf8',
+        }
+      );
+      expect(result.status).toBe(0);
+
+      const derived = readFileSync(join(wiki, 'metrics.jsonl'), 'utf8')
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line))
+        .filter((e) => e.kind === 'derive');
+      expect(derived.length).toBe(1);
+      // The count, not the candidates: whether a session's own evidence
+      // supports any finding at all is the number that says this is working.
+      expect(derived[0].candidates).toBeGreaterThan(0);
+    } finally {
+      try {
+        rmSync(workspace, { recursive: true, force: true });
+      } catch {
+        /* windows */
+      }
+    }
+  });
+});
+
+describe('what counts as the same attempt', () => {
+  it('ignores flags, so a retry pairs with the command it retries', () => {
+    expect(attemptKey('deploy --retry')).toBe(attemptKey('deploy'));
+    expect(attemptKey('npm run build -- --skipLibCheck')).toBe(attemptKey('npm run build'));
+  });
+
+  it('keeps two scripts behind one runner apart', () => {
+    expect(attemptKey('npm run build')).not.toBe(attemptKey('npm run test'));
+  });
+});

--- a/tests/hooks/derive.test.mjs
+++ b/tests/hooks/derive.test.mjs
@@ -17,7 +17,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { record, recordToolOutcome } from '../../hooks-core/metrics.mjs';
 import { transcriptDir, safeName } from '../../hooks-core/transcript.mjs';
-import { derive, CONFIDENCE, attemptKey } from '../../hooks-core/derive.mjs';
+import { load, putNode, putEdge, nodeId } from '../../hooks-core/wiki.mjs';
+import { indexFile } from '../../hooks-core/staleness.mjs';
+import { canonicalPath } from '../../hooks-core/paths.mjs';
+import { ORIGIN_HARVESTED, ORIGIN_HUMAN } from '../../hooks-core/curate.mjs';
+import { derive, CONFIDENCE, attemptKey, projectAnchor } from '../../hooks-core/derive.mjs';
 
 let dir;
 
@@ -65,6 +69,29 @@ const archiveTurns = (sessionId, turns) => {
 
 const run = (options = {}) =>
   derive(dir, { sessionId: 's', projectRoot: dir, ...options });
+
+/**
+ * A project marker, so the derived anchor RESOLVES.
+ *
+ * Without one the anchor falls back to the project root, `indexFile` cannot read
+ * a directory, and `writeHarvested` correctly refuses every candidate -- which
+ * means a storage test written against a bare temp directory asserts `written`
+ * is empty and passes whether storage works or not.
+ */
+const withManifest = () => {
+  const manifest = join(dir, 'package.json');
+  writeFileSync(manifest, '{"name":"fixture"}');
+  return manifest;
+};
+
+/** One failed-then-succeeded pair, which yields a command and a failure. */
+const onePair = () => {
+  outcome('deploy', { success: false, output: 'connection refused by host', at: 1 });
+  outcome('deploy --retry', { success: true, at: 2 });
+};
+
+const storedFindings = () =>
+  [...load(dir).nodes.values()].filter((node) => node.kind === 'finding');
 
 describe('a command that failed and then succeeded', () => {
   it('turns a failed-then-succeeded command into a command and a failure finding', () => {
@@ -277,14 +304,6 @@ describe('the contract the caller relies on', () => {
     expect(JSON.stringify(candidates)).not.toContain('abcdef123456');
   });
 
-  it('writes nothing, and stores nothing, on its own', () => {
-    // Selection and storage belong to the caller, under a budget.
-    outcome('deploy', { success: false, output: 'connection refused by host', at: 1 });
-    outcome('deploy --retry', { success: true, at: 2 });
-
-    expect(run().written).toEqual([]);
-  });
-
   it('threads the authoritative session id back untouched', () => {
     // `writeHarvested` needs it to resolve the `answers` edge: `taskForAnchors`
     // returns null without one, so an unverified string produces no edge at all.
@@ -323,6 +342,189 @@ describe('the contract the caller relies on', () => {
     expect(() => run()).not.toThrow();
     expect(() => derive(null, null)).not.toThrow();
     expect(() => derive(dir)).not.toThrow();
+  });
+});
+
+describe('storage, under a budget', () => {
+  it('stores what it derives, and reports the keys', () => {
+    withManifest();
+    onePair();
+
+    const { candidates, written } = run();
+    expect(candidates.map((c) => c.type).sort()).toEqual(['command', 'failure']);
+    expect(written).toHaveLength(2);
+    expect(storedFindings().map((f) => f.type).sort()).toEqual(['command', 'failure']);
+  });
+
+  it('stamps harvested origin and never human, because these are machine guesses', () => {
+    // `curate.mjs` states the reason in its own header: a hand-written assertion
+    // and a machine guess look identical three months later, which quietly
+    // destroys a reader's ability to calibrate trust. The standing-rules layer
+    // selects on human origin to inject on EVERY turn, so this is not a
+    // labelling detail.
+    withManifest();
+    onePair();
+    run();
+
+    const stored = storedFindings();
+    expect(stored.length).toBeGreaterThan(0);
+    for (const finding of stored) {
+      expect(finding.origin).toBe(ORIGIN_HARVESTED);
+      expect(finding.origin).not.toBe(ORIGIN_HUMAN);
+      expect(finding.quote).toBeUndefined();
+    }
+  });
+
+  it('the budget bounds one session, so a long afternoon cannot fill the graph', () => {
+    // THE RISK THIS CLOSES. `selectForConsolidation` had no caller, so nothing
+    // bounded what a session added -- and everything stored competes for the
+    // 500-token per-command injection budget of every session afterwards,
+    // forever. 120 pairs is an ordinary long day of failing commands.
+    withManifest();
+    for (let i = 0; i < 120; i += 1) {
+      outcome(`cmd${i} alpha`, { success: false, output: `error number ${i} happened here`, at: i * 2 + 1 });
+      outcome(`cmd${i} alpha --fix`, { success: true, at: i * 2 + 2 });
+    }
+
+    const { candidates, written, selectedTokens } = run();
+    expect(candidates.length).toBeGreaterThan(100);
+    expect(written.length).toBeGreaterThan(0);
+    expect(written.length).toBeLessThan(candidates.length);
+    expect(selectedTokens).toBeLessThanOrEqual(1000);
+  });
+
+  it('admits dead ends on the floor when the budget is too small for ranking', () => {
+    // Cheap to find is not cheap to find AGAIN: a negative result exists nowhere
+    // else, not in the code and not in the commit log. Ranking alone would drop
+    // it, so `failure` is admitted before scoring -- which is visible only when
+    // the budget is tight enough that ranking would otherwise have decided.
+    withManifest();
+    for (let i = 0; i < 40; i += 1) {
+      outcome(`cmd${i} alpha`, { success: false, output: `error number ${i} happened here`, at: i * 2 + 1 });
+      outcome(`cmd${i} alpha --fix`, { success: true, at: i * 2 + 2 });
+    }
+
+    const previous = process.env.TOKEN_OPTIMIZER_DERIVE_BUDGET;
+    process.env.TOKEN_OPTIMIZER_DERIVE_BUDGET = '60';
+    try {
+      run();
+    } finally {
+      if (previous === undefined) delete process.env.TOKEN_OPTIMIZER_DERIVE_BUDGET;
+      else process.env.TOKEN_OPTIMIZER_DERIVE_BUDGET = previous;
+    }
+
+    const types = storedFindings().map((f) => f.type);
+    expect(types.length).toBeGreaterThan(0);
+    // Every survivor is a dead end: the floor spent the budget before ranking
+    // ever ran, which is the design's stated ordering rather than an accident.
+    expect([...new Set(types)]).toEqual(['failure']);
+  });
+
+  it('refuses a candidate whose anchor cannot be indexed, rather than weakening the rule', () => {
+    // No manifest, so the anchor falls back to the project ROOT -- and
+    // `indexFile` returns null for a directory, so nothing can ever be checked
+    // against it. An un-indexable anchor is an un-invalidatable claim, and
+    // `writeHarvested` refuses it. Deriving the candidate and storing none of it
+    // is the correct outcome, which is why the count and the storage are both
+    // asserted: `written` being empty proves nothing on its own.
+    onePair();
+
+    const { candidates, written } = run();
+    expect(candidates.length).toBeGreaterThan(0);
+    expect(written).toEqual([]);
+    expect(storedFindings()).toEqual([]);
+  });
+
+  it('anchors to the file that declares the project commands, not to the directory', () => {
+    const manifest = withManifest();
+    onePair();
+
+    expect(projectAnchor(dir)).toBe(manifest);
+    expect(run().candidates[0].anchors).toEqual([manifest]);
+  });
+
+  it('picks the same .NET anchor on every host, so one finding is not two nodes', () => {
+    // readdir order is not stable across hosts, and an anchor that varies by host
+    // splits one claim into two graph nodes that can never merge.
+    writeFileSync(join(dir, 'Zed.sln'), '');
+    writeFileSync(join(dir, 'Alpha.sln'), '');
+    expect(projectAnchor(dir)).toBe(join(dir, 'Alpha.sln'));
+  });
+
+  it('a second session deriving the same lesson enriches one node instead of adding another', () => {
+    // THE BLOAT PATH THIS SETTLES. The commonest real case is the same command
+    // failing and being fixed the same way twice -- a graph that files one
+    // finding per session about one fact grows without bound and spends the
+    // injection budget saying the same thing N times. `writeHarvested`
+    // fingerprints the claim and returns the EXISTING key, so the second session
+    // adds edges and no node.
+    withManifest();
+    onePair();
+
+    const first = derive(dir, { sessionId: 's1', projectRoot: dir });
+    const second = derive(dir, { sessionId: 's2', projectRoot: dir });
+
+    expect(first.written.length).toBeGreaterThan(0);
+    expect(second.written).toEqual(first.written);
+    expect(storedFindings()).toHaveLength(first.written.length);
+  });
+
+  it('makes the `answers` edge fire on a default install, given an authoritative id', () => {
+    // The edge is DECLARED in EDGE_KINDS and its only other producer is
+    // credential-gated, so it fired nowhere on a machine without an API key.
+    // `taskForAnchors` needs an id from a channel the caller does not control
+    // AND a session task that covered every anchor -- both, not either.
+    const manifest = withManifest();
+    onePair();
+    indexFile(dir, manifest);
+    putEdge(
+      dir,
+      putNode(dir, { kind: 'task', key: 'hook-payload-id' }),
+      'derived_from',
+      nodeId('file', canonicalPath(manifest))
+    );
+
+    run({ authoritativeSessionId: 'hook-payload-id' });
+    expect(load(dir).edges.filter((e) => e.edge === 'answers').length).toBeGreaterThan(0);
+  });
+
+  it('writes no `answers` edge from a session id nothing cross-checked', () => {
+    // An unverified string must not buy provenance. `sessionId` alone is a
+    // model-typed argument everywhere except a hook payload.
+    const manifest = withManifest();
+    onePair();
+    indexFile(dir, manifest);
+    putEdge(
+      dir,
+      putNode(dir, { kind: 'task', key: 's' }),
+      'derived_from',
+      nodeId('file', canonicalPath(manifest))
+    );
+
+    run();
+    expect(load(dir).edges.filter((e) => e.edge === 'answers')).toEqual([]);
+  });
+
+  it('finishes the session when the storage step itself throws', () => {
+    // FAULT INJECTED WHERE IT ACTUALLY LANDS, not somewhere harmless. The first
+    // version of this passed a number as the project root, which merely failed
+    // to resolve -- nothing threw, so deleting the try/catch around storage did
+    // not fail the test. An anchor whose `String()` throws raises inside
+    // `selectForConsolidation`, which is the storage step, and storage is the
+    // last thing a finished session does: a graph write that fails must not turn
+    // a completed session into a hook error.
+    withManifest();
+    onePair();
+    const hostile = {
+      toString() {
+        throw new Error('anchor cannot be stringified');
+      },
+    };
+    let result;
+    expect(() => {
+      result = derive(dir, { sessionId: 's', projectRoot: hostile });
+    }).not.toThrow();
+    expect(result.written).toEqual([]);
   });
 });
 

--- a/tests/hooks/loo.test.mjs
+++ b/tests/hooks/loo.test.mjs
@@ -1,0 +1,878 @@
+/**
+ * Layer 2 -- per-finding causal value by leave-one-out.
+ *
+ * FIXTURES ARE BUILT WITH THE REAL PRODUCERS, and that is not a style
+ * preference. `record` writes the inject rows, `recordToolOutcome` performs the
+ * real (episodeId, toolCallId) join, and `record` writes the `read` rows -- so
+ * these tests exercise the same event shapes production writes. Three tasks on
+ * these plans shipped code whose tests passed against fixtures that did not
+ * match production, and the shapes below were checked field by field against
+ * this repository's own `metrics.jsonl`:
+ *
+ *   inject        { schemaVersion, id, kind, episodeId, sessionId, toolCallId,
+ *                   surface, anchor, holdout, tokens, deliveredTokens,
+ *                   shadowTokens, count, candidateCount, findingIds,
+ *                   shadowFindingIds, stale, injectionId, at }
+ *   tool-outcome  { ..., toolName, success, durationMs, injectionId,
+ *                   findingIds, joinMethod, at }
+ *   read          { kind, anchor, sessionId, tokens, at }
+ *
+ * THREE CORRECTIONS TO THE BRIEF'S SNIPPET, each of which would have made a
+ * test pass for the wrong reason:
+ *
+ *   1. Its pinned-finding test passes a SINGLE key. Layer 2 refuses to withhold
+ *      the only finding on a touch (that is `inHoldout`, not a leave-one-out),
+ *      so that assertion would have held with the pinned guard deleted. Every
+ *      guard below is tested against a candidate set where withholding is
+ *      otherwise possible, and each such test also asserts that the mechanism
+ *      still fires for the unprotected key.
+ *   2. Its kill-switch test has the same shape, so it too is written against a
+ *      set that yields a non-null answer with the switch on.
+ *   3. `graphWith` needs `origin` and `pinned` per key rather than one shared
+ *      shape, or "never a human-origin finding" cannot be told apart from
+ *      "never any finding".
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { record, recordToolOutcome, readEvidence } from '../../hooks-core/metrics.mjs';
+import { classify, referenceRate } from '../../hooks-core/usage.mjs';
+import {
+  withheldFor,
+  exploreOrder,
+  observations,
+  effects,
+  looNote,
+  servingPolicyVersion,
+  LOO_ENABLED,
+  MIN_PRIOR_INJECTIONS,
+  MIN_SERVED,
+  MIN_WITHHELD,
+  EPSILON,
+  FDR_Q,
+  WITHHOLD_FRACTION,
+  MAX_WITHHELD_PER_SESSION,
+  SHRINKAGE_K,
+} from '../../hooks-core/loo.mjs';
+import { forTouch } from '../../hooks-core/inject.mjs';
+import { renderAudit } from '../../hooks-core/audit.mjs';
+import { load, putNode, putEdge, nodeId } from '../../hooks-core/wiki.mjs';
+import { canonicalPath } from '../../hooks-core/paths.mjs';
+import { indexFile } from '../../hooks-core/staleness.mjs';
+
+let workspace;
+let dir;
+let clock;
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), 'loo-'));
+  dir = join(workspace, 'wiki');
+  clock = 1;
+  delete process.env.TOKEN_OPTIMIZER_LOO;
+  // Pinned OFF so a random workspace path cannot drop a test into the
+  // all-findings control arm -- the flakiness injection.test.mjs documents.
+  process.env.TOKEN_OPTIMIZER_HOLDOUT = '0';
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+  delete process.env.TOKEN_OPTIMIZER_LOO;
+  delete process.env.TOKEN_OPTIMIZER_HOLDOUT;
+});
+
+const trialsFloor = (n) => Math.floor(n * 0.7);
+
+/** A graph shaped the way `load()` shapes one: nodes keyed by id. */
+const graphWith = (specs) => ({
+  nodes: new Map(
+    specs.map((spec, index) => {
+      const s = typeof spec === 'string' ? { key: spec } : spec;
+      return [
+        `finding:${index}`,
+        { kind: 'finding', key: s.key, pinned: Boolean(s.pinned), origin: s.origin || 'harvested' },
+      ];
+    })
+  ),
+});
+
+/** One injection, written by the real recorder. */
+function inject({
+  keys = ['k1', 'k2'],
+  session = 's',
+  loo = null,
+  anchor = 'a.ts',
+  surface = 'file',
+  holdout = false,
+  policy = 'p1',
+  at = null,
+} = {}) {
+  clock += 10;
+  const toolCallId = `tc-${clock}`;
+  return record(dir, {
+    kind: 'inject',
+    episodeId: session,
+    sessionId: session,
+    toolCallId,
+    surface,
+    anchor,
+    holdout,
+    tokens: 10,
+    deliveredTokens: 10,
+    shadowTokens: 10,
+    count: keys.length,
+    candidateCount: keys.length,
+    findingIds: holdout ? [] : keys,
+    shadowFindingIds: keys,
+    stale: false,
+    looPolicy: policy,
+    ...(loo ? { loo } : {}),
+    at: at ?? clock,
+  });
+}
+
+/** The post-tool result that makes the injection attributable, via the real join. */
+function outcome(event) {
+  return recordToolOutcome(dir, {
+    episodeId: event.episodeId,
+    sessionId: event.sessionId,
+    toolCallId: event.toolCallId,
+    surface: event.surface,
+    anchor: event.anchor,
+    toolName: 'Read',
+    success: true,
+    at: (event.at || 0) + 1,
+  });
+}
+
+const readEvent = ({ session = 's', anchor = 'a.ts', tokens, at }) =>
+  record(dir, { kind: 'read', anchor, sessionId: session, tokens, at });
+
+/**
+ * `n` injections of `keys`, each in its own session with its own joined
+ * outcome and a downstream read of `cost` tokens.
+ *
+ * ONE SESSION PER TOUCH, because `observations` splits a (session, anchor)
+ * read total across the injections that share it -- exactly as `buildReport`
+ * does. Separate sessions keep the fixture's arithmetic the arithmetic under
+ * test rather than the split's.
+ */
+function touches(
+  n,
+  { keys, loo = null, cost = 0, tag = 't', policy = 'p1', joined = true, anchor = 'a.ts' } = {}
+) {
+  const made = [];
+  for (let i = 0; i < n; i += 1) {
+    const session = `${tag}-${i}`;
+    const event = inject({ keys, session, loo, policy, anchor });
+    if (joined) outcome(event);
+    if (cost) readEvent({ session, anchor, tokens: cost, at: (event.at || 0) + 5 });
+    made.push(event);
+  }
+  return made;
+}
+
+/** MIN_PRIOR_INJECTIONS ordinary injections, so `keys` are enrolled afterwards. */
+const warmup = (keys) => touches(MIN_PRIOR_INJECTIONS, { keys, tag: 'warm', cost: 0 });
+
+/** A session id whose arm for `key` is the one asked for. Deterministic, not random. */
+function sessionWhere(key, wantWithheld, { keys = null, graph = null } = {}) {
+  const list = keys || [key, 'other'];
+  const g = graph || graphWith(list);
+  for (let i = 0; i < 400; i += 1) {
+    const session = `probe-${i}`;
+    const chosen = withheldFor(list, session, g, dir, { surface: 'file', anchor: 'a.ts' });
+    if (wantWithheld ? chosen === key : chosen === null) return session;
+  }
+  throw new Error(`no session found with arm ${wantWithheld ? 'withheld' : 'served'} for ${key}`);
+}
+
+describe('Layer 2 -- the withholding decision', () => {
+  it('never withholds a pinned finding, and still withholds an unprotected one', () => {
+    warmup(['k1', 'k2']);
+    const graph = graphWith([{ key: 'k1', pinned: true }, { key: 'k2' }]);
+    const chosen = new Set();
+    for (let i = 0; i < 200; i += 1)
+      chosen.add(withheldFor(['k1', 'k2'], `s${i}`, graph, dir, { surface: 'file', anchor: 'a.ts' }));
+    expect(chosen.has('k1')).toBe(false);
+    // The mechanism was live: without this the test would pass with every
+    // guard in the file deleted.
+    expect(chosen.has('k2')).toBe(true);
+  });
+
+  it('never withholds a human-origin finding, and still withholds a harvested one', () => {
+    warmup(['k1', 'k2']);
+    const graph = graphWith([{ key: 'k1', origin: 'human' }, { key: 'k2', origin: 'harvested' }]);
+    const chosen = new Set();
+    for (let i = 0; i < 200; i += 1)
+      chosen.add(withheldFor(['k1', 'k2'], `s${i}`, graph, dir, { surface: 'file', anchor: 'a.ts' }));
+    expect(chosen.has('k1')).toBe(false);
+    expect(chosen.has('k2')).toBe(true);
+  });
+
+  it('refuses a key it cannot find in the graph, because it cannot check pinned or origin', () => {
+    warmup(['k1', 'k2']);
+    // k2 is absent from the graph: unknown provenance fails CLOSED.
+    const graph = graphWith([{ key: 'k1' }]);
+    const chosen = new Set();
+    for (let i = 0; i < 200; i += 1)
+      chosen.add(withheldFor(['k1', 'k2'], `s${i}`, graph, dir, { surface: 'file', anchor: 'a.ts' }));
+    expect(chosen.has('k2')).toBe(false);
+    expect(chosen.has('k1')).toBe(true);
+  });
+
+  it('withholds at most one finding per touch', () => {
+    warmup(['k1', 'k2', 'k3']);
+    const graph = graphWith(['k1', 'k2', 'k3']);
+    let withheldSomething = 0;
+    for (let i = 0; i < 200; i += 1) {
+      const chosen = withheldFor(['k1', 'k2', 'k3'], `s${i}`, graph, dir, {
+        surface: 'file',
+        anchor: 'a.ts',
+      });
+      expect(typeof chosen === 'string' || chosen === null).toBe(true);
+      if (chosen) {
+        withheldSomething += 1;
+        expect(['k1', 'k2', 'k3']).toContain(chosen);
+      }
+    }
+    // A single string can only name one finding; what this really pins is that
+    // a session with three armed candidates still yields one.
+    expect(withheldSomething).toBeGreaterThan(0);
+  });
+
+  it('is stable for a session, so an arm cannot flip mid-session', () => {
+    warmup(['k1', 'k2']);
+    const graph = graphWith(['k1', 'k2']);
+    // ACROSS MANY SESSIONS AND TWO ANCHORS. Checking one session would pass
+    // even if the arm were salted with the anchor, because most sessions
+    // withhold nothing and `null === null`.
+    const arms = new Set();
+    let withheldSomewhere = 0;
+    for (let i = 0; i < 200; i += 1) {
+      const session = `s${i}`;
+      const a = withheldFor(['k1', 'k2'], session, graph, dir, { surface: 'file', anchor: 'a.ts' });
+      const b = withheldFor(['k1', 'k2'], session, graph, dir, { surface: 'file', anchor: 'b.ts' });
+      const c = withheldFor(['k1', 'k2'], session, graph, dir, { surface: 'file', anchor: 'a.ts' });
+      expect([session, b]).toEqual([session, a]);
+      expect([session, c]).toEqual([session, a]);
+      if (a) withheldSomewhere += 1;
+      arms.add(a);
+    }
+    // The arm genuinely varies BETWEEN sessions, or stability would be the
+    // trivial kind: a constant.
+    expect(arms.size).toBeGreaterThan(1);
+    expect(withheldSomewhere).toBeGreaterThan(0);
+  });
+
+  it('assigns the arm without consulting the serving policy, so a config change cannot flip it', () => {
+    warmup(['k1', 'k2']);
+    const graph = graphWith(['k1', 'k2']);
+    const before = servingPolicyVersion();
+    const armsBefore = [];
+    for (let i = 0; i < 40; i += 1)
+      armsBefore.push(withheldFor(['k1', 'k2'], `s${i}`, graph, dir, { surface: 'file', anchor: 'a.ts' }));
+    process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET = '250';
+    try {
+      // The policy version MUST move, or this test proves nothing.
+      expect(servingPolicyVersion()).not.toBe(before);
+      const armsAfter = [];
+      for (let i = 0; i < 40; i += 1)
+        armsAfter.push(withheldFor(['k1', 'k2'], `s${i}`, graph, dir, { surface: 'file', anchor: 'a.ts' }));
+      expect(armsAfter).toEqual(armsBefore);
+    } finally {
+      delete process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET;
+    }
+  });
+
+  it('does not enter a finding into the experiment before enough prior injections', () => {
+    expect(MIN_PRIOR_INJECTIONS).toBeGreaterThanOrEqual(4);
+    const graph = graphWith(['k1', 'k2']);
+    // One short of the threshold: nothing may be withheld.
+    touches(MIN_PRIOR_INJECTIONS - 1, { keys: ['k1', 'k2'], tag: 'warm' });
+    const short = new Set();
+    for (let i = 0; i < 200; i += 1)
+      short.add(withheldFor(['k1', 'k2'], `s${i}`, graph, dir, { surface: 'file', anchor: 'a.ts' }));
+    expect([...short]).toEqual([null]);
+    // One more injection and the same sessions start withholding.
+    touches(1, { keys: ['k1', 'k2'], tag: 'warm2' });
+    const enrolled = new Set();
+    for (let i = 0; i < 200; i += 1)
+      enrolled.add(withheldFor(['k1', 'k2'], `s${i}`, graph, dir, { surface: 'file', anchor: 'a.ts' }));
+    expect(enrolled.size).toBeGreaterThan(1);
+  });
+
+  it('never withholds the only finding on a touch, which would be the all-findings holdout', () => {
+    warmup(['k1', 'k2']);
+    const graph = graphWith(['k1', 'k2']);
+    for (let i = 0; i < 200; i += 1)
+      expect(withheldFor(['k1'], `s${i}`, graph, dir, { surface: 'file', anchor: 'a.ts' })).toBeNull();
+    // Two candidates: the same sessions do withhold.
+    const arms = new Set();
+    for (let i = 0; i < 200; i += 1)
+      arms.add(withheldFor(['k1', 'k2'], `s${i}`, graph, dir, { surface: 'file', anchor: 'a.ts' }));
+    expect(arms.size).toBeGreaterThan(1);
+  });
+
+  it('never withholds inside the all-findings holdout arm', () => {
+    warmup(['k1', 'k2']);
+    const graph = graphWith(['k1', 'k2']);
+    const session = sessionWhere('k1', true);
+    expect(
+      withheldFor(['k1', 'k2'], session, graph, dir, { surface: 'file', anchor: 'a.ts', holdout: true })
+    ).toBeNull();
+    expect(
+      withheldFor(['k1', 'k2'], session, graph, dir, { surface: 'file', anchor: 'a.ts', holdout: false })
+    ).toBe('k1');
+  });
+
+  it('never withholds on a command surface, where no read event can be joined', () => {
+    warmup(['k1', 'k2']);
+    const graph = graphWith(['k1', 'k2']);
+    const session = sessionWhere('k1', true);
+    expect(
+      withheldFor(['k1', 'k2'], session, graph, dir, { surface: 'command', anchor: 'npm test' })
+    ).toBeNull();
+    expect(withheldFor(['k1', 'k2'], session, graph, dir, { surface: 'file', anchor: '' })).toBeNull();
+    expect(
+      withheldFor(['k1', 'k2'], session, graph, dir, { surface: 'file', anchor: 'a.ts' })
+    ).toBe('k1');
+  });
+
+  it('withholds at most one finding per session', () => {
+    warmup(['k1', 'k2']);
+    const graph = graphWith(['k1', 'k2']);
+    const session = sessionWhere('k1', true);
+    expect(MAX_WITHHELD_PER_SESSION).toBe(1);
+    // The session has now spent its budget.
+    inject({ keys: ['k2'], session, loo: 'k1' });
+    expect(
+      withheldFor(['k1', 'k2'], session, graph, dir, { surface: 'file', anchor: 'b.ts' })
+    ).toBeNull();
+    // A different session is unaffected, so the cap is per session and not global.
+    const other = sessionWhere('k1', true);
+    expect(withheldFor(['k1', 'k2'], other, graph, dir, { surface: 'file', anchor: 'a.ts' })).toBe('k1');
+  });
+
+  it('refuses without a usable session id, which would pin one arm forever', () => {
+    warmup(['k1', 'k2']);
+    const graph = graphWith(['k1', 'k2']);
+    expect(withheldFor(['k1', 'k2'], '', graph, dir, { surface: 'file', anchor: 'a.ts' })).toBeNull();
+    expect(withheldFor(['k1', 'k2'], null, graph, dir, { surface: 'file', anchor: 'a.ts' })).toBeNull();
+  });
+
+  it('is disabled by the kill switch', () => {
+    warmup(['k1', 'k2']);
+    const graph = graphWith(['k1', 'k2']);
+    const session = sessionWhere('k1', true);
+    expect(withheldFor(['k1', 'k2'], session, graph, dir, { surface: 'file', anchor: 'a.ts' })).toBe('k1');
+    process.env.TOKEN_OPTIMIZER_LOO = 'off';
+    try {
+      expect(LOO_ENABLED()).toBe(false);
+      expect(
+        withheldFor(['k1', 'k2'], session, graph, dir, { surface: 'file', anchor: 'a.ts' })
+      ).toBeNull();
+    } finally {
+      delete process.env.TOKEN_OPTIMIZER_LOO;
+    }
+    expect(LOO_ENABLED()).toBe(true);
+  });
+
+  it('withholds roughly WITHHOLD_FRACTION of sessions, not all of them and not none', () => {
+    warmup(['k1', 'k2']);
+    const graph = graphWith(['k1', 'k2']);
+    expect(WITHHOLD_FRACTION).toBe(0.25);
+    let withheldK1 = 0;
+    const trials = 600;
+    for (let i = 0; i < trials; i += 1)
+      if (withheldFor(['k1', 'k2'], `frac-${i}`, graph, dir, { surface: 'file', anchor: 'a.ts' }) === 'k1')
+        withheldK1 += 1;
+    // BOUNDS IN ABSOLUTE NUMBERS, not derived from the constant under test --
+    // the first version computed them FROM `WITHHOLD_FRACTION`, so raising the
+    // constant to 1 moved the goalposts with it and the assertion could not
+    // fail. Expected rate: k1 is armed a quarter of the time and loses the
+    // tiebreak to an armed k2 about half of that quarter, so
+    // 0.25 * (1 - 0.25/2) = 0.219, with a standard error near 1.7% at n=600.
+    expect(withheldK1 / trials).toBeGreaterThan(0.12);
+    expect(withheldK1 / trials).toBeLessThan(0.32);
+  });
+});
+
+describe('Layer 2 -- exploration', () => {
+  const items = (keys) => keys.map((key) => ({ finding: { key } }));
+
+  it('promotes the least-served candidate on about EPSILON of touches', () => {
+    // k1 well served, k2 never: exploration must promote k2.
+    touches(6, { keys: ['k1'], tag: 'warm' });
+    let explored = 0;
+    const trials = 600;
+    for (let i = 0; i < trials; i += 1) {
+      const out = exploreOrder(items(['k1', 'k2']), dir, { sessionId: 's', anchor: `a${i}.ts` });
+      if (out[0].finding.key === 'k2') explored += 1;
+      else expect(out.map((o) => o.finding.key)).toEqual(['k1', 'k2']);
+    }
+    expect(explored / trials).toBeGreaterThan(EPSILON / 3);
+    expect(explored / trials).toBeLessThan(EPSILON * 2);
+  });
+
+  it('leaves the utility order alone when it is not exploring', () => {
+    touches(6, { keys: ['k1'], tag: 'warm' });
+    const anchors = [];
+    for (let i = 0; i < 600; i += 1) anchors.push(`a${i}.ts`);
+    const unchanged = anchors.filter(
+      (anchor) =>
+        exploreOrder(items(['k1', 'k2']), dir, { sessionId: 's', anchor })[0].finding.key === 'k1'
+    );
+    expect(unchanged.length).toBeGreaterThan(trialsFloor(anchors.length));
+  });
+
+  it('explores nothing when the kill switch is off or there is one candidate', () => {
+    touches(6, { keys: ['k1'], tag: 'warm' });
+    process.env.TOKEN_OPTIMIZER_LOO = 'off';
+    try {
+      let moved = 0;
+      for (let i = 0; i < 300; i += 1)
+        if (exploreOrder(items(['k1', 'k2']), dir, { sessionId: 's', anchor: `a${i}.ts` })[0].finding.key === 'k2')
+          moved += 1;
+      expect(moved).toBe(0);
+    } finally {
+      delete process.env.TOKEN_OPTIMIZER_LOO;
+    }
+    expect(exploreOrder(items(['k1']), dir, { sessionId: 's', anchor: 'a.ts' })).toHaveLength(1);
+  });
+});
+
+describe('Layer 2 -- observations', () => {
+  it('gates every observation on the existing tool-outcome join', () => {
+    warmup(['k1', 'k2']);
+    touches(2, { keys: ['k1', 'k2'], tag: 'joined', cost: 100 });
+    touches(3, { keys: ['k1', 'k2'], tag: 'orphan', cost: 100, joined: false });
+    const obs = observations(dir);
+    expect(obs.rows.filter((row) => row.findingKey === 'k1')).toHaveLength(2);
+    // Unattributable rows are reported, never folded into an arm.
+    expect(obs.unattributable).toBe(6);
+  });
+
+  it('excludes a command injection, a holdout injection and a fixture anchor', () => {
+    warmup(['k1', 'k2']);
+    outcome(inject({ keys: ['k1', 'k2'], session: 'c', surface: 'command', anchor: 'npm test' }));
+    outcome(inject({ keys: ['k1', 'k2'], session: 'h', holdout: true }));
+    outcome(inject({ keys: ['k1', 'k2'], session: 'f', anchor: join(tmpdir(), 'holdout-x', 'a.ts') }));
+    const obs = observations(dir);
+    expect(obs.excluded.command).toBe(1);
+    expect(obs.excluded.holdout).toBe(1);
+    expect(obs.excluded.fixture).toBe(1);
+    expect(obs.rows).toHaveLength(0);
+  });
+
+  it('counts only reads that happened after the injection', () => {
+    warmup(['k1', 'k2']);
+    const event = inject({ keys: ['k1', 'k2'], session: 'after' });
+    outcome(event);
+    readEvent({ session: 'after', tokens: 900, at: (event.at || 0) - 5 });
+    expect(observations(dir).rows.every((row) => row.cost === 0)).toBe(true);
+    readEvent({ session: 'after', tokens: 700, at: (event.at || 0) + 5 });
+    expect(observations(dir).rows.every((row) => row.cost === 700)).toBe(true);
+  });
+
+  it('splits one anchor read total across the injections that share it', () => {
+    warmup(['k1', 'k2']);
+    const a = inject({ keys: ['k1', 'k2'], session: 'share' });
+    outcome(a);
+    const b = inject({ keys: ['k1', 'k2'], session: 'share' });
+    outcome(b);
+    readEvent({ session: 'share', tokens: 400, at: (b.at || 0) + 5 });
+    // 400 tokens, two touches of one anchor: 200 each, not 400 each.
+    expect(observations(dir).rows.map((row) => row.cost)).toEqual([200, 200, 200, 200]);
+  });
+
+  it('does not observe a finding before it is enrolled', () => {
+    touches(2, { keys: ['k1'], tag: 'early', cost: 50 });
+    expect(observations(dir).rows).toHaveLength(0);
+    touches(MIN_PRIOR_INJECTIONS, { keys: ['k1'], tag: 'more', cost: 50 });
+    expect(observations(dir).rows.length).toBeGreaterThan(0);
+  });
+});
+
+describe('Layer 2 -- effects', () => {
+  /** 6 served / 3 withheld for k1, with the withheld arm reading far more. */
+  function publishable({ servedCost = 100, withheldCost = 5000 } = {}) {
+    warmup(['k1', 'k2']);
+    touches(MIN_SERVED, { keys: ['k1', 'k2'], tag: 'srv', cost: servedCost });
+    touches(MIN_WITHHELD, { keys: ['k2'], loo: 'k1', tag: 'wth', cost: withheldCost });
+  }
+
+  it('publishes no verdict below the observation floor', () => {
+    warmup(['k1', 'k2']);
+    touches(MIN_SERVED - 1, { keys: ['k1', 'k2'], tag: 'srv', cost: 100 });
+    touches(MIN_WITHHELD - 1, { keys: ['k2'], loo: 'k1', tag: 'wth', cost: 5000 });
+    const rows = effects(dir);
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.every((row) => row.published === false)).toBe(true);
+    expect(rows.every((row) => row.p === null)).toBe(true);
+    // And a below-floor row is not a zero: the estimate exists, unpublished.
+    const k1 = rows.find((row) => row.findingKey === 'k1');
+    expect(k1.raw).toBeGreaterThan(0);
+  });
+
+  it('publishes a verdict once the floor and the FDR are both cleared', () => {
+    publishable();
+    const k1 = effects(dir).find((row) => row.findingKey === 'k1');
+    expect(k1.served).toBe(MIN_SERVED);
+    expect(k1.withheld).toBe(MIN_WITHHELD);
+    expect(k1.p).toBeLessThan(0.1);
+    expect(k1.published).toBe(true);
+    expect(k1.raw).toBeCloseTo(4900, 6);
+  });
+
+  it('cannot publish when no read cost was ever observed, by the arithmetic itself', () => {
+    // Same design, same counts, but the read channel never fired. There is no
+    // separate guard for this and there must not be one: with every cost zero
+    // the permutation statistic is zero for every relabelling, so p is exactly
+    // 1 and no FDR threshold can pass it. Pinning p here is what makes that
+    // claim checkable rather than a comment.
+    publishable({ servedCost: 0, withheldCost: 0 });
+    const rows = effects(dir);
+    const k1 = rows.find((row) => row.findingKey === 'k1');
+    expect(k1.served).toBe(MIN_SERVED);
+    expect(k1.withheld).toBe(MIN_WITHHELD);
+    expect(k1.raw).toBe(0);
+    expect(k1.p).toBe(1);
+    expect(rows.every((row) => row.published === false)).toBe(true);
+    expect(observations(dir).costObservations).toBe(0);
+  });
+
+  it('shrinks a low-observation effect toward the population mean', () => {
+    // A well-observed small effect and a barely-observed large one.
+    warmup(['k1', 'k2']);
+    touches(12, { keys: ['k1'], tag: 'asrv', cost: 100 });
+    touches(6, { keys: ['k2'], loo: 'k1', tag: 'awth', cost: 200 });
+    warmup(['k3', 'k4']);
+    touches(MIN_SERVED, { keys: ['k3'], tag: 'bsrv', cost: 100 });
+    touches(MIN_WITHHELD, { keys: ['k4'], loo: 'k3', tag: 'bwth', cost: 5000 });
+
+    const rows = effects(dir);
+    const low = rows.find((row) => row.served + row.withheld < 10 && row.raw !== null);
+    expect(low.findingKey).toBe('k3');
+    expect(Math.abs(low.shrunk)).toBeLessThan(Math.abs(low.raw));
+    // The general property, which holds whatever the population mean is.
+    const prior =
+      rows.filter((r) => r.raw !== null).reduce((sum, r) => sum + r.raw, 0) /
+      rows.filter((r) => r.raw !== null).length;
+    expect(Math.abs(low.shrunk - prior)).toBeLessThan(Math.abs(low.raw - prior));
+  });
+
+  it('estimates the shrinkage weight from the data rather than always using the fallback', () => {
+    // Costs VARY inside each arm, so the within-finding variance is non-zero
+    // and the empirical weight is estimable.
+    warmup(['k1', 'k2']);
+    for (let i = 0; i < 8; i += 1)
+      touches(1, { keys: ['k1'], tag: `v${i}`, cost: 100 + i * 40 });
+    for (let i = 0; i < 4; i += 1)
+      touches(1, { keys: ['k2'], loo: 'k1', tag: `w${i}`, cost: 900 + i * 60 });
+    warmup(['k3', 'k4']);
+    for (let i = 0; i < 8; i += 1)
+      touches(1, { keys: ['k3'], tag: `x${i}`, cost: 3000 + i * 50 });
+    for (let i = 0; i < 4; i += 1)
+      touches(1, { keys: ['k4'], loo: 'k3', tag: `y${i}`, cost: 100 + i * 30 });
+
+    const rows = effects(dir).filter((row) => row.raw !== null);
+    expect(rows).toHaveLength(2);
+    const prior = rows.reduce((sum, row) => sum + row.raw, 0) / rows.length;
+    for (const row of rows) {
+      const n = row.served + row.withheld;
+      const fallback = (n * row.raw + SHRINKAGE_K * prior) / (n + SHRINKAGE_K);
+      // Between-finding spread here is large relative to the within-arm noise,
+      // so the estimated weight is far below the fallback and the shrunk value
+      // stays much closer to the finding's own data.
+      expect(Math.abs(row.shrunk - row.raw)).toBeLessThan(Math.abs(fallback - row.raw));
+    }
+  });
+
+  it('never pools observations across serving-policy versions', () => {
+    warmup(['k1', 'k2']);
+    touches(MIN_SERVED, { keys: ['k1', 'k2'], tag: 'p1s', cost: 100, policy: 'p1' });
+    touches(MIN_WITHHELD, { keys: ['k2'], loo: 'k1', tag: 'p1w', cost: 5000, policy: 'p1' });
+    touches(MIN_SERVED, { keys: ['k1', 'k2'], tag: 'p2s', cost: 100, policy: 'p2' });
+    const rows = effects(dir).filter((row) => row.findingKey === 'k1');
+    expect(rows.map((row) => row.policy).sort()).toEqual(['p1', 'p2']);
+    expect(rows.find((row) => row.policy === 'p1').withheld).toBe(MIN_WITHHELD);
+    expect(rows.find((row) => row.policy === 'p2').withheld).toBe(0);
+  });
+
+  /** `n` findings whose two arms read identically: a true null, p = 1. */
+  function nulls(n) {
+    for (let i = 0; i < n; i += 1) {
+      const keys = [`n${i}`, `m${i}`];
+      touches(MIN_PRIOR_INJECTIONS, { keys, tag: `nw${i}` });
+      touches(MIN_SERVED, { keys, tag: `ns${i}`, cost: 100 });
+      touches(MIN_WITHHELD, { keys: [`m${i}`], loo: `n${i}`, tag: `nx${i}`, cost: 100 });
+    }
+  }
+
+  it('publishes the one real effect among a handful of null findings', () => {
+    publishable();
+    nulls(5);
+    const rows = effects(dir);
+    expect(rows.filter((row) => row.published).map((row) => row.findingKey)).toEqual(['k1']);
+    // The null findings have an estimate and no verdict, which is the point.
+    expect(rows.find((row) => row.findingKey === 'n0').raw).toBe(0);
+    expect(rows.find((row) => row.findingKey === 'n0').published).toBe(false);
+    expect(rows.find((row) => row.findingKey === 'n0').p).toBeCloseTo(1, 6);
+  });
+
+  it('withholds the verdict when the same p-value is tested against enough findings', () => {
+    // THE MULTIPLICITY CORRECTION, shown binding rather than asserted. The
+    // strongest effect 6 served and 3 withheld observations can produce has an
+    // exact permutation p of 1/84 = 0.0119, which clears q = 0.10 alone and
+    // clears q/m for six candidates -- and does NOT clear it for thirteen.
+    // Without Benjamini-Hochberg this row would publish either way.
+    publishable();
+    nulls(12);
+    const rows = effects(dir);
+    const k1 = rows.find((row) => row.findingKey === 'k1');
+    expect(k1.p).toBeLessThan(FDR_Q);
+    expect(k1.published).toBe(false);
+    expect(rows.filter((row) => row.published)).toEqual([]);
+  });
+});
+
+describe('Layer 2 is independent of Layer 1', () => {
+  it('ignores the explicit-reference channel Layer 1 is built on', () => {
+    warmup(['k1', 'k2']);
+    touches(MIN_SERVED, { keys: ['k1', 'k2'], tag: 'srv', cost: 100 });
+    touches(MIN_WITHHELD, { keys: ['k2'], loo: 'k1', tag: 'wth', cost: 5000 });
+    const before = effects(dir);
+
+    // Queries naming the finding: the ONLY thing Layer 1 counts.
+    for (let i = 0; i < 20; i += 1)
+      record(dir, { kind: 'query', operation: 'get', key: 'k1', sessionId: `srv-${i}`, at: 900_000 + i });
+
+    // Layer 1 moves...
+    expect(classify(dir).some((row) => row.label === 'referenced')).toBe(true);
+    expect(referenceRate(dir).referenced).toBeGreaterThan(0);
+    // ...and Layer 2 does not, at all.
+    expect(effects(dir)).toEqual(before);
+  });
+
+  it('moves on read cost, which Layer 1 ignores', () => {
+    warmup(['k1', 'k2']);
+    touches(MIN_SERVED, { keys: ['k1', 'k2'], tag: 'srv', cost: 100 });
+    const withheldTouches = touches(MIN_WITHHELD, { keys: ['k2'], loo: 'k1', tag: 'wth', cost: 100 });
+    const flatRate = referenceRate(dir);
+    const flat = effects(dir).find((row) => row.findingKey === 'k1');
+    expect(flat.raw).toBe(0);
+
+    // A big read in the withheld arm only.
+    for (const event of withheldTouches)
+      readEvent({ session: event.sessionId, tokens: 4000, at: (event.at || 0) + 9 });
+
+    const moved = effects(dir).find((row) => row.findingKey === 'k1');
+    expect(moved.raw).toBeGreaterThan(0);
+    // Layer 1's arithmetic is untouched by the read channel.
+    expect(referenceRate(dir)).toEqual(flatRate);
+  });
+});
+
+describe('Layer 2 -- what the audit prints', () => {
+  it('says nothing at all when the experiment has collected nothing', () => {
+    expect(looNote(dir)).toBeNull();
+    warmup(['k1', 'k2']);
+    expect(looNote(dir)).toBeNull();
+  });
+
+  it('refuses with counts, rather than a number, below the floor', () => {
+    warmup(['k1', 'k2']);
+    touches(2, { keys: ['k1', 'k2'], tag: 'srv', cost: 100 });
+    touches(1, { keys: ['k2'], loo: 'k1', tag: 'wth', cost: 5000 });
+    const note = looNote(dir);
+    expect(note).toContain('NOT MEASURABLE YET');
+    expect(note).toContain('not the same as an effect of zero');
+    expect(note).not.toMatch(/saves ~/);
+    // Read cost WAS observed here, so the absent-channel clause must not appear.
+    expect(note).not.toContain('no read cost has been observed');
+  });
+
+  it('says the read channel never fired, rather than implying no effect', () => {
+    warmup(['k1', 'k2']);
+    touches(2, { keys: ['k1', 'k2'], tag: 'srv', cost: 0 });
+    touches(1, { keys: ['k2'], loo: 'k1', tag: 'wth', cost: 0 });
+    const note = looNote(dir);
+    expect(note).toContain('no read cost has been observed in either arm');
+    expect(note).toContain('NOT MEASURABLE YET');
+  });
+
+  it('quotes the shrunk effect once a verdict is published', () => {
+    warmup(['k1', 'k2']);
+    touches(MIN_SERVED, { keys: ['k1', 'k2'], tag: 'srv', cost: 100 });
+    touches(MIN_WITHHELD, { keys: ['k2'], loo: 'k1', tag: 'wth', cost: 5000 });
+    const note = looNote(dir);
+    // NAMES THE FINDING AND THE SIZE, not just a count of verdicts: a reader
+    // who cannot see which finding earned its place cannot act on the number.
+    expect(note).toContain('k1 saves ~');
+    expect(note).toMatch(/saves ~\d+ tokens\/touch/);
+    expect(note).toContain('6 served, 3 withheld');
+    expect(note).toContain('p=');
+    expect(note).not.toContain('NOT MEASURABLE');
+  });
+
+  it('discloses unattributable observations and exempt findings', () => {
+    warmup(['k1', 'k2']);
+    touches(2, { keys: ['k1', 'k2'], tag: 'orphan', cost: 100, joined: false });
+    touches(1, { keys: ['k2'], loo: 'k1', tag: 'wth', cost: 10 });
+    const note = looNote(dir, { graph: graphWith([{ key: 'k9', pinned: true }, { key: 'k1' }]) });
+    expect(note).toContain('unattributable');
+    expect(note).toContain('exempt from withholding');
+  });
+
+  it('reaches a human through renderAudit', () => {
+    warmup(['k1', 'k2']);
+    touches(MIN_SERVED, { keys: ['k1', 'k2'], tag: 'srv', cost: 100 });
+    touches(MIN_WITHHELD, { keys: ['k2'], loo: 'k1', tag: 'wth', cost: 5000 });
+    expect(renderAudit(dir, []).text).toContain('leave-one-out');
+  });
+});
+
+describe('Layer 2 inside the injection path', () => {
+  const write = (name, text) => {
+    const path = join(workspace, name);
+    writeFileSync(path, text);
+    return path;
+  };
+
+  function seed(path, key, claim, confidence = 0.9) {
+    const id = putNode(dir, { kind: 'finding', key, claim, confidence, type: 'finding' });
+    putEdge(dir, id, 'derived_from', nodeId('file', path));
+    return id;
+  }
+
+  function twoFindings() {
+    const path = write('auth.ts', 'export function verify() {}');
+    indexFile(dir, path);
+    seed(path, 'k1', 'expired tokens are rejected in verify');
+    seed(path, 'k2', 'the refresh path shares one retry budget');
+    // Enrol both.
+    touches(MIN_PRIOR_INJECTIONS, { keys: ['k1', 'k2'], tag: 'warm', anchor: path });
+    return path;
+  }
+
+  it('withholds one finding, delivers the rest, and records which', () => {
+    const path = twoFindings();
+    const graph = load(dir);
+    const session = sessionWhere('k1', true, { keys: ['k1', 'k2'], graph });
+    const out = forTouch(dir, graph, path, { sessionId: session });
+    expect(out).toContain('refresh path');
+    expect(out).not.toContain('expired tokens');
+
+    const injects = injectsIn(session);
+    expect(injects).toHaveLength(1);
+    expect(injects[0].loo).toBe('k1');
+    expect(injects[0].findingIds).toEqual(['k2']);
+    expect(injects[0].count).toBe(1);
+    expect(injects[0].looPolicy).toBe(servingPolicyVersion());
+    // RE-PRICED: the recorded cost is the delivered text, not the kept set.
+    expect(injects[0].tokens).toBeLessThan(injects[0].shadowTokens);
+    expect(injects[0].shadowFindingIds.sort()).toEqual(['k1', 'k2']);
+  });
+
+  it('delivers everything when the kill switch is off', () => {
+    const path = twoFindings();
+    const graph = load(dir);
+    const session = sessionWhere('k1', true, { keys: ['k1', 'k2'], graph });
+    process.env.TOKEN_OPTIMIZER_LOO = 'off';
+    try {
+      const out = forTouch(dir, graph, path, { sessionId: session });
+      expect(out).toContain('refresh path');
+      expect(out).toContain('expired tokens');
+      const injects = injectsIn(session);
+      expect(injects[0].loo).toBeUndefined();
+      expect(injects[0].looPolicy).toBeUndefined();
+      expect(injects[0].tokens).toBe(injects[0].shadowTokens);
+    } finally {
+      delete process.env.TOKEN_OPTIMIZER_LOO;
+    }
+  });
+
+  it('records no leave-one-out arm inside the all-findings holdout', () => {
+    const path = twoFindings();
+    const graph = load(dir);
+    const session = sessionWhere('k1', true, { keys: ['k1', 'k2'], graph });
+    process.env.TOKEN_OPTIMIZER_HOLDOUT = '1';
+    try {
+      expect(forTouch(dir, graph, path, { sessionId: session })).toBeNull();
+      const injects = injectsIn(session);
+      expect(injects[0].holdout).toBe(true);
+      expect(injects[0].loo).toBeUndefined();
+      expect(injects[0].findingIds).toEqual([]);
+    } finally {
+      process.env.TOKEN_OPTIMIZER_HOLDOUT = '0';
+    }
+  });
+
+  it('lets exploration change what a tight budget actually serves', () => {
+    // THE WIRING TEST FOR EXPLORATION. Three findings, a budget that fits one,
+    // and a utility order that would always keep the same one: without
+    // `exploreOrder` in `forTouch`, the least-served finding could never be
+    // served at all, and its score could never improve.
+    const path = write('explore.ts', 'export const a = 1;');
+    indexFile(dir, path);
+    seed(path, 'top', 'the top ranked claim about explore', 0.95);
+    seed(path, 'mid', 'the middle ranked claim about explore', 0.9);
+    seed(path, 'rare', 'the never served claim about explore', 0.85);
+    // `top` is well served; `rare` has never been served at all.
+    touches(6, { keys: ['top', 'mid'], tag: 'expwarm', anchor: path });
+    const graph = load(dir);
+    const budget = 20;
+
+    const exploring = sessionWhereExploring(path, true);
+    const notExploring = sessionWhereExploring(path, false);
+    const explored = forTouch(dir, graph, path, { sessionId: exploring, budget });
+    const ordinary = forTouch(dir, graph, path, {
+      sessionId: notExploring,
+      budget,
+      alreadyInjected: new Set(),
+    });
+    expect(ordinary).toContain('top ranked');
+    expect(explored).toContain('never served');
+    expect(explored).not.toContain('top ranked');
+  });
+
+  /**
+   * A session id for which `exploreOrder` does (or does not) fire on `anchor`.
+   *
+   * CANONICALISED, because `forTouch` hashes `canonicalPath(rawPath)` and
+   * `join()` produces backslashes on Windows -- probing with the raw spelling
+   * finds sessions for a different bucket entirely, which is this repository's
+   * oldest defect shape and cost this test one red run.
+   */
+  function sessionWhereExploring(rawAnchor, want) {
+    const anchor = canonicalPath(rawAnchor);
+    const probe = [{ finding: { key: 'top' } }, { finding: { key: 'rare' } }];
+    for (let i = 0; i < 400; i += 1) {
+      const sessionId = `exp-${i}`;
+      const fired =
+        exploreOrder(probe, dir, { sessionId, anchor })[0].finding.key === 'rare';
+      if (fired === want) return sessionId;
+    }
+    throw new Error('no session found with the requested exploration state');
+  }
+
+  it('serves both findings in a session whose arm is served', () => {
+    const path = twoFindings();
+    const graph = load(dir);
+    const session = sessionWhere('k1', false, { keys: ['k1', 'k2'], graph });
+    const out = forTouch(dir, graph, path, { sessionId: session });
+    expect(out).toContain('expired tokens');
+    expect(out).toContain('refresh path');
+    const injects = injectsIn(session);
+    expect(injects[0].loo).toBeUndefined();
+    expect(injects[0].findingIds.sort()).toEqual(['k1', 'k2']);
+  });
+
+  /** The inject rows this session wrote, read back through the real reader. */
+  function injectsIn(session) {
+    return readEvidence(dir).filter(
+      (event) => event.kind === 'inject' && event.sessionId === session
+    );
+  }
+});

--- a/tests/hooks/loo.test.mjs
+++ b/tests/hooks/loo.test.mjs
@@ -43,6 +43,7 @@ import {
   exploreOrder,
   observations,
   effects,
+  permutationP,
   looNote,
   servingPolicyVersion,
   LOO_ENABLED,
@@ -82,6 +83,31 @@ afterEach(() => {
 });
 
 const trialsFloor = (n) => Math.floor(n * 0.7);
+
+describe('the shared permutation statistic', () => {
+  it('is two-sided on the smallest cross-layer design', () => {
+    // Of the 20 ways to split six values 3:3, both complete separations are as
+    // extreme as the observed one. A one-sided implementation would return
+    // 1/20 and make this project's own evidence twice as strong.
+    expect(permutationP([0, 0, 0], [1, 1, 1])).toBeCloseTo(2 / 20, 12);
+  });
+
+  it('is reproducible for one seed and actually uses a caller-supplied seed when sampling', () => {
+    // C(22, 11) is above the exact-enumeration budget, so this exercises the
+    // sampled path. Two seeds must select different relabellings, while the
+    // same seed must reproduce the same verdict byte-for-byte.
+    const served = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const withheld = [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+    const first = permutationP(served, withheld, { seed: 1 });
+    expect(permutationP(served, withheld, { seed: 1 })).toBe(first);
+    expect(permutationP(served, withheld, { seed: 2 })).not.toBe(first);
+    // Layer 2 does not pass a seed. Its historical fixed sequence is therefore
+    // unchanged by exposing the option for the cross-layer caller.
+    expect(permutationP(served, withheld)).toBe(
+      permutationP(served, withheld, { seed: 0x9e3779b9 })
+    );
+  });
+});
 
 /** A graph shaped the way `load()` shapes one: nodes keyed by id. */
 const graphWith = (specs) => ({

--- a/tests/hooks/policy-asks-for-findings.test.mjs
+++ b/tests/hooks/policy-asks-for-findings.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from '@jest/globals';
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from '@jest/globals';
 import { pathToFileURL } from 'url';
 import { join } from 'path';
 
@@ -9,8 +9,9 @@ import { join } from 'path';
  * days of work. Not because extraction was broken -- `wiki_write` works, and
  * writes a finding anchored to real file nodes -- but because nothing ever asked
  * for it. The only other route was `harvest.mjs`, which calls a SEPARATE model
- * and is therefore opt-in for cost and disclosure reasons, so on a default
- * install the semantic layer could never fill.
+ * and is gated on a credential -- not opt-in, as this comment used to say, but
+ * `off:no-key` wherever there is no key -- so on a default install the semantic
+ * layer could never fill.
  *
  * The session already running is the right extractor: it knows what it
  * concluded, at no marginal cost, with nothing leaving the machine. The lever
@@ -28,9 +29,13 @@ const ADAPTER = pathToFileURL(
 ).href;
 
 let policyText;
+let volatileLines;
 
 beforeAll(async () => {
   ({ policyText } = await import(ADAPTER));
+  ({ volatileLines } = await import(
+    pathToFileURL(join(process.cwd(), 'hooks-core', 'cache.mjs')).href
+  ));
 });
 
 describe('the standing policy asks for findings', () => {
@@ -56,5 +61,108 @@ describe('the standing policy asks for findings', () => {
     // deny a tool call. Recording findings is not an enforcement feature, so it
     // must not disappear along with the denial language.
     expect(policyText(false)).toMatch(/wiki_write/);
+  });
+});
+
+/**
+ * ...and says whether anything else is going to extract them.
+ *
+ * The state was legible only from the doctor, which is a place somebody goes
+ * after they already suspect a problem. A user watching a graph fill with
+ * structural nodes and no verdicts has no reason to suspect one -- the failure
+ * this project has now measured twice -- and the model holding a conclusion has
+ * no way to know whether dropping it costs anything.
+ *
+ * SO THE LINE IS ADDRESSED TO THE MODEL, which is what earns it a place in the
+ * prefix instead of a systemMessage. Each mode is asserted separately because
+ * the useful content differs per mode, and the one a default install actually
+ * gets is the one most likely to be written carelessly.
+ */
+describe('the standing policy states what will extract findings after the session', () => {
+  const KEYS = [
+    'TOKEN_OPTIMIZER_MODE',
+    'TOKEN_OPTIMIZER_HARVEST',
+    'TOKEN_OPTIMIZER_HARVEST_ENDPOINT',
+    'TOKEN_OPTIMIZER_API_KEY',
+    'ANTHROPIC_API_KEY',
+  ];
+  const saved = new Map();
+
+  beforeEach(() => {
+    saved.clear();
+    for (const key of KEYS) {
+      saved.set(key, process.env[key]);
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const [key, value] of saved) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it('says a local endpoint runs it free and private, with nothing leaving the machine', () => {
+    // The configuration a user would choose if they knew it existed, and the one
+    // that was buried deepest: no credential, no billing, no digest sent.
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT =
+      'http://127.0.0.1:11434/v1/chat/completions';
+    const text = policyText(true);
+
+    expect(text).toMatch(/local model endpoint is configured/i);
+    expect(text).toMatch(/free and private/i);
+    expect(text).toMatch(/nothing leaving this machine/i);
+  });
+
+  it('names what a credentialed harvest sends, and what it never sends', () => {
+    process.env.TOKEN_OPTIMIZER_API_KEY = 'sk-test';
+    const text = policyText(true);
+
+    expect(text).toMatch(/bounded digest/i);
+    expect(text).toMatch(/never file contents/i);
+  });
+
+  it('on a machine with no credential, states the consequence and names the free option', () => {
+    // THE DEFAULT STATE, and the whole reason this line exists. `off:no-key` is
+    // CI, corporate laptops and every subscription-only login.
+    const text = policyText(true);
+
+    expect(text).toMatch(/no separate extractor will run/i);
+    expect(text).toMatch(/derived locally/i);
+    expect(text).toMatch(/TOKEN_OPTIMIZER_HARVEST_ENDPOINT/);
+  });
+
+  it('does not argue with a deliberate opt-out, but still states the consequence', () => {
+    // Nagging about a setting somebody chose is how a notice stops being read,
+    // and this one is charged to every session's prefix.
+    process.env.TOKEN_OPTIMIZER_HARVEST = '0';
+    process.env.TOKEN_OPTIMIZER_API_KEY = 'sk-test';
+    const text = policyText(true);
+
+    expect(text).toMatch(/off by configuration/i);
+    expect(text).toMatch(/derived locally/i);
+    expect(text).not.toMatch(/TOKEN_OPTIMIZER_HARVEST_ENDPOINT/);
+  });
+
+  it('carries nothing volatile in ANY mode, so it cannot re-price the prefix', () => {
+    // This text lands near the FRONT of the prompt prefix, which a cache
+    // invalidates from the first differing byte onward -- and unlike the project
+    // briefing, policyText does NOT pass through `stableText`, so a volatile
+    // construct here is emitted rather than dropped. cache.test.mjs asserts this
+    // for whatever mode the ambient environment happens to be in; the notice is
+    // the one part of the block that differs per mode, so each mode is checked.
+    // Volatile means what `volatileLines` means -- a date, a session id, a sha,
+    // a run counter, an epoch -- not any digit at all.
+    for (const env of [
+      {},
+      { TOKEN_OPTIMIZER_API_KEY: 'sk-test' },
+      { TOKEN_OPTIMIZER_HARVEST: '0' },
+      { TOKEN_OPTIMIZER_HARVEST_ENDPOINT: 'http://localhost:11434/v1/chat/completions' },
+    ]) {
+      for (const key of KEYS) delete process.env[key];
+      Object.assign(process.env, env);
+      expect(volatileLines(policyText(true))).toHaveLength(0);
+    }
   });
 });

--- a/tests/hooks/reachability.test.mjs
+++ b/tests/hooks/reachability.test.mjs
@@ -93,7 +93,6 @@ const ALLOWED = new Map([
   // assertion at the bottom of this file holds the count to a ceiling that can
   // only fall, and refuses any entry that is neither one of these five nor
   // genuine public API.
-
   // NOTHING IS LEFT, and the last four did not leave by being re-described.
   //
   // They were held here for a stated reason -- "the producing action does not

--- a/tests/hooks/reachability.test.mjs
+++ b/tests/hooks/reachability.test.mjs
@@ -93,11 +93,13 @@ const ALLOWED = new Map([
   // assertion at the bottom of this file holds the count to a ceiling that can
   // only fall, and refuses any entry that is neither one of these five nor
   // genuine public API.
-  // NOTHING IS LEFT, and the last four did not leave by being re-described.
+  // ONE DELIBERATE EXCEPTION IS LEFT, and the other three did not leave by being
+  // re-described.
   //
   // They were held here for a stated reason -- "the producing action does not
   // exist" -- which was true and was still an excuse, because the producing
-  // action was the work. All four now have one:
+  // action was the work. Three now have in-repo callers; the fourth is the
+  // boundary an external refresh issuer must call:
   //
   //   selectForConsolidation  runs in the semantic harvest, so what a session
   //     stores is chosen under a token budget instead of stored wholesale.
@@ -109,13 +111,15 @@ const ALLOWED = new Map([
   //   consolidationRatio      reported per finding by /api/wiki/node and shown
   //     in the dashboard detail view -- the number #204 opens on, which was
   //     computed for no finding anybody could look at.
-  //   recordRefresh           the keep-warm decision is written to the ledger
-  //     when cache_audit issues it.
+  //   recordRefresh           remains public and deliberately unwired: this
+  //     repository recommends refreshes but never issues one, and recording at
+  //     the recommendation site would score refreshes that were never bought.
   //   recordRefreshOutcome    scored from the event log by
   //     scoreOutstandingRefreshes, which resolves whether a turn actually
   //     arrived inside the window the advice predicted. The signal needed no
   //     new instrumentation; it was in the log the whole time.
   //
+  ['recordRefresh', 'PUBLIC API, UNWIRED BY DESIGN: an external client that actually issues a keep-warm refresh calls this; cache_audit only recommends one, so wiring it there would fabricate purchases.'],
   // ------------------------------------------------------------------
   // The policyText entry lived here as "GENUINE PUBLIC API", and it was stale
   // in the same way forTouch was: adapter.mjs and the SessionStart hook both
@@ -276,8 +280,10 @@ describe('every exported function in the live hook path is reachable', () => {
     // that its producing action did not exist, until it was built.
     //
     // Every future entry must be genuine public API and say so. Anything else
-    // is the backlog re-forming under a new name.
-    expect([...ALLOWED.keys()]).toEqual([]);
+    // is the backlog re-forming under a new name. The sole current entry is the
+    // issuer boundary: deleting it would make the feedback loop impossible for
+    // the client that actually spends the refresh.
+    expect([...ALLOWED.keys()]).toEqual(['recordRefresh']);
 
     const unattributed = [...ALLOWED.entries()]
       .filter(([, reason]) => !/^PUBLIC API/.test(reason))

--- a/tests/hooks/reachability.test.mjs
+++ b/tests/hooks/reachability.test.mjs
@@ -114,8 +114,8 @@ const ALLOWED = new Map([
   //   recordRefresh           remains public and deliberately unwired: this
   //     repository recommends refreshes but never issues one, and recording at
   //     the recommendation site would score refreshes that were never bought.
-  //   recordRefreshOutcome    scored from the event log by
-  //     scoreOutstandingRefreshes, which resolves whether a turn actually
+  //   recordRefreshOutcome    scored from the event log by scoreRefreshes,
+  //     which resolves whether a turn actually
   //     arrived inside the window the advice predicted. The signal needed no
   //     new instrumentation; it was in the log the whole time.
   //

--- a/tests/hooks/recall.test.mjs
+++ b/tests/hooks/recall.test.mjs
@@ -1,0 +1,462 @@
+/**
+ * The recall probe -- is the no-embeddings stance falsifiable yet?
+ *
+ * THE ONE THING THIS FILE EXISTS TO PREVENT is a probe that cannot fail.
+ * `docs/WIKI_GRAPH.md` says embeddings get added "if measurement shows real
+ * recall loss", and a measurement whose only possible answer is 1.0 turns that
+ * into a claim nothing can contradict -- worse than no measurement, because a
+ * permanent 1.0 published as a recall rate reads as "retrieval is perfect".
+ *
+ * So the plan's own first test -- `expect(recallProbe(dir).rate).toBe(1)` -- is
+ * NOT here as written. It asserted the tautology: `findingsFor(graph, A)` walks
+ * `derived_from` edges backwards into A, and the edge F -> A is what makes A an
+ * anchor of F, so F comes back by CONSTRUCTION for every graph, forever. That
+ * check is kept, and it is asserted below on `integrity`, whose own `what`
+ * string says it is not a recall rate. `rate` is asserted to be capable of 0,
+ * 0.5 and 1 over the SAME by-construction-perfect graphs, which is the whole
+ * difference between a measurement and a slogan.
+ *
+ * FIXTURES ARE BUILT WITH THE REAL PRODUCERS -- `putNode`, `putEdge`,
+ * `putNodeWithEdges` -- and read back through the real `load`, so nothing here
+ * hand-writes a graph shape production does not write. The anchor keys use NATO
+ * words and the opaque claims use Jabberwocky nonsense for one measured reason:
+ * the first draft of the miss fixture used `module0.ts` against a claim
+ * `zqxwv0 ...` and scored a HIT, because `tokenize` splits `zqxwv0` into
+ * `zqxwv` + `0` and `module0` into `module` + `0`, so the digit matched. A
+ * fixture that accidentally overlaps proves the probe cannot miss when in fact
+ * it can.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  putNode,
+  putEdge,
+  putNodeWithEdges,
+  load,
+  findingsFor,
+} from '../../hooks-core/wiki.mjs';
+import { recallProbe, MIN_PROBED, MAX_FINDINGS } from '../../hooks-core/recall.mjs';
+import { graphBalanceSheet } from '../../hooks-core/crosslayer.mjs';
+
+let workspace;
+let dir;
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), 'recall-'));
+  dir = join(workspace, 'wiki');
+  mkdirSync(dir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+const WORDS = [
+  'alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot', 'golf', 'hotel',
+  'india', 'juliet', 'kilo', 'lima', 'mike', 'november', 'oscar', 'papa',
+  'quebec', 'romeo', 'sierra', 'tango', 'uniform', 'victor', 'whiskey', 'xray',
+  'yankee', 'zulu', 'apple', 'banana', 'cherry', 'grape', 'melon', 'peach',
+];
+
+/** Nonsense with no token in common with any anchor path this file builds. */
+const OPAQUE = [
+  'zqxwv', 'qzjhb', 'plurgh', 'snicker', 'frumious', 'bandersnatch', 'mimsy',
+  'borogove', 'slithy', 'toves', 'gimble', 'wabe', 'jubjub', 'tulgey', 'uffish',
+  'galumph', 'beamish', 'frabjous', 'callooh', 'callay', 'chortle', 'brillig',
+  'outgrabe', 'momerath', 'vorpalled', 'snickersnack', 'manxome', 'whiffling',
+  'burbled', 'gyre', 'raths', 'wabbling',
+];
+
+/**
+ * `count` findings, each anchored to its own file. The first `naming` of them
+ * mention their own file in the claim, so BM25 from the anchor's key can find
+ * them; the rest are opaque, so nothing but the deleted edge ever could.
+ */
+function corpusOf(target, count, naming) {
+  for (let i = 0; i < count; i += 1) {
+    const word = WORDS[i % WORDS.length];
+    const file = putNode(target, {
+      kind: 'file',
+      key: `C:/repo/src/${word}.ts`,
+      hash: `hash-${word}`,
+    });
+    putNodeWithEdges(
+      target,
+      {
+        kind: 'finding',
+        key: `${OPAQUE[i % OPAQUE.length]}-${i}`,
+        claim:
+          i < naming
+            ? `${word}.ts rejects an empty payload`
+            : `${OPAQUE[i % OPAQUE.length]} ${OPAQUE[(i + 3) % OPAQUE.length]}`,
+        confidence: 0.7,
+        origin: 'harvested',
+      },
+      [{ edge: 'derived_from', to: file }]
+    );
+  }
+}
+
+/**
+ * `count` findings with opaque claims, each anchored BOTH to a file and to a
+ * symbol that file contains -- so deleting either edge leaves the other, and
+ * traversal alone recovers it.
+ */
+function doubleAnchored(target, count) {
+  for (let i = 0; i < count; i += 1) {
+    const word = WORDS[i % WORDS.length];
+    const file = putNode(target, {
+      kind: 'file',
+      key: `C:/repo/src/${word}.ts`,
+      hash: `hash-${word}`,
+    });
+    const symbol = putNode(target, {
+      kind: 'symbol',
+      key: `C:/repo/src/${word}.ts#Thing${i}`,
+    });
+    putEdge(target, file, 'contains', symbol);
+    putNodeWithEdges(
+      target,
+      {
+        kind: 'finding',
+        key: `${OPAQUE[i % OPAQUE.length]}-d${i}`,
+        claim: `${OPAQUE[i % OPAQUE.length]} ${OPAQUE[(i + 5) % OPAQUE.length]}`,
+        confidence: 0.7,
+      },
+      [
+        { edge: 'derived_from', to: file },
+        { edge: 'derived_from', to: symbol },
+      ]
+    );
+  }
+}
+
+// A corpus big enough to clear BOTH publication gates: more than MIN_PROBED
+// findings, and more than the retrieval limit the probe is run at.
+const LIMIT = 5;
+const BIG = 26;
+
+describe('the probe is a measurement, not a tautology', () => {
+  it('can report a rate of ZERO on a graph whose by-construction check is perfect', () => {
+    // THE CENTRAL TEST. Every finding here is anchored, so the plan's original
+    // assertion (`rate === 1`) would hold on this graph -- and retrieval
+    // recovers NOTHING once the anchor edge it was told to follow is gone.
+    corpusOf(dir, BIG, 0);
+    const result = recallProbe(dir, { limit: LIMIT });
+
+    expect(result.rate).toBe(0);
+    expect(result.retrieved).toBe(0);
+    expect(result.probed).toBe(BIG);
+    expect(result.misses).toHaveLength(BIG);
+
+    // The tautology, on the same graph, at the same moment.
+    expect(result.integrity.rate).toBe(1);
+    expect(result.integrity.ok).toBe(true);
+  });
+
+  it('can report a rate between zero and one, so the number carries information', () => {
+    corpusOf(dir, BIG, BIG / 2);
+    const result = recallProbe(dir, { limit: LIMIT });
+
+    expect(result.rate).toBe(0.5);
+    expect(result.retrieved).toBe(BIG / 2);
+    expect(result.integrity.rate).toBe(1);
+  });
+
+  it('reports one when retrieval really does recover every finding', () => {
+    corpusOf(dir, BIG, BIG);
+    const result = recallProbe(dir, { limit: LIMIT });
+
+    expect(result.rate).toBe(1);
+    expect(result.byArm.lexical).toBe(BIG);
+    expect(result.byArm.traversal).toBe(0);
+  });
+
+  it('never publishes the by-construction check as the recall rate', () => {
+    corpusOf(dir, BIG, 0);
+    const result = recallProbe(dir, { limit: LIMIT });
+
+    // A rate of 0 beside an integrity of 1 is the whole point: they are
+    // different questions and this asserts they cannot be confused.
+    expect(result.rate).not.toBe(result.integrity.rate);
+    expect(result.integrity.what).toMatch(/NOT a recall rate/);
+  });
+
+  it('proves the tautology directly: findingsFor always returns a finding from its own anchor', () => {
+    // Not an assertion about this module -- an assertion about the primitive the
+    // plan's Step 3 would have measured. If this ever fails, the reasoning above
+    // is wrong and the integrity check has become a real test.
+    corpusOf(dir, 8, 0);
+    const graph = load(dir);
+    const findings = [...graph.nodes.values()].filter((n) => n.kind === 'finding');
+    expect(findings).toHaveLength(8);
+    for (const finding of findings) {
+      const anchors = graph.edges
+        .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+        .map((e) => e.to);
+      expect(anchors.length).toBeGreaterThan(0);
+      for (const anchor of anchors) {
+        expect(findingsFor(graph, anchor).map((f) => f.id)).toContain(finding.id);
+      }
+    }
+  });
+});
+
+describe('the two arms are independent and each can carry a hit alone', () => {
+  it('recovers by TRAVERSAL when a second anchor survives the deletion', () => {
+    doubleAnchored(dir, BIG);
+    const result = recallProbe(dir, { limit: LIMIT });
+
+    expect(result.rate).toBe(1);
+    expect(result.byArm.traversal).toBe(BIG * 2);
+    expect(result.byArm.lexical).toBe(0);
+  });
+
+  it('recovers by LEXICAL rank when no structural route survives', () => {
+    corpusOf(dir, BIG, BIG);
+    const result = recallProbe(dir, { limit: LIMIT });
+
+    expect(result.byArm.traversal).toBe(0);
+    expect(result.byArm.lexical).toBeGreaterThan(0);
+  });
+
+  it('finds a sibling-symbol finding through the shared parent file', () => {
+    // The neighbourhood is [anchor, ...contains-parents]; children need no call
+    // because findingsFor expands them itself. This pins the parent hop.
+    corpusOf(dir, BIG, 0);
+    const file = putNode(dir, { kind: 'file', key: 'C:/repo/src/shared.ts', hash: 'h' });
+    const one = putNode(dir, { kind: 'symbol', key: 'C:/repo/src/shared.ts#One' });
+    const two = putNode(dir, { kind: 'symbol', key: 'C:/repo/src/shared.ts#Two' });
+    putEdge(dir, file, 'contains', one);
+    putEdge(dir, file, 'contains', two);
+    putNodeWithEdges(
+      dir,
+      { kind: 'finding', key: 'sibling-claim', claim: 'zqxwv qzjhb plurgh', confidence: 0.9 },
+      [
+        { edge: 'derived_from', to: one },
+        { edge: 'derived_from', to: two },
+      ]
+    );
+
+    const result = recallProbe(dir, { limit: LIMIT });
+    expect(result.misses.map((m) => m.key)).not.toContain('sibling-claim');
+    expect(result.byArm.traversal).toBe(2);
+  });
+});
+
+describe('misses are named, with a reason', () => {
+  it('reports a finding reachable by neither traversal nor lexical rank as a miss', () => {
+    corpusOf(dir, BIG, BIG);
+    const lonely = putNode(dir, { kind: 'file', key: 'C:/repo/src/lonely.ts', hash: 'h' });
+    putNodeWithEdges(
+      dir,
+      { kind: 'finding', key: 'orphan', claim: 'zqxwv unrelated bandersnatch', confidence: 0.8 },
+      [{ edge: 'derived_from', to: lonely }]
+    );
+
+    const result = recallProbe(dir, { limit: LIMIT });
+    expect(result.misses.map((m) => m.key)).toContain('orphan');
+  });
+
+  it('reports an UNANCHORED finding as a miss and as an integrity failure', () => {
+    corpusOf(dir, BIG, BIG);
+    putNodeWithEdges(dir, {
+      kind: 'finding',
+      key: 'unanchored',
+      claim: 'zqxwv unrelated bandersnatch',
+      confidence: 0.8,
+    });
+
+    const result = recallProbe(dir, { limit: LIMIT });
+    expect(result.misses.map((m) => m.key)).toContain('unanchored');
+    expect(result.misses.find((m) => m.key === 'unanchored').reason).toMatch(/no anchor/);
+    // And the integrity check stops being 1.0, because an active finding with
+    // no anchor is the record `writeHarvested` refuses to create.
+    expect(result.integrity.ok).toBe(false);
+    expect(result.integrity.rate).toBeLessThan(1);
+  });
+
+  it('excludes retired findings from both the probe and the corpus', () => {
+    corpusOf(dir, BIG, BIG);
+    const file = putNode(dir, { kind: 'file', key: 'C:/repo/src/gone.ts', hash: 'h' });
+    putNodeWithEdges(
+      dir,
+      { kind: 'finding', key: 'withdrawn', claim: 'zqxwv gone', retired: true },
+      [{ edge: 'derived_from', to: file }]
+    );
+
+    const result = recallProbe(dir, { limit: LIMIT });
+    expect(result.probed).toBe(BIG);
+    expect(result.corpus).toBe(BIG);
+    expect(result.misses.map((m) => m.key)).not.toContain('withdrawn');
+  });
+
+  it('counts a finding lost from ANY of its anchors as a miss, and names that anchor', () => {
+    // Strict aggregation. This finding is recoverable from the symbol (its file
+    // sibling survives) but not from a second, unrelated file with an opaque
+    // claim -- so it is a miss, biasing the rate DOWN.
+    corpusOf(dir, BIG, 0);
+    const near = putNode(dir, { kind: 'file', key: 'C:/repo/src/near.ts', hash: 'h1' });
+    const symbol = putNode(dir, { kind: 'symbol', key: 'C:/repo/src/near.ts#Thing' });
+    putEdge(dir, near, 'contains', symbol);
+    const far = putNode(dir, { kind: 'file', key: 'C:/repo/src/far.ts', hash: 'h2' });
+    putNodeWithEdges(
+      dir,
+      { kind: 'finding', key: 'partial', claim: 'zqxwv qzjhb plurgh', confidence: 0.9 },
+      [
+        { edge: 'derived_from', to: near },
+        { edge: 'derived_from', to: symbol },
+        { edge: 'derived_from', to: far },
+      ]
+    );
+
+    const result = recallProbe(dir, { limit: LIMIT });
+    const miss = result.misses.find((m) => m.key === 'partial');
+    expect(miss).toBeDefined();
+    expect(miss.reason).toContain('far.ts');
+    // The edge-level counts still show the two that WERE recovered.
+    expect(result.recoveredEdges).toBeGreaterThan(0);
+  });
+});
+
+describe('it refuses rather than publishing a number it cannot support', () => {
+  it('returns a null rate with a reason on an empty graph', () => {
+    writeFileSync(join(dir, 'graph.jsonl'), '');
+    const result = recallProbe(dir);
+
+    expect(result.rate).toBeNull();
+    expect(result.reason).toMatch(/not measured/);
+    expect(result.integrity.rate).toBeNull();
+  });
+
+  it('returns a null rate below the observation floor, and says what the count was', () => {
+    // n = 1 is this machine's real graph. A rate over one observation is not a
+    // rate, and this is the branch the Definition of done exercises here.
+    corpusOf(dir, 1, 1);
+    const result = recallProbe(dir, { limit: LIMIT });
+
+    expect(result.probed).toBe(1);
+    expect(result.retrieved).toBe(1);
+    expect(result.rate).toBeNull();
+    expect(result.reason).toMatch(/below the floor of 10/);
+    expect(result.reason).toMatch(/count and not a rate/);
+    // The tautology would have published 1.0 right here.
+    expect(result.integrity.rate).toBe(1);
+  });
+
+  it('refuses a rate when the corpus is no larger than the retrieval limit', () => {
+    // MIN_PROBED is cleared -- 12 probeable findings -- but at limit 20 nothing
+    // is ever cut for budget, so the lexical arm is more permissive than
+    // production and the rate is withheld anyway.
+    corpusOf(dir, 12, 12);
+    const result = recallProbe(dir, { limit: 20 });
+
+    expect(result.probed).toBeGreaterThanOrEqual(MIN_PROBED);
+    expect(result.discriminating).toBe(false);
+    expect(result.rate).toBeNull();
+    expect(result.reason).toMatch(/nothing is ever cut for budget/);
+    expect(result.retrieved).toBe(12);
+  });
+
+  it('does not count an anchor edge with no node as a miss', () => {
+    // `expand.promote` writes anchor edges to file ids that were never indexed,
+    // and this machine's shared graph holds 14 active findings in exactly that
+    // state. There is no anchor key to query BM25 with, so the question could
+    // not be asked -- scoring it a miss would manufacture a recall loss out of
+    // a graph-integrity defect.
+    putNodeWithEdges(
+      dir,
+      { kind: 'finding', key: 'dangling', claim: 'zqxwv qzjhb', confidence: 0.6 },
+      [{ edge: 'derived_from', to: 'file:deadbeefdeadbeef' }]
+    );
+
+    const result = recallProbe(dir);
+    expect(result.probed).toBe(0);
+    expect(result.misses).toHaveLength(0);
+    expect(result.unprobeable.map((u) => u.key)).toContain('dangling');
+    expect(result.unprobeable[0].reason).toMatch(/no node in the graph/);
+    expect(result.rate).toBeNull();
+    expect(result.reason).toMatch(/not the same as a rate of zero/);
+  });
+
+  it('fails open when the graph log CANNOT BE READ rather than throwing', () => {
+    // THIS ASSERTION WAS VACUOUS IN ITS FIRST FORM and a mutation found it: it
+    // passed a nonexistent directory, and `load` returns an EMPTY graph for a
+    // missing log rather than throwing, so the catch it meant to exercise never
+    // ran and replacing the refusal with `throw` survived. A directory where
+    // the log file should be makes `readFileSync` throw for real.
+    mkdirSync(join(dir, 'graph.jsonl'), { recursive: true });
+    const result = recallProbe(dir);
+
+    expect(result.rate).toBeNull();
+    expect(result.probed).toBe(0);
+    expect(result.reason).toMatch(/could not be read/);
+  });
+
+  it('fails open when the probe itself throws on a malformed graph', () => {
+    // The second catch, pinned separately: a caller-supplied graph whose
+    // `nodes` is not a Map. A report path must lose a section, never throw.
+    const result = recallProbe(dir, { graph: { nodes: null, edges: [] } });
+
+    expect(result.rate).toBeNull();
+    expect(result.reason).toMatch(/the probe failed/);
+  });
+
+  it('caps the number of findings probed, says when the cap bit, and still ranks against the whole corpus', () => {
+    // The default cap is bigger than any graph a unit test should build, so the
+    // MECHANISM is exercised through the option and the DEFAULT is pinned as a
+    // constant. `corpus` must stay at the full size: the cap is a sample of
+    // which findings are probed, never of what they compete against, or a
+    // truncated run would report an easier ranking problem than the real one.
+    // The `corpus` field reads the SAME variable BM25 ranks over, so this
+    // assertion is behavioural -- reading a parallel `all.length` instead let a
+    // mutation shrink the ranking corpus and survive.
+    expect(MAX_FINDINGS).toBe(200);
+    expect(MAX_FINDINGS).toBeGreaterThan(MIN_PROBED);
+
+    corpusOf(dir, 26, 26);
+    const capped = recallProbe(dir, { limit: LIMIT, maxFindings: 12 });
+    expect(capped.truncated).toBe(true);
+    expect(capped.probed).toBe(12);
+    expect(capped.corpus).toBe(26);
+    expect(capped.integrity.probed).toBe(12);
+
+    const uncapped = recallProbe(dir, { limit: LIMIT });
+    expect(uncapped.truncated).toBe(false);
+    expect(uncapped.probed).toBe(26);
+  });
+});
+
+describe('it is wired into the balance sheet, labelled as an offline probe', () => {
+  it('graphBalanceSheet carries the probe and its basis', () => {
+    corpusOf(dir, BIG, BIG / 2);
+    const sheet = graphBalanceSheet(dir, { limit: LIMIT });
+
+    expect(sheet.recall).toBeDefined();
+    expect(sheet.recall.basis).toBe('offline probe over the current graph');
+    expect(sheet.recall.rate).toBe(0.5);
+  });
+
+  it('the probe writes nothing to the graph', () => {
+    corpusOf(dir, BIG, BIG / 2);
+    const before = load(dir);
+    recallProbe(dir, { limit: LIMIT });
+    const after = load(dir);
+
+    expect(after.nodes.size).toBe(before.nodes.size);
+    expect(after.edges.length).toBe(before.edges.length);
+  });
+
+  it('does not mutate the graph object it was handed', () => {
+    corpusOf(dir, BIG, 0);
+    const graph = load(dir);
+    const edges = graph.edges.length;
+    const nodes = graph.nodes.size;
+    recallProbe(dir, { graph, limit: LIMIT });
+
+    expect(graph.edges.length).toBe(edges);
+    expect(graph.nodes.size).toBe(nodes);
+  });
+});

--- a/tests/hooks/redact.test.mjs
+++ b/tests/hooks/redact.test.mjs
@@ -1,0 +1,25 @@
+// tests/hooks/redact.test.mjs
+import { describe, it, expect } from '@jest/globals';
+import { redact } from '../../hooks-core/redact.mjs';
+
+describe('redact', () => {
+  it('removes bearer tokens', () => {
+    expect(redact('failed: Authorization: Bearer sk-abc123def456ghi789')).not.toContain('sk-abc123');
+  });
+  it('removes assignments that look like secrets', () => {
+    expect(redact('AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG')).not.toContain('wJalrXUtnFEMI');
+  });
+  it('removes connection strings with credentials', () => {
+    expect(redact('postgres://user:hunter2@db:5432/x')).not.toContain('hunter2');
+  });
+  it('keeps ordinary error text intact', () => {
+    const text = 'TS2345: Argument of type string is not assignable to number';
+    expect(redact(text)).toBe(text);
+  });
+  it('caps length', () => {
+    expect(redact('x'.repeat(5000), { max: 400 }).length).toBeLessThanOrEqual(400);
+  });
+  it('never throws on non-string input', () => {
+    expect(() => redact(null)).not.toThrow();
+  });
+});

--- a/tests/hooks/redact.test.mjs
+++ b/tests/hooks/redact.test.mjs
@@ -4,13 +4,30 @@ import { redact } from '../../hooks-core/redact.mjs';
 
 describe('redact', () => {
   it('removes bearer tokens', () => {
-    expect(redact('failed: Authorization: Bearer sk-abc123def456ghi789')).not.toContain('sk-abc123');
+    // This token does NOT start with sk-/pk-/ghp-/etc, so only the bearer
+    // pattern can catch it -- isolates the bearer pattern from the
+    // key-prefix pattern.
+    expect(redact('failed: Authorization: Bearer abcdefghijklmnopqrstuvwxyz012345')).not.toContain('abcdefghijklmnopqrstuvwxyz012345');
+  });
+  it('removes API-key-shaped tokens', () => {
+    // Not preceded by "Bearer", so only the sk-/pk-/ghp-/... prefix pattern
+    // can catch it -- isolates the key-prefix pattern from the bearer
+    // pattern.
+    expect(redact('token=sk-abc123def456ghi789')).not.toContain('sk-abc123');
   });
   it('removes assignments that look like secrets', () => {
     expect(redact('AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG')).not.toContain('wJalrXUtnFEMI');
   });
   it('removes connection strings with credentials', () => {
     expect(redact('postgres://user:hunter2@db:5432/x')).not.toContain('hunter2');
+  });
+  it('removes PEM private key blocks', () => {
+    const text = '-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAK\n-----END RSA PRIVATE KEY-----';
+    expect(redact(text)).not.toContain('MIIBOgIBAAJBAK');
+  });
+  it('leaves non-private-key PEM-shaped blocks alone', () => {
+    const text = '-----BEGIN CERTIFICATE-----\nMIIBOgIBAAJBAK\n-----END CERTIFICATE-----';
+    expect(redact(text)).toBe(text);
   });
   it('keeps ordinary error text intact', () => {
     const text = 'TS2345: Argument of type string is not assignable to number';
@@ -21,5 +38,14 @@ describe('redact', () => {
   });
   it('never throws on non-string input', () => {
     expect(() => redact(null)).not.toThrow();
+    expect(() => redact(undefined)).not.toThrow();
+  });
+  it('turns a missing value into an empty string, not the literal text "null"/"undefined"', () => {
+    // Without the `?? ''` guard, String(null) === 'null' and
+    // String(undefined) === 'undefined' -- neither throws, so a garbage
+    // four-character claim would silently reach the graph and model
+    // context instead of surfacing as a failure.
+    expect(redact(null)).toBe('');
+    expect(redact(undefined)).toBe('');
   });
 });

--- a/tests/hooks/reread-waste.test.mjs
+++ b/tests/hooks/reread-waste.test.mjs
@@ -21,7 +21,7 @@ import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { record, rereadWaste, fingerprint, recordRead } from '../../hooks-core/metrics.mjs';
+import { record, rereadWaste, rereadsByAnchor, fingerprint, recordRead } from '../../hooks-core/metrics.mjs';
 
 let dir;
 let project;
@@ -140,5 +140,78 @@ describe('the fingerprint itself', () => {
     expect(w.repeats).toBe(1);
     expect(w.wasteful).toBe(1);
     expect(w.coverage).toBe(1);
+  });
+});
+
+/**
+ * The per-anchor rows, which exist because two consumers now need them.
+ *
+ * The churn detector in derive.mjs asks WHICH file was re-read pointlessly;
+ * rereadWaste asks HOW MUCH was wasted in total. Answering both from one
+ * grouping is the point -- a second implementation would be a second definition
+ * of "wasteful", and the two would drift.
+ */
+describe('re-reads grouped by anchor', () => {
+  it('groups re-reads by anchor, worst first', () => {
+    const events = [
+      { kind: 'read', anchor: 'a.ts', fp: 'x', tokens: 100, at: 1 },
+      { kind: 'read', anchor: 'a.ts', fp: 'x', tokens: 100, at: 2 },
+      { kind: 'read', anchor: 'a.ts', fp: 'x', tokens: 100, at: 3 },
+      { kind: 'read', anchor: 'b.ts', fp: 'y', tokens: 50, at: 4 },
+      { kind: 'read', anchor: 'b.ts', fp: 'z', tokens: 50, at: 5 },
+    ];
+    const rows = rereadsByAnchor(events);
+    expect(rows[0].anchor).toBe('a.ts');
+    // Two repeats with an unchanged fingerprint are wasteful; b.ts changed, so it is not.
+    expect(rows[0].wasteful).toBe(2);
+    expect(rows.find((r) => r.anchor === 'b.ts').wasteful).toBe(0);
+  });
+
+  it('reports only the WASTEFUL tokens on a row, never the legitimate ones', () => {
+    // A row whose headline number included re-reads of a file that changed
+    // would overstate the recoverable waste in exactly the way the 14.6M
+    // headline did.
+    const events = [
+      { kind: 'read', anchor: 'a.ts', fp: 'x', tokens: 100, at: 1 },
+      { kind: 'read', anchor: 'a.ts', fp: 'x', tokens: 100, at: 2 },
+      { kind: 'read', anchor: 'a.ts', fp: 'CHANGED', tokens: 999, at: 3 },
+    ];
+    const [row] = rereadsByAnchor(events);
+    expect(row.tokens).toBe(100);
+    expect(row.legitimateTokens).toBe(999);
+  });
+
+  it('merges one anchor across sessions into one row without inventing a repeat', () => {
+    // Grouping is per session -- a file read once in each of two sessions is
+    // not a re-read -- but the ROW is per anchor, so a caller asking "which
+    // file do we keep re-reading" gets one answer rather than one per session.
+    const events = [
+      { kind: 'read', anchor: 'a.ts', sessionId: 's1', fp: 'x', tokens: 10, at: 1 },
+      { kind: 'read', anchor: 'a.ts', sessionId: 's1', fp: 'x', tokens: 10, at: 2 },
+      { kind: 'read', anchor: 'a.ts', sessionId: 's2', fp: 'x', tokens: 10, at: 3 },
+      { kind: 'read', anchor: 'a.ts', sessionId: 's2', fp: 'x', tokens: 10, at: 4 },
+    ];
+    const rows = rereadsByAnchor(events);
+    expect(rows.length).toBe(1);
+    expect(rows[0].repeats).toBe(2);
+  });
+
+  it('leaves every existing rereadWaste field untouched', () => {
+    const events = [
+      { kind: 'read', anchor: '/src/a.ts', sessionId: 's1', fp: 'x', tokens: 100, at: 1 },
+      { kind: 'read', anchor: '/src/a.ts', sessionId: 's1', fp: 'x', tokens: 100, at: 2 },
+    ];
+    const before = rereadWaste(dir, { events, includeFixtures: true });
+    expect(before).toHaveProperty('repeats', 1);
+    expect(before).toHaveProperty('wasteful', 1);
+    expect(before).toHaveProperty('wastefulTokens', 100);
+    expect(before).toHaveProperty('legitimate', 0);
+    expect(before).toHaveProperty('legitimateTokens', 0);
+    expect(before).toHaveProperty('undecidable', 0);
+    expect(before).toHaveProperty('undecidableTokens', 0);
+    expect(before).toHaveProperty('coverage', 1);
+    // Additive, and bounded: the offenders behind the totals.
+    expect(Array.isArray(before.worst)).toBe(true);
+    expect(before.worst[0].anchor).toBe('/src/a.ts');
   });
 });

--- a/tests/hooks/standing-rules.test.mjs
+++ b/tests/hooks/standing-rules.test.mjs
@@ -81,6 +81,44 @@ describe('what qualifies', () => {
   });
 });
 
+describe('how the next rule gets here', () => {
+  it('asks for wiki_write by name, with the anchor the tool requires', () => {
+    // A model reading a set of standing rules has no way to add to it unless the
+    // block says how one is made. Both routes into this list -- a pin and a
+    // person's verified correction -- start as a wiki_write, and an unanchored
+    // write is refused, so naming the tool without the anchor would produce
+    // refusals the agent cannot diagnose.
+    seed({ key: 'p1', claim: 'Build against an isolated worktree.', pinned: true });
+    const out = standingRules(dir, load(dir));
+
+    expect(out).toMatch(/wiki_write/);
+    expect(out).toMatch(/anchor/i);
+  });
+
+  it('spends ONE LINE on it, charged inside the budget rather than beside it', () => {
+    // The guidance is part of the message the budget bounds -- `spent` starts at
+    // the heading's own cost -- so every token it takes is a token a real rule
+    // does not get. The documented shape of the budget is "400 tokens is roughly
+    // a dozen rules", and that has to survive the addition: a paragraph here
+    // would silently push rules out of a block whose whole justification is
+    // that it is tightly bounded.
+    // MEASURED AS THE FIXED OVERHEAD, not as "twelve short rules still fit".
+    // The first version of this asserted the latter, and a five-line paragraph
+    // pasted into the heading still left room for twelve 12-token rules inside
+    // 400 -- so it passed for the wrong reason and proved nothing about the
+    // size of the addition. One seeded rule isolates what the wrapper costs.
+    seed({ key: 'p1', claim: 'A pinned rule.', pinned: true });
+    const out = standingRules(dir, load(dir));
+    const tokens = Math.ceil(out.length / 4);
+
+    expect(out).toMatch(/wiki_write/);
+    // A sixth of the 400-token budget for heading plus guidance plus one rule.
+    // The documented shape is "400 tokens is roughly a dozen rules"; a wrapper
+    // that grows past this is spending rules on prose about rules.
+    expect(tokens).toBeLessThanOrEqual(70);
+  });
+});
+
 describe('ordering', () => {
   it("puts a person's own correction above an inferred pin", () => {
     seed({ key: 'pin', claim: 'PINNED RULE', pinned: true, confidence: 0.99 });

--- a/tests/hooks/usage.test.mjs
+++ b/tests/hooks/usage.test.mjs
@@ -1,0 +1,308 @@
+/**
+ * Layer 1 -- explicit-reference classification.
+ *
+ * TWO CORRECTIONS TO THE BRIEF'S TEST SNIPPET, both found by reading the
+ * producers rather than trusting the plan:
+ *
+ *   1. `inject` events carry `findingIds`, not `findingKeys`. All five call
+ *      sites in inject.mjs write `findingIds`, and `recordToolOutcome` copies
+ *      that field. A test written against `findingKeys` would have passed
+ *      against an implementation that read a field production never writes --
+ *      a metric with no producer, validated by its own suite.
+ *   2. `expand` does not name a finding. `recordExpansion` writes a truncation
+ *      capture `ref`, a tool, a shape and a free-text `asked`. None is a graph
+ *      key, and all 64 live `expand` events on this machine carry
+ *      `sessionId: null`. So the reference channel is `query` alone, and there
+ *      is a test below pinning that rather than leaving it implicit.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { record, recordToolOutcome } from '../../hooks-core/metrics.mjs';
+import {
+  classify,
+  referenceRate,
+  referenceNote,
+} from '../../hooks-core/usage.mjs';
+import { renderAudit } from '../../hooks-core/audit.mjs';
+
+let dir;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'usage-'));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+const inject = (over = {}) =>
+  record(dir, {
+    kind: 'inject',
+    anchor: 'a.ts',
+    findingIds: ['k1'],
+    sessionId: 's',
+    at: 1,
+    ...over,
+  });
+
+const query = (over = {}) =>
+  record(dir, {
+    kind: 'query',
+    operation: 'get',
+    key: 'k1',
+    sessionId: 's',
+    at: 2,
+    ...over,
+  });
+
+const labelOf = (key = 'k1') =>
+  classify(dir).find((row) => row.findingKey === key)?.label;
+
+describe('Layer 1 classification', () => {
+  it('labels an injection referenced when a later query names the finding', () => {
+    inject();
+    query();
+    expect(labelOf()).toBe('referenced');
+  });
+
+  it('does not count a query that preceded the injection', () => {
+    query({ at: 1 });
+    inject({ at: 2 });
+    expect(labelOf()).not.toBe('referenced');
+  });
+
+  it('labels an injection not-referenced when the session went on without asking', () => {
+    inject();
+    // Activity in the same session after the injection: the opportunity
+    // existed and was not taken.
+    record(dir, { kind: 'read', anchor: 'b.ts', sessionId: 's', at: 5 });
+    expect(labelOf()).toBe('not-referenced');
+  });
+
+  it('labels an injection unknown when nothing followed it', () => {
+    inject();
+    expect(labelOf()).toBe('unknown');
+  });
+
+  it('credits a reference only within the same session', () => {
+    inject({ sessionId: 's' });
+    query({ sessionId: 'other', at: 3 });
+    expect(labelOf()).not.toBe('referenced');
+  });
+
+  it('treats an expand as opportunity but never as a reference', () => {
+    // `expand` names a capture ref, not a finding key -- so even an expand
+    // whose ref happens to equal the finding key must not count.
+    inject();
+    record(dir, { kind: 'expand', ref: 'k1', sessionId: 's', at: 4 });
+    expect(labelOf()).toBe('not-referenced');
+  });
+
+  it('never reads an expand as a reference, even one carrying a key', () => {
+    // THE CHANNEL IS `query` ALONE. Widening REFERENCE_KINDS to include
+    // `expand` for symmetry with the brief must not silently start crediting
+    // expansions -- they name a truncation capture, not a finding.
+    inject();
+    record(dir, { kind: 'expand', key: 'k1', sessionId: 's', at: 4 });
+    expect(labelOf()).toBe('not-referenced');
+  });
+
+  it('never reads a capture ref as a finding key', () => {
+    // `ref` is a 16-hex digest of captured tool output. Consulting it as a
+    // fallback for `key` would attribute a reference to a finding whose key
+    // merely collided with a capture id.
+    inject();
+    record(dir, { kind: 'query', ref: 'k1', sessionId: 's', at: 4 });
+    expect(labelOf()).toBe('not-referenced');
+  });
+
+  it('returns rows in time order, not in log order', () => {
+    // The consumer pairs these rows against Layer 2's per-finding effects, so
+    // the order is contract rather than incidental -- and the log is written in
+    // WRITE order, which detached workers do not guarantee matches `at`.
+    inject({ findingIds: ['late'], at: 90 });
+    inject({ findingIds: ['early'], at: 10 });
+    expect(classify(dir).map((row) => row.findingKey)).toEqual([
+      'early',
+      'late',
+    ]);
+  });
+
+  it('counts each injection of a finding as its own opportunity', () => {
+    inject({ at: 1 });
+    inject({ at: 10 });
+    query({ at: 2 });
+    const labels = classify(dir).map((row) => row.label);
+    expect(labels).toEqual(['referenced', 'unknown']);
+  });
+
+  it('uses the outcome join as opportunity when the log has no session id', () => {
+    const injection = record(dir, {
+      kind: 'inject',
+      anchor: 'a.ts',
+      findingIds: ['k1'],
+      episodeId: 'e',
+      toolCallId: 'tc',
+      at: 1,
+    });
+    recordToolOutcome(dir, {
+      episodeId: 'e',
+      toolCallId: 'tc',
+      anchor: 'a.ts',
+      at: 2,
+      success: true,
+    });
+    expect(injection.injectionId).toBeTruthy();
+    expect(labelOf()).toBe('not-referenced');
+  });
+
+  it('ignores an injection that carried no findings', () => {
+    inject({ findingIds: [] });
+    expect(classify(dir)).toEqual([]);
+  });
+});
+
+describe('Layer 1 rate', () => {
+  it('excludes unknown from the denominator instead of scoring it a miss', () => {
+    inject();
+    query();
+    record(dir, {
+      kind: 'inject',
+      anchor: 'b.ts',
+      findingIds: ['k2'],
+      sessionId: 's2',
+      at: 3,
+    });
+    const rate = referenceRate(dir);
+    expect(rate.denominator).toBeLessThan(classify(dir).length);
+    expect(rate.unknown).toBe(1);
+    expect(rate.rate).toBe(1);
+  });
+
+  it('returns a null rate rather than 0 when there is no evidence', () => {
+    expect(referenceRate(dir).rate).toBeNull();
+  });
+
+  it('returns a null rate when the reference channel never fired at all', () => {
+    // A real denominator, and zero references -- but no query event exists in
+    // the window, so 0% would be measuring the absence of a producer.
+    inject();
+    record(dir, { kind: 'read', anchor: 'b.ts', sessionId: 's', at: 5 });
+    const rate = referenceRate(dir);
+    expect(rate.denominator).toBe(1);
+    expect(rate.referenceEvents).toBe(0);
+    expect(rate.rate).toBeNull();
+  });
+
+  it('reports a real 0 once the channel has fired and named something else', () => {
+    inject();
+    record(dir, { kind: 'read', anchor: 'b.ts', sessionId: 's', at: 5 });
+    query({ key: 'somethingElse', at: 6 });
+    const rate = referenceRate(dir);
+    expect(rate.referenceEvents).toBe(1);
+    expect(rate.rate).toBe(0);
+  });
+
+  it('counts a query with no session id as unscoped rather than crediting it', () => {
+    inject();
+    query({ sessionId: null, at: 2 });
+    const rate = referenceRate(dir);
+    expect(rate.unscopedReferences).toBe(1);
+    expect(rate.referenceEvents).toBe(0);
+    expect(rate.referenced).toBe(0);
+  });
+
+  it('separates outcomes the join could not attribute from both arms', () => {
+    recordToolOutcome(dir, {
+      episodeId: 'nothing-injected',
+      toolCallId: 'tc',
+      anchor: 'z.ts',
+      at: 1,
+      success: true,
+    });
+    const rate = referenceRate(dir);
+    expect(rate.unattributable).toBe(1);
+    // No injection was ever attached to that tool call, so the join did not
+    // FAIL -- there was nothing to join to. The two figures must not agree.
+    expect(rate.unattributableWithInjectedToolCall).toBe(0);
+    expect(rate.denominator).toBe(0);
+  });
+
+  it('does not score a whole session a join failure because one call was injected', () => {
+    // THE MEASUREMENT-BIAS REGRESSION. `episodeId` IS the session id, so
+    // keying the join-failure count on the episode scored every tool call of
+    // the session -- 2,559 of them on this repository's real log -- as a
+    // failed join, where the true number is zero.
+    record(dir, {
+      kind: 'inject',
+      anchor: 'a.ts',
+      findingIds: ['k1'],
+      episodeId: 'e',
+      toolCallId: 'injected-call',
+      sessionId: 's',
+      at: 1,
+    });
+    for (const id of ['other-1', 'other-2', 'other-3']) {
+      recordToolOutcome(dir, {
+        episodeId: 'e',
+        toolCallId: id,
+        anchor: 'elsewhere.ts',
+        at: 2,
+        success: true,
+      });
+    }
+    const rate = referenceRate(dir);
+    expect(rate.unattributable).toBe(3);
+    expect(rate.unattributableWithInjectedToolCall).toBe(0);
+  });
+
+  it('marks an unattributable outcome on an injected tool call as a real join failure', () => {
+    record(dir, {
+      kind: 'inject',
+      anchor: 'a.ts',
+      findingIds: ['k1'],
+      episodeId: 'e',
+      toolCallId: 'tc',
+      sessionId: 's',
+      at: 1,
+    });
+    // Same tool call, but a DIFFERENT episode, so recordToolOutcome finds no
+    // candidate and reports `none` on a call that did carry findings.
+    recordToolOutcome(dir, {
+      episodeId: 'elsewhere',
+      toolCallId: 'tc',
+      anchor: 'a.ts',
+      at: 2,
+      success: true,
+    });
+    const rate = referenceRate(dir);
+    expect(rate.unattributable).toBe(1);
+    expect(rate.unattributableWithInjectedToolCall).toBe(1);
+  });
+});
+
+describe('Layer 1 disclosure', () => {
+  it('says nothing at all when there is nothing to say', () => {
+    expect(referenceNote(dir)).toBeNull();
+  });
+
+  it('says not measurable rather than 0% when the channel never fired', () => {
+    inject();
+    record(dir, { kind: 'read', anchor: 'b.ts', sessionId: 's', at: 5 });
+    expect(referenceNote(dir)).toContain('not measurable');
+  });
+
+  it('quotes the measured rate once there is one', () => {
+    inject();
+    query();
+    expect(referenceNote(dir)).toContain('1/1');
+  });
+
+  it('reaches the audit report, which is its only production reader', () => {
+    // WIRING, not logic. A measurement with no reader is how this project
+    // shipped two metrics whose only consumer was their own test suite, so the
+    // path from classify() to something a human sees is asserted directly.
+    inject();
+    query();
+    const { text } = renderAudit(dir, []);
+    expect(text).toContain('Injected findings referenced later');
+  });
+});

--- a/tests/hooks/usage.test.mjs
+++ b/tests/hooks/usage.test.mjs
@@ -82,10 +82,19 @@ describe('Layer 1 classification', () => {
     expect(labelOf()).toBe('unknown');
   });
 
-  it('credits a reference only within the same session', () => {
+  it('credits a reference from another session, because a session id is not evidence', () => {
+    // `wiki_query` takes `sessionId` as an OPTIONAL input the model has to
+    // volunteer, so scoping on it made the numerator depend on the model
+    // choosing to identify itself. The finding key is the specific part.
     inject({ sessionId: 's' });
     query({ sessionId: 'other', at: 3 });
-    expect(labelOf()).not.toBe('referenced');
+    expect(labelOf()).toBe('referenced');
+  });
+
+  it('credits a query that carries no session id at all', () => {
+    inject();
+    query({ sessionId: null, at: 3 });
+    expect(labelOf()).toBe('referenced');
   });
 
   it('treats an expand as opportunity but never as a reference', () => {
@@ -201,13 +210,15 @@ describe('Layer 1 rate', () => {
     expect(rate.rate).toBe(0);
   });
 
-  it('counts a query with no session id as unscoped rather than crediting it', () => {
+  it('counts a query with no session id as a usable reference event', () => {
     inject();
     query({ sessionId: null, at: 2 });
     const rate = referenceRate(dir);
-    expect(rate.unscopedReferences).toBe(1);
-    expect(rate.referenceEvents).toBe(0);
-    expect(rate.referenced).toBe(0);
+    expect(rate.referenceEvents).toBe(1);
+    expect(rate.referenced).toBe(1);
+    // The field that counted the session-less losses is gone, not zeroed: a
+    // permanent 0 would read as "the loss was fixed".
+    expect(rate).not.toHaveProperty('unscopedReferences');
   });
 
   it('separates outcomes the join could not attribute from both arms', () => {
@@ -294,6 +305,33 @@ describe('Layer 1 disclosure', () => {
     inject();
     query();
     expect(referenceNote(dir)).toContain('1/1');
+  });
+
+  it('discloses the cross-attribution cost beside the number it qualifies', () => {
+    // The caveat has to live where a human meets the figure. A task report is
+    // not where someone quoting the number will look.
+    inject();
+    query();
+    expect(referenceNote(dir)).toContain('cross-attribute');
+  });
+
+  it('says the denominator can understate when the read was truncated', () => {
+    // One oversized record forces `readMetrics` past its byte cap, which is
+    // the same truncation that hid both of this repository's real injections.
+    record(dir, { kind: 'padding', pad: 'x'.repeat(2_200_000), at: 0 });
+    inject();
+    query();
+    const rate = referenceRate(dir);
+    expect(rate.windowed).toBe(true);
+    expect(referenceNote(dir)).toContain('can understate');
+  });
+
+  it('does not claim a window when the caller supplied its own events', () => {
+    const events = [
+      { kind: 'inject', findingIds: ['k1'], injectionId: 'i', sessionId: 's', at: 1 },
+      { kind: 'query', operation: 'get', key: 'k1', sessionId: 's', at: 2 },
+    ];
+    expect(referenceRate(dir, { events }).windowed).toBe(false);
   });
 
   it('reaches the audit report, which is its only production reader', () => {

--- a/tests/unit/doctor-reports-harvest-state.test.ts
+++ b/tests/unit/doctor-reports-harvest-state.test.ts
@@ -96,6 +96,38 @@ describe('probeHarvest', () => {
     expect(check.detail).toMatch(/local/i);
   });
 
+  it('says plainly what a local endpoint buys, because it is the buried option', () => {
+    // This is the configuration a user would pick if they knew it existed: the
+    // only one under which the semantic harvest runs with no credential, no
+    // billing and no digest leaving the machine. The previous wording named it
+    // as "also enables fallback extraction", which states the mechanism and
+    // none of the three facts that decide whether somebody wants it.
+    envOnly({
+      TOKEN_OPTIMIZER_HARVEST_ENDPOINT:
+        'http://127.0.0.1:11434/v1/chat/completions',
+    });
+    const [check] = probeHarvest();
+
+    expect(check.detail).toMatch(/local model found/i);
+    expect(check.detail).toMatch(/free and private/i);
+    expect(check.detail).toMatch(/nothing leaves this machine/i);
+  });
+
+  it('names the trade on a machine with no credential, not just the absence', () => {
+    // The default state, so the text most users read. "Unavailable" alone tells
+    // them neither what they are missing, nor that local findings still
+    // accumulate, nor that the free option exists.
+    envOnly({});
+    const [check] = probeHarvest();
+
+    expect(check.detail).toMatch(/derive/i);
+    expect(check.detail).toMatch(/TOKEN_OPTIMIZER_HARVEST_ENDPOINT/);
+    expect(check.detail).toMatch(/free and private/i);
+    // What a credentialed harvest would send, stated where the user is deciding
+    // whether to configure one.
+    expect(check.detail).toMatch(/never file contents/i);
+  });
+
   it('passes when opted in with a credential', () => {
     envOnly({
       TOKEN_OPTIMIZER_HARVEST: 'true',

--- a/tests/unit/optimization-report.test.ts
+++ b/tests/unit/optimization-report.test.ts
@@ -1,0 +1,184 @@
+/**
+ * `get_optimization_report` -- the graph balance sheet, and the one rule about
+ * currency.
+ *
+ * THE RULE: a dollar figure may appear beside a MEASURED COUNTERFACTUAL and
+ * nowhere else. The holdout figure, the consolidation ratio and the calibration
+ * verdict are estimates, and pricing an estimate makes this project's headline
+ * saving larger for free -- the measurement-bias class that has produced six
+ * defects across these plans, every one of them in this project's own favour.
+ * So the assertions below are written against the RENDERED TEXT: with a rate
+ * configured, the measured line must carry currency and no line that says
+ * "estimate" may.
+ */
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { AnalyticsManager } from '../../src/analytics/analytics-manager.js';
+import type {
+  AggregatedStats,
+  AnalyticsEntry,
+} from '../../src/analytics/analytics-types.js';
+import { getOptimizationReportTool } from '../../src/tools/analytics/get-optimization-report.js';
+
+const RATE_ENV = 'TOKEN_OPTIMIZER_EFFECTIVE_INPUT_USD_PER_MILLION';
+
+let workspace: string;
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), 'report-'));
+  // A graph of our own, so the section under test does not depend on whatever
+  // this developer's own repository happens to have measured today.
+  process.env.TOKEN_OPTIMIZER_WIKI_DIR = join(workspace, 'wiki');
+  delete process.env[RATE_ENV];
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+  delete process.env.TOKEN_OPTIMIZER_WIKI_DIR;
+  delete process.env[RATE_ENV];
+});
+
+const summary = {
+  totalOperations: 0,
+  totalOriginalTokens: 0,
+  totalOptimizedTokens: 0,
+  totalTokensSaved: 0,
+};
+
+const noRows: AggregatedStats[] = [];
+const noEntries: AnalyticsEntry[] = [];
+
+const manager = () =>
+  ({
+    getHookAnalytics: async () => ({ summary, byHook: noRows }),
+    getActionAnalytics: async () => ({ summary, byAction: noRows }),
+    getServerAnalytics: async () => ({ summary, byServer: noRows }),
+    getEntries: async () => noEntries,
+    count: async () => 0,
+  }) as unknown as AnalyticsManager;
+
+/**
+ * A finding that carries a derivation cost, written with the real graph writer.
+ *
+ * Needed because the consolidation line has two branches and only this one can
+ * carry a price at all -- so a test that never seeds a `derivedCost` asserts the
+ * no-currency rule against the branch that could not have broken it.
+ */
+async function seedFindingWithDerivedCost() {
+  const wiki = await import(
+    pathToFileURL(join(process.cwd(), 'hooks-core', 'wiki.mjs')).href
+  );
+  wiki.putNode(process.env.TOKEN_OPTIMIZER_WIKI_DIR, {
+    kind: 'finding',
+    key: 'expand:seeded',
+    claim: 'x'.repeat(200),
+    derivedCost: 5_000,
+    confidence: 0.7,
+  });
+}
+
+const run = async () =>
+  JSON.parse(await getOptimizationReportTool(manager())({})) as Record<
+    string,
+    any
+  >;
+
+describe('get_optimization_report and the graph', () => {
+  it('shows the graph balance sheet', async () => {
+    const report = await run();
+    expect(report.graph).toBeDefined();
+    expect(report.graph).not.toBeNull();
+    // The four sections Task 8 adds, beside the two the sheet already had.
+    expect(report.graph.measuredCounterfactual).toBeDefined();
+    expect(report.graph.estimatedCausal).toBeDefined();
+    expect(report.graph.layer1).not.toBeNull();
+    expect(report.graph.layer2).not.toBeNull();
+    expect(report.graph.calibration).toBeDefined();
+    expect(report.graph.consolidation).toBeDefined();
+    expect(report.formatted).toContain('Graph balance sheet');
+  });
+
+  it('refuses to publish a calibration it cannot compute, with no gap number', async () => {
+    const report = await run();
+    expect(report.graph.calibration.publishable).toBe(false);
+    expect(report.graph.calibration.verdict).toMatch(/not calibrated/);
+    // NOT `gap: 0`. A permanent zero reads as "measured, and they agree".
+    expect('gap' in report.graph.calibration).toBe(false);
+    expect(report.formatted).toMatch(/calibration\s+: not calibrated/);
+  });
+
+  it('puts a dollar figure only on measured lines', async () => {
+    // A configured rate, so currency is available to every line that asks for
+    // it. Without this the test would pass on a machine that simply cannot
+    // price anything, which is the vacuous version of this assertion.
+    process.env[RATE_ENV] = '3';
+    await seedFindingWithDerivedCost();
+    const report = await run();
+    const lines: string[] = report.formatted.split('\n');
+
+    const estimated = lines.filter((line) => /estimat/i.test(line));
+    expect(estimated.length).toBeGreaterThan(0);
+    for (const line of estimated) expect(line).not.toMatch(/\$/);
+
+    // And the measured counterfactual DID get its price, so the absence above
+    // is a rule and not an inability.
+    const measured = lines.find((line) => /measured counterfactual/.test(line));
+    expect(measured).toBeDefined();
+    expect(measured).toMatch(/\$/);
+  });
+
+  it('prices nothing at all when no effective rate is configured', async () => {
+    const report = await run();
+    const measured = report.formatted
+      .split('\n')
+      .find((line: string) => /measured counterfactual/.test(line));
+    expect(measured).toMatch(/not priced/);
+    expect(measured).not.toMatch(/\$/);
+  });
+
+  it('labels the consolidation ratio an estimate rather than pricing it', async () => {
+    process.env[RATE_ENV] = '3';
+    await seedFindingWithDerivedCost();
+    const report = await run();
+    // THE BRANCH THAT COULD CARRY A PRICE, exercised on purpose.
+    expect(report.graph.consolidation.withDerivedCost).toBe(1);
+    expect(report.graph.consolidation.basis).toBe('estimate');
+    expect(report.graph.consolidation.priced).toBe(false);
+    const line = report.formatted
+      .split('\n')
+      .find((l: string) => /consolidation\s+:/.test(l));
+    expect(line).toMatch(/estimate, deliberately not priced/);
+    expect(line).not.toMatch(/\$/);
+  });
+
+  it('carries the unclassifiable repeat count beside the confirmed waste', async () => {
+    // `rereadWaste` reports three groups and this line prints the confirmed one.
+    // Its count of repeats it could not judge travels with it, or the figure
+    // arrives without the fact that the classification is incomplete.
+    const report = await run();
+    const line = report.formatted
+      .split(String.fromCharCode(10))
+      .find((l: string) => /re-read waste/.test(l));
+    expect(line).toMatch(/unclassifiable/);
+    expect(line).not.toMatch(/\$/);
+  });
+
+  it('still renders a section for a graph directory that does not exist', async () => {
+    // A fresh install has no graph. The section must still appear, carrying its
+    // refusal -- a missing directory is not a reason to hide the loop's state,
+    // and it is certainly not a reason to break the report.
+    process.env.TOKEN_OPTIMIZER_WIKI_DIR = join(
+      workspace,
+      'nonexistent',
+      'wiki'
+    );
+    const report = await run();
+    expect(report.success).toBe(true);
+    expect(report.graph).not.toBeNull();
+    expect(report.graph.calibration.publishable).toBe(false);
+    expect(report.formatted).toContain('Graph balance sheet');
+  });
+});

--- a/tests/unit/optimization-report.test.ts
+++ b/tests/unit/optimization-report.test.ts
@@ -166,6 +166,32 @@ describe('get_optimization_report and the graph', () => {
     expect(line).not.toMatch(/\$/);
   });
 
+  it('renders the recall probe, labelled offline, with no rate it cannot support', async () => {
+    // The seeded finding has no anchor, so the probe reports one unanchored
+    // miss and REFUSES a rate -- the branch a fresh machine actually takes.
+    // What the line must never do is print the by-construction check's 1.0.
+    process.env[RATE_ENV] = '3';
+    await seedFindingWithDerivedCost();
+    const report = await run();
+
+    expect(report.graph.recall).toBeDefined();
+    expect(report.graph.recall.basis).toBe(
+      'offline probe over the current graph'
+    );
+    expect(report.graph.recall.rate).toBeNull();
+    // The tautology is present, separately, and it is 1.0 -- which is exactly
+    // why it may not be the thing the rate line prints.
+    expect(report.graph.recall.integrity.rate).toBe(0);
+
+    const line = report.formatted
+      .split('\n')
+      .find((l: string) => /recall \(offline probe\)/.test(l));
+    expect(line).toBeDefined();
+    expect(line).toMatch(/no rate/);
+    expect(line).not.toMatch(/\$/);
+    expect(line).not.toMatch(/100(\.0)?%/);
+  });
+
   it('still renders a section for a graph directory that does not exist', async () => {
     // A fresh install has no graph. The section must still appear, carrying its
     // refusal -- a missing directory is not a reason to hide the loop's state,


### PR DESCRIPTION
Part 2 of 3 toward #204. Plan 1 shipped as #315; Plan 3 shipped as #323.

Closes #320. Refs #204.

## What this changes

Plan 1 made the graph readable. This makes it produce findings on a default install, then measures whether those findings help.

| Layer | What ships |
|---|---|
| Production | Mandatory redaction; failure-only output/exit capture; zero-cost command, test/build, correction, and churn extractors; bounded transcript recovery; command-aware attempt grouping; budgeted consolidation before storage; Stop-time derivation |
| Layer 1 | Explicit-reference classification keyed by finding and time order, with unattributable rows excluded rather than guessed |
| Layer 2 | Per-finding leave-one-out causal utility with empirical-Bayes shrinkage, BH-FDR at q=0.10, and epsilon exploration |
| Calibration | Cross-layer gap published only when the two-sided permutation test passes at p <= 0.10; exact for small arms, deterministically sampled for large arms |
| Keep-warm | Refresh outcomes scored from same-session arrivals only after the full TTL closes; observations may lower, never raise, the modeled probability; floor aligned with the 10-observation tripwire |
| Recall | A runnable recall probe so the no-embeddings design is falsifiable rather than asserted |

The balance sheet is routed into `get_optimization_report` and the audit. Local derivation now reports evidence observed, candidates derived, and findings stored together, because any one count alone makes “nothing found” indistinguishable from “selection rejected everything.”

## Measurement decisions that matter

Thirteen measurement-bias defects were found across Plans 1 and 2. Every one inflated the product's apparent value in its own favor.

- A referenced finding is not automatically useful. Layer 1 and Layer 2 use independent estimands, then calibration tests whether the cheap signal predicts the causal one.
- A positive mean calibration gap is not enough. The headline now requires its own two-sided permutation test.
- Keep-warm hit rate answers `P(gap < TTL)`; one ping's opportunity answers `P(TTL < gap < 2*TTL)`. Substituting the first for the second recommends refreshing forever on this repository's data.
- A hit is not scored early while a miss waits out the TTL. Both arms wait until the window closes, avoiding right-censoring bias.
- `cache_audit` recommends a refresh but does not issue one. The current `master` implementation recorded that recommendation as a purchase; this rebase removes the call. `recordRefresh` remains the public boundary for a client that actually spends the refresh.
- Missing attribution, insufficient history, an open TTL window, and an already-scored refresh record nothing rather than becoming misses.

## Rebase integration with Plan 3

This branch was replayed onto current `master` instead of opening the old stacked branch, which would have shown 60 commits / 394 files and risked reverting Plan 3.

Plan 3's guards found two integration seams on the first full run:

1. its reachability check exposed the false `cache_audit -> recordRefresh` wiring described above;
2. its event census found that the new `derive` event had a producer but no production reader.

Both are fixed here. The focused audit/census/reachability/cache set is 120/120, and the decisive full rerun is green.

## Honest real-data status

- The cross-layer report correctly refuses to publish: Layer 1 has 0 attributable reference observations and Layer 2 has 0 effect rows, so there is no gap or p-value.
- Keep-warm is loop-complete but dormant on the measured repository: 0 keep-warm events in 7,554 rows. The existing decision remains `refresh / 5m`; no learned rate is fabricated.
- The dormant Stop-path scorer measured about 70 ms median on the existing multi-megabyte log, comparable to the derivation work already on that path. This is stated in code rather than described as a “small read.”
- A known unrelated limitation remains: `mutationSucceeded` does not read the `postToolUse` status envelope. It changes no verdict today and is not folded into this PR silently.

## Verification

- `npm test`: **231/231 suites, 3,005 passed, 5 skipped, 0 failed**
- focused rebase-sensitive set: **120/120**
- `npx tsc --noEmit`: clean
- `npm run format:check`: clean
- `npx commitlint --from origin/master --to HEAD`: clean
- `npm run build`: clean
- `npm run sync:hooks:check`: all generated client copies in sync
- `npm run lint`: **0 errors**, 539 existing warnings
- Task 9 mutation audit: **26/26 killed**
- Task 13 mutation audit: **9/9 killed**

The large file count is generated fan-out: review `hooks-core/`, `src/tools/analytics/get-optimization-report.ts`, `src/server/cache-tool.ts`, and the tests first; `npm run sync:hooks` produces the client copies.

## Review guide

- Production path: `hooks-core/derive.mjs`, `hooks-core/adapter.mjs`, `hooks-core/consolidate.mjs`
- Measurement: `hooks-core/usage.mjs`, `hooks-core/loo.mjs`, `hooks-core/crosslayer.mjs`
- Keep-warm: `hooks-core/keepwarm.mjs`
- Falsifiability: `hooks-core/recall.mjs`
- Execution record and corrections: `docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md`
