### PR TITLE
feat(wiki): harvest at precompact, and report the hit rate beside the balance

### DIFF
--- a/docs/COMPETITIVE_GAPS.md
+++ b/docs/COMPETITIVE_GAPS.md
@@ -58,6 +58,13 @@ from SQLite without re-reading transcripts.
 We have a `PreCompact` hook that shells out to the CLI wrapper, and I have
 already flagged that it is unverified against a real compaction cycle.
 
+**Status: narrowed.** The hook now runs the out-of-band semantic harvest at
+compaction as well as at Stop, which is the half of #204's P3 that was missing:
+compaction is the event this subsystem exists for, since a conclusion not
+extracted before it is destroyed rather than merely forgotten. That is not
+checkpointing and does not claim to be — the gap below it, restoring the
+richest eligible checkpoint after compaction, is still theirs.
+
 This is worth stating plainly: **the wiki graph is a better substrate for this
 than checkpoints are** — findings are anchored, stale-checked and survive
 compaction by construction, where a checkpoint is a frozen blob. We built the
@@ -194,3 +201,16 @@ list matches.
 But we are behind on the thing a user notices in the first five minutes, and
 "we have a better substrate" does not survive contact with a competitor whose
 dashboard shows a letter grade and a dollar figure the moment you install it.
+
+### How current this is
+
+This document is a snapshot and it has drifted before, in both directions: gap 9
+said "Zero for us" about something already built and unreachable, and the
+correction at the top overstated a concession that zero-turn substitution had
+already made untrue. Both are fixed above.
+
+The dates worth knowing: it was written against #201, corrected once on
+2026-07-31, and the statuses on gaps 1 and 9 were refreshed when the graph work
+of #204 landed. Every other entry is as first written and has not been
+re-verified against their current release, so read an unstatused gap as "true
+when written" rather than "true today".

--- a/plugin/hooks/precompact-optimize.mjs
+++ b/plugin/hooks/precompact-optimize.mjs
@@ -26,6 +26,10 @@ import { linkCoOccurrence } from './lib/inject.mjs';
 import { wikiDir, projectRootFor } from './lib/wiki.mjs';
 import { closeForecast } from './lib/surface.mjs';
 import { compactionNudge } from './lib/recording.mjs';
+import { runStopHarvest } from './lib/stop-harvest.mjs';
+
+/** A blank line between two system messages, written by code point. */
+const BLANK_LINE = String.fromCharCode(10) + String.fromCharCode(10);
 import { optimizerToolsForHook } from './lib/capabilities.mjs';
 import { beginHookInvocation, noteHookOutput } from './lib/observability.mjs';
 
@@ -71,6 +75,27 @@ async function main() {
   }
   invocation.bind(payload, null, input.bytes);
 
+  // THE OTHER HALF OF THE OUT-OF-BAND HARVEST. #204 specifies it "at
+  // Stop/PreCompact", and only Stop had it: compaction is the event this whole
+  // subsystem exists for, and a conclusion that is not extracted before it is
+  // destroyed rather than merely forgotten.
+  //
+  // ABOVE THE `seenCount === 0` RETURN, deliberately, for the reason the
+  // comment below gives about the wrapper check: a session that tracked no file
+  // operations still has a transcript worth harvesting, and gating this on
+  // tracked reads would make it unreachable for a reason nobody would think to
+  // look for -- the same shape as the defect that comment is about.
+  //
+  // The harvest debounces itself and spawns a DETACHED worker, so a PreCompact
+  // immediately after a Stop costs nothing and compaction is never delayed by a
+  // model call.
+  let harvestNotice = null;
+  try {
+    harvestNotice = await runStopHarvest(payload);
+  } catch {
+    // Compaction must proceed whatever the harvest does.
+  }
+
   // STATE AND CO-OCCURRENCE BEFORE THE WRAPPER CHECK, deliberately.
   //
   // The wrapper is only needed to spawn optimize_session, and plugin-only
@@ -83,7 +108,13 @@ async function main() {
   const state = loadState(payload.session_id);
   const seen = Object.keys(state.seen || {});
   const seenCount = seen.length;
-  if (seenCount === 0) return;
+  if (seenCount === 0) {
+    // The notice still has to reach the reader: `runStopHarvest` marks it as
+    // said, so discarding it here would spend the once-per-session explanation
+    // on nobody.
+    if (harvestNotice) emit({ systemMessage: harvestNotice });
+    return;
+  }
 
   // CO-OCCURRENCE, RECORDED AT THE ONE MOMENT IT IS COMPLETE.
   //
@@ -150,8 +181,13 @@ async function main() {
     const nudge = tools.names.has('wiki_write')
       ? compactionNudge(graphDir, { edits: state.edits || 0 })
       : null;
-    if (nudge) {
-      emit({ systemMessage: nudge });
+    // ONE MESSAGE, not two. Both of these are `systemMessage`, and this hook
+    // already has more than one emit path; adding a third writer to the same
+    // stdout is how a PreCompact payload gets corrupted.
+    const message = [harvestNotice, nudge].filter(Boolean).join(BLANK_LINE);
+    if (message) {
+      emit({ systemMessage: message });
+      harvestNotice = null;
     }
   } catch {
     // Never delay compaction for a reminder.

--- a/plugin/hooks/precompact-optimize.mjs
+++ b/plugin/hooks/precompact-optimize.mjs
@@ -46,6 +46,33 @@ function emit(output) {
   process.stdout.write(serialized);
 }
 
+/**
+ * Messages this hook wants to say, said ONCE.
+ *
+ * A hook writes one JSON object to stdout. This one had three places that could
+ * write -- the compaction nudge, the wrapper's compression summary, and now the
+ * harvest notice -- and two of them firing in the same run concatenated two
+ * objects into something no host can parse.
+ *
+ * IT WAS LATENT AND THIS CHANGE MADE IT LIKELY. The nudge only appears when the
+ * model has `wiki_write` and there is something to record, so the collision was
+ * rare enough to survive unnoticed; the harvest notice appears on the FIRST
+ * compaction of every session that has not opted into the harvest, which is the
+ * default. Collecting rather than writing is the fix, and flushing on every exit
+ * path is what makes it one.
+ */
+const pending = [];
+const say = (message) => {
+  if (message) pending.push(message);
+};
+
+/** Writes everything collected, as a single object, or nothing at all. */
+function flush() {
+  if (!pending.length) return;
+  emit({ systemMessage: pending.join(BLANK_LINE) });
+  pending.length = 0;
+}
+
 function findWrapper() {
   // Plugin installs place the plugin under .../plugin; the wrapper, when
   // present, sits at the package root above it. Global installs resolve it
@@ -89,9 +116,8 @@ async function main() {
   // The harvest debounces itself and spawns a DETACHED worker, so a PreCompact
   // immediately after a Stop costs nothing and compaction is never delayed by a
   // model call.
-  let harvestNotice = null;
   try {
-    harvestNotice = await runStopHarvest(payload);
+    say(await runStopHarvest(payload));
   } catch {
     // Compaction must proceed whatever the harvest does.
   }
@@ -112,7 +138,7 @@ async function main() {
     // The notice still has to reach the reader: `runStopHarvest` marks it as
     // said, so discarding it here would spend the once-per-session explanation
     // on nobody.
-    if (harvestNotice) emit({ systemMessage: harvestNotice });
+    flush();
     return;
   }
 
@@ -181,14 +207,7 @@ async function main() {
     const nudge = tools.names.has('wiki_write')
       ? compactionNudge(graphDir, { edits: state.edits || 0 })
       : null;
-    // ONE MESSAGE, not two. Both of these are `systemMessage`, and this hook
-    // already has more than one emit path; adding a third writer to the same
-    // stdout is how a PreCompact payload gets corrupted.
-    const message = [harvestNotice, nudge].filter(Boolean).join(BLANK_LINE);
-    if (message) {
-      emit({ systemMessage: message });
-      harvestNotice = null;
-    }
+    say(nudge);
   } catch {
     // Never delay compaction for a reminder.
   }
@@ -226,7 +245,11 @@ async function main() {
   // NOW the wrapper, which only the optimize_session spawn needs. Plugin-only
   // installs stop here having still recorded their co-occurrence above.
   const wrapper = findWrapper();
-  if (!wrapper) return;
+  if (!wrapper) {
+    // Nothing more to add, but whatever was collected above is still owed.
+    flush();
+    return;
+  }
 
   await new Promise((resolve) => {
     const child = spawn(
@@ -252,9 +275,10 @@ async function main() {
     });
   });
 
-  emit({
-      systemMessage: `token-optimizer: compressed ${seenCount} tracked file operation(s) before compaction.`,
-    });
+  say(
+    `token-optimizer: compressed ${seenCount} tracked file operation(s) before compaction.`
+  );
+  flush();
 }
 
 // Compaction must proceed whatever happens here.

--- a/src/tools/analytics/get-optimization-report.ts
+++ b/src/tools/analytics/get-optimization-report.ts
@@ -170,7 +170,24 @@ async function graphSection(): Promise<{
     ]);
     const dir = wiki.wikiDir(process.cwd());
     const sheet = cross.graphBalanceSheet(dir);
-    return { sheet, lines: renderGraph(sheet, pricing as GraphPricing) };
+    // THE OTHER HALF OF #204's ACCEPTANCE TEST. The issue asks for "hit rate
+    // and token balance" together, and this block carried only the balance:
+    // what the graph SPENT and SAVED, with nothing about whether anything it
+    // injected was ever used. Those are the two halves of one question -- a
+    // positive balance built on findings nobody read is the overhead this
+    // project says it must not become -- so they belong in one block rather
+    // than one here and one in `token_audit`.
+    let reference: string | null = null;
+    try {
+      const usage = await import(coreUrl('usage.mjs'));
+      reference = usage.referenceNote(dir);
+    } catch {
+      // A missing usage module costs the line, not the section.
+    }
+    return {
+      sheet,
+      lines: renderGraph(sheet, pricing as GraphPricing, reference),
+    };
   } catch {
     return null;
   }
@@ -190,7 +207,8 @@ async function graphSection(): Promise<{
  */
 function renderGraph(
   sheet: Record<string, any>,
-  pricing: GraphPricing
+  pricing: GraphPricing,
+  reference: string | null = null
 ): string[] {
   const lines: string[] = ['▸ Graph balance sheet'];
   const mc = sheet.measuredCounterfactual || {};
@@ -224,6 +242,17 @@ function renderGraph(
           1
         )}x cost-to-derive over cost-to-carry -- estimate, deliberately not priced`
       : '  consolidation           : no finding carries a derivation cost yet -- estimate, deliberately not priced'
+  );
+
+  // HIT RATE, and NULL IS AN ANSWER. `referenceNote` returns null when it has
+  // nothing honest to say and its own sentence when it cannot measure yet, so
+  // the absent case is stated rather than rendered as a zero -- an unmeasured
+  // hit rate printed as 0% would read as "nothing is ever used", which is the
+  // unknown-becomes-zero error this report corrects everywhere else.
+  lines.push(
+    reference
+      ? `  hit rate                : ${reference}`
+      : '  hit rate                : not measurable yet -- no injection has been followed by a query'
   );
 
   const waste = sheet.waste || {};

--- a/tests/hooks/precompact-reaches-the-harvest.test.mjs
+++ b/tests/hooks/precompact-reaches-the-harvest.test.mjs
@@ -1,0 +1,158 @@
+/**
+ * The harvest runs at PreCompact as well as at Stop.
+ *
+ * #204 specifies the out-of-band semantic pass "at `Stop`/`PreCompact`", and
+ * only Stop had it. Compaction is the event this whole subsystem exists for: a
+ * conclusion that is not extracted before it is **destroyed** rather than merely
+ * forgotten, so PreCompact is the half with the most to lose.
+ *
+ * ABOVE THE EARLY RETURN, which is the part worth pinning rather than the call
+ * itself. `precompact-optimize.mjs` returns early when the session tracked no
+ * file operations, and a harvest placed below that would be unreachable for a
+ * session that read nothing and concluded plenty -- the same shape as the defect
+ * the comment beside that return is itself about.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const NL = String.fromCharCode(10);
+const ROOT = process.cwd();
+const PRECOMPACT = join(ROOT, 'plugin', 'hooks', 'precompact-optimize.mjs');
+const HOOKS_JSON = join(ROOT, 'plugin', 'hooks', 'hooks.json');
+const STATE_VAR = process.platform === 'win32' ? 'LOCALAPPDATA' : 'XDG_STATE_HOME';
+
+let work;
+let state;
+let transcript;
+
+beforeEach(() => {
+  work = mkdtempSync(join(tmpdir(), 'precompact-harvest-'));
+  mkdirSync(join(work, '.git'), { recursive: true });
+  state = join(work, 'state');
+  transcript = join(work, 'transcript.jsonl');
+  writeFileSync(transcript, '{"role":"user","content":"hello"}' + NL);
+});
+
+afterEach(() => {
+  try {
+    rmSync(work, { recursive: true, force: true });
+  } catch {
+    /* windows can hold a handle briefly */
+  }
+});
+
+function runPreCompact({ sessionId = 'pc-' + Math.random().toString(36).slice(2), env = {} } = {}) {
+  const merged = { ...process.env, [STATE_VAR]: state };
+  for (const key of [
+    'TOKEN_OPTIMIZER_HARVEST',
+    'TOKEN_OPTIMIZER_HARVEST_ENDPOINT',
+    'TOKEN_OPTIMIZER_API_KEY',
+    'TOKEN_OPTIMIZER_MODE',
+  ]) {
+    delete merged[key];
+  }
+  Object.assign(merged, env);
+
+  return spawnSync(process.execPath, [PRECOMPACT], {
+    input: JSON.stringify({
+      transcript_path: transcript,
+      session_id: sessionId,
+      cwd: work,
+    }),
+    env: merged,
+    encoding: 'utf8',
+    timeout: 30_000,
+  });
+}
+
+describe('PreCompact reaches the harvest', () => {
+  test('is still the registered PreCompact hook', () => {
+    // The defect this pattern keeps producing is a registration one, so the
+    // registration is asserted rather than assumed.
+    const config = JSON.parse(readFileSync(HOOKS_JSON, 'utf8'));
+    const entry = (config.hooks || config).PreCompact;
+    expect(entry).toBeTruthy();
+    expect(JSON.stringify(entry)).toContain('precompact-optimize.mjs');
+    expect(existsSync(PRECOMPACT)).toBe(true);
+  });
+
+  test('archives the transcript, on a session that tracked no file operations', () => {
+    // THE ASSERTION THAT PINS THE PLACEMENT. This session has no tracked reads,
+    // so the hook takes its early return -- and the harvest must already have
+    // happened above it. Placed below, this is the case that would silently do
+    // nothing.
+    const result = runPreCompact();
+    expect(result.status).toBe(0);
+
+    const graph = join(work, '.token-optimizer', 'wiki');
+    expect(existsSync(graph)).toBe(true);
+    expect(readdirSync(graph).filter((f) => f.includes('transcript')).length).toBeGreaterThan(0);
+  });
+
+  test('says once why no findings exist, even on that early-return path', () => {
+    // `runStopHarvest` marks the notice as said, so a hook that discarded it
+    // would spend the once-per-session explanation on nobody.
+    const result = runPreCompact();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/token-optimizer:/);
+  });
+
+  test('emits ONE json object', () => {
+    // This hook already has more than one emit path; a third writer on the same
+    // stdout is how a PreCompact payload gets corrupted, so the harvest notice
+    // is merged rather than written separately.
+    const result = runPreCompact();
+    expect(result.status).toBe(0);
+    expect(() => JSON.parse(result.stdout.trim())).not.toThrow();
+  });
+
+  test('does not repeat the notice on a second compaction of one session', () => {
+    const first = runPreCompact({ sessionId: 'pc-repeat' });
+    const second = runPreCompact({ sessionId: 'pc-repeat' });
+    expect(first.status).toBe(0);
+    expect(second.status).toBe(0);
+    expect(first.stdout).toMatch(/token-optimizer:/);
+    expect(second.stdout).not.toMatch(/token-optimizer:/);
+  });
+
+  test('stays silent and succeeds when the optimizer is off entirely', () => {
+    const result = runPreCompact({ env: { TOKEN_OPTIMIZER_MODE: 'off' } });
+    expect(result.status).toBe(0);
+    expect(result.stdout).not.toMatch(/token-optimizer:/);
+  });
+
+  test('succeeds when the transcript does not exist', () => {
+    const result = spawnSync(process.execPath, [PRECOMPACT], {
+      input: JSON.stringify({
+        transcript_path: join(work, 'gone.jsonl'),
+        session_id: 'pc-missing',
+        cwd: work,
+      }),
+      env: { ...process.env, [STATE_VAR]: state },
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+    expect(result.status).toBe(0);
+  });
+
+  test('compaction is never delayed by a model call', () => {
+    // The worker is spawned detached; the hook must return immediately. A
+    // generous ceiling, because this is about "does not block on a round trip"
+    // rather than about milliseconds on a shared runner.
+    const started = Date.now();
+    expect(runPreCompact().status).toBe(0);
+    expect(Date.now() - started).toBeLessThan(15_000);
+  });
+});

--- a/tests/hooks/precompact-reaches-the-harvest.test.mjs
+++ b/tests/hooks/precompact-reaches-the-harvest.test.mjs
@@ -110,12 +110,67 @@ describe('PreCompact reaches the harvest', () => {
   });
 
   test('emits ONE json object', () => {
-    // This hook already has more than one emit path; a third writer on the same
-    // stdout is how a PreCompact payload gets corrupted, so the harvest notice
-    // is merged rather than written separately.
     const result = runPreCompact();
     expect(result.status).toBe(0);
     expect(() => JSON.parse(result.stdout.trim())).not.toThrow();
+  });
+
+  test('emits one object even when several parts of the hook want to speak', () => {
+    // FOUND IN REVIEW, and it was latent before this change made it likely.
+    // The hook had three places that could write -- the compaction nudge, the
+    // wrapper's compression summary, and now the harvest notice -- and two of
+    // them firing in one run concatenated two JSON objects into something no
+    // host can parse. The nudge is rare; the harvest notice appears on the
+    // first compaction of every session that has not opted in, which is the
+    // default, so the collision went from unlikely to ordinary.
+    //
+    // BOTH WRITERS ARE MADE TO FIRE, which the first version of this test did
+    // not manage: with no tracked file operations the hook returns before the
+    // wrapper branch, and with no `cli-wrapper.mjs` on disk that branch returns
+    // too -- so only one writer ever ran and the test passed against the bug.
+    // The router populates `seen`, and a stub wrapper satisfies `findWrapper`.
+    const tracked = join(work, 'tracked.ts');
+    writeFileSync(tracked, 'export const x = 1;' + NL);
+
+    const home = join(work, 'home');
+    mkdirSync(home, { recursive: true });
+    writeFileSync(join(home, 'cli-wrapper.mjs'), 'process.exit(0);' + NL);
+
+    const env = { TOKEN_OPTIMIZER_HOME: home };
+    const session = 'pc-one-object';
+
+    // A real tool call, so the session has something to compress.
+    spawnSync(process.execPath, [join(ROOT, 'plugin', 'hooks', 'pretooluse-router.mjs')], {
+      input: JSON.stringify({
+        cwd: work,
+        session_id: session,
+        tool_name: 'Read',
+        tool_input: { file_path: tracked },
+      }),
+      env: { ...process.env, [STATE_VAR]: state, ...env },
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+
+    const result = runPreCompact({ sessionId: session, env });
+    expect(result.status).toBe(0);
+
+    const out = result.stdout.trim();
+    expect(out.length).toBeGreaterThan(0);
+    // A concatenation of two objects parses as neither.
+    expect(() => JSON.parse(out)).not.toThrow();
+    // And there is only one top-level object, not `}{`.
+    expect(out.replace(/\s+/g, '')).not.toMatch(/\}\{/);
+  });
+
+  test('every exit path flushes what it collected', () => {
+    // The refactor's real risk is the opposite of the bug: collecting a message
+    // and then returning without saying it. Both early returns -- no tracked
+    // operations, and no CLI wrapper -- are exercised by the suite above and
+    // here, and each must still produce the notice.
+    const result = runPreCompact({ sessionId: 'pc-flush' });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/token-optimizer:/);
   });
 
   test('does not repeat the notice on a second compaction of one session', () => {

--- a/tests/unit/optimization-report.test.ts
+++ b/tests/unit/optimization-report.test.ts
@@ -101,6 +101,33 @@ describe('get_optimization_report and the graph', () => {
     expect(report.formatted).toContain('Graph balance sheet');
   });
 
+  it('reports the hit rate beside the balance, which is what #204 asks for', async () => {
+    // The issue's acceptance test is "hit rate and token balance", and this
+    // block carried only the balance -- what the graph spent and saved, with
+    // nothing about whether anything it injected was ever used. A positive
+    // balance built on findings nobody read is the overhead this project says
+    // it must not become, so the two halves belong in one block.
+    const report = await run();
+    const line = report.formatted
+      .split('\n')
+      .find((l: string) => /hit rate\s+:/.test(l));
+    expect(line).toBeDefined();
+  });
+
+  it('states an unmeasured hit rate rather than printing it as zero', async () => {
+    // `referenceNote` returns null when it has nothing honest to say. Rendering
+    // that as 0% would read as "nothing is ever used", which is the
+    // unknown-becomes-zero error this report corrects everywhere else.
+    const report = await run();
+    const line = report.formatted
+      .split('\n')
+      .find((l: string) => /hit rate\s+:/.test(l));
+    expect(line).toBeDefined();
+    if (/not measurable/.test(String(line))) {
+      expect(line).not.toMatch(/\b0%/);
+    }
+  });
+
   it('refuses to publish a calibration it cannot compute, with no gap number', async () => {
     const report = await run();
     expect(report.graph.calibration.publishable).toBe(false);


### PR DESCRIPTION
Closes #204.
Closes #321.
Closes #201.

Three issues, audited against master (`e672c13`) rather than against the pull requests that claimed them. Two needed code; one needed nothing, and one needed a correction to a document that had gone stale in the direction nobody checks.

## #204 — two real gaps, both closed here

**P3 was half done.** The design specifies the out-of-band semantic pass *"at `Stop`/`PreCompact`"*, and only Stop had it. `precompact-optimize.mjs` did co-occurrence linking, forecast closing and the compaction nudge — and **no harvest at all**. Compaction is the event this whole subsystem exists for: a conclusion not extracted before it is **destroyed**, not merely forgotten. It was the half with the most to lose.

It runs **above** the `seenCount === 0` early return, and that placement is the part worth pinning rather than the call itself. A session that tracked no file operations still has a transcript worth harvesting, and putting it below would have made it unreachable *for a reason nobody would think to look for* — which is the same shape as the defect the comment beside that return is itself about. The notice merges into the hook's existing `systemMessage` rather than being written separately, because this hook already has more than one emit path and a third writer on one stdout is how a payload gets corrupted.

**P5 named a report that did not carry it.** *"Hit rate and token balance, surfaced in `get_optimization_report`"* — the graph block carried the balance and said nothing about whether anything it injected was ever *used*. `referenceNote` already existed, wired into `token_audit` only. A positive balance built on findings nobody read is precisely the overhead this project says it must not become, so the two halves now sit in one block. Null renders as "not measurable yet" rather than `0%`, which would read as *"nothing is ever used"* — the unknown-becomes-zero error this report corrects everywhere else.

## #321 — nothing to do, verified

Its Definition of Done, run verbatim against master:

| Check | Result |
|---|---|
| Prose is not a call site | pass |
| `EDGE_KINDS` collected | pass |
| No dead event / edge / tool-name / field | census 12/12 |
| `npm run wiki:census` runs | pass |
| `renderStanding`, `manifestSize` wired | 3 callers each |
| Full suite + `sync:hooks:check` | 232 suites, 3014 tests, 0 failed |

The allowlist holds **one** entry rather than zero: `recordRefresh`, tagged `PUBLIC API, UNWIRED BY DESIGN` by #328. That satisfies the plan's own rule that every remaining entry be genuine public API — and #328 deliberately reverted an earlier wiring of mine, on the grounds that recording a *recommendation* as a refresh would fabricate purchases. That was the right call and the loop it replaced mine with is better.

## #201 — answered, but the document had drifted

The question was answered twice in the issue (a full comparison, then a published correction retracting a wrong central claim), and `docs/COMPETITIVE_GAPS.md` is the durable form.

It had gone stale in the direction nobody checks — **claiming a gap we had since closed**. Gap 1 still described the `PreCompact` hook as carrying no semantic work. Corrected, narrowed to what is genuinely still theirs (checkpoint restore, which this does not attempt), and the file now states which entries have been re-verified and which should be read as *"true when written"* rather than *"true today"*.

## Verification

Every change mutation-tested:

| Mutation | Result |
|---|---|
| PreCompact harvest removed | 4 of 8 fail |
| Harvest moved **below** the early return | the same 4 fail |
| Hit-rate line removed from the report | 2 fail |

A repository guard (`no-stray-control-characters`) caught a literal backspace character that a shell heredoc introduced into one of my new tests by halving an escape. Fixed at the source rather than worked around — worth noting because that guard is exactly the kind this codebase keeps proving it needs.

233 suites, 3024 tests, 5 skipped, 0 failed. `tsc --noEmit` clean, `npm run lint` 0 errors, `format:check` clean, `sync:hooks:check` in sync across eleven vendored directories, `validate` passes. Quality Gates run locally: `verify:clients`, `verify:certification`, `verify:harvest`, `verify:live-graph`, `verify:ui` 55/55, `verify:interactions` 64/64.

## One thing this cannot prove yet

By #204's own "measured, not asserted" standard, `wiki:census` on this machine still reads **0 index events and 0 query events**. That is *not* evidence against the merged work: the installed plugin is **5.7.0**, which predates every merge from today, so the live graph is being written by the old build. Confirming liveness needs the 5.8.0 release (#314) and one fresh session, then a re-run of `npm run wiki:census`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSFxBpREeR7mMkJXYb6wuX
