### PR TITLE
fix: stamp the shipped version at publish time so releases can reach npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,21 @@ jobs:
       - name: Verify generated configs match their generators
         run: npm run sync:hooks:check
 
+      # AFTER the drift check and BEFORE the tarball is built, which is the only
+      # window where both can hold. The version is deliberately absent from git:
+      # a version literal in a generated-and-committed file makes "generated
+      # output == committed file" an invariant that cannot survive a release
+      # commit, because release-please bumps package.json without regenerating.
+      # That invariant has cost this project three releases -- v5.4.0, v5.4.1 and
+      # v5.7.1 were all tagged with GitHub Releases and none reached npm -- and
+      # it cannot be repaired on master, because this job checks out the TAG.
+      #
+      # So git carries no version and the tarball carries an exact one. The step
+      # must stay above `Generate CHECKSUMS.sha256`, which hashes exactly what
+      # ships; a stamp applied after it would ship files the checksums disown.
+      - name: Stamp the shipped version into the packaged hooks
+        run: npm run stamp:version
+
       - name: Build project
         run: npm run build
 

--- a/hooks-core/observability.mjs
+++ b/hooks-core/observability.mjs
@@ -21,7 +21,8 @@ import {
 } from 'node:fs';
 import { createHash, randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export const HOOK_LOG_SCHEMA_VERSION = 2;
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
@@ -31,6 +32,75 @@ const DEFAULT_DEADLINE_MS = 4200;
 const MAX_ERROR_CHARS = 4000;
 const MAX_DIMENSION_CHARS = 160;
 let activeInvocation = null;
+
+/**
+ * Manifests that carry this package's version, nearest first.
+ *
+ * WHY THIS IS RESOLVED RATHER THAN COMPILED IN. The generators used to write the
+ * version into all 48 generated files, which made "generated output == committed
+ * file" an invariant that cannot survive a release: release-please bumps
+ * package.json without regenerating, so the release commit is born drifted and
+ * `publish-npm` -- which checks out the tag -- fails its drift gate. It has cost
+ * this project three releases (v5.4.0, v5.4.1, v5.7.1: all tagged, none on npm).
+ *
+ * The stamp is now applied at publish time only, so an npm install still reports
+ * an exact version from the env. Everything else resolves here instead of
+ * reporting a stale literal -- a lagging version is not a version, it is a wrong
+ * one, and this file exists to make failures correlatable.
+ *
+ * Inside the tarball the walk finds the package's own package.json; a plugin
+ * installed from the marketplace finds .claude-plugin/plugin.json, which
+ * release-please keeps correct. A bare copy into a client hook directory finds
+ * nothing and says 'unknown', which is what this reported before the stamp
+ * existed and is honest.
+ */
+const VERSION_MANIFESTS = [
+  ['package.json'],
+  ['.claude-plugin', 'plugin.json'],
+  ['.codex-plugin', 'plugin.json'],
+];
+const MAX_MANIFEST_DEPTH = 6;
+
+let cachedManifestVersion;
+
+function versionFromNearestManifest() {
+  if (cachedManifestVersion !== undefined) return cachedManifestVersion;
+  cachedManifestVersion = '';
+  try {
+    let dir = dirname(fileURLToPath(import.meta.url));
+    for (let depth = 0; depth < MAX_MANIFEST_DEPTH; depth++) {
+      for (const parts of VERSION_MANIFESTS) {
+        const candidate = join(dir, ...parts);
+        if (!existsSync(candidate)) continue;
+        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (typeof version === 'string' && version) {
+          cachedManifestVersion = version;
+          return cachedManifestVersion;
+        }
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // Diagnostics must never be the reason a hook fails.
+  }
+  return cachedManifestVersion;
+}
+
+/**
+ * The version this process reports. Env first so the publish-time stamp and any
+ * host that sets it still win; only the filesystem walk is cached, so the env
+ * stays authoritative for the life of the process.
+ */
+export function serviceVersion() {
+  return (
+    process.env.TOKEN_OPTIMIZER_VERSION ||
+    process.env.npm_package_version ||
+    versionFromNearestManifest() ||
+    'unknown'
+  );
+}
 
 function positiveInteger(name, fallback) {
   const value = Number(process.env[name]);
@@ -158,10 +228,7 @@ export function writeHookEvent(event) {
       schemaVersion: HOOK_LOG_SCHEMA_VERSION,
       timestamp: now.toISOString(),
       service: 'token-optimizer',
-      serviceVersion:
-        process.env.TOKEN_OPTIMIZER_VERSION ||
-        process.env.npm_package_version ||
-        'unknown',
+      serviceVersion: serviceVersion(),
       ...severity(event.level),
       body: event.event || 'hook.event',
       ...event,

--- a/hooks-core/observability.mjs
+++ b/hooks-core/observability.mjs
@@ -59,6 +59,20 @@ const VERSION_MANIFESTS = [
   ['.claude-plugin', 'plugin.json'],
   ['.codex-plugin', 'plugin.json'],
 ];
+
+/**
+ * The names that prove a manifest is OURS.
+ *
+ * FOUND IN REVIEW. Without this the walk reports the version of whatever
+ * package.json happens to sit above the hook, so a copy of these hooks
+ * vendored into someone else's repository would report that repository's
+ * version as the optimizer's -- a wrong version, which is the exact failure
+ * this file was changed to avoid. `npm_package_version` is ambient for the same
+ * reason: it belongs to whichever npm script is running, not necessarily to us.
+ */
+const PACKAGE_NAME = '@ooples/token-optimizer-mcp';
+const PLUGIN_NAME = 'token-optimizer';
+const OWNED_MANIFEST_NAMES = new Set([PACKAGE_NAME, PLUGIN_NAME]);
 const MAX_MANIFEST_DEPTH = 6;
 
 let cachedManifestVersion;
@@ -72,7 +86,8 @@ function versionFromNearestManifest() {
       for (const parts of VERSION_MANIFESTS) {
         const candidate = join(dir, ...parts);
         if (!existsSync(candidate)) continue;
-        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        const { name, version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (!OWNED_MANIFEST_NAMES.has(name)) continue;
         if (typeof version === 'string' && version) {
           cachedManifestVersion = version;
           return cachedManifestVersion;
@@ -96,7 +111,9 @@ function versionFromNearestManifest() {
 export function serviceVersion() {
   return (
     process.env.TOKEN_OPTIMIZER_VERSION ||
-    process.env.npm_package_version ||
+    (process.env.npm_package_name === PACKAGE_NAME
+      ? process.env.npm_package_version
+      : '') ||
     versionFromNearestManifest() ||
     'unknown'
   );
@@ -118,7 +135,10 @@ export function hookLogDirectory() {
 
 function hash(value, length = 16) {
   if (!value) return null;
-  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+  return createHash('sha256')
+    .update(String(value))
+    .digest('hex')
+    .slice(0, length);
 }
 
 function sanitize(text) {
@@ -127,9 +147,15 @@ function sanitize(text) {
   const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
   value = value
-    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(
+      /\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g,
+      '[REDACTED]'
+    )
     .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
-    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+    .replace(
+      /\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi,
+      '$1=[REDACTED]'
+    );
   return value.slice(0, MAX_ERROR_CHARS);
 }
 
@@ -161,7 +187,10 @@ function activeLogPath(now = new Date()) {
 function rotateIfNeeded(path) {
   try {
     if (!existsSync(path)) return;
-    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    const maxBytes = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_BYTES',
+      DEFAULT_MAX_BYTES
+    );
     if (statSync(path).size < maxBytes) return;
 
     const lock = join(hookLogDirectory(), '.rotate.lock');
@@ -182,7 +211,11 @@ function rotateIfNeeded(path) {
       }
     } finally {
       // Non-recursive removal of the one fixed-name lock directory only.
-      try { rmdirSync(lock); } catch { /* best effort */ }
+      try {
+        rmdirSync(lock);
+      } catch {
+        /* best effort */
+      }
     }
   } catch {
     // Diagnostics must never become the reason a lifecycle hook fails.
@@ -193,14 +226,26 @@ function pruneIfDue(now = new Date()) {
   try {
     const dir = hookLogDirectory();
     const marker = join(dir, '.last-prune');
-    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+    if (
+      existsSync(marker) &&
+      now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000
+    )
       return;
     writeFileSync(marker, now.toISOString(), { flag: 'w' });
 
     const retentionMs =
-      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
-      24 * 60 * 60 * 1000;
-    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+      positiveInteger(
+        'TOKEN_OPTIMIZER_LOG_RETENTION_DAYS',
+        DEFAULT_RETENTION_DAYS
+      ) *
+      24 *
+      60 *
+      60 *
+      1000;
+    const maxFiles = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_FILES',
+      DEFAULT_MAX_FILES
+    );
     const files = readdirSync(dir)
       .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
       .map((name) => {
@@ -290,7 +335,11 @@ export function beginHookInvocation(client, event, options = {}) {
   });
 
   let deadline;
-  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+  const finish = (
+    nextOutcome = outcome,
+    nextReason = reason,
+    nextError = error
+  ) => {
     if (ended) return;
     ended = true;
     if (deadline) clearTimeout(deadline);
@@ -298,7 +347,10 @@ export function beginHookInvocation(client, event, options = {}) {
     process.removeListener('uncaughtException', onUncaughtException);
     process.removeListener('unhandledRejection', onUnhandledRejection);
     writeHookEvent({
-      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      level:
+        nextOutcome === 'failure' || nextOutcome === 'timeout'
+          ? 'error'
+          : 'info',
       event: 'hook.completed',
       outcome: nextOutcome,
       reason: nextReason,
@@ -326,31 +378,43 @@ export function beginHookInvocation(client, event, options = {}) {
   process.once('uncaughtException', onUncaughtException);
   process.once('unhandledRejection', onUnhandledRejection);
 
-  deadline = setTimeout(() => {
-    outcome = 'timeout';
-    reason = 'internal_deadline_exceeded';
-    finish(outcome, reason);
-    // Beat the host's five-second timeout and fail open deterministically.
-    process.exit(0);
-  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline = setTimeout(
+    () => {
+      outcome = 'timeout';
+      reason = 'internal_deadline_exceeded';
+      finish(outcome, reason);
+      // Beat the host's five-second timeout and fail open deterministically.
+      process.exit(0);
+    },
+    options.deadlineMs ??
+      positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS)
+  );
   deadline.unref();
 
   const invocation = {
     invocationId,
     bind(raw = {}, payload = null, payloadBytes = null) {
-      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      const sessionId =
+        raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
       dimensions.sessionIdHash = hash(sessionId);
       dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
       dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
-      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.toolName =
+        payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
       dimensions.rawToolName = dimension(
         raw.tool_name ?? raw.toolName ?? raw.tool ?? null
       );
       dimensions.codeModeEnvelope =
         payload?.tool_input?.code_mode_envelope === true;
-      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
-      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
-      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.clientVersion = dimension(
+        raw.client_version ?? raw.clientVersion ?? null
+      );
+      dimensions.model = dimension(
+        raw.model ?? raw.model_name ?? raw.modelName ?? null
+      );
+      dimensions.cwdHash = hash(
+        raw.cwd ?? raw.working_directory ?? process.cwd()
+      );
       dimensions.payloadBytes = payloadBytes;
       dimensions.inputStatus = 'ok';
       if (sessionId) traceId = hash(sessionId, 32);
@@ -371,15 +435,21 @@ export function beginHookInvocation(client, event, options = {}) {
       reason = nextReason;
     },
     noteOutput(output, outputBytes = null) {
-      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      dimensions.outputBytes =
+        outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
       if (!output || typeof output !== 'object' || Array.isArray(output)) {
         dimensions.outputShape = [];
         return;
       }
       const shape = Object.keys(output).sort();
       const hookSpecific = output.hookSpecificOutput;
-      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
-        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      if (
+        hookSpecific &&
+        typeof hookSpecific === 'object' &&
+        !Array.isArray(hookSpecific)
+      ) {
+        for (const key of Object.keys(hookSpecific).sort())
+          shape.push(`hookSpecificOutput.${key}`);
       }
       dimensions.outputShape = shape;
     },
@@ -440,7 +510,10 @@ export function readHookEvents({
       .reverse();
     const events = [];
     for (const file of files) {
-      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      const lines = readFileSync(file, 'utf8')
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .reverse();
       for (const line of lines) {
         try {
           const event = JSON.parse(line);
@@ -528,7 +601,9 @@ export function hookHealthSummary(options = {}) {
   for (const current of Object.values(byClient)) current.hookEvents.sort();
   const percentile = (p) =>
     durations.length
-      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      ? durations[
+          Math.min(durations.length - 1, Math.floor(durations.length * p))
+        ]
       : null;
   const summary = {
     schemaVersion: HOOK_LOG_SCHEMA_VERSION,

--- a/integrations/cline/hooks/token-optimizer/lib/observability.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/observability.mjs
@@ -1,6 +1,5 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *
@@ -24,7 +23,8 @@ import {
 } from 'node:fs';
 import { createHash, randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export const HOOK_LOG_SCHEMA_VERSION = 2;
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
@@ -34,6 +34,75 @@ const DEFAULT_DEADLINE_MS = 4200;
 const MAX_ERROR_CHARS = 4000;
 const MAX_DIMENSION_CHARS = 160;
 let activeInvocation = null;
+
+/**
+ * Manifests that carry this package's version, nearest first.
+ *
+ * WHY THIS IS RESOLVED RATHER THAN COMPILED IN. The generators used to write the
+ * version into all 48 generated files, which made "generated output == committed
+ * file" an invariant that cannot survive a release: release-please bumps
+ * package.json without regenerating, so the release commit is born drifted and
+ * `publish-npm` -- which checks out the tag -- fails its drift gate. It has cost
+ * this project three releases (v5.4.0, v5.4.1, v5.7.1: all tagged, none on npm).
+ *
+ * The stamp is now applied at publish time only, so an npm install still reports
+ * an exact version from the env. Everything else resolves here instead of
+ * reporting a stale literal -- a lagging version is not a version, it is a wrong
+ * one, and this file exists to make failures correlatable.
+ *
+ * Inside the tarball the walk finds the package's own package.json; a plugin
+ * installed from the marketplace finds .claude-plugin/plugin.json, which
+ * release-please keeps correct. A bare copy into a client hook directory finds
+ * nothing and says 'unknown', which is what this reported before the stamp
+ * existed and is honest.
+ */
+const VERSION_MANIFESTS = [
+  ['package.json'],
+  ['.claude-plugin', 'plugin.json'],
+  ['.codex-plugin', 'plugin.json'],
+];
+const MAX_MANIFEST_DEPTH = 6;
+
+let cachedManifestVersion;
+
+function versionFromNearestManifest() {
+  if (cachedManifestVersion !== undefined) return cachedManifestVersion;
+  cachedManifestVersion = '';
+  try {
+    let dir = dirname(fileURLToPath(import.meta.url));
+    for (let depth = 0; depth < MAX_MANIFEST_DEPTH; depth++) {
+      for (const parts of VERSION_MANIFESTS) {
+        const candidate = join(dir, ...parts);
+        if (!existsSync(candidate)) continue;
+        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (typeof version === 'string' && version) {
+          cachedManifestVersion = version;
+          return cachedManifestVersion;
+        }
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // Diagnostics must never be the reason a hook fails.
+  }
+  return cachedManifestVersion;
+}
+
+/**
+ * The version this process reports. Env first so the publish-time stamp and any
+ * host that sets it still win; only the filesystem walk is cached, so the env
+ * stays authoritative for the life of the process.
+ */
+export function serviceVersion() {
+  return (
+    process.env.TOKEN_OPTIMIZER_VERSION ||
+    process.env.npm_package_version ||
+    versionFromNearestManifest() ||
+    'unknown'
+  );
+}
 
 function positiveInteger(name, fallback) {
   const value = Number(process.env[name]);
@@ -161,10 +230,7 @@ export function writeHookEvent(event) {
       schemaVersion: HOOK_LOG_SCHEMA_VERSION,
       timestamp: now.toISOString(),
       service: 'token-optimizer',
-      serviceVersion:
-        process.env.TOKEN_OPTIMIZER_VERSION ||
-        process.env.npm_package_version ||
-        'unknown',
+      serviceVersion: serviceVersion(),
       ...severity(event.level),
       body: event.event || 'hook.event',
       ...event,

--- a/integrations/cline/hooks/token-optimizer/lib/observability.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/observability.mjs
@@ -61,6 +61,20 @@ const VERSION_MANIFESTS = [
   ['.claude-plugin', 'plugin.json'],
   ['.codex-plugin', 'plugin.json'],
 ];
+
+/**
+ * The names that prove a manifest is OURS.
+ *
+ * FOUND IN REVIEW. Without this the walk reports the version of whatever
+ * package.json happens to sit above the hook, so a copy of these hooks
+ * vendored into someone else's repository would report that repository's
+ * version as the optimizer's -- a wrong version, which is the exact failure
+ * this file was changed to avoid. `npm_package_version` is ambient for the same
+ * reason: it belongs to whichever npm script is running, not necessarily to us.
+ */
+const PACKAGE_NAME = '@ooples/token-optimizer-mcp';
+const PLUGIN_NAME = 'token-optimizer';
+const OWNED_MANIFEST_NAMES = new Set([PACKAGE_NAME, PLUGIN_NAME]);
 const MAX_MANIFEST_DEPTH = 6;
 
 let cachedManifestVersion;
@@ -74,7 +88,8 @@ function versionFromNearestManifest() {
       for (const parts of VERSION_MANIFESTS) {
         const candidate = join(dir, ...parts);
         if (!existsSync(candidate)) continue;
-        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        const { name, version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (!OWNED_MANIFEST_NAMES.has(name)) continue;
         if (typeof version === 'string' && version) {
           cachedManifestVersion = version;
           return cachedManifestVersion;
@@ -98,7 +113,9 @@ function versionFromNearestManifest() {
 export function serviceVersion() {
   return (
     process.env.TOKEN_OPTIMIZER_VERSION ||
-    process.env.npm_package_version ||
+    (process.env.npm_package_name === PACKAGE_NAME
+      ? process.env.npm_package_version
+      : '') ||
     versionFromNearestManifest() ||
     'unknown'
   );
@@ -120,7 +137,10 @@ export function hookLogDirectory() {
 
 function hash(value, length = 16) {
   if (!value) return null;
-  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+  return createHash('sha256')
+    .update(String(value))
+    .digest('hex')
+    .slice(0, length);
 }
 
 function sanitize(text) {
@@ -129,9 +149,15 @@ function sanitize(text) {
   const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
   value = value
-    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(
+      /\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g,
+      '[REDACTED]'
+    )
     .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
-    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+    .replace(
+      /\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi,
+      '$1=[REDACTED]'
+    );
   return value.slice(0, MAX_ERROR_CHARS);
 }
 
@@ -163,7 +189,10 @@ function activeLogPath(now = new Date()) {
 function rotateIfNeeded(path) {
   try {
     if (!existsSync(path)) return;
-    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    const maxBytes = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_BYTES',
+      DEFAULT_MAX_BYTES
+    );
     if (statSync(path).size < maxBytes) return;
 
     const lock = join(hookLogDirectory(), '.rotate.lock');
@@ -184,7 +213,11 @@ function rotateIfNeeded(path) {
       }
     } finally {
       // Non-recursive removal of the one fixed-name lock directory only.
-      try { rmdirSync(lock); } catch { /* best effort */ }
+      try {
+        rmdirSync(lock);
+      } catch {
+        /* best effort */
+      }
     }
   } catch {
     // Diagnostics must never become the reason a lifecycle hook fails.
@@ -195,14 +228,26 @@ function pruneIfDue(now = new Date()) {
   try {
     const dir = hookLogDirectory();
     const marker = join(dir, '.last-prune');
-    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+    if (
+      existsSync(marker) &&
+      now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000
+    )
       return;
     writeFileSync(marker, now.toISOString(), { flag: 'w' });
 
     const retentionMs =
-      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
-      24 * 60 * 60 * 1000;
-    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+      positiveInteger(
+        'TOKEN_OPTIMIZER_LOG_RETENTION_DAYS',
+        DEFAULT_RETENTION_DAYS
+      ) *
+      24 *
+      60 *
+      60 *
+      1000;
+    const maxFiles = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_FILES',
+      DEFAULT_MAX_FILES
+    );
     const files = readdirSync(dir)
       .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
       .map((name) => {
@@ -292,7 +337,11 @@ export function beginHookInvocation(client, event, options = {}) {
   });
 
   let deadline;
-  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+  const finish = (
+    nextOutcome = outcome,
+    nextReason = reason,
+    nextError = error
+  ) => {
     if (ended) return;
     ended = true;
     if (deadline) clearTimeout(deadline);
@@ -300,7 +349,10 @@ export function beginHookInvocation(client, event, options = {}) {
     process.removeListener('uncaughtException', onUncaughtException);
     process.removeListener('unhandledRejection', onUnhandledRejection);
     writeHookEvent({
-      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      level:
+        nextOutcome === 'failure' || nextOutcome === 'timeout'
+          ? 'error'
+          : 'info',
       event: 'hook.completed',
       outcome: nextOutcome,
       reason: nextReason,
@@ -328,31 +380,43 @@ export function beginHookInvocation(client, event, options = {}) {
   process.once('uncaughtException', onUncaughtException);
   process.once('unhandledRejection', onUnhandledRejection);
 
-  deadline = setTimeout(() => {
-    outcome = 'timeout';
-    reason = 'internal_deadline_exceeded';
-    finish(outcome, reason);
-    // Beat the host's five-second timeout and fail open deterministically.
-    process.exit(0);
-  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline = setTimeout(
+    () => {
+      outcome = 'timeout';
+      reason = 'internal_deadline_exceeded';
+      finish(outcome, reason);
+      // Beat the host's five-second timeout and fail open deterministically.
+      process.exit(0);
+    },
+    options.deadlineMs ??
+      positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS)
+  );
   deadline.unref();
 
   const invocation = {
     invocationId,
     bind(raw = {}, payload = null, payloadBytes = null) {
-      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      const sessionId =
+        raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
       dimensions.sessionIdHash = hash(sessionId);
       dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
       dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
-      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.toolName =
+        payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
       dimensions.rawToolName = dimension(
         raw.tool_name ?? raw.toolName ?? raw.tool ?? null
       );
       dimensions.codeModeEnvelope =
         payload?.tool_input?.code_mode_envelope === true;
-      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
-      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
-      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.clientVersion = dimension(
+        raw.client_version ?? raw.clientVersion ?? null
+      );
+      dimensions.model = dimension(
+        raw.model ?? raw.model_name ?? raw.modelName ?? null
+      );
+      dimensions.cwdHash = hash(
+        raw.cwd ?? raw.working_directory ?? process.cwd()
+      );
       dimensions.payloadBytes = payloadBytes;
       dimensions.inputStatus = 'ok';
       if (sessionId) traceId = hash(sessionId, 32);
@@ -373,15 +437,21 @@ export function beginHookInvocation(client, event, options = {}) {
       reason = nextReason;
     },
     noteOutput(output, outputBytes = null) {
-      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      dimensions.outputBytes =
+        outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
       if (!output || typeof output !== 'object' || Array.isArray(output)) {
         dimensions.outputShape = [];
         return;
       }
       const shape = Object.keys(output).sort();
       const hookSpecific = output.hookSpecificOutput;
-      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
-        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      if (
+        hookSpecific &&
+        typeof hookSpecific === 'object' &&
+        !Array.isArray(hookSpecific)
+      ) {
+        for (const key of Object.keys(hookSpecific).sort())
+          shape.push(`hookSpecificOutput.${key}`);
       }
       dimensions.outputShape = shape;
     },
@@ -442,7 +512,10 @@ export function readHookEvents({
       .reverse();
     const events = [];
     for (const file of files) {
-      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      const lines = readFileSync(file, 'utf8')
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .reverse();
       for (const line of lines) {
         try {
           const event = JSON.parse(line);
@@ -530,7 +603,9 @@ export function hookHealthSummary(options = {}) {
   for (const current of Object.values(byClient)) current.hookEvents.sort();
   const percentile = (p) =>
     durations.length
-      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      ? durations[
+          Math.min(durations.length - 1, Math.floor(durations.length * p))
+        ]
       : null;
   const summary = {
     schemaVersion: HOOK_LOG_SCHEMA_VERSION,

--- a/integrations/cline/hooks/token-optimizer/post-tool.mjs
+++ b/integrations/cline/hooks/token-optimizer/post-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/cline/hooks/token-optimizer/pre-tool.mjs
+++ b/integrations/cline/hooks/token-optimizer/pre-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/cline/hooks/token-optimizer/session-start.mjs
+++ b/integrations/cline/hooks/token-optimizer/session-start.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/hooks/lib/observability.mjs
+++ b/integrations/codex/hooks/lib/observability.mjs
@@ -1,6 +1,5 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *
@@ -24,7 +23,8 @@ import {
 } from 'node:fs';
 import { createHash, randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export const HOOK_LOG_SCHEMA_VERSION = 2;
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
@@ -34,6 +34,75 @@ const DEFAULT_DEADLINE_MS = 4200;
 const MAX_ERROR_CHARS = 4000;
 const MAX_DIMENSION_CHARS = 160;
 let activeInvocation = null;
+
+/**
+ * Manifests that carry this package's version, nearest first.
+ *
+ * WHY THIS IS RESOLVED RATHER THAN COMPILED IN. The generators used to write the
+ * version into all 48 generated files, which made "generated output == committed
+ * file" an invariant that cannot survive a release: release-please bumps
+ * package.json without regenerating, so the release commit is born drifted and
+ * `publish-npm` -- which checks out the tag -- fails its drift gate. It has cost
+ * this project three releases (v5.4.0, v5.4.1, v5.7.1: all tagged, none on npm).
+ *
+ * The stamp is now applied at publish time only, so an npm install still reports
+ * an exact version from the env. Everything else resolves here instead of
+ * reporting a stale literal -- a lagging version is not a version, it is a wrong
+ * one, and this file exists to make failures correlatable.
+ *
+ * Inside the tarball the walk finds the package's own package.json; a plugin
+ * installed from the marketplace finds .claude-plugin/plugin.json, which
+ * release-please keeps correct. A bare copy into a client hook directory finds
+ * nothing and says 'unknown', which is what this reported before the stamp
+ * existed and is honest.
+ */
+const VERSION_MANIFESTS = [
+  ['package.json'],
+  ['.claude-plugin', 'plugin.json'],
+  ['.codex-plugin', 'plugin.json'],
+];
+const MAX_MANIFEST_DEPTH = 6;
+
+let cachedManifestVersion;
+
+function versionFromNearestManifest() {
+  if (cachedManifestVersion !== undefined) return cachedManifestVersion;
+  cachedManifestVersion = '';
+  try {
+    let dir = dirname(fileURLToPath(import.meta.url));
+    for (let depth = 0; depth < MAX_MANIFEST_DEPTH; depth++) {
+      for (const parts of VERSION_MANIFESTS) {
+        const candidate = join(dir, ...parts);
+        if (!existsSync(candidate)) continue;
+        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (typeof version === 'string' && version) {
+          cachedManifestVersion = version;
+          return cachedManifestVersion;
+        }
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // Diagnostics must never be the reason a hook fails.
+  }
+  return cachedManifestVersion;
+}
+
+/**
+ * The version this process reports. Env first so the publish-time stamp and any
+ * host that sets it still win; only the filesystem walk is cached, so the env
+ * stays authoritative for the life of the process.
+ */
+export function serviceVersion() {
+  return (
+    process.env.TOKEN_OPTIMIZER_VERSION ||
+    process.env.npm_package_version ||
+    versionFromNearestManifest() ||
+    'unknown'
+  );
+}
 
 function positiveInteger(name, fallback) {
   const value = Number(process.env[name]);
@@ -161,10 +230,7 @@ export function writeHookEvent(event) {
       schemaVersion: HOOK_LOG_SCHEMA_VERSION,
       timestamp: now.toISOString(),
       service: 'token-optimizer',
-      serviceVersion:
-        process.env.TOKEN_OPTIMIZER_VERSION ||
-        process.env.npm_package_version ||
-        'unknown',
+      serviceVersion: serviceVersion(),
       ...severity(event.level),
       body: event.event || 'hook.event',
       ...event,

--- a/integrations/codex/hooks/lib/observability.mjs
+++ b/integrations/codex/hooks/lib/observability.mjs
@@ -61,6 +61,20 @@ const VERSION_MANIFESTS = [
   ['.claude-plugin', 'plugin.json'],
   ['.codex-plugin', 'plugin.json'],
 ];
+
+/**
+ * The names that prove a manifest is OURS.
+ *
+ * FOUND IN REVIEW. Without this the walk reports the version of whatever
+ * package.json happens to sit above the hook, so a copy of these hooks
+ * vendored into someone else's repository would report that repository's
+ * version as the optimizer's -- a wrong version, which is the exact failure
+ * this file was changed to avoid. `npm_package_version` is ambient for the same
+ * reason: it belongs to whichever npm script is running, not necessarily to us.
+ */
+const PACKAGE_NAME = '@ooples/token-optimizer-mcp';
+const PLUGIN_NAME = 'token-optimizer';
+const OWNED_MANIFEST_NAMES = new Set([PACKAGE_NAME, PLUGIN_NAME]);
 const MAX_MANIFEST_DEPTH = 6;
 
 let cachedManifestVersion;
@@ -74,7 +88,8 @@ function versionFromNearestManifest() {
       for (const parts of VERSION_MANIFESTS) {
         const candidate = join(dir, ...parts);
         if (!existsSync(candidate)) continue;
-        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        const { name, version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (!OWNED_MANIFEST_NAMES.has(name)) continue;
         if (typeof version === 'string' && version) {
           cachedManifestVersion = version;
           return cachedManifestVersion;
@@ -98,7 +113,9 @@ function versionFromNearestManifest() {
 export function serviceVersion() {
   return (
     process.env.TOKEN_OPTIMIZER_VERSION ||
-    process.env.npm_package_version ||
+    (process.env.npm_package_name === PACKAGE_NAME
+      ? process.env.npm_package_version
+      : '') ||
     versionFromNearestManifest() ||
     'unknown'
   );
@@ -120,7 +137,10 @@ export function hookLogDirectory() {
 
 function hash(value, length = 16) {
   if (!value) return null;
-  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+  return createHash('sha256')
+    .update(String(value))
+    .digest('hex')
+    .slice(0, length);
 }
 
 function sanitize(text) {
@@ -129,9 +149,15 @@ function sanitize(text) {
   const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
   value = value
-    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(
+      /\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g,
+      '[REDACTED]'
+    )
     .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
-    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+    .replace(
+      /\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi,
+      '$1=[REDACTED]'
+    );
   return value.slice(0, MAX_ERROR_CHARS);
 }
 
@@ -163,7 +189,10 @@ function activeLogPath(now = new Date()) {
 function rotateIfNeeded(path) {
   try {
     if (!existsSync(path)) return;
-    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    const maxBytes = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_BYTES',
+      DEFAULT_MAX_BYTES
+    );
     if (statSync(path).size < maxBytes) return;
 
     const lock = join(hookLogDirectory(), '.rotate.lock');
@@ -184,7 +213,11 @@ function rotateIfNeeded(path) {
       }
     } finally {
       // Non-recursive removal of the one fixed-name lock directory only.
-      try { rmdirSync(lock); } catch { /* best effort */ }
+      try {
+        rmdirSync(lock);
+      } catch {
+        /* best effort */
+      }
     }
   } catch {
     // Diagnostics must never become the reason a lifecycle hook fails.
@@ -195,14 +228,26 @@ function pruneIfDue(now = new Date()) {
   try {
     const dir = hookLogDirectory();
     const marker = join(dir, '.last-prune');
-    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+    if (
+      existsSync(marker) &&
+      now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000
+    )
       return;
     writeFileSync(marker, now.toISOString(), { flag: 'w' });
 
     const retentionMs =
-      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
-      24 * 60 * 60 * 1000;
-    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+      positiveInteger(
+        'TOKEN_OPTIMIZER_LOG_RETENTION_DAYS',
+        DEFAULT_RETENTION_DAYS
+      ) *
+      24 *
+      60 *
+      60 *
+      1000;
+    const maxFiles = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_FILES',
+      DEFAULT_MAX_FILES
+    );
     const files = readdirSync(dir)
       .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
       .map((name) => {
@@ -292,7 +337,11 @@ export function beginHookInvocation(client, event, options = {}) {
   });
 
   let deadline;
-  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+  const finish = (
+    nextOutcome = outcome,
+    nextReason = reason,
+    nextError = error
+  ) => {
     if (ended) return;
     ended = true;
     if (deadline) clearTimeout(deadline);
@@ -300,7 +349,10 @@ export function beginHookInvocation(client, event, options = {}) {
     process.removeListener('uncaughtException', onUncaughtException);
     process.removeListener('unhandledRejection', onUnhandledRejection);
     writeHookEvent({
-      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      level:
+        nextOutcome === 'failure' || nextOutcome === 'timeout'
+          ? 'error'
+          : 'info',
       event: 'hook.completed',
       outcome: nextOutcome,
       reason: nextReason,
@@ -328,31 +380,43 @@ export function beginHookInvocation(client, event, options = {}) {
   process.once('uncaughtException', onUncaughtException);
   process.once('unhandledRejection', onUnhandledRejection);
 
-  deadline = setTimeout(() => {
-    outcome = 'timeout';
-    reason = 'internal_deadline_exceeded';
-    finish(outcome, reason);
-    // Beat the host's five-second timeout and fail open deterministically.
-    process.exit(0);
-  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline = setTimeout(
+    () => {
+      outcome = 'timeout';
+      reason = 'internal_deadline_exceeded';
+      finish(outcome, reason);
+      // Beat the host's five-second timeout and fail open deterministically.
+      process.exit(0);
+    },
+    options.deadlineMs ??
+      positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS)
+  );
   deadline.unref();
 
   const invocation = {
     invocationId,
     bind(raw = {}, payload = null, payloadBytes = null) {
-      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      const sessionId =
+        raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
       dimensions.sessionIdHash = hash(sessionId);
       dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
       dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
-      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.toolName =
+        payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
       dimensions.rawToolName = dimension(
         raw.tool_name ?? raw.toolName ?? raw.tool ?? null
       );
       dimensions.codeModeEnvelope =
         payload?.tool_input?.code_mode_envelope === true;
-      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
-      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
-      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.clientVersion = dimension(
+        raw.client_version ?? raw.clientVersion ?? null
+      );
+      dimensions.model = dimension(
+        raw.model ?? raw.model_name ?? raw.modelName ?? null
+      );
+      dimensions.cwdHash = hash(
+        raw.cwd ?? raw.working_directory ?? process.cwd()
+      );
       dimensions.payloadBytes = payloadBytes;
       dimensions.inputStatus = 'ok';
       if (sessionId) traceId = hash(sessionId, 32);
@@ -373,15 +437,21 @@ export function beginHookInvocation(client, event, options = {}) {
       reason = nextReason;
     },
     noteOutput(output, outputBytes = null) {
-      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      dimensions.outputBytes =
+        outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
       if (!output || typeof output !== 'object' || Array.isArray(output)) {
         dimensions.outputShape = [];
         return;
       }
       const shape = Object.keys(output).sort();
       const hookSpecific = output.hookSpecificOutput;
-      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
-        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      if (
+        hookSpecific &&
+        typeof hookSpecific === 'object' &&
+        !Array.isArray(hookSpecific)
+      ) {
+        for (const key of Object.keys(hookSpecific).sort())
+          shape.push(`hookSpecificOutput.${key}`);
       }
       dimensions.outputShape = shape;
     },
@@ -442,7 +512,10 @@ export function readHookEvents({
       .reverse();
     const events = [];
     for (const file of files) {
-      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      const lines = readFileSync(file, 'utf8')
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .reverse();
       for (const line of lines) {
         try {
           const event = JSON.parse(line);
@@ -530,7 +603,9 @@ export function hookHealthSummary(options = {}) {
   for (const current of Object.values(byClient)) current.hookEvents.sort();
   const percentile = (p) =>
     durations.length
-      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      ? durations[
+          Math.min(durations.length - 1, Math.floor(durations.length * p))
+        ]
       : null;
   const summary = {
     schemaVersion: HOOK_LOG_SCHEMA_VERSION,

--- a/integrations/codex/hooks/post-tool.mjs
+++ b/integrations/codex/hooks/post-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/hooks/pre-tool.mjs
+++ b/integrations/codex/hooks/pre-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/hooks/session-start.mjs
+++ b/integrations/codex/hooks/session-start.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/hooks/stop.mjs
+++ b/integrations/codex/hooks/stop.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/plugin/hooks/lib/observability.mjs
+++ b/integrations/codex/plugin/hooks/lib/observability.mjs
@@ -1,6 +1,5 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *
@@ -24,7 +23,8 @@ import {
 } from 'node:fs';
 import { createHash, randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export const HOOK_LOG_SCHEMA_VERSION = 2;
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
@@ -34,6 +34,75 @@ const DEFAULT_DEADLINE_MS = 4200;
 const MAX_ERROR_CHARS = 4000;
 const MAX_DIMENSION_CHARS = 160;
 let activeInvocation = null;
+
+/**
+ * Manifests that carry this package's version, nearest first.
+ *
+ * WHY THIS IS RESOLVED RATHER THAN COMPILED IN. The generators used to write the
+ * version into all 48 generated files, which made "generated output == committed
+ * file" an invariant that cannot survive a release: release-please bumps
+ * package.json without regenerating, so the release commit is born drifted and
+ * `publish-npm` -- which checks out the tag -- fails its drift gate. It has cost
+ * this project three releases (v5.4.0, v5.4.1, v5.7.1: all tagged, none on npm).
+ *
+ * The stamp is now applied at publish time only, so an npm install still reports
+ * an exact version from the env. Everything else resolves here instead of
+ * reporting a stale literal -- a lagging version is not a version, it is a wrong
+ * one, and this file exists to make failures correlatable.
+ *
+ * Inside the tarball the walk finds the package's own package.json; a plugin
+ * installed from the marketplace finds .claude-plugin/plugin.json, which
+ * release-please keeps correct. A bare copy into a client hook directory finds
+ * nothing and says 'unknown', which is what this reported before the stamp
+ * existed and is honest.
+ */
+const VERSION_MANIFESTS = [
+  ['package.json'],
+  ['.claude-plugin', 'plugin.json'],
+  ['.codex-plugin', 'plugin.json'],
+];
+const MAX_MANIFEST_DEPTH = 6;
+
+let cachedManifestVersion;
+
+function versionFromNearestManifest() {
+  if (cachedManifestVersion !== undefined) return cachedManifestVersion;
+  cachedManifestVersion = '';
+  try {
+    let dir = dirname(fileURLToPath(import.meta.url));
+    for (let depth = 0; depth < MAX_MANIFEST_DEPTH; depth++) {
+      for (const parts of VERSION_MANIFESTS) {
+        const candidate = join(dir, ...parts);
+        if (!existsSync(candidate)) continue;
+        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (typeof version === 'string' && version) {
+          cachedManifestVersion = version;
+          return cachedManifestVersion;
+        }
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // Diagnostics must never be the reason a hook fails.
+  }
+  return cachedManifestVersion;
+}
+
+/**
+ * The version this process reports. Env first so the publish-time stamp and any
+ * host that sets it still win; only the filesystem walk is cached, so the env
+ * stays authoritative for the life of the process.
+ */
+export function serviceVersion() {
+  return (
+    process.env.TOKEN_OPTIMIZER_VERSION ||
+    process.env.npm_package_version ||
+    versionFromNearestManifest() ||
+    'unknown'
+  );
+}
 
 function positiveInteger(name, fallback) {
   const value = Number(process.env[name]);
@@ -161,10 +230,7 @@ export function writeHookEvent(event) {
       schemaVersion: HOOK_LOG_SCHEMA_VERSION,
       timestamp: now.toISOString(),
       service: 'token-optimizer',
-      serviceVersion:
-        process.env.TOKEN_OPTIMIZER_VERSION ||
-        process.env.npm_package_version ||
-        'unknown',
+      serviceVersion: serviceVersion(),
       ...severity(event.level),
       body: event.event || 'hook.event',
       ...event,

--- a/integrations/codex/plugin/hooks/lib/observability.mjs
+++ b/integrations/codex/plugin/hooks/lib/observability.mjs
@@ -61,6 +61,20 @@ const VERSION_MANIFESTS = [
   ['.claude-plugin', 'plugin.json'],
   ['.codex-plugin', 'plugin.json'],
 ];
+
+/**
+ * The names that prove a manifest is OURS.
+ *
+ * FOUND IN REVIEW. Without this the walk reports the version of whatever
+ * package.json happens to sit above the hook, so a copy of these hooks
+ * vendored into someone else's repository would report that repository's
+ * version as the optimizer's -- a wrong version, which is the exact failure
+ * this file was changed to avoid. `npm_package_version` is ambient for the same
+ * reason: it belongs to whichever npm script is running, not necessarily to us.
+ */
+const PACKAGE_NAME = '@ooples/token-optimizer-mcp';
+const PLUGIN_NAME = 'token-optimizer';
+const OWNED_MANIFEST_NAMES = new Set([PACKAGE_NAME, PLUGIN_NAME]);
 const MAX_MANIFEST_DEPTH = 6;
 
 let cachedManifestVersion;
@@ -74,7 +88,8 @@ function versionFromNearestManifest() {
       for (const parts of VERSION_MANIFESTS) {
         const candidate = join(dir, ...parts);
         if (!existsSync(candidate)) continue;
-        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        const { name, version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (!OWNED_MANIFEST_NAMES.has(name)) continue;
         if (typeof version === 'string' && version) {
           cachedManifestVersion = version;
           return cachedManifestVersion;
@@ -98,7 +113,9 @@ function versionFromNearestManifest() {
 export function serviceVersion() {
   return (
     process.env.TOKEN_OPTIMIZER_VERSION ||
-    process.env.npm_package_version ||
+    (process.env.npm_package_name === PACKAGE_NAME
+      ? process.env.npm_package_version
+      : '') ||
     versionFromNearestManifest() ||
     'unknown'
   );
@@ -120,7 +137,10 @@ export function hookLogDirectory() {
 
 function hash(value, length = 16) {
   if (!value) return null;
-  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+  return createHash('sha256')
+    .update(String(value))
+    .digest('hex')
+    .slice(0, length);
 }
 
 function sanitize(text) {
@@ -129,9 +149,15 @@ function sanitize(text) {
   const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
   value = value
-    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(
+      /\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g,
+      '[REDACTED]'
+    )
     .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
-    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+    .replace(
+      /\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi,
+      '$1=[REDACTED]'
+    );
   return value.slice(0, MAX_ERROR_CHARS);
 }
 
@@ -163,7 +189,10 @@ function activeLogPath(now = new Date()) {
 function rotateIfNeeded(path) {
   try {
     if (!existsSync(path)) return;
-    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    const maxBytes = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_BYTES',
+      DEFAULT_MAX_BYTES
+    );
     if (statSync(path).size < maxBytes) return;
 
     const lock = join(hookLogDirectory(), '.rotate.lock');
@@ -184,7 +213,11 @@ function rotateIfNeeded(path) {
       }
     } finally {
       // Non-recursive removal of the one fixed-name lock directory only.
-      try { rmdirSync(lock); } catch { /* best effort */ }
+      try {
+        rmdirSync(lock);
+      } catch {
+        /* best effort */
+      }
     }
   } catch {
     // Diagnostics must never become the reason a lifecycle hook fails.
@@ -195,14 +228,26 @@ function pruneIfDue(now = new Date()) {
   try {
     const dir = hookLogDirectory();
     const marker = join(dir, '.last-prune');
-    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+    if (
+      existsSync(marker) &&
+      now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000
+    )
       return;
     writeFileSync(marker, now.toISOString(), { flag: 'w' });
 
     const retentionMs =
-      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
-      24 * 60 * 60 * 1000;
-    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+      positiveInteger(
+        'TOKEN_OPTIMIZER_LOG_RETENTION_DAYS',
+        DEFAULT_RETENTION_DAYS
+      ) *
+      24 *
+      60 *
+      60 *
+      1000;
+    const maxFiles = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_FILES',
+      DEFAULT_MAX_FILES
+    );
     const files = readdirSync(dir)
       .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
       .map((name) => {
@@ -292,7 +337,11 @@ export function beginHookInvocation(client, event, options = {}) {
   });
 
   let deadline;
-  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+  const finish = (
+    nextOutcome = outcome,
+    nextReason = reason,
+    nextError = error
+  ) => {
     if (ended) return;
     ended = true;
     if (deadline) clearTimeout(deadline);
@@ -300,7 +349,10 @@ export function beginHookInvocation(client, event, options = {}) {
     process.removeListener('uncaughtException', onUncaughtException);
     process.removeListener('unhandledRejection', onUnhandledRejection);
     writeHookEvent({
-      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      level:
+        nextOutcome === 'failure' || nextOutcome === 'timeout'
+          ? 'error'
+          : 'info',
       event: 'hook.completed',
       outcome: nextOutcome,
       reason: nextReason,
@@ -328,31 +380,43 @@ export function beginHookInvocation(client, event, options = {}) {
   process.once('uncaughtException', onUncaughtException);
   process.once('unhandledRejection', onUnhandledRejection);
 
-  deadline = setTimeout(() => {
-    outcome = 'timeout';
-    reason = 'internal_deadline_exceeded';
-    finish(outcome, reason);
-    // Beat the host's five-second timeout and fail open deterministically.
-    process.exit(0);
-  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline = setTimeout(
+    () => {
+      outcome = 'timeout';
+      reason = 'internal_deadline_exceeded';
+      finish(outcome, reason);
+      // Beat the host's five-second timeout and fail open deterministically.
+      process.exit(0);
+    },
+    options.deadlineMs ??
+      positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS)
+  );
   deadline.unref();
 
   const invocation = {
     invocationId,
     bind(raw = {}, payload = null, payloadBytes = null) {
-      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      const sessionId =
+        raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
       dimensions.sessionIdHash = hash(sessionId);
       dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
       dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
-      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.toolName =
+        payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
       dimensions.rawToolName = dimension(
         raw.tool_name ?? raw.toolName ?? raw.tool ?? null
       );
       dimensions.codeModeEnvelope =
         payload?.tool_input?.code_mode_envelope === true;
-      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
-      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
-      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.clientVersion = dimension(
+        raw.client_version ?? raw.clientVersion ?? null
+      );
+      dimensions.model = dimension(
+        raw.model ?? raw.model_name ?? raw.modelName ?? null
+      );
+      dimensions.cwdHash = hash(
+        raw.cwd ?? raw.working_directory ?? process.cwd()
+      );
       dimensions.payloadBytes = payloadBytes;
       dimensions.inputStatus = 'ok';
       if (sessionId) traceId = hash(sessionId, 32);
@@ -373,15 +437,21 @@ export function beginHookInvocation(client, event, options = {}) {
       reason = nextReason;
     },
     noteOutput(output, outputBytes = null) {
-      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      dimensions.outputBytes =
+        outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
       if (!output || typeof output !== 'object' || Array.isArray(output)) {
         dimensions.outputShape = [];
         return;
       }
       const shape = Object.keys(output).sort();
       const hookSpecific = output.hookSpecificOutput;
-      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
-        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      if (
+        hookSpecific &&
+        typeof hookSpecific === 'object' &&
+        !Array.isArray(hookSpecific)
+      ) {
+        for (const key of Object.keys(hookSpecific).sort())
+          shape.push(`hookSpecificOutput.${key}`);
       }
       dimensions.outputShape = shape;
     },
@@ -442,7 +512,10 @@ export function readHookEvents({
       .reverse();
     const events = [];
     for (const file of files) {
-      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      const lines = readFileSync(file, 'utf8')
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .reverse();
       for (const line of lines) {
         try {
           const event = JSON.parse(line);
@@ -530,7 +603,9 @@ export function hookHealthSummary(options = {}) {
   for (const current of Object.values(byClient)) current.hookEvents.sort();
   const percentile = (p) =>
     durations.length
-      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      ? durations[
+          Math.min(durations.length - 1, Math.floor(durations.length * p))
+        ]
       : null;
   const summary = {
     schemaVersion: HOOK_LOG_SCHEMA_VERSION,

--- a/integrations/codex/plugin/hooks/post-tool.mjs
+++ b/integrations/codex/plugin/hooks/post-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/plugin/hooks/pre-tool.mjs
+++ b/integrations/codex/plugin/hooks/pre-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/plugin/hooks/session-start.mjs
+++ b/integrations/codex/plugin/hooks/session-start.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/plugin/hooks/stop.mjs
+++ b/integrations/codex/plugin/hooks/stop.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/copilot/.github/hooks/lib/observability.mjs
+++ b/integrations/copilot/.github/hooks/lib/observability.mjs
@@ -1,6 +1,5 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *
@@ -24,7 +23,8 @@ import {
 } from 'node:fs';
 import { createHash, randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export const HOOK_LOG_SCHEMA_VERSION = 2;
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
@@ -34,6 +34,75 @@ const DEFAULT_DEADLINE_MS = 4200;
 const MAX_ERROR_CHARS = 4000;
 const MAX_DIMENSION_CHARS = 160;
 let activeInvocation = null;
+
+/**
+ * Manifests that carry this package's version, nearest first.
+ *
+ * WHY THIS IS RESOLVED RATHER THAN COMPILED IN. The generators used to write the
+ * version into all 48 generated files, which made "generated output == committed
+ * file" an invariant that cannot survive a release: release-please bumps
+ * package.json without regenerating, so the release commit is born drifted and
+ * `publish-npm` -- which checks out the tag -- fails its drift gate. It has cost
+ * this project three releases (v5.4.0, v5.4.1, v5.7.1: all tagged, none on npm).
+ *
+ * The stamp is now applied at publish time only, so an npm install still reports
+ * an exact version from the env. Everything else resolves here instead of
+ * reporting a stale literal -- a lagging version is not a version, it is a wrong
+ * one, and this file exists to make failures correlatable.
+ *
+ * Inside the tarball the walk finds the package's own package.json; a plugin
+ * installed from the marketplace finds .claude-plugin/plugin.json, which
+ * release-please keeps correct. A bare copy into a client hook directory finds
+ * nothing and says 'unknown', which is what this reported before the stamp
+ * existed and is honest.
+ */
+const VERSION_MANIFESTS = [
+  ['package.json'],
+  ['.claude-plugin', 'plugin.json'],
+  ['.codex-plugin', 'plugin.json'],
+];
+const MAX_MANIFEST_DEPTH = 6;
+
+let cachedManifestVersion;
+
+function versionFromNearestManifest() {
+  if (cachedManifestVersion !== undefined) return cachedManifestVersion;
+  cachedManifestVersion = '';
+  try {
+    let dir = dirname(fileURLToPath(import.meta.url));
+    for (let depth = 0; depth < MAX_MANIFEST_DEPTH; depth++) {
+      for (const parts of VERSION_MANIFESTS) {
+        const candidate = join(dir, ...parts);
+        if (!existsSync(candidate)) continue;
+        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (typeof version === 'string' && version) {
+          cachedManifestVersion = version;
+          return cachedManifestVersion;
+        }
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // Diagnostics must never be the reason a hook fails.
+  }
+  return cachedManifestVersion;
+}
+
+/**
+ * The version this process reports. Env first so the publish-time stamp and any
+ * host that sets it still win; only the filesystem walk is cached, so the env
+ * stays authoritative for the life of the process.
+ */
+export function serviceVersion() {
+  return (
+    process.env.TOKEN_OPTIMIZER_VERSION ||
+    process.env.npm_package_version ||
+    versionFromNearestManifest() ||
+    'unknown'
+  );
+}
 
 function positiveInteger(name, fallback) {
   const value = Number(process.env[name]);
@@ -161,10 +230,7 @@ export function writeHookEvent(event) {
       schemaVersion: HOOK_LOG_SCHEMA_VERSION,
       timestamp: now.toISOString(),
       service: 'token-optimizer',
-      serviceVersion:
-        process.env.TOKEN_OPTIMIZER_VERSION ||
-        process.env.npm_package_version ||
-        'unknown',
+      serviceVersion: serviceVersion(),
       ...severity(event.level),
       body: event.event || 'hook.event',
       ...event,

--- a/integrations/copilot/.github/hooks/lib/observability.mjs
+++ b/integrations/copilot/.github/hooks/lib/observability.mjs
@@ -61,6 +61,20 @@ const VERSION_MANIFESTS = [
   ['.claude-plugin', 'plugin.json'],
   ['.codex-plugin', 'plugin.json'],
 ];
+
+/**
+ * The names that prove a manifest is OURS.
+ *
+ * FOUND IN REVIEW. Without this the walk reports the version of whatever
+ * package.json happens to sit above the hook, so a copy of these hooks
+ * vendored into someone else's repository would report that repository's
+ * version as the optimizer's -- a wrong version, which is the exact failure
+ * this file was changed to avoid. `npm_package_version` is ambient for the same
+ * reason: it belongs to whichever npm script is running, not necessarily to us.
+ */
+const PACKAGE_NAME = '@ooples/token-optimizer-mcp';
+const PLUGIN_NAME = 'token-optimizer';
+const OWNED_MANIFEST_NAMES = new Set([PACKAGE_NAME, PLUGIN_NAME]);
 const MAX_MANIFEST_DEPTH = 6;
 
 let cachedManifestVersion;
@@ -74,7 +88,8 @@ function versionFromNearestManifest() {
       for (const parts of VERSION_MANIFESTS) {
         const candidate = join(dir, ...parts);
         if (!existsSync(candidate)) continue;
-        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        const { name, version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (!OWNED_MANIFEST_NAMES.has(name)) continue;
         if (typeof version === 'string' && version) {
           cachedManifestVersion = version;
           return cachedManifestVersion;
@@ -98,7 +113,9 @@ function versionFromNearestManifest() {
 export function serviceVersion() {
   return (
     process.env.TOKEN_OPTIMIZER_VERSION ||
-    process.env.npm_package_version ||
+    (process.env.npm_package_name === PACKAGE_NAME
+      ? process.env.npm_package_version
+      : '') ||
     versionFromNearestManifest() ||
     'unknown'
   );
@@ -120,7 +137,10 @@ export function hookLogDirectory() {
 
 function hash(value, length = 16) {
   if (!value) return null;
-  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+  return createHash('sha256')
+    .update(String(value))
+    .digest('hex')
+    .slice(0, length);
 }
 
 function sanitize(text) {
@@ -129,9 +149,15 @@ function sanitize(text) {
   const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
   value = value
-    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(
+      /\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g,
+      '[REDACTED]'
+    )
     .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
-    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+    .replace(
+      /\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi,
+      '$1=[REDACTED]'
+    );
   return value.slice(0, MAX_ERROR_CHARS);
 }
 
@@ -163,7 +189,10 @@ function activeLogPath(now = new Date()) {
 function rotateIfNeeded(path) {
   try {
     if (!existsSync(path)) return;
-    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    const maxBytes = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_BYTES',
+      DEFAULT_MAX_BYTES
+    );
     if (statSync(path).size < maxBytes) return;
 
     const lock = join(hookLogDirectory(), '.rotate.lock');
@@ -184,7 +213,11 @@ function rotateIfNeeded(path) {
       }
     } finally {
       // Non-recursive removal of the one fixed-name lock directory only.
-      try { rmdirSync(lock); } catch { /* best effort */ }
+      try {
+        rmdirSync(lock);
+      } catch {
+        /* best effort */
+      }
     }
   } catch {
     // Diagnostics must never become the reason a lifecycle hook fails.
@@ -195,14 +228,26 @@ function pruneIfDue(now = new Date()) {
   try {
     const dir = hookLogDirectory();
     const marker = join(dir, '.last-prune');
-    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+    if (
+      existsSync(marker) &&
+      now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000
+    )
       return;
     writeFileSync(marker, now.toISOString(), { flag: 'w' });
 
     const retentionMs =
-      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
-      24 * 60 * 60 * 1000;
-    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+      positiveInteger(
+        'TOKEN_OPTIMIZER_LOG_RETENTION_DAYS',
+        DEFAULT_RETENTION_DAYS
+      ) *
+      24 *
+      60 *
+      60 *
+      1000;
+    const maxFiles = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_FILES',
+      DEFAULT_MAX_FILES
+    );
     const files = readdirSync(dir)
       .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
       .map((name) => {
@@ -292,7 +337,11 @@ export function beginHookInvocation(client, event, options = {}) {
   });
 
   let deadline;
-  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+  const finish = (
+    nextOutcome = outcome,
+    nextReason = reason,
+    nextError = error
+  ) => {
     if (ended) return;
     ended = true;
     if (deadline) clearTimeout(deadline);
@@ -300,7 +349,10 @@ export function beginHookInvocation(client, event, options = {}) {
     process.removeListener('uncaughtException', onUncaughtException);
     process.removeListener('unhandledRejection', onUnhandledRejection);
     writeHookEvent({
-      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      level:
+        nextOutcome === 'failure' || nextOutcome === 'timeout'
+          ? 'error'
+          : 'info',
       event: 'hook.completed',
       outcome: nextOutcome,
       reason: nextReason,
@@ -328,31 +380,43 @@ export function beginHookInvocation(client, event, options = {}) {
   process.once('uncaughtException', onUncaughtException);
   process.once('unhandledRejection', onUnhandledRejection);
 
-  deadline = setTimeout(() => {
-    outcome = 'timeout';
-    reason = 'internal_deadline_exceeded';
-    finish(outcome, reason);
-    // Beat the host's five-second timeout and fail open deterministically.
-    process.exit(0);
-  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline = setTimeout(
+    () => {
+      outcome = 'timeout';
+      reason = 'internal_deadline_exceeded';
+      finish(outcome, reason);
+      // Beat the host's five-second timeout and fail open deterministically.
+      process.exit(0);
+    },
+    options.deadlineMs ??
+      positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS)
+  );
   deadline.unref();
 
   const invocation = {
     invocationId,
     bind(raw = {}, payload = null, payloadBytes = null) {
-      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      const sessionId =
+        raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
       dimensions.sessionIdHash = hash(sessionId);
       dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
       dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
-      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.toolName =
+        payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
       dimensions.rawToolName = dimension(
         raw.tool_name ?? raw.toolName ?? raw.tool ?? null
       );
       dimensions.codeModeEnvelope =
         payload?.tool_input?.code_mode_envelope === true;
-      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
-      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
-      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.clientVersion = dimension(
+        raw.client_version ?? raw.clientVersion ?? null
+      );
+      dimensions.model = dimension(
+        raw.model ?? raw.model_name ?? raw.modelName ?? null
+      );
+      dimensions.cwdHash = hash(
+        raw.cwd ?? raw.working_directory ?? process.cwd()
+      );
       dimensions.payloadBytes = payloadBytes;
       dimensions.inputStatus = 'ok';
       if (sessionId) traceId = hash(sessionId, 32);
@@ -373,15 +437,21 @@ export function beginHookInvocation(client, event, options = {}) {
       reason = nextReason;
     },
     noteOutput(output, outputBytes = null) {
-      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      dimensions.outputBytes =
+        outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
       if (!output || typeof output !== 'object' || Array.isArray(output)) {
         dimensions.outputShape = [];
         return;
       }
       const shape = Object.keys(output).sort();
       const hookSpecific = output.hookSpecificOutput;
-      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
-        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      if (
+        hookSpecific &&
+        typeof hookSpecific === 'object' &&
+        !Array.isArray(hookSpecific)
+      ) {
+        for (const key of Object.keys(hookSpecific).sort())
+          shape.push(`hookSpecificOutput.${key}`);
       }
       dimensions.outputShape = shape;
     },
@@ -442,7 +512,10 @@ export function readHookEvents({
       .reverse();
     const events = [];
     for (const file of files) {
-      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      const lines = readFileSync(file, 'utf8')
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .reverse();
       for (const line of lines) {
         try {
           const event = JSON.parse(line);
@@ -530,7 +603,9 @@ export function hookHealthSummary(options = {}) {
   for (const current of Object.values(byClient)) current.hookEvents.sort();
   const percentile = (p) =>
     durations.length
-      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      ? durations[
+          Math.min(durations.length - 1, Math.floor(durations.length * p))
+        ]
       : null;
   const summary = {
     schemaVersion: HOOK_LOG_SCHEMA_VERSION,

--- a/integrations/copilot/.github/hooks/post-tool.mjs
+++ b/integrations/copilot/.github/hooks/post-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/copilot/.github/hooks/pre-tool.mjs
+++ b/integrations/copilot/.github/hooks/pre-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/copilot/.github/hooks/session-start.mjs
+++ b/integrations/copilot/.github/hooks/session-start.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/copilot/.github/hooks/stop.mjs
+++ b/integrations/copilot/.github/hooks/stop.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/cursor/hooks/lib/observability.mjs
+++ b/integrations/cursor/hooks/lib/observability.mjs
@@ -1,6 +1,5 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *
@@ -24,7 +23,8 @@ import {
 } from 'node:fs';
 import { createHash, randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export const HOOK_LOG_SCHEMA_VERSION = 2;
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
@@ -34,6 +34,75 @@ const DEFAULT_DEADLINE_MS = 4200;
 const MAX_ERROR_CHARS = 4000;
 const MAX_DIMENSION_CHARS = 160;
 let activeInvocation = null;
+
+/**
+ * Manifests that carry this package's version, nearest first.
+ *
+ * WHY THIS IS RESOLVED RATHER THAN COMPILED IN. The generators used to write the
+ * version into all 48 generated files, which made "generated output == committed
+ * file" an invariant that cannot survive a release: release-please bumps
+ * package.json without regenerating, so the release commit is born drifted and
+ * `publish-npm` -- which checks out the tag -- fails its drift gate. It has cost
+ * this project three releases (v5.4.0, v5.4.1, v5.7.1: all tagged, none on npm).
+ *
+ * The stamp is now applied at publish time only, so an npm install still reports
+ * an exact version from the env. Everything else resolves here instead of
+ * reporting a stale literal -- a lagging version is not a version, it is a wrong
+ * one, and this file exists to make failures correlatable.
+ *
+ * Inside the tarball the walk finds the package's own package.json; a plugin
+ * installed from the marketplace finds .claude-plugin/plugin.json, which
+ * release-please keeps correct. A bare copy into a client hook directory finds
+ * nothing and says 'unknown', which is what this reported before the stamp
+ * existed and is honest.
+ */
+const VERSION_MANIFESTS = [
+  ['package.json'],
+  ['.claude-plugin', 'plugin.json'],
+  ['.codex-plugin', 'plugin.json'],
+];
+const MAX_MANIFEST_DEPTH = 6;
+
+let cachedManifestVersion;
+
+function versionFromNearestManifest() {
+  if (cachedManifestVersion !== undefined) return cachedManifestVersion;
+  cachedManifestVersion = '';
+  try {
+    let dir = dirname(fileURLToPath(import.meta.url));
+    for (let depth = 0; depth < MAX_MANIFEST_DEPTH; depth++) {
+      for (const parts of VERSION_MANIFESTS) {
+        const candidate = join(dir, ...parts);
+        if (!existsSync(candidate)) continue;
+        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (typeof version === 'string' && version) {
+          cachedManifestVersion = version;
+          return cachedManifestVersion;
+        }
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // Diagnostics must never be the reason a hook fails.
+  }
+  return cachedManifestVersion;
+}
+
+/**
+ * The version this process reports. Env first so the publish-time stamp and any
+ * host that sets it still win; only the filesystem walk is cached, so the env
+ * stays authoritative for the life of the process.
+ */
+export function serviceVersion() {
+  return (
+    process.env.TOKEN_OPTIMIZER_VERSION ||
+    process.env.npm_package_version ||
+    versionFromNearestManifest() ||
+    'unknown'
+  );
+}
 
 function positiveInteger(name, fallback) {
   const value = Number(process.env[name]);
@@ -161,10 +230,7 @@ export function writeHookEvent(event) {
       schemaVersion: HOOK_LOG_SCHEMA_VERSION,
       timestamp: now.toISOString(),
       service: 'token-optimizer',
-      serviceVersion:
-        process.env.TOKEN_OPTIMIZER_VERSION ||
-        process.env.npm_package_version ||
-        'unknown',
+      serviceVersion: serviceVersion(),
       ...severity(event.level),
       body: event.event || 'hook.event',
       ...event,

--- a/integrations/cursor/hooks/lib/observability.mjs
+++ b/integrations/cursor/hooks/lib/observability.mjs
@@ -61,6 +61,20 @@ const VERSION_MANIFESTS = [
   ['.claude-plugin', 'plugin.json'],
   ['.codex-plugin', 'plugin.json'],
 ];
+
+/**
+ * The names that prove a manifest is OURS.
+ *
+ * FOUND IN REVIEW. Without this the walk reports the version of whatever
+ * package.json happens to sit above the hook, so a copy of these hooks
+ * vendored into someone else's repository would report that repository's
+ * version as the optimizer's -- a wrong version, which is the exact failure
+ * this file was changed to avoid. `npm_package_version` is ambient for the same
+ * reason: it belongs to whichever npm script is running, not necessarily to us.
+ */
+const PACKAGE_NAME = '@ooples/token-optimizer-mcp';
+const PLUGIN_NAME = 'token-optimizer';
+const OWNED_MANIFEST_NAMES = new Set([PACKAGE_NAME, PLUGIN_NAME]);
 const MAX_MANIFEST_DEPTH = 6;
 
 let cachedManifestVersion;
@@ -74,7 +88,8 @@ function versionFromNearestManifest() {
       for (const parts of VERSION_MANIFESTS) {
         const candidate = join(dir, ...parts);
         if (!existsSync(candidate)) continue;
-        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        const { name, version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (!OWNED_MANIFEST_NAMES.has(name)) continue;
         if (typeof version === 'string' && version) {
           cachedManifestVersion = version;
           return cachedManifestVersion;
@@ -98,7 +113,9 @@ function versionFromNearestManifest() {
 export function serviceVersion() {
   return (
     process.env.TOKEN_OPTIMIZER_VERSION ||
-    process.env.npm_package_version ||
+    (process.env.npm_package_name === PACKAGE_NAME
+      ? process.env.npm_package_version
+      : '') ||
     versionFromNearestManifest() ||
     'unknown'
   );
@@ -120,7 +137,10 @@ export function hookLogDirectory() {
 
 function hash(value, length = 16) {
   if (!value) return null;
-  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+  return createHash('sha256')
+    .update(String(value))
+    .digest('hex')
+    .slice(0, length);
 }
 
 function sanitize(text) {
@@ -129,9 +149,15 @@ function sanitize(text) {
   const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
   value = value
-    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(
+      /\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g,
+      '[REDACTED]'
+    )
     .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
-    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+    .replace(
+      /\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi,
+      '$1=[REDACTED]'
+    );
   return value.slice(0, MAX_ERROR_CHARS);
 }
 
@@ -163,7 +189,10 @@ function activeLogPath(now = new Date()) {
 function rotateIfNeeded(path) {
   try {
     if (!existsSync(path)) return;
-    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    const maxBytes = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_BYTES',
+      DEFAULT_MAX_BYTES
+    );
     if (statSync(path).size < maxBytes) return;
 
     const lock = join(hookLogDirectory(), '.rotate.lock');
@@ -184,7 +213,11 @@ function rotateIfNeeded(path) {
       }
     } finally {
       // Non-recursive removal of the one fixed-name lock directory only.
-      try { rmdirSync(lock); } catch { /* best effort */ }
+      try {
+        rmdirSync(lock);
+      } catch {
+        /* best effort */
+      }
     }
   } catch {
     // Diagnostics must never become the reason a lifecycle hook fails.
@@ -195,14 +228,26 @@ function pruneIfDue(now = new Date()) {
   try {
     const dir = hookLogDirectory();
     const marker = join(dir, '.last-prune');
-    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+    if (
+      existsSync(marker) &&
+      now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000
+    )
       return;
     writeFileSync(marker, now.toISOString(), { flag: 'w' });
 
     const retentionMs =
-      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
-      24 * 60 * 60 * 1000;
-    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+      positiveInteger(
+        'TOKEN_OPTIMIZER_LOG_RETENTION_DAYS',
+        DEFAULT_RETENTION_DAYS
+      ) *
+      24 *
+      60 *
+      60 *
+      1000;
+    const maxFiles = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_FILES',
+      DEFAULT_MAX_FILES
+    );
     const files = readdirSync(dir)
       .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
       .map((name) => {
@@ -292,7 +337,11 @@ export function beginHookInvocation(client, event, options = {}) {
   });
 
   let deadline;
-  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+  const finish = (
+    nextOutcome = outcome,
+    nextReason = reason,
+    nextError = error
+  ) => {
     if (ended) return;
     ended = true;
     if (deadline) clearTimeout(deadline);
@@ -300,7 +349,10 @@ export function beginHookInvocation(client, event, options = {}) {
     process.removeListener('uncaughtException', onUncaughtException);
     process.removeListener('unhandledRejection', onUnhandledRejection);
     writeHookEvent({
-      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      level:
+        nextOutcome === 'failure' || nextOutcome === 'timeout'
+          ? 'error'
+          : 'info',
       event: 'hook.completed',
       outcome: nextOutcome,
       reason: nextReason,
@@ -328,31 +380,43 @@ export function beginHookInvocation(client, event, options = {}) {
   process.once('uncaughtException', onUncaughtException);
   process.once('unhandledRejection', onUnhandledRejection);
 
-  deadline = setTimeout(() => {
-    outcome = 'timeout';
-    reason = 'internal_deadline_exceeded';
-    finish(outcome, reason);
-    // Beat the host's five-second timeout and fail open deterministically.
-    process.exit(0);
-  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline = setTimeout(
+    () => {
+      outcome = 'timeout';
+      reason = 'internal_deadline_exceeded';
+      finish(outcome, reason);
+      // Beat the host's five-second timeout and fail open deterministically.
+      process.exit(0);
+    },
+    options.deadlineMs ??
+      positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS)
+  );
   deadline.unref();
 
   const invocation = {
     invocationId,
     bind(raw = {}, payload = null, payloadBytes = null) {
-      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      const sessionId =
+        raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
       dimensions.sessionIdHash = hash(sessionId);
       dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
       dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
-      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.toolName =
+        payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
       dimensions.rawToolName = dimension(
         raw.tool_name ?? raw.toolName ?? raw.tool ?? null
       );
       dimensions.codeModeEnvelope =
         payload?.tool_input?.code_mode_envelope === true;
-      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
-      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
-      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.clientVersion = dimension(
+        raw.client_version ?? raw.clientVersion ?? null
+      );
+      dimensions.model = dimension(
+        raw.model ?? raw.model_name ?? raw.modelName ?? null
+      );
+      dimensions.cwdHash = hash(
+        raw.cwd ?? raw.working_directory ?? process.cwd()
+      );
       dimensions.payloadBytes = payloadBytes;
       dimensions.inputStatus = 'ok';
       if (sessionId) traceId = hash(sessionId, 32);
@@ -373,15 +437,21 @@ export function beginHookInvocation(client, event, options = {}) {
       reason = nextReason;
     },
     noteOutput(output, outputBytes = null) {
-      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      dimensions.outputBytes =
+        outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
       if (!output || typeof output !== 'object' || Array.isArray(output)) {
         dimensions.outputShape = [];
         return;
       }
       const shape = Object.keys(output).sort();
       const hookSpecific = output.hookSpecificOutput;
-      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
-        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      if (
+        hookSpecific &&
+        typeof hookSpecific === 'object' &&
+        !Array.isArray(hookSpecific)
+      ) {
+        for (const key of Object.keys(hookSpecific).sort())
+          shape.push(`hookSpecificOutput.${key}`);
       }
       dimensions.outputShape = shape;
     },
@@ -442,7 +512,10 @@ export function readHookEvents({
       .reverse();
     const events = [];
     for (const file of files) {
-      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      const lines = readFileSync(file, 'utf8')
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .reverse();
       for (const line of lines) {
         try {
           const event = JSON.parse(line);
@@ -530,7 +603,9 @@ export function hookHealthSummary(options = {}) {
   for (const current of Object.values(byClient)) current.hookEvents.sort();
   const percentile = (p) =>
     durations.length
-      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      ? durations[
+          Math.min(durations.length - 1, Math.floor(durations.length * p))
+        ]
       : null;
   const summary = {
     schemaVersion: HOOK_LOG_SCHEMA_VERSION,

--- a/integrations/cursor/hooks/post-tool.mjs
+++ b/integrations/cursor/hooks/post-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/cursor/hooks/pre-tool.mjs
+++ b/integrations/cursor/hooks/pre-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/cursor/hooks/session-start.mjs
+++ b/integrations/cursor/hooks/session-start.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/cursor/hooks/stop.mjs
+++ b/integrations/cursor/hooks/stop.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/gemini/hooks/lib/observability.mjs
+++ b/integrations/gemini/hooks/lib/observability.mjs
@@ -1,6 +1,5 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *
@@ -24,7 +23,8 @@ import {
 } from 'node:fs';
 import { createHash, randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export const HOOK_LOG_SCHEMA_VERSION = 2;
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
@@ -34,6 +34,75 @@ const DEFAULT_DEADLINE_MS = 4200;
 const MAX_ERROR_CHARS = 4000;
 const MAX_DIMENSION_CHARS = 160;
 let activeInvocation = null;
+
+/**
+ * Manifests that carry this package's version, nearest first.
+ *
+ * WHY THIS IS RESOLVED RATHER THAN COMPILED IN. The generators used to write the
+ * version into all 48 generated files, which made "generated output == committed
+ * file" an invariant that cannot survive a release: release-please bumps
+ * package.json without regenerating, so the release commit is born drifted and
+ * `publish-npm` -- which checks out the tag -- fails its drift gate. It has cost
+ * this project three releases (v5.4.0, v5.4.1, v5.7.1: all tagged, none on npm).
+ *
+ * The stamp is now applied at publish time only, so an npm install still reports
+ * an exact version from the env. Everything else resolves here instead of
+ * reporting a stale literal -- a lagging version is not a version, it is a wrong
+ * one, and this file exists to make failures correlatable.
+ *
+ * Inside the tarball the walk finds the package's own package.json; a plugin
+ * installed from the marketplace finds .claude-plugin/plugin.json, which
+ * release-please keeps correct. A bare copy into a client hook directory finds
+ * nothing and says 'unknown', which is what this reported before the stamp
+ * existed and is honest.
+ */
+const VERSION_MANIFESTS = [
+  ['package.json'],
+  ['.claude-plugin', 'plugin.json'],
+  ['.codex-plugin', 'plugin.json'],
+];
+const MAX_MANIFEST_DEPTH = 6;
+
+let cachedManifestVersion;
+
+function versionFromNearestManifest() {
+  if (cachedManifestVersion !== undefined) return cachedManifestVersion;
+  cachedManifestVersion = '';
+  try {
+    let dir = dirname(fileURLToPath(import.meta.url));
+    for (let depth = 0; depth < MAX_MANIFEST_DEPTH; depth++) {
+      for (const parts of VERSION_MANIFESTS) {
+        const candidate = join(dir, ...parts);
+        if (!existsSync(candidate)) continue;
+        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (typeof version === 'string' && version) {
+          cachedManifestVersion = version;
+          return cachedManifestVersion;
+        }
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // Diagnostics must never be the reason a hook fails.
+  }
+  return cachedManifestVersion;
+}
+
+/**
+ * The version this process reports. Env first so the publish-time stamp and any
+ * host that sets it still win; only the filesystem walk is cached, so the env
+ * stays authoritative for the life of the process.
+ */
+export function serviceVersion() {
+  return (
+    process.env.TOKEN_OPTIMIZER_VERSION ||
+    process.env.npm_package_version ||
+    versionFromNearestManifest() ||
+    'unknown'
+  );
+}
 
 function positiveInteger(name, fallback) {
   const value = Number(process.env[name]);
@@ -161,10 +230,7 @@ export function writeHookEvent(event) {
       schemaVersion: HOOK_LOG_SCHEMA_VERSION,
       timestamp: now.toISOString(),
       service: 'token-optimizer',
-      serviceVersion:
-        process.env.TOKEN_OPTIMIZER_VERSION ||
-        process.env.npm_package_version ||
-        'unknown',
+      serviceVersion: serviceVersion(),
       ...severity(event.level),
       body: event.event || 'hook.event',
       ...event,

--- a/integrations/gemini/hooks/lib/observability.mjs
+++ b/integrations/gemini/hooks/lib/observability.mjs
@@ -61,6 +61,20 @@ const VERSION_MANIFESTS = [
   ['.claude-plugin', 'plugin.json'],
   ['.codex-plugin', 'plugin.json'],
 ];
+
+/**
+ * The names that prove a manifest is OURS.
+ *
+ * FOUND IN REVIEW. Without this the walk reports the version of whatever
+ * package.json happens to sit above the hook, so a copy of these hooks
+ * vendored into someone else's repository would report that repository's
+ * version as the optimizer's -- a wrong version, which is the exact failure
+ * this file was changed to avoid. `npm_package_version` is ambient for the same
+ * reason: it belongs to whichever npm script is running, not necessarily to us.
+ */
+const PACKAGE_NAME = '@ooples/token-optimizer-mcp';
+const PLUGIN_NAME = 'token-optimizer';
+const OWNED_MANIFEST_NAMES = new Set([PACKAGE_NAME, PLUGIN_NAME]);
 const MAX_MANIFEST_DEPTH = 6;
 
 let cachedManifestVersion;
@@ -74,7 +88,8 @@ function versionFromNearestManifest() {
       for (const parts of VERSION_MANIFESTS) {
         const candidate = join(dir, ...parts);
         if (!existsSync(candidate)) continue;
-        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        const { name, version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (!OWNED_MANIFEST_NAMES.has(name)) continue;
         if (typeof version === 'string' && version) {
           cachedManifestVersion = version;
           return cachedManifestVersion;
@@ -98,7 +113,9 @@ function versionFromNearestManifest() {
 export function serviceVersion() {
   return (
     process.env.TOKEN_OPTIMIZER_VERSION ||
-    process.env.npm_package_version ||
+    (process.env.npm_package_name === PACKAGE_NAME
+      ? process.env.npm_package_version
+      : '') ||
     versionFromNearestManifest() ||
     'unknown'
   );
@@ -120,7 +137,10 @@ export function hookLogDirectory() {
 
 function hash(value, length = 16) {
   if (!value) return null;
-  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+  return createHash('sha256')
+    .update(String(value))
+    .digest('hex')
+    .slice(0, length);
 }
 
 function sanitize(text) {
@@ -129,9 +149,15 @@ function sanitize(text) {
   const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
   value = value
-    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(
+      /\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g,
+      '[REDACTED]'
+    )
     .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
-    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+    .replace(
+      /\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi,
+      '$1=[REDACTED]'
+    );
   return value.slice(0, MAX_ERROR_CHARS);
 }
 
@@ -163,7 +189,10 @@ function activeLogPath(now = new Date()) {
 function rotateIfNeeded(path) {
   try {
     if (!existsSync(path)) return;
-    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    const maxBytes = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_BYTES',
+      DEFAULT_MAX_BYTES
+    );
     if (statSync(path).size < maxBytes) return;
 
     const lock = join(hookLogDirectory(), '.rotate.lock');
@@ -184,7 +213,11 @@ function rotateIfNeeded(path) {
       }
     } finally {
       // Non-recursive removal of the one fixed-name lock directory only.
-      try { rmdirSync(lock); } catch { /* best effort */ }
+      try {
+        rmdirSync(lock);
+      } catch {
+        /* best effort */
+      }
     }
   } catch {
     // Diagnostics must never become the reason a lifecycle hook fails.
@@ -195,14 +228,26 @@ function pruneIfDue(now = new Date()) {
   try {
     const dir = hookLogDirectory();
     const marker = join(dir, '.last-prune');
-    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+    if (
+      existsSync(marker) &&
+      now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000
+    )
       return;
     writeFileSync(marker, now.toISOString(), { flag: 'w' });
 
     const retentionMs =
-      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
-      24 * 60 * 60 * 1000;
-    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+      positiveInteger(
+        'TOKEN_OPTIMIZER_LOG_RETENTION_DAYS',
+        DEFAULT_RETENTION_DAYS
+      ) *
+      24 *
+      60 *
+      60 *
+      1000;
+    const maxFiles = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_FILES',
+      DEFAULT_MAX_FILES
+    );
     const files = readdirSync(dir)
       .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
       .map((name) => {
@@ -292,7 +337,11 @@ export function beginHookInvocation(client, event, options = {}) {
   });
 
   let deadline;
-  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+  const finish = (
+    nextOutcome = outcome,
+    nextReason = reason,
+    nextError = error
+  ) => {
     if (ended) return;
     ended = true;
     if (deadline) clearTimeout(deadline);
@@ -300,7 +349,10 @@ export function beginHookInvocation(client, event, options = {}) {
     process.removeListener('uncaughtException', onUncaughtException);
     process.removeListener('unhandledRejection', onUnhandledRejection);
     writeHookEvent({
-      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      level:
+        nextOutcome === 'failure' || nextOutcome === 'timeout'
+          ? 'error'
+          : 'info',
       event: 'hook.completed',
       outcome: nextOutcome,
       reason: nextReason,
@@ -328,31 +380,43 @@ export function beginHookInvocation(client, event, options = {}) {
   process.once('uncaughtException', onUncaughtException);
   process.once('unhandledRejection', onUnhandledRejection);
 
-  deadline = setTimeout(() => {
-    outcome = 'timeout';
-    reason = 'internal_deadline_exceeded';
-    finish(outcome, reason);
-    // Beat the host's five-second timeout and fail open deterministically.
-    process.exit(0);
-  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline = setTimeout(
+    () => {
+      outcome = 'timeout';
+      reason = 'internal_deadline_exceeded';
+      finish(outcome, reason);
+      // Beat the host's five-second timeout and fail open deterministically.
+      process.exit(0);
+    },
+    options.deadlineMs ??
+      positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS)
+  );
   deadline.unref();
 
   const invocation = {
     invocationId,
     bind(raw = {}, payload = null, payloadBytes = null) {
-      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      const sessionId =
+        raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
       dimensions.sessionIdHash = hash(sessionId);
       dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
       dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
-      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.toolName =
+        payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
       dimensions.rawToolName = dimension(
         raw.tool_name ?? raw.toolName ?? raw.tool ?? null
       );
       dimensions.codeModeEnvelope =
         payload?.tool_input?.code_mode_envelope === true;
-      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
-      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
-      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.clientVersion = dimension(
+        raw.client_version ?? raw.clientVersion ?? null
+      );
+      dimensions.model = dimension(
+        raw.model ?? raw.model_name ?? raw.modelName ?? null
+      );
+      dimensions.cwdHash = hash(
+        raw.cwd ?? raw.working_directory ?? process.cwd()
+      );
       dimensions.payloadBytes = payloadBytes;
       dimensions.inputStatus = 'ok';
       if (sessionId) traceId = hash(sessionId, 32);
@@ -373,15 +437,21 @@ export function beginHookInvocation(client, event, options = {}) {
       reason = nextReason;
     },
     noteOutput(output, outputBytes = null) {
-      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      dimensions.outputBytes =
+        outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
       if (!output || typeof output !== 'object' || Array.isArray(output)) {
         dimensions.outputShape = [];
         return;
       }
       const shape = Object.keys(output).sort();
       const hookSpecific = output.hookSpecificOutput;
-      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
-        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      if (
+        hookSpecific &&
+        typeof hookSpecific === 'object' &&
+        !Array.isArray(hookSpecific)
+      ) {
+        for (const key of Object.keys(hookSpecific).sort())
+          shape.push(`hookSpecificOutput.${key}`);
       }
       dimensions.outputShape = shape;
     },
@@ -442,7 +512,10 @@ export function readHookEvents({
       .reverse();
     const events = [];
     for (const file of files) {
-      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      const lines = readFileSync(file, 'utf8')
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .reverse();
       for (const line of lines) {
         try {
           const event = JSON.parse(line);
@@ -530,7 +603,9 @@ export function hookHealthSummary(options = {}) {
   for (const current of Object.values(byClient)) current.hookEvents.sort();
   const percentile = (p) =>
     durations.length
-      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      ? durations[
+          Math.min(durations.length - 1, Math.floor(durations.length * p))
+        ]
       : null;
   const summary = {
     schemaVersion: HOOK_LOG_SCHEMA_VERSION,

--- a/integrations/gemini/hooks/post-tool.mjs
+++ b/integrations/gemini/hooks/post-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/gemini/hooks/pre-tool.mjs
+++ b/integrations/gemini/hooks/pre-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/gemini/hooks/session-start.mjs
+++ b/integrations/gemini/hooks/session-start.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/gemini/hooks/stop.mjs
+++ b/integrations/gemini/hooks/stop.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/kilo/hooks/lib/observability.mjs
+++ b/integrations/kilo/hooks/lib/observability.mjs
@@ -1,6 +1,5 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *
@@ -24,7 +23,8 @@ import {
 } from 'node:fs';
 import { createHash, randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export const HOOK_LOG_SCHEMA_VERSION = 2;
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
@@ -34,6 +34,75 @@ const DEFAULT_DEADLINE_MS = 4200;
 const MAX_ERROR_CHARS = 4000;
 const MAX_DIMENSION_CHARS = 160;
 let activeInvocation = null;
+
+/**
+ * Manifests that carry this package's version, nearest first.
+ *
+ * WHY THIS IS RESOLVED RATHER THAN COMPILED IN. The generators used to write the
+ * version into all 48 generated files, which made "generated output == committed
+ * file" an invariant that cannot survive a release: release-please bumps
+ * package.json without regenerating, so the release commit is born drifted and
+ * `publish-npm` -- which checks out the tag -- fails its drift gate. It has cost
+ * this project three releases (v5.4.0, v5.4.1, v5.7.1: all tagged, none on npm).
+ *
+ * The stamp is now applied at publish time only, so an npm install still reports
+ * an exact version from the env. Everything else resolves here instead of
+ * reporting a stale literal -- a lagging version is not a version, it is a wrong
+ * one, and this file exists to make failures correlatable.
+ *
+ * Inside the tarball the walk finds the package's own package.json; a plugin
+ * installed from the marketplace finds .claude-plugin/plugin.json, which
+ * release-please keeps correct. A bare copy into a client hook directory finds
+ * nothing and says 'unknown', which is what this reported before the stamp
+ * existed and is honest.
+ */
+const VERSION_MANIFESTS = [
+  ['package.json'],
+  ['.claude-plugin', 'plugin.json'],
+  ['.codex-plugin', 'plugin.json'],
+];
+const MAX_MANIFEST_DEPTH = 6;
+
+let cachedManifestVersion;
+
+function versionFromNearestManifest() {
+  if (cachedManifestVersion !== undefined) return cachedManifestVersion;
+  cachedManifestVersion = '';
+  try {
+    let dir = dirname(fileURLToPath(import.meta.url));
+    for (let depth = 0; depth < MAX_MANIFEST_DEPTH; depth++) {
+      for (const parts of VERSION_MANIFESTS) {
+        const candidate = join(dir, ...parts);
+        if (!existsSync(candidate)) continue;
+        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (typeof version === 'string' && version) {
+          cachedManifestVersion = version;
+          return cachedManifestVersion;
+        }
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // Diagnostics must never be the reason a hook fails.
+  }
+  return cachedManifestVersion;
+}
+
+/**
+ * The version this process reports. Env first so the publish-time stamp and any
+ * host that sets it still win; only the filesystem walk is cached, so the env
+ * stays authoritative for the life of the process.
+ */
+export function serviceVersion() {
+  return (
+    process.env.TOKEN_OPTIMIZER_VERSION ||
+    process.env.npm_package_version ||
+    versionFromNearestManifest() ||
+    'unknown'
+  );
+}
 
 function positiveInteger(name, fallback) {
   const value = Number(process.env[name]);
@@ -161,10 +230,7 @@ export function writeHookEvent(event) {
       schemaVersion: HOOK_LOG_SCHEMA_VERSION,
       timestamp: now.toISOString(),
       service: 'token-optimizer',
-      serviceVersion:
-        process.env.TOKEN_OPTIMIZER_VERSION ||
-        process.env.npm_package_version ||
-        'unknown',
+      serviceVersion: serviceVersion(),
       ...severity(event.level),
       body: event.event || 'hook.event',
       ...event,

--- a/integrations/kilo/hooks/lib/observability.mjs
+++ b/integrations/kilo/hooks/lib/observability.mjs
@@ -61,6 +61,20 @@ const VERSION_MANIFESTS = [
   ['.claude-plugin', 'plugin.json'],
   ['.codex-plugin', 'plugin.json'],
 ];
+
+/**
+ * The names that prove a manifest is OURS.
+ *
+ * FOUND IN REVIEW. Without this the walk reports the version of whatever
+ * package.json happens to sit above the hook, so a copy of these hooks
+ * vendored into someone else's repository would report that repository's
+ * version as the optimizer's -- a wrong version, which is the exact failure
+ * this file was changed to avoid. `npm_package_version` is ambient for the same
+ * reason: it belongs to whichever npm script is running, not necessarily to us.
+ */
+const PACKAGE_NAME = '@ooples/token-optimizer-mcp';
+const PLUGIN_NAME = 'token-optimizer';
+const OWNED_MANIFEST_NAMES = new Set([PACKAGE_NAME, PLUGIN_NAME]);
 const MAX_MANIFEST_DEPTH = 6;
 
 let cachedManifestVersion;
@@ -74,7 +88,8 @@ function versionFromNearestManifest() {
       for (const parts of VERSION_MANIFESTS) {
         const candidate = join(dir, ...parts);
         if (!existsSync(candidate)) continue;
-        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        const { name, version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (!OWNED_MANIFEST_NAMES.has(name)) continue;
         if (typeof version === 'string' && version) {
           cachedManifestVersion = version;
           return cachedManifestVersion;
@@ -98,7 +113,9 @@ function versionFromNearestManifest() {
 export function serviceVersion() {
   return (
     process.env.TOKEN_OPTIMIZER_VERSION ||
-    process.env.npm_package_version ||
+    (process.env.npm_package_name === PACKAGE_NAME
+      ? process.env.npm_package_version
+      : '') ||
     versionFromNearestManifest() ||
     'unknown'
   );
@@ -120,7 +137,10 @@ export function hookLogDirectory() {
 
 function hash(value, length = 16) {
   if (!value) return null;
-  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+  return createHash('sha256')
+    .update(String(value))
+    .digest('hex')
+    .slice(0, length);
 }
 
 function sanitize(text) {
@@ -129,9 +149,15 @@ function sanitize(text) {
   const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
   value = value
-    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(
+      /\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g,
+      '[REDACTED]'
+    )
     .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
-    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+    .replace(
+      /\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi,
+      '$1=[REDACTED]'
+    );
   return value.slice(0, MAX_ERROR_CHARS);
 }
 
@@ -163,7 +189,10 @@ function activeLogPath(now = new Date()) {
 function rotateIfNeeded(path) {
   try {
     if (!existsSync(path)) return;
-    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    const maxBytes = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_BYTES',
+      DEFAULT_MAX_BYTES
+    );
     if (statSync(path).size < maxBytes) return;
 
     const lock = join(hookLogDirectory(), '.rotate.lock');
@@ -184,7 +213,11 @@ function rotateIfNeeded(path) {
       }
     } finally {
       // Non-recursive removal of the one fixed-name lock directory only.
-      try { rmdirSync(lock); } catch { /* best effort */ }
+      try {
+        rmdirSync(lock);
+      } catch {
+        /* best effort */
+      }
     }
   } catch {
     // Diagnostics must never become the reason a lifecycle hook fails.
@@ -195,14 +228,26 @@ function pruneIfDue(now = new Date()) {
   try {
     const dir = hookLogDirectory();
     const marker = join(dir, '.last-prune');
-    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+    if (
+      existsSync(marker) &&
+      now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000
+    )
       return;
     writeFileSync(marker, now.toISOString(), { flag: 'w' });
 
     const retentionMs =
-      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
-      24 * 60 * 60 * 1000;
-    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+      positiveInteger(
+        'TOKEN_OPTIMIZER_LOG_RETENTION_DAYS',
+        DEFAULT_RETENTION_DAYS
+      ) *
+      24 *
+      60 *
+      60 *
+      1000;
+    const maxFiles = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_FILES',
+      DEFAULT_MAX_FILES
+    );
     const files = readdirSync(dir)
       .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
       .map((name) => {
@@ -292,7 +337,11 @@ export function beginHookInvocation(client, event, options = {}) {
   });
 
   let deadline;
-  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+  const finish = (
+    nextOutcome = outcome,
+    nextReason = reason,
+    nextError = error
+  ) => {
     if (ended) return;
     ended = true;
     if (deadline) clearTimeout(deadline);
@@ -300,7 +349,10 @@ export function beginHookInvocation(client, event, options = {}) {
     process.removeListener('uncaughtException', onUncaughtException);
     process.removeListener('unhandledRejection', onUnhandledRejection);
     writeHookEvent({
-      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      level:
+        nextOutcome === 'failure' || nextOutcome === 'timeout'
+          ? 'error'
+          : 'info',
       event: 'hook.completed',
       outcome: nextOutcome,
       reason: nextReason,
@@ -328,31 +380,43 @@ export function beginHookInvocation(client, event, options = {}) {
   process.once('uncaughtException', onUncaughtException);
   process.once('unhandledRejection', onUnhandledRejection);
 
-  deadline = setTimeout(() => {
-    outcome = 'timeout';
-    reason = 'internal_deadline_exceeded';
-    finish(outcome, reason);
-    // Beat the host's five-second timeout and fail open deterministically.
-    process.exit(0);
-  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline = setTimeout(
+    () => {
+      outcome = 'timeout';
+      reason = 'internal_deadline_exceeded';
+      finish(outcome, reason);
+      // Beat the host's five-second timeout and fail open deterministically.
+      process.exit(0);
+    },
+    options.deadlineMs ??
+      positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS)
+  );
   deadline.unref();
 
   const invocation = {
     invocationId,
     bind(raw = {}, payload = null, payloadBytes = null) {
-      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      const sessionId =
+        raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
       dimensions.sessionIdHash = hash(sessionId);
       dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
       dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
-      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.toolName =
+        payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
       dimensions.rawToolName = dimension(
         raw.tool_name ?? raw.toolName ?? raw.tool ?? null
       );
       dimensions.codeModeEnvelope =
         payload?.tool_input?.code_mode_envelope === true;
-      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
-      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
-      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.clientVersion = dimension(
+        raw.client_version ?? raw.clientVersion ?? null
+      );
+      dimensions.model = dimension(
+        raw.model ?? raw.model_name ?? raw.modelName ?? null
+      );
+      dimensions.cwdHash = hash(
+        raw.cwd ?? raw.working_directory ?? process.cwd()
+      );
       dimensions.payloadBytes = payloadBytes;
       dimensions.inputStatus = 'ok';
       if (sessionId) traceId = hash(sessionId, 32);
@@ -373,15 +437,21 @@ export function beginHookInvocation(client, event, options = {}) {
       reason = nextReason;
     },
     noteOutput(output, outputBytes = null) {
-      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      dimensions.outputBytes =
+        outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
       if (!output || typeof output !== 'object' || Array.isArray(output)) {
         dimensions.outputShape = [];
         return;
       }
       const shape = Object.keys(output).sort();
       const hookSpecific = output.hookSpecificOutput;
-      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
-        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      if (
+        hookSpecific &&
+        typeof hookSpecific === 'object' &&
+        !Array.isArray(hookSpecific)
+      ) {
+        for (const key of Object.keys(hookSpecific).sort())
+          shape.push(`hookSpecificOutput.${key}`);
       }
       dimensions.outputShape = shape;
     },
@@ -442,7 +512,10 @@ export function readHookEvents({
       .reverse();
     const events = [];
     for (const file of files) {
-      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      const lines = readFileSync(file, 'utf8')
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .reverse();
       for (const line of lines) {
         try {
           const event = JSON.parse(line);
@@ -530,7 +603,9 @@ export function hookHealthSummary(options = {}) {
   for (const current of Object.values(byClient)) current.hookEvents.sort();
   const percentile = (p) =>
     durations.length
-      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      ? durations[
+          Math.min(durations.length - 1, Math.floor(durations.length * p))
+        ]
       : null;
   const summary = {
     schemaVersion: HOOK_LOG_SCHEMA_VERSION,

--- a/integrations/kilo/hooks/post-tool.mjs
+++ b/integrations/kilo/hooks/post-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/kilo/hooks/pre-tool.mjs
+++ b/integrations/kilo/hooks/pre-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/kilo/hooks/session-start.mjs
+++ b/integrations/kilo/hooks/session-start.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/opencode/hooks/lib/observability.mjs
+++ b/integrations/opencode/hooks/lib/observability.mjs
@@ -1,6 +1,5 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *
@@ -24,7 +23,8 @@ import {
 } from 'node:fs';
 import { createHash, randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export const HOOK_LOG_SCHEMA_VERSION = 2;
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
@@ -34,6 +34,75 @@ const DEFAULT_DEADLINE_MS = 4200;
 const MAX_ERROR_CHARS = 4000;
 const MAX_DIMENSION_CHARS = 160;
 let activeInvocation = null;
+
+/**
+ * Manifests that carry this package's version, nearest first.
+ *
+ * WHY THIS IS RESOLVED RATHER THAN COMPILED IN. The generators used to write the
+ * version into all 48 generated files, which made "generated output == committed
+ * file" an invariant that cannot survive a release: release-please bumps
+ * package.json without regenerating, so the release commit is born drifted and
+ * `publish-npm` -- which checks out the tag -- fails its drift gate. It has cost
+ * this project three releases (v5.4.0, v5.4.1, v5.7.1: all tagged, none on npm).
+ *
+ * The stamp is now applied at publish time only, so an npm install still reports
+ * an exact version from the env. Everything else resolves here instead of
+ * reporting a stale literal -- a lagging version is not a version, it is a wrong
+ * one, and this file exists to make failures correlatable.
+ *
+ * Inside the tarball the walk finds the package's own package.json; a plugin
+ * installed from the marketplace finds .claude-plugin/plugin.json, which
+ * release-please keeps correct. A bare copy into a client hook directory finds
+ * nothing and says 'unknown', which is what this reported before the stamp
+ * existed and is honest.
+ */
+const VERSION_MANIFESTS = [
+  ['package.json'],
+  ['.claude-plugin', 'plugin.json'],
+  ['.codex-plugin', 'plugin.json'],
+];
+const MAX_MANIFEST_DEPTH = 6;
+
+let cachedManifestVersion;
+
+function versionFromNearestManifest() {
+  if (cachedManifestVersion !== undefined) return cachedManifestVersion;
+  cachedManifestVersion = '';
+  try {
+    let dir = dirname(fileURLToPath(import.meta.url));
+    for (let depth = 0; depth < MAX_MANIFEST_DEPTH; depth++) {
+      for (const parts of VERSION_MANIFESTS) {
+        const candidate = join(dir, ...parts);
+        if (!existsSync(candidate)) continue;
+        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (typeof version === 'string' && version) {
+          cachedManifestVersion = version;
+          return cachedManifestVersion;
+        }
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // Diagnostics must never be the reason a hook fails.
+  }
+  return cachedManifestVersion;
+}
+
+/**
+ * The version this process reports. Env first so the publish-time stamp and any
+ * host that sets it still win; only the filesystem walk is cached, so the env
+ * stays authoritative for the life of the process.
+ */
+export function serviceVersion() {
+  return (
+    process.env.TOKEN_OPTIMIZER_VERSION ||
+    process.env.npm_package_version ||
+    versionFromNearestManifest() ||
+    'unknown'
+  );
+}
 
 function positiveInteger(name, fallback) {
   const value = Number(process.env[name]);
@@ -161,10 +230,7 @@ export function writeHookEvent(event) {
       schemaVersion: HOOK_LOG_SCHEMA_VERSION,
       timestamp: now.toISOString(),
       service: 'token-optimizer',
-      serviceVersion:
-        process.env.TOKEN_OPTIMIZER_VERSION ||
-        process.env.npm_package_version ||
-        'unknown',
+      serviceVersion: serviceVersion(),
       ...severity(event.level),
       body: event.event || 'hook.event',
       ...event,

--- a/integrations/opencode/hooks/lib/observability.mjs
+++ b/integrations/opencode/hooks/lib/observability.mjs
@@ -61,6 +61,20 @@ const VERSION_MANIFESTS = [
   ['.claude-plugin', 'plugin.json'],
   ['.codex-plugin', 'plugin.json'],
 ];
+
+/**
+ * The names that prove a manifest is OURS.
+ *
+ * FOUND IN REVIEW. Without this the walk reports the version of whatever
+ * package.json happens to sit above the hook, so a copy of these hooks
+ * vendored into someone else's repository would report that repository's
+ * version as the optimizer's -- a wrong version, which is the exact failure
+ * this file was changed to avoid. `npm_package_version` is ambient for the same
+ * reason: it belongs to whichever npm script is running, not necessarily to us.
+ */
+const PACKAGE_NAME = '@ooples/token-optimizer-mcp';
+const PLUGIN_NAME = 'token-optimizer';
+const OWNED_MANIFEST_NAMES = new Set([PACKAGE_NAME, PLUGIN_NAME]);
 const MAX_MANIFEST_DEPTH = 6;
 
 let cachedManifestVersion;
@@ -74,7 +88,8 @@ function versionFromNearestManifest() {
       for (const parts of VERSION_MANIFESTS) {
         const candidate = join(dir, ...parts);
         if (!existsSync(candidate)) continue;
-        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        const { name, version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (!OWNED_MANIFEST_NAMES.has(name)) continue;
         if (typeof version === 'string' && version) {
           cachedManifestVersion = version;
           return cachedManifestVersion;
@@ -98,7 +113,9 @@ function versionFromNearestManifest() {
 export function serviceVersion() {
   return (
     process.env.TOKEN_OPTIMIZER_VERSION ||
-    process.env.npm_package_version ||
+    (process.env.npm_package_name === PACKAGE_NAME
+      ? process.env.npm_package_version
+      : '') ||
     versionFromNearestManifest() ||
     'unknown'
   );
@@ -120,7 +137,10 @@ export function hookLogDirectory() {
 
 function hash(value, length = 16) {
   if (!value) return null;
-  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+  return createHash('sha256')
+    .update(String(value))
+    .digest('hex')
+    .slice(0, length);
 }
 
 function sanitize(text) {
@@ -129,9 +149,15 @@ function sanitize(text) {
   const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
   value = value
-    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(
+      /\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g,
+      '[REDACTED]'
+    )
     .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
-    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+    .replace(
+      /\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi,
+      '$1=[REDACTED]'
+    );
   return value.slice(0, MAX_ERROR_CHARS);
 }
 
@@ -163,7 +189,10 @@ function activeLogPath(now = new Date()) {
 function rotateIfNeeded(path) {
   try {
     if (!existsSync(path)) return;
-    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    const maxBytes = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_BYTES',
+      DEFAULT_MAX_BYTES
+    );
     if (statSync(path).size < maxBytes) return;
 
     const lock = join(hookLogDirectory(), '.rotate.lock');
@@ -184,7 +213,11 @@ function rotateIfNeeded(path) {
       }
     } finally {
       // Non-recursive removal of the one fixed-name lock directory only.
-      try { rmdirSync(lock); } catch { /* best effort */ }
+      try {
+        rmdirSync(lock);
+      } catch {
+        /* best effort */
+      }
     }
   } catch {
     // Diagnostics must never become the reason a lifecycle hook fails.
@@ -195,14 +228,26 @@ function pruneIfDue(now = new Date()) {
   try {
     const dir = hookLogDirectory();
     const marker = join(dir, '.last-prune');
-    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+    if (
+      existsSync(marker) &&
+      now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000
+    )
       return;
     writeFileSync(marker, now.toISOString(), { flag: 'w' });
 
     const retentionMs =
-      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
-      24 * 60 * 60 * 1000;
-    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+      positiveInteger(
+        'TOKEN_OPTIMIZER_LOG_RETENTION_DAYS',
+        DEFAULT_RETENTION_DAYS
+      ) *
+      24 *
+      60 *
+      60 *
+      1000;
+    const maxFiles = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_FILES',
+      DEFAULT_MAX_FILES
+    );
     const files = readdirSync(dir)
       .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
       .map((name) => {
@@ -292,7 +337,11 @@ export function beginHookInvocation(client, event, options = {}) {
   });
 
   let deadline;
-  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+  const finish = (
+    nextOutcome = outcome,
+    nextReason = reason,
+    nextError = error
+  ) => {
     if (ended) return;
     ended = true;
     if (deadline) clearTimeout(deadline);
@@ -300,7 +349,10 @@ export function beginHookInvocation(client, event, options = {}) {
     process.removeListener('uncaughtException', onUncaughtException);
     process.removeListener('unhandledRejection', onUnhandledRejection);
     writeHookEvent({
-      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      level:
+        nextOutcome === 'failure' || nextOutcome === 'timeout'
+          ? 'error'
+          : 'info',
       event: 'hook.completed',
       outcome: nextOutcome,
       reason: nextReason,
@@ -328,31 +380,43 @@ export function beginHookInvocation(client, event, options = {}) {
   process.once('uncaughtException', onUncaughtException);
   process.once('unhandledRejection', onUnhandledRejection);
 
-  deadline = setTimeout(() => {
-    outcome = 'timeout';
-    reason = 'internal_deadline_exceeded';
-    finish(outcome, reason);
-    // Beat the host's five-second timeout and fail open deterministically.
-    process.exit(0);
-  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline = setTimeout(
+    () => {
+      outcome = 'timeout';
+      reason = 'internal_deadline_exceeded';
+      finish(outcome, reason);
+      // Beat the host's five-second timeout and fail open deterministically.
+      process.exit(0);
+    },
+    options.deadlineMs ??
+      positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS)
+  );
   deadline.unref();
 
   const invocation = {
     invocationId,
     bind(raw = {}, payload = null, payloadBytes = null) {
-      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      const sessionId =
+        raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
       dimensions.sessionIdHash = hash(sessionId);
       dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
       dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
-      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.toolName =
+        payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
       dimensions.rawToolName = dimension(
         raw.tool_name ?? raw.toolName ?? raw.tool ?? null
       );
       dimensions.codeModeEnvelope =
         payload?.tool_input?.code_mode_envelope === true;
-      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
-      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
-      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.clientVersion = dimension(
+        raw.client_version ?? raw.clientVersion ?? null
+      );
+      dimensions.model = dimension(
+        raw.model ?? raw.model_name ?? raw.modelName ?? null
+      );
+      dimensions.cwdHash = hash(
+        raw.cwd ?? raw.working_directory ?? process.cwd()
+      );
       dimensions.payloadBytes = payloadBytes;
       dimensions.inputStatus = 'ok';
       if (sessionId) traceId = hash(sessionId, 32);
@@ -373,15 +437,21 @@ export function beginHookInvocation(client, event, options = {}) {
       reason = nextReason;
     },
     noteOutput(output, outputBytes = null) {
-      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      dimensions.outputBytes =
+        outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
       if (!output || typeof output !== 'object' || Array.isArray(output)) {
         dimensions.outputShape = [];
         return;
       }
       const shape = Object.keys(output).sort();
       const hookSpecific = output.hookSpecificOutput;
-      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
-        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      if (
+        hookSpecific &&
+        typeof hookSpecific === 'object' &&
+        !Array.isArray(hookSpecific)
+      ) {
+        for (const key of Object.keys(hookSpecific).sort())
+          shape.push(`hookSpecificOutput.${key}`);
       }
       dimensions.outputShape = shape;
     },
@@ -442,7 +512,10 @@ export function readHookEvents({
       .reverse();
     const events = [];
     for (const file of files) {
-      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      const lines = readFileSync(file, 'utf8')
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .reverse();
       for (const line of lines) {
         try {
           const event = JSON.parse(line);
@@ -530,7 +603,9 @@ export function hookHealthSummary(options = {}) {
   for (const current of Object.values(byClient)) current.hookEvents.sort();
   const percentile = (p) =>
     durations.length
-      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      ? durations[
+          Math.min(durations.length - 1, Math.floor(durations.length * p))
+        ]
       : null;
   const summary = {
     schemaVersion: HOOK_LOG_SCHEMA_VERSION,

--- a/integrations/opencode/hooks/post-tool.mjs
+++ b/integrations/opencode/hooks/post-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/opencode/hooks/pre-tool.mjs
+++ b/integrations/opencode/hooks/pre-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/opencode/hooks/session-start.mjs
+++ b/integrations/opencode/hooks/session-start.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/qwen/hooks/lib/observability.mjs
+++ b/integrations/qwen/hooks/lib/observability.mjs
@@ -1,6 +1,5 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *
@@ -24,7 +23,8 @@ import {
 } from 'node:fs';
 import { createHash, randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export const HOOK_LOG_SCHEMA_VERSION = 2;
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
@@ -34,6 +34,75 @@ const DEFAULT_DEADLINE_MS = 4200;
 const MAX_ERROR_CHARS = 4000;
 const MAX_DIMENSION_CHARS = 160;
 let activeInvocation = null;
+
+/**
+ * Manifests that carry this package's version, nearest first.
+ *
+ * WHY THIS IS RESOLVED RATHER THAN COMPILED IN. The generators used to write the
+ * version into all 48 generated files, which made "generated output == committed
+ * file" an invariant that cannot survive a release: release-please bumps
+ * package.json without regenerating, so the release commit is born drifted and
+ * `publish-npm` -- which checks out the tag -- fails its drift gate. It has cost
+ * this project three releases (v5.4.0, v5.4.1, v5.7.1: all tagged, none on npm).
+ *
+ * The stamp is now applied at publish time only, so an npm install still reports
+ * an exact version from the env. Everything else resolves here instead of
+ * reporting a stale literal -- a lagging version is not a version, it is a wrong
+ * one, and this file exists to make failures correlatable.
+ *
+ * Inside the tarball the walk finds the package's own package.json; a plugin
+ * installed from the marketplace finds .claude-plugin/plugin.json, which
+ * release-please keeps correct. A bare copy into a client hook directory finds
+ * nothing and says 'unknown', which is what this reported before the stamp
+ * existed and is honest.
+ */
+const VERSION_MANIFESTS = [
+  ['package.json'],
+  ['.claude-plugin', 'plugin.json'],
+  ['.codex-plugin', 'plugin.json'],
+];
+const MAX_MANIFEST_DEPTH = 6;
+
+let cachedManifestVersion;
+
+function versionFromNearestManifest() {
+  if (cachedManifestVersion !== undefined) return cachedManifestVersion;
+  cachedManifestVersion = '';
+  try {
+    let dir = dirname(fileURLToPath(import.meta.url));
+    for (let depth = 0; depth < MAX_MANIFEST_DEPTH; depth++) {
+      for (const parts of VERSION_MANIFESTS) {
+        const candidate = join(dir, ...parts);
+        if (!existsSync(candidate)) continue;
+        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (typeof version === 'string' && version) {
+          cachedManifestVersion = version;
+          return cachedManifestVersion;
+        }
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // Diagnostics must never be the reason a hook fails.
+  }
+  return cachedManifestVersion;
+}
+
+/**
+ * The version this process reports. Env first so the publish-time stamp and any
+ * host that sets it still win; only the filesystem walk is cached, so the env
+ * stays authoritative for the life of the process.
+ */
+export function serviceVersion() {
+  return (
+    process.env.TOKEN_OPTIMIZER_VERSION ||
+    process.env.npm_package_version ||
+    versionFromNearestManifest() ||
+    'unknown'
+  );
+}
 
 function positiveInteger(name, fallback) {
   const value = Number(process.env[name]);
@@ -161,10 +230,7 @@ export function writeHookEvent(event) {
       schemaVersion: HOOK_LOG_SCHEMA_VERSION,
       timestamp: now.toISOString(),
       service: 'token-optimizer',
-      serviceVersion:
-        process.env.TOKEN_OPTIMIZER_VERSION ||
-        process.env.npm_package_version ||
-        'unknown',
+      serviceVersion: serviceVersion(),
       ...severity(event.level),
       body: event.event || 'hook.event',
       ...event,

--- a/integrations/qwen/hooks/lib/observability.mjs
+++ b/integrations/qwen/hooks/lib/observability.mjs
@@ -61,6 +61,20 @@ const VERSION_MANIFESTS = [
   ['.claude-plugin', 'plugin.json'],
   ['.codex-plugin', 'plugin.json'],
 ];
+
+/**
+ * The names that prove a manifest is OURS.
+ *
+ * FOUND IN REVIEW. Without this the walk reports the version of whatever
+ * package.json happens to sit above the hook, so a copy of these hooks
+ * vendored into someone else's repository would report that repository's
+ * version as the optimizer's -- a wrong version, which is the exact failure
+ * this file was changed to avoid. `npm_package_version` is ambient for the same
+ * reason: it belongs to whichever npm script is running, not necessarily to us.
+ */
+const PACKAGE_NAME = '@ooples/token-optimizer-mcp';
+const PLUGIN_NAME = 'token-optimizer';
+const OWNED_MANIFEST_NAMES = new Set([PACKAGE_NAME, PLUGIN_NAME]);
 const MAX_MANIFEST_DEPTH = 6;
 
 let cachedManifestVersion;
@@ -74,7 +88,8 @@ function versionFromNearestManifest() {
       for (const parts of VERSION_MANIFESTS) {
         const candidate = join(dir, ...parts);
         if (!existsSync(candidate)) continue;
-        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        const { name, version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (!OWNED_MANIFEST_NAMES.has(name)) continue;
         if (typeof version === 'string' && version) {
           cachedManifestVersion = version;
           return cachedManifestVersion;
@@ -98,7 +113,9 @@ function versionFromNearestManifest() {
 export function serviceVersion() {
   return (
     process.env.TOKEN_OPTIMIZER_VERSION ||
-    process.env.npm_package_version ||
+    (process.env.npm_package_name === PACKAGE_NAME
+      ? process.env.npm_package_version
+      : '') ||
     versionFromNearestManifest() ||
     'unknown'
   );
@@ -120,7 +137,10 @@ export function hookLogDirectory() {
 
 function hash(value, length = 16) {
   if (!value) return null;
-  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+  return createHash('sha256')
+    .update(String(value))
+    .digest('hex')
+    .slice(0, length);
 }
 
 function sanitize(text) {
@@ -129,9 +149,15 @@ function sanitize(text) {
   const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
   value = value
-    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(
+      /\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g,
+      '[REDACTED]'
+    )
     .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
-    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+    .replace(
+      /\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi,
+      '$1=[REDACTED]'
+    );
   return value.slice(0, MAX_ERROR_CHARS);
 }
 
@@ -163,7 +189,10 @@ function activeLogPath(now = new Date()) {
 function rotateIfNeeded(path) {
   try {
     if (!existsSync(path)) return;
-    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    const maxBytes = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_BYTES',
+      DEFAULT_MAX_BYTES
+    );
     if (statSync(path).size < maxBytes) return;
 
     const lock = join(hookLogDirectory(), '.rotate.lock');
@@ -184,7 +213,11 @@ function rotateIfNeeded(path) {
       }
     } finally {
       // Non-recursive removal of the one fixed-name lock directory only.
-      try { rmdirSync(lock); } catch { /* best effort */ }
+      try {
+        rmdirSync(lock);
+      } catch {
+        /* best effort */
+      }
     }
   } catch {
     // Diagnostics must never become the reason a lifecycle hook fails.
@@ -195,14 +228,26 @@ function pruneIfDue(now = new Date()) {
   try {
     const dir = hookLogDirectory();
     const marker = join(dir, '.last-prune');
-    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+    if (
+      existsSync(marker) &&
+      now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000
+    )
       return;
     writeFileSync(marker, now.toISOString(), { flag: 'w' });
 
     const retentionMs =
-      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
-      24 * 60 * 60 * 1000;
-    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+      positiveInteger(
+        'TOKEN_OPTIMIZER_LOG_RETENTION_DAYS',
+        DEFAULT_RETENTION_DAYS
+      ) *
+      24 *
+      60 *
+      60 *
+      1000;
+    const maxFiles = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_FILES',
+      DEFAULT_MAX_FILES
+    );
     const files = readdirSync(dir)
       .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
       .map((name) => {
@@ -292,7 +337,11 @@ export function beginHookInvocation(client, event, options = {}) {
   });
 
   let deadline;
-  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+  const finish = (
+    nextOutcome = outcome,
+    nextReason = reason,
+    nextError = error
+  ) => {
     if (ended) return;
     ended = true;
     if (deadline) clearTimeout(deadline);
@@ -300,7 +349,10 @@ export function beginHookInvocation(client, event, options = {}) {
     process.removeListener('uncaughtException', onUncaughtException);
     process.removeListener('unhandledRejection', onUnhandledRejection);
     writeHookEvent({
-      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      level:
+        nextOutcome === 'failure' || nextOutcome === 'timeout'
+          ? 'error'
+          : 'info',
       event: 'hook.completed',
       outcome: nextOutcome,
       reason: nextReason,
@@ -328,31 +380,43 @@ export function beginHookInvocation(client, event, options = {}) {
   process.once('uncaughtException', onUncaughtException);
   process.once('unhandledRejection', onUnhandledRejection);
 
-  deadline = setTimeout(() => {
-    outcome = 'timeout';
-    reason = 'internal_deadline_exceeded';
-    finish(outcome, reason);
-    // Beat the host's five-second timeout and fail open deterministically.
-    process.exit(0);
-  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline = setTimeout(
+    () => {
+      outcome = 'timeout';
+      reason = 'internal_deadline_exceeded';
+      finish(outcome, reason);
+      // Beat the host's five-second timeout and fail open deterministically.
+      process.exit(0);
+    },
+    options.deadlineMs ??
+      positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS)
+  );
   deadline.unref();
 
   const invocation = {
     invocationId,
     bind(raw = {}, payload = null, payloadBytes = null) {
-      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      const sessionId =
+        raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
       dimensions.sessionIdHash = hash(sessionId);
       dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
       dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
-      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.toolName =
+        payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
       dimensions.rawToolName = dimension(
         raw.tool_name ?? raw.toolName ?? raw.tool ?? null
       );
       dimensions.codeModeEnvelope =
         payload?.tool_input?.code_mode_envelope === true;
-      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
-      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
-      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.clientVersion = dimension(
+        raw.client_version ?? raw.clientVersion ?? null
+      );
+      dimensions.model = dimension(
+        raw.model ?? raw.model_name ?? raw.modelName ?? null
+      );
+      dimensions.cwdHash = hash(
+        raw.cwd ?? raw.working_directory ?? process.cwd()
+      );
       dimensions.payloadBytes = payloadBytes;
       dimensions.inputStatus = 'ok';
       if (sessionId) traceId = hash(sessionId, 32);
@@ -373,15 +437,21 @@ export function beginHookInvocation(client, event, options = {}) {
       reason = nextReason;
     },
     noteOutput(output, outputBytes = null) {
-      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      dimensions.outputBytes =
+        outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
       if (!output || typeof output !== 'object' || Array.isArray(output)) {
         dimensions.outputShape = [];
         return;
       }
       const shape = Object.keys(output).sort();
       const hookSpecific = output.hookSpecificOutput;
-      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
-        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      if (
+        hookSpecific &&
+        typeof hookSpecific === 'object' &&
+        !Array.isArray(hookSpecific)
+      ) {
+        for (const key of Object.keys(hookSpecific).sort())
+          shape.push(`hookSpecificOutput.${key}`);
       }
       dimensions.outputShape = shape;
     },
@@ -442,7 +512,10 @@ export function readHookEvents({
       .reverse();
     const events = [];
     for (const file of files) {
-      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      const lines = readFileSync(file, 'utf8')
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .reverse();
       for (const line of lines) {
         try {
           const event = JSON.parse(line);
@@ -530,7 +603,9 @@ export function hookHealthSummary(options = {}) {
   for (const current of Object.values(byClient)) current.hookEvents.sort();
   const percentile = (p) =>
     durations.length
-      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      ? durations[
+          Math.min(durations.length - 1, Math.floor(durations.length * p))
+        ]
       : null;
   const summary = {
     schemaVersion: HOOK_LOG_SCHEMA_VERSION,

--- a/integrations/qwen/hooks/post-tool.mjs
+++ b/integrations/qwen/hooks/post-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/qwen/hooks/pre-tool.mjs
+++ b/integrations/qwen/hooks/pre-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/qwen/hooks/session-start.mjs
+++ b/integrations/qwen/hooks/session-start.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/qwen/hooks/stop.mjs
+++ b/integrations/qwen/hooks/stop.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/windsurf/hooks/lib/observability.mjs
+++ b/integrations/windsurf/hooks/lib/observability.mjs
@@ -1,6 +1,5 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *
@@ -24,7 +23,8 @@ import {
 } from 'node:fs';
 import { createHash, randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export const HOOK_LOG_SCHEMA_VERSION = 2;
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
@@ -34,6 +34,75 @@ const DEFAULT_DEADLINE_MS = 4200;
 const MAX_ERROR_CHARS = 4000;
 const MAX_DIMENSION_CHARS = 160;
 let activeInvocation = null;
+
+/**
+ * Manifests that carry this package's version, nearest first.
+ *
+ * WHY THIS IS RESOLVED RATHER THAN COMPILED IN. The generators used to write the
+ * version into all 48 generated files, which made "generated output == committed
+ * file" an invariant that cannot survive a release: release-please bumps
+ * package.json without regenerating, so the release commit is born drifted and
+ * `publish-npm` -- which checks out the tag -- fails its drift gate. It has cost
+ * this project three releases (v5.4.0, v5.4.1, v5.7.1: all tagged, none on npm).
+ *
+ * The stamp is now applied at publish time only, so an npm install still reports
+ * an exact version from the env. Everything else resolves here instead of
+ * reporting a stale literal -- a lagging version is not a version, it is a wrong
+ * one, and this file exists to make failures correlatable.
+ *
+ * Inside the tarball the walk finds the package's own package.json; a plugin
+ * installed from the marketplace finds .claude-plugin/plugin.json, which
+ * release-please keeps correct. A bare copy into a client hook directory finds
+ * nothing and says 'unknown', which is what this reported before the stamp
+ * existed and is honest.
+ */
+const VERSION_MANIFESTS = [
+  ['package.json'],
+  ['.claude-plugin', 'plugin.json'],
+  ['.codex-plugin', 'plugin.json'],
+];
+const MAX_MANIFEST_DEPTH = 6;
+
+let cachedManifestVersion;
+
+function versionFromNearestManifest() {
+  if (cachedManifestVersion !== undefined) return cachedManifestVersion;
+  cachedManifestVersion = '';
+  try {
+    let dir = dirname(fileURLToPath(import.meta.url));
+    for (let depth = 0; depth < MAX_MANIFEST_DEPTH; depth++) {
+      for (const parts of VERSION_MANIFESTS) {
+        const candidate = join(dir, ...parts);
+        if (!existsSync(candidate)) continue;
+        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (typeof version === 'string' && version) {
+          cachedManifestVersion = version;
+          return cachedManifestVersion;
+        }
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // Diagnostics must never be the reason a hook fails.
+  }
+  return cachedManifestVersion;
+}
+
+/**
+ * The version this process reports. Env first so the publish-time stamp and any
+ * host that sets it still win; only the filesystem walk is cached, so the env
+ * stays authoritative for the life of the process.
+ */
+export function serviceVersion() {
+  return (
+    process.env.TOKEN_OPTIMIZER_VERSION ||
+    process.env.npm_package_version ||
+    versionFromNearestManifest() ||
+    'unknown'
+  );
+}
 
 function positiveInteger(name, fallback) {
   const value = Number(process.env[name]);
@@ -161,10 +230,7 @@ export function writeHookEvent(event) {
       schemaVersion: HOOK_LOG_SCHEMA_VERSION,
       timestamp: now.toISOString(),
       service: 'token-optimizer',
-      serviceVersion:
-        process.env.TOKEN_OPTIMIZER_VERSION ||
-        process.env.npm_package_version ||
-        'unknown',
+      serviceVersion: serviceVersion(),
       ...severity(event.level),
       body: event.event || 'hook.event',
       ...event,

--- a/integrations/windsurf/hooks/lib/observability.mjs
+++ b/integrations/windsurf/hooks/lib/observability.mjs
@@ -61,6 +61,20 @@ const VERSION_MANIFESTS = [
   ['.claude-plugin', 'plugin.json'],
   ['.codex-plugin', 'plugin.json'],
 ];
+
+/**
+ * The names that prove a manifest is OURS.
+ *
+ * FOUND IN REVIEW. Without this the walk reports the version of whatever
+ * package.json happens to sit above the hook, so a copy of these hooks
+ * vendored into someone else's repository would report that repository's
+ * version as the optimizer's -- a wrong version, which is the exact failure
+ * this file was changed to avoid. `npm_package_version` is ambient for the same
+ * reason: it belongs to whichever npm script is running, not necessarily to us.
+ */
+const PACKAGE_NAME = '@ooples/token-optimizer-mcp';
+const PLUGIN_NAME = 'token-optimizer';
+const OWNED_MANIFEST_NAMES = new Set([PACKAGE_NAME, PLUGIN_NAME]);
 const MAX_MANIFEST_DEPTH = 6;
 
 let cachedManifestVersion;
@@ -74,7 +88,8 @@ function versionFromNearestManifest() {
       for (const parts of VERSION_MANIFESTS) {
         const candidate = join(dir, ...parts);
         if (!existsSync(candidate)) continue;
-        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        const { name, version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (!OWNED_MANIFEST_NAMES.has(name)) continue;
         if (typeof version === 'string' && version) {
           cachedManifestVersion = version;
           return cachedManifestVersion;
@@ -98,7 +113,9 @@ function versionFromNearestManifest() {
 export function serviceVersion() {
   return (
     process.env.TOKEN_OPTIMIZER_VERSION ||
-    process.env.npm_package_version ||
+    (process.env.npm_package_name === PACKAGE_NAME
+      ? process.env.npm_package_version
+      : '') ||
     versionFromNearestManifest() ||
     'unknown'
   );
@@ -120,7 +137,10 @@ export function hookLogDirectory() {
 
 function hash(value, length = 16) {
   if (!value) return null;
-  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+  return createHash('sha256')
+    .update(String(value))
+    .digest('hex')
+    .slice(0, length);
 }
 
 function sanitize(text) {
@@ -129,9 +149,15 @@ function sanitize(text) {
   const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
   value = value
-    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(
+      /\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g,
+      '[REDACTED]'
+    )
     .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
-    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+    .replace(
+      /\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi,
+      '$1=[REDACTED]'
+    );
   return value.slice(0, MAX_ERROR_CHARS);
 }
 
@@ -163,7 +189,10 @@ function activeLogPath(now = new Date()) {
 function rotateIfNeeded(path) {
   try {
     if (!existsSync(path)) return;
-    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    const maxBytes = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_BYTES',
+      DEFAULT_MAX_BYTES
+    );
     if (statSync(path).size < maxBytes) return;
 
     const lock = join(hookLogDirectory(), '.rotate.lock');
@@ -184,7 +213,11 @@ function rotateIfNeeded(path) {
       }
     } finally {
       // Non-recursive removal of the one fixed-name lock directory only.
-      try { rmdirSync(lock); } catch { /* best effort */ }
+      try {
+        rmdirSync(lock);
+      } catch {
+        /* best effort */
+      }
     }
   } catch {
     // Diagnostics must never become the reason a lifecycle hook fails.
@@ -195,14 +228,26 @@ function pruneIfDue(now = new Date()) {
   try {
     const dir = hookLogDirectory();
     const marker = join(dir, '.last-prune');
-    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+    if (
+      existsSync(marker) &&
+      now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000
+    )
       return;
     writeFileSync(marker, now.toISOString(), { flag: 'w' });
 
     const retentionMs =
-      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
-      24 * 60 * 60 * 1000;
-    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+      positiveInteger(
+        'TOKEN_OPTIMIZER_LOG_RETENTION_DAYS',
+        DEFAULT_RETENTION_DAYS
+      ) *
+      24 *
+      60 *
+      60 *
+      1000;
+    const maxFiles = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_FILES',
+      DEFAULT_MAX_FILES
+    );
     const files = readdirSync(dir)
       .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
       .map((name) => {
@@ -292,7 +337,11 @@ export function beginHookInvocation(client, event, options = {}) {
   });
 
   let deadline;
-  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+  const finish = (
+    nextOutcome = outcome,
+    nextReason = reason,
+    nextError = error
+  ) => {
     if (ended) return;
     ended = true;
     if (deadline) clearTimeout(deadline);
@@ -300,7 +349,10 @@ export function beginHookInvocation(client, event, options = {}) {
     process.removeListener('uncaughtException', onUncaughtException);
     process.removeListener('unhandledRejection', onUnhandledRejection);
     writeHookEvent({
-      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      level:
+        nextOutcome === 'failure' || nextOutcome === 'timeout'
+          ? 'error'
+          : 'info',
       event: 'hook.completed',
       outcome: nextOutcome,
       reason: nextReason,
@@ -328,31 +380,43 @@ export function beginHookInvocation(client, event, options = {}) {
   process.once('uncaughtException', onUncaughtException);
   process.once('unhandledRejection', onUnhandledRejection);
 
-  deadline = setTimeout(() => {
-    outcome = 'timeout';
-    reason = 'internal_deadline_exceeded';
-    finish(outcome, reason);
-    // Beat the host's five-second timeout and fail open deterministically.
-    process.exit(0);
-  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline = setTimeout(
+    () => {
+      outcome = 'timeout';
+      reason = 'internal_deadline_exceeded';
+      finish(outcome, reason);
+      // Beat the host's five-second timeout and fail open deterministically.
+      process.exit(0);
+    },
+    options.deadlineMs ??
+      positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS)
+  );
   deadline.unref();
 
   const invocation = {
     invocationId,
     bind(raw = {}, payload = null, payloadBytes = null) {
-      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      const sessionId =
+        raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
       dimensions.sessionIdHash = hash(sessionId);
       dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
       dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
-      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.toolName =
+        payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
       dimensions.rawToolName = dimension(
         raw.tool_name ?? raw.toolName ?? raw.tool ?? null
       );
       dimensions.codeModeEnvelope =
         payload?.tool_input?.code_mode_envelope === true;
-      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
-      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
-      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.clientVersion = dimension(
+        raw.client_version ?? raw.clientVersion ?? null
+      );
+      dimensions.model = dimension(
+        raw.model ?? raw.model_name ?? raw.modelName ?? null
+      );
+      dimensions.cwdHash = hash(
+        raw.cwd ?? raw.working_directory ?? process.cwd()
+      );
       dimensions.payloadBytes = payloadBytes;
       dimensions.inputStatus = 'ok';
       if (sessionId) traceId = hash(sessionId, 32);
@@ -373,15 +437,21 @@ export function beginHookInvocation(client, event, options = {}) {
       reason = nextReason;
     },
     noteOutput(output, outputBytes = null) {
-      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      dimensions.outputBytes =
+        outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
       if (!output || typeof output !== 'object' || Array.isArray(output)) {
         dimensions.outputShape = [];
         return;
       }
       const shape = Object.keys(output).sort();
       const hookSpecific = output.hookSpecificOutput;
-      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
-        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      if (
+        hookSpecific &&
+        typeof hookSpecific === 'object' &&
+        !Array.isArray(hookSpecific)
+      ) {
+        for (const key of Object.keys(hookSpecific).sort())
+          shape.push(`hookSpecificOutput.${key}`);
       }
       dimensions.outputShape = shape;
     },
@@ -442,7 +512,10 @@ export function readHookEvents({
       .reverse();
     const events = [];
     for (const file of files) {
-      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      const lines = readFileSync(file, 'utf8')
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .reverse();
       for (const line of lines) {
         try {
           const event = JSON.parse(line);
@@ -530,7 +603,9 @@ export function hookHealthSummary(options = {}) {
   for (const current of Object.values(byClient)) current.hookEvents.sort();
   const percentile = (p) =>
     durations.length
-      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      ? durations[
+          Math.min(durations.length - 1, Math.floor(durations.length * p))
+        ]
       : null;
   const summary = {
     schemaVersion: HOOK_LOG_SCHEMA_VERSION,

--- a/integrations/windsurf/hooks/post-tool.mjs
+++ b/integrations/windsurf/hooks/post-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/windsurf/hooks/pre-tool.mjs
+++ b/integrations/windsurf/hooks/pre-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "validate": "node scripts/validate-package.js",
     "sync:hooks": "node scripts/sync-hook-core.mjs && node scripts/generate-client-entries.mjs && node scripts/generate-client-configs.mjs && node scripts/pin-mcp-version.mjs",
     "sync:hooks:check": "node scripts/sync-hook-core.mjs --check && node scripts/generate-client-entries.mjs --check && node scripts/generate-client-configs.mjs --check && node scripts/pin-mcp-version.mjs --check",
+    "stamp:version": "node scripts/sync-hook-core.mjs --stamp && node scripts/generate-client-entries.mjs --stamp",
     "verify:ui": "node scripts/verify-wiki-ui.mjs",
     "verify:harvest": "node scripts/verify-harvest-api.mjs",
     "verify:live-graph": "node scripts/verify-live-graph-flow.mjs",

--- a/plugin/hooks/lib/observability.mjs
+++ b/plugin/hooks/lib/observability.mjs
@@ -1,6 +1,5 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *
@@ -24,7 +23,8 @@ import {
 } from 'node:fs';
 import { createHash, randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export const HOOK_LOG_SCHEMA_VERSION = 2;
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
@@ -34,6 +34,75 @@ const DEFAULT_DEADLINE_MS = 4200;
 const MAX_ERROR_CHARS = 4000;
 const MAX_DIMENSION_CHARS = 160;
 let activeInvocation = null;
+
+/**
+ * Manifests that carry this package's version, nearest first.
+ *
+ * WHY THIS IS RESOLVED RATHER THAN COMPILED IN. The generators used to write the
+ * version into all 48 generated files, which made "generated output == committed
+ * file" an invariant that cannot survive a release: release-please bumps
+ * package.json without regenerating, so the release commit is born drifted and
+ * `publish-npm` -- which checks out the tag -- fails its drift gate. It has cost
+ * this project three releases (v5.4.0, v5.4.1, v5.7.1: all tagged, none on npm).
+ *
+ * The stamp is now applied at publish time only, so an npm install still reports
+ * an exact version from the env. Everything else resolves here instead of
+ * reporting a stale literal -- a lagging version is not a version, it is a wrong
+ * one, and this file exists to make failures correlatable.
+ *
+ * Inside the tarball the walk finds the package's own package.json; a plugin
+ * installed from the marketplace finds .claude-plugin/plugin.json, which
+ * release-please keeps correct. A bare copy into a client hook directory finds
+ * nothing and says 'unknown', which is what this reported before the stamp
+ * existed and is honest.
+ */
+const VERSION_MANIFESTS = [
+  ['package.json'],
+  ['.claude-plugin', 'plugin.json'],
+  ['.codex-plugin', 'plugin.json'],
+];
+const MAX_MANIFEST_DEPTH = 6;
+
+let cachedManifestVersion;
+
+function versionFromNearestManifest() {
+  if (cachedManifestVersion !== undefined) return cachedManifestVersion;
+  cachedManifestVersion = '';
+  try {
+    let dir = dirname(fileURLToPath(import.meta.url));
+    for (let depth = 0; depth < MAX_MANIFEST_DEPTH; depth++) {
+      for (const parts of VERSION_MANIFESTS) {
+        const candidate = join(dir, ...parts);
+        if (!existsSync(candidate)) continue;
+        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (typeof version === 'string' && version) {
+          cachedManifestVersion = version;
+          return cachedManifestVersion;
+        }
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // Diagnostics must never be the reason a hook fails.
+  }
+  return cachedManifestVersion;
+}
+
+/**
+ * The version this process reports. Env first so the publish-time stamp and any
+ * host that sets it still win; only the filesystem walk is cached, so the env
+ * stays authoritative for the life of the process.
+ */
+export function serviceVersion() {
+  return (
+    process.env.TOKEN_OPTIMIZER_VERSION ||
+    process.env.npm_package_version ||
+    versionFromNearestManifest() ||
+    'unknown'
+  );
+}
 
 function positiveInteger(name, fallback) {
   const value = Number(process.env[name]);
@@ -161,10 +230,7 @@ export function writeHookEvent(event) {
       schemaVersion: HOOK_LOG_SCHEMA_VERSION,
       timestamp: now.toISOString(),
       service: 'token-optimizer',
-      serviceVersion:
-        process.env.TOKEN_OPTIMIZER_VERSION ||
-        process.env.npm_package_version ||
-        'unknown',
+      serviceVersion: serviceVersion(),
       ...severity(event.level),
       body: event.event || 'hook.event',
       ...event,

--- a/plugin/hooks/lib/observability.mjs
+++ b/plugin/hooks/lib/observability.mjs
@@ -61,6 +61,20 @@ const VERSION_MANIFESTS = [
   ['.claude-plugin', 'plugin.json'],
   ['.codex-plugin', 'plugin.json'],
 ];
+
+/**
+ * The names that prove a manifest is OURS.
+ *
+ * FOUND IN REVIEW. Without this the walk reports the version of whatever
+ * package.json happens to sit above the hook, so a copy of these hooks
+ * vendored into someone else's repository would report that repository's
+ * version as the optimizer's -- a wrong version, which is the exact failure
+ * this file was changed to avoid. `npm_package_version` is ambient for the same
+ * reason: it belongs to whichever npm script is running, not necessarily to us.
+ */
+const PACKAGE_NAME = '@ooples/token-optimizer-mcp';
+const PLUGIN_NAME = 'token-optimizer';
+const OWNED_MANIFEST_NAMES = new Set([PACKAGE_NAME, PLUGIN_NAME]);
 const MAX_MANIFEST_DEPTH = 6;
 
 let cachedManifestVersion;
@@ -74,7 +88,8 @@ function versionFromNearestManifest() {
       for (const parts of VERSION_MANIFESTS) {
         const candidate = join(dir, ...parts);
         if (!existsSync(candidate)) continue;
-        const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        const { name, version } = JSON.parse(readFileSync(candidate, 'utf8'));
+        if (!OWNED_MANIFEST_NAMES.has(name)) continue;
         if (typeof version === 'string' && version) {
           cachedManifestVersion = version;
           return cachedManifestVersion;
@@ -98,7 +113,9 @@ function versionFromNearestManifest() {
 export function serviceVersion() {
   return (
     process.env.TOKEN_OPTIMIZER_VERSION ||
-    process.env.npm_package_version ||
+    (process.env.npm_package_name === PACKAGE_NAME
+      ? process.env.npm_package_version
+      : '') ||
     versionFromNearestManifest() ||
     'unknown'
   );
@@ -120,7 +137,10 @@ export function hookLogDirectory() {
 
 function hash(value, length = 16) {
   if (!value) return null;
-  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+  return createHash('sha256')
+    .update(String(value))
+    .digest('hex')
+    .slice(0, length);
 }
 
 function sanitize(text) {
@@ -129,9 +149,15 @@ function sanitize(text) {
   const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
   value = value
-    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(
+      /\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g,
+      '[REDACTED]'
+    )
     .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
-    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+    .replace(
+      /\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi,
+      '$1=[REDACTED]'
+    );
   return value.slice(0, MAX_ERROR_CHARS);
 }
 
@@ -163,7 +189,10 @@ function activeLogPath(now = new Date()) {
 function rotateIfNeeded(path) {
   try {
     if (!existsSync(path)) return;
-    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    const maxBytes = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_BYTES',
+      DEFAULT_MAX_BYTES
+    );
     if (statSync(path).size < maxBytes) return;
 
     const lock = join(hookLogDirectory(), '.rotate.lock');
@@ -184,7 +213,11 @@ function rotateIfNeeded(path) {
       }
     } finally {
       // Non-recursive removal of the one fixed-name lock directory only.
-      try { rmdirSync(lock); } catch { /* best effort */ }
+      try {
+        rmdirSync(lock);
+      } catch {
+        /* best effort */
+      }
     }
   } catch {
     // Diagnostics must never become the reason a lifecycle hook fails.
@@ -195,14 +228,26 @@ function pruneIfDue(now = new Date()) {
   try {
     const dir = hookLogDirectory();
     const marker = join(dir, '.last-prune');
-    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+    if (
+      existsSync(marker) &&
+      now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000
+    )
       return;
     writeFileSync(marker, now.toISOString(), { flag: 'w' });
 
     const retentionMs =
-      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
-      24 * 60 * 60 * 1000;
-    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+      positiveInteger(
+        'TOKEN_OPTIMIZER_LOG_RETENTION_DAYS',
+        DEFAULT_RETENTION_DAYS
+      ) *
+      24 *
+      60 *
+      60 *
+      1000;
+    const maxFiles = positiveInteger(
+      'TOKEN_OPTIMIZER_LOG_MAX_FILES',
+      DEFAULT_MAX_FILES
+    );
     const files = readdirSync(dir)
       .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
       .map((name) => {
@@ -292,7 +337,11 @@ export function beginHookInvocation(client, event, options = {}) {
   });
 
   let deadline;
-  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+  const finish = (
+    nextOutcome = outcome,
+    nextReason = reason,
+    nextError = error
+  ) => {
     if (ended) return;
     ended = true;
     if (deadline) clearTimeout(deadline);
@@ -300,7 +349,10 @@ export function beginHookInvocation(client, event, options = {}) {
     process.removeListener('uncaughtException', onUncaughtException);
     process.removeListener('unhandledRejection', onUnhandledRejection);
     writeHookEvent({
-      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      level:
+        nextOutcome === 'failure' || nextOutcome === 'timeout'
+          ? 'error'
+          : 'info',
       event: 'hook.completed',
       outcome: nextOutcome,
       reason: nextReason,
@@ -328,31 +380,43 @@ export function beginHookInvocation(client, event, options = {}) {
   process.once('uncaughtException', onUncaughtException);
   process.once('unhandledRejection', onUnhandledRejection);
 
-  deadline = setTimeout(() => {
-    outcome = 'timeout';
-    reason = 'internal_deadline_exceeded';
-    finish(outcome, reason);
-    // Beat the host's five-second timeout and fail open deterministically.
-    process.exit(0);
-  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline = setTimeout(
+    () => {
+      outcome = 'timeout';
+      reason = 'internal_deadline_exceeded';
+      finish(outcome, reason);
+      // Beat the host's five-second timeout and fail open deterministically.
+      process.exit(0);
+    },
+    options.deadlineMs ??
+      positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS)
+  );
   deadline.unref();
 
   const invocation = {
     invocationId,
     bind(raw = {}, payload = null, payloadBytes = null) {
-      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      const sessionId =
+        raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
       dimensions.sessionIdHash = hash(sessionId);
       dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
       dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
-      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.toolName =
+        payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
       dimensions.rawToolName = dimension(
         raw.tool_name ?? raw.toolName ?? raw.tool ?? null
       );
       dimensions.codeModeEnvelope =
         payload?.tool_input?.code_mode_envelope === true;
-      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
-      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
-      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.clientVersion = dimension(
+        raw.client_version ?? raw.clientVersion ?? null
+      );
+      dimensions.model = dimension(
+        raw.model ?? raw.model_name ?? raw.modelName ?? null
+      );
+      dimensions.cwdHash = hash(
+        raw.cwd ?? raw.working_directory ?? process.cwd()
+      );
       dimensions.payloadBytes = payloadBytes;
       dimensions.inputStatus = 'ok';
       if (sessionId) traceId = hash(sessionId, 32);
@@ -373,15 +437,21 @@ export function beginHookInvocation(client, event, options = {}) {
       reason = nextReason;
     },
     noteOutput(output, outputBytes = null) {
-      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      dimensions.outputBytes =
+        outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
       if (!output || typeof output !== 'object' || Array.isArray(output)) {
         dimensions.outputShape = [];
         return;
       }
       const shape = Object.keys(output).sort();
       const hookSpecific = output.hookSpecificOutput;
-      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
-        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      if (
+        hookSpecific &&
+        typeof hookSpecific === 'object' &&
+        !Array.isArray(hookSpecific)
+      ) {
+        for (const key of Object.keys(hookSpecific).sort())
+          shape.push(`hookSpecificOutput.${key}`);
       }
       dimensions.outputShape = shape;
     },
@@ -442,7 +512,10 @@ export function readHookEvents({
       .reverse();
     const events = [];
     for (const file of files) {
-      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      const lines = readFileSync(file, 'utf8')
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .reverse();
       for (const line of lines) {
         try {
           const event = JSON.parse(line);
@@ -530,7 +603,9 @@ export function hookHealthSummary(options = {}) {
   for (const current of Object.values(byClient)) current.hookEvents.sort();
   const percentile = (p) =>
     durations.length
-      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      ? durations[
+          Math.min(durations.length - 1, Math.floor(durations.length * p))
+        ]
       : null;
   const summary = {
     schemaVersion: HOOK_LOG_SCHEMA_VERSION,

--- a/plugin/hooks/post-tool.mjs
+++ b/plugin/hooks/post-tool.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/plugin/hooks/stop.mjs
+++ b/plugin/hooks/stop.mjs
@@ -4,7 +4,6 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/scripts/generate-client-entries.mjs
+++ b/scripts/generate-client-entries.mjs
@@ -68,6 +68,18 @@ const ENTRIES = [
 // though `sync:hooks` would have overwritten it -- exactly the drift the check
 // exists to prevent, just one level up.
 const check = process.argv.includes('--check');
+
+/**
+ * Publish-time only, for the reason spelled out in scripts/sync-hook-core.mjs:
+ * a committed version literal cannot survive a release commit, and the drift it
+ * guarantees fails `publish-npm` at the tag. Thirty-seven entry files carried
+ * one, which is why the surface was never going to be fixable by listing the
+ * files somewhere.
+ */
+const stamp = process.argv.includes('--stamp');
+const versionStamp = stamp
+  ? `process.env.TOKEN_OPTIMIZER_VERSION = '${PACKAGE_VERSION}';\n`
+  : '';
 let drifted = 0;
 
 for (const [dir, client, event, name] of ENTRIES) {
@@ -80,8 +92,7 @@ for (const [dir, client, event, name] of ENTRIES) {
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '${PACKAGE_VERSION}';
-// These entry points ship beside an MCP declaration for this same package. Hosts
+${versionStamp}// These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
 process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= '${BUNDLED_MCP_CAPABILITIES}';

--- a/scripts/sync-hook-core.mjs
+++ b/scripts/sync-hook-core.mjs
@@ -43,12 +43,33 @@ const TARGETS = [
 ];
 
 const check = process.argv.includes('--check');
+
+/**
+ * Publish-time only. The version is NOT committed into the generated copies.
+ *
+ * A version literal in a generated-and-committed file makes the invariant
+ * "generated output == committed file" one that CANNOT hold across a release:
+ * release-please bumps package.json without regenerating, so every release
+ * commit is born drifted and `sync:hooks:check` fails inside `publish-npm` --
+ * which checks out the tag, so a later repair on master cannot rescue it.
+ *
+ * This repository has now paid for that invariant three times: v5.4.0 and
+ * v5.4.1 were tagged with GitHub Releases and neither reached npm, and v5.7.1
+ * repeated it after the stamp was reintroduced here. scripts/pin-mcp-version.mjs
+ * and scripts/generate-client-configs.mjs both carry the post-mortem, and both
+ * name the remedy: pin at publish time only, so the tarball carries an exact
+ * version while git carries none. Nothing in git can then go stale.
+ *
+ * `npm run stamp:version` applies it, and release.yml runs that after the drift
+ * check and before the tarball is built.
+ */
+const stamp = process.argv.includes('--stamp');
 const files = readdirSync(SOURCE).filter((f) => f.endsWith('.mjs'));
 
 const banner = (name) =>
   `// GENERATED FILE -- do not edit.\n` +
   `// Source of truth: hooks-core/${name}. Regenerate with \`npm run sync:hooks\`.\n` +
-  (name === 'observability.mjs'
+  (stamp && name === 'observability.mjs'
     ? `process.env.TOKEN_OPTIMIZER_VERSION = '${PACKAGE_VERSION}';\n`
     : '');
 

--- a/tests/hooks/observability.test.mjs
+++ b/tests/hooks/observability.test.mjs
@@ -15,6 +15,28 @@ const ROOT = process.cwd();
 const PACKAGE_VERSION = JSON.parse(
   readFileSync(join(ROOT, 'package.json'), 'utf8')
 ).version;
+
+/**
+ * A child environment WITHOUT the injected version.
+ *
+ * The generated entry files used to open with an unconditional
+ * `process.env.TOKEN_OPTIMIZER_VERSION = '<version>'`, so a spawned hook
+ * reported the package version whatever it inherited. That literal is applied
+ * at publish time only now: a version committed into a generated file makes
+ * "generated output == committed file" an invariant that cannot survive a
+ * release commit, and the drift it guarantees has cost this project three
+ * releases (v5.4.0, v5.4.1, v5.7.1 -- all tagged, none on npm).
+ *
+ * Unsetting it keeps the assertion below identical and makes it stronger: the
+ * child now has to resolve its own version from the nearest manifest, which is
+ * exactly what a marketplace plugin install does.
+ */
+function childEnv(extra) {
+  const env = { ...process.env, ...extra };
+  delete env.TOKEN_OPTIMIZER_VERSION;
+  return env;
+}
+
 let workspace;
 let previous;
 
@@ -227,10 +249,7 @@ describe('cross-client hook observability', () => {
       [join(ROOT, 'plugin', 'hooks', 'pretooluse-router.mjs')],
       {
         cwd: workspace,
-        env: {
-          ...process.env,
-          TOKEN_OPTIMIZER_LOG_DIR: join(workspace, 'claude-logs'),
-        },
+        env: childEnv({ TOKEN_OPTIMIZER_LOG_DIR: join(workspace, 'claude-logs') }),
         stdio: ['pipe', 'pipe', 'pipe'],
       }
     );
@@ -271,10 +290,7 @@ describe('cross-client hook observability', () => {
         const logDirectory = join(workspace, `${client}-logs`);
         const child = spawn(process.execPath, [join(ROOT, ...entryParts)], {
           cwd: workspace,
-          env: {
-            ...process.env,
-            TOKEN_OPTIMIZER_LOG_DIR: logDirectory,
-          },
+          env: childEnv({ TOKEN_OPTIMIZER_LOG_DIR: logDirectory }),
           stdio: ['pipe', 'pipe', 'pipe'],
         });
         child.stdin.end(

--- a/tests/hooks/version-stamp-is-publish-time-only.test.mjs
+++ b/tests/hooks/version-stamp-is-publish-time-only.test.mjs
@@ -1,0 +1,233 @@
+/**
+ * The package version is stamped at publish time and never committed.
+ *
+ * WHY THIS IS A GUARD AND NOT A PREFERENCE. A version literal written into a
+ * generated-and-committed file makes "generated output == committed file" an
+ * invariant that CANNOT hold across a release: release-please bumps
+ * package.json without regenerating, so the release commit is born drifted.
+ * `publish-npm` then fails its drift gate -- and because that job checks out the
+ * TAG, no repair on master can rescue the release that is already cut.
+ *
+ * This repository has paid for that invariant three times. v5.4.0 and v5.4.1
+ * were tagged with GitHub Releases and neither reached npm; the post-mortem is
+ * written into scripts/pin-mcp-version.mjs and scripts/generate-client-configs.mjs,
+ * which removed the version from nine configs and named the remedy: pin at
+ * publish time only, so the tarball carries an exact version while git carries
+ * none. The stamp was then reintroduced by a different generator, into 48 files,
+ * and v5.7.1 was tagged and never reached npm either.
+ *
+ * So the rule is asserted rather than remembered.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from '@jest/globals';
+import { spawnSync } from 'node:child_process';
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { serviceVersion } from '../../hooks-core/observability.mjs';
+
+const ROOT = process.cwd();
+const GENERATED_DIRS = ['plugin', 'integrations'];
+const STAMP = /TOKEN_OPTIMIZER_VERSION = '/;
+const SKIP = new Set(['node_modules', 'dist', '.git']);
+
+/**
+ * Every generated .mjs under `dir`, INCLUDING the `lib` directories.
+ *
+ * `walk` in tests/fixtures/source-scan.mjs deliberately skips `lib`, because for
+ * a reachability scan the vendored copies would make every function look used by
+ * its own duplicate. Reusing it here made this scan vacuous: `lib` is exactly
+ * where the eleven vendored observability.mjs copies live, so the check that was
+ * meant to catch a reintroduced stamp could never see one. Caught by mutation.
+ */
+function generatedFiles(dir, out = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (!SKIP.has(entry)) generatedFiles(full, out);
+    } else if (entry.endsWith('.mjs')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// A version that exists nowhere else, so a stamp found in the output can only
+// have come from the package.json this fixture controls.
+const FIXTURE_VERSION = '9.9.9-fixture';
+
+let sandbox;
+
+/** A minimal ROOT the generators can run against without touching the repo. */
+beforeAll(() => {
+  sandbox = mkdtempSync(join(tmpdir(), 'version-stamp-'));
+  mkdirSync(join(sandbox, 'scripts'), { recursive: true });
+  cpSync(join(ROOT, 'scripts', 'lib'), join(sandbox, 'scripts', 'lib'), { recursive: true });
+  cpSync(join(ROOT, 'hooks-core'), join(sandbox, 'hooks-core'), { recursive: true });
+  for (const script of ['sync-hook-core.mjs', 'generate-client-entries.mjs']) {
+    cpSync(join(ROOT, 'scripts', script), join(sandbox, 'scripts', script));
+  }
+  writeFileSync(
+    join(sandbox, 'package.json'),
+    JSON.stringify({ name: 'fixture', version: FIXTURE_VERSION })
+  );
+});
+
+afterAll(() => {
+  try {
+    rmSync(sandbox, { recursive: true, force: true });
+  } catch {
+    /* windows can hold a handle briefly */
+  }
+});
+
+function generate(script, ...flags) {
+  const result = spawnSync(process.execPath, [join(sandbox, 'scripts', script), ...flags], {
+    encoding: 'utf8',
+    timeout: 60_000,
+  });
+  expect([script, result.status]).toEqual([script, 0]);
+  return result;
+}
+
+const sandboxFile = (...parts) => readFileSync(join(sandbox, ...parts), 'utf8');
+
+describe('generated output carries no version by default', () => {
+  test('the vendored core is version-free even when package.json has one', () => {
+    generate('sync-hook-core.mjs');
+    // The fixture package.json says 9.9.9-fixture. If the generator reads it into
+    // the output at all, this fails.
+    expect(sandboxFile('plugin', 'hooks', 'lib', 'observability.mjs')).not.toMatch(STAMP);
+  });
+
+  test('the client entry points are version-free too', () => {
+    generate('generate-client-entries.mjs');
+    expect(sandboxFile('plugin', 'hooks', 'stop.mjs')).not.toMatch(STAMP);
+  });
+
+  test('no committed generated file carries a version literal', () => {
+    // The repository-wide form of the same rule: it is the committed files that
+    // the release commit strands, so they are what must stay clean.
+    const offenders = [];
+    for (const dir of GENERATED_DIRS) {
+      for (const file of generatedFiles(join(ROOT, dir))) {
+        if (STAMP.test(readFileSync(file, 'utf8'))) offenders.push(file.slice(ROOT.length + 1));
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('the publish-time stamp is real', () => {
+  // The defect class this repository keeps producing is correct code that
+  // nothing calls, so the flag is exercised rather than assumed to work.
+  test('--stamp writes the exact version into the vendored core', () => {
+    generate('sync-hook-core.mjs', '--stamp');
+    expect(sandboxFile('plugin', 'hooks', 'lib', 'observability.mjs')).toContain(
+      `TOKEN_OPTIMIZER_VERSION = '${FIXTURE_VERSION}'`
+    );
+  });
+
+  test('--stamp writes it into every client entry point', () => {
+    generate('generate-client-entries.mjs', '--stamp');
+    expect(sandboxFile('plugin', 'hooks', 'stop.mjs')).toContain(
+      `TOKEN_OPTIMIZER_VERSION = '${FIXTURE_VERSION}'`
+    );
+  });
+
+  test('npm run stamp:version applies both generators', () => {
+    const { scripts } = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
+    expect(scripts['stamp:version']).toContain('sync-hook-core.mjs --stamp');
+    expect(scripts['stamp:version']).toContain('generate-client-entries.mjs --stamp');
+  });
+});
+
+describe('the release workflow applies it, in the only window that works', () => {
+  const workflow = () => readFileSync(join(ROOT, '.github', 'workflows', 'release.yml'), 'utf8');
+
+  test('publish-npm runs the stamp', () => {
+    expect(workflow()).toContain('npm run stamp:version');
+  });
+
+  test('after the drift check, so the check sees the committed tree', () => {
+    const text = workflow();
+    // Without this, a MISSING step passes every ordering test: indexOf returns
+    // -1, and -1 is less than every real index. Caught by mutation.
+    expect(text).toContain('npm run stamp:version');
+    expect(text.indexOf('npm run sync:hooks:check')).toBeLessThan(
+      text.indexOf('npm run stamp:version')
+    );
+  });
+
+  test('before the checksums, which hash exactly what ships', () => {
+    // A stamp applied after this point would ship files the checksums disown.
+    const text = workflow();
+    // Without this, a MISSING step passes every ordering test: indexOf returns
+    // -1, and -1 is less than every real index. Caught by mutation.
+    expect(text).toContain('npm run stamp:version');
+    expect(text.indexOf('npm run stamp:version')).toBeLessThan(
+      text.indexOf('scripts/checksums.mjs')
+    );
+  });
+
+  test('and before the publish itself', () => {
+    const text = workflow();
+    // Without this, a MISSING step passes every ordering test: indexOf returns
+    // -1, and -1 is less than every real index. Caught by mutation.
+    expect(text).toContain('npm run stamp:version');
+    expect(text.indexOf('npm run stamp:version')).toBeLessThan(text.indexOf('npm publish'));
+  });
+});
+
+describe('removing the stamp did not cost the version', () => {
+  // The stamp was added to make dashboard evidence carry a real version, and
+  // taking it out of git must not quietly regress that to 'unknown'. Inside the
+  // tarball the walk finds the package's own package.json; a marketplace plugin
+  // install finds .claude-plugin/plugin.json, which release-please keeps correct.
+  const withEnv = (values, body) => {
+    const saved = {
+      TOKEN_OPTIMIZER_VERSION: process.env.TOKEN_OPTIMIZER_VERSION,
+      npm_package_version: process.env.npm_package_version,
+    };
+    for (const [key, value] of Object.entries(values)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    try {
+      body();
+    } finally {
+      for (const [key, value] of Object.entries(saved)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  };
+
+  test('resolves from the nearest manifest when nothing is stamped', () => {
+    withEnv({ TOKEN_OPTIMIZER_VERSION: undefined, npm_package_version: undefined }, () => {
+      const { version } = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
+      expect(serviceVersion()).toBe(version);
+    });
+  });
+
+  test('the publish-time stamp still wins when present', () => {
+    withEnv({ TOKEN_OPTIMIZER_VERSION: 'stamped-1.2.3' }, () => {
+      expect(serviceVersion()).toBe('stamped-1.2.3');
+    });
+  });
+});

--- a/tests/hooks/version-stamp-is-publish-time-only.test.mjs
+++ b/tests/hooks/version-stamp-is-publish-time-only.test.mjs
@@ -33,11 +33,20 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { pathToFileURL } from 'node:url';
 import { serviceVersion } from '../../hooks-core/observability.mjs';
 
 const ROOT = process.cwd();
 const GENERATED_DIRS = ['plugin', 'integrations'];
-const STAMP = /TOKEN_OPTIMIZER_VERSION = '/;
+/**
+ * Any assignment of a version literal, in any spacing or quote style.
+ *
+ * FOUND IN REVIEW: this matched one exact spelling, so a reintroduced stamp
+ * written as TOKEN_OPTIMIZER_VERSION="1.2.3" would have walked past all three
+ * no-stamp assertions. A guard that only catches the formatting of the bug it
+ * was written for is not a guard.
+ */
+const STAMP = /TOKEN_OPTIMIZER_VERSION\s*=\s*['"`]/;
 const SKIP = new Set(['node_modules', 'dist', '.git']);
 
 /**
@@ -77,8 +86,12 @@ let sandbox;
 beforeAll(() => {
   sandbox = mkdtempSync(join(tmpdir(), 'version-stamp-'));
   mkdirSync(join(sandbox, 'scripts'), { recursive: true });
-  cpSync(join(ROOT, 'scripts', 'lib'), join(sandbox, 'scripts', 'lib'), { recursive: true });
-  cpSync(join(ROOT, 'hooks-core'), join(sandbox, 'hooks-core'), { recursive: true });
+  cpSync(join(ROOT, 'scripts', 'lib'), join(sandbox, 'scripts', 'lib'), {
+    recursive: true,
+  });
+  cpSync(join(ROOT, 'hooks-core'), join(sandbox, 'hooks-core'), {
+    recursive: true,
+  });
   for (const script of ['sync-hook-core.mjs', 'generate-client-entries.mjs']) {
     cpSync(join(ROOT, 'scripts', script), join(sandbox, 'scripts', script));
   }
@@ -97,10 +110,14 @@ afterAll(() => {
 });
 
 function generate(script, ...flags) {
-  const result = spawnSync(process.execPath, [join(sandbox, 'scripts', script), ...flags], {
-    encoding: 'utf8',
-    timeout: 60_000,
-  });
+  const result = spawnSync(
+    process.execPath,
+    [join(sandbox, 'scripts', script), ...flags],
+    {
+      encoding: 'utf8',
+      timeout: 60_000,
+    }
+  );
   expect([script, result.status]).toEqual([script, 0]);
   return result;
 }
@@ -112,7 +129,9 @@ describe('generated output carries no version by default', () => {
     generate('sync-hook-core.mjs');
     // The fixture package.json says 9.9.9-fixture. If the generator reads it into
     // the output at all, this fails.
-    expect(sandboxFile('plugin', 'hooks', 'lib', 'observability.mjs')).not.toMatch(STAMP);
+    expect(
+      sandboxFile('plugin', 'hooks', 'lib', 'observability.mjs')
+    ).not.toMatch(STAMP);
   });
 
   test('the client entry points are version-free too', () => {
@@ -126,7 +145,8 @@ describe('generated output carries no version by default', () => {
     const offenders = [];
     for (const dir of GENERATED_DIRS) {
       for (const file of generatedFiles(join(ROOT, dir))) {
-        if (STAMP.test(readFileSync(file, 'utf8'))) offenders.push(file.slice(ROOT.length + 1));
+        if (STAMP.test(readFileSync(file, 'utf8')))
+          offenders.push(file.slice(ROOT.length + 1));
       }
     }
     expect(offenders).toEqual([]);
@@ -138,9 +158,9 @@ describe('the publish-time stamp is real', () => {
   // nothing calls, so the flag is exercised rather than assumed to work.
   test('--stamp writes the exact version into the vendored core', () => {
     generate('sync-hook-core.mjs', '--stamp');
-    expect(sandboxFile('plugin', 'hooks', 'lib', 'observability.mjs')).toContain(
-      `TOKEN_OPTIMIZER_VERSION = '${FIXTURE_VERSION}'`
-    );
+    expect(
+      sandboxFile('plugin', 'hooks', 'lib', 'observability.mjs')
+    ).toContain(`TOKEN_OPTIMIZER_VERSION = '${FIXTURE_VERSION}'`);
   });
 
   test('--stamp writes it into every client entry point', () => {
@@ -151,21 +171,57 @@ describe('the publish-time stamp is real', () => {
   });
 
   test('npm run stamp:version applies both generators', () => {
-    const { scripts } = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
+    const { scripts } = JSON.parse(
+      readFileSync(join(ROOT, 'package.json'), 'utf8')
+    );
     expect(scripts['stamp:version']).toContain('sync-hook-core.mjs --stamp');
-    expect(scripts['stamp:version']).toContain('generate-client-entries.mjs --stamp');
+    expect(scripts['stamp:version']).toContain(
+      'generate-client-entries.mjs --stamp'
+    );
   });
 });
 
 describe('the release workflow applies it, in the only window that works', () => {
-  const workflow = () => readFileSync(join(ROOT, '.github', 'workflows', 'release.yml'), 'utf8');
+  /**
+   * Just the `publish-npm` job.
+   *
+   * FOUND IN REVIEW: these assertions read positions in the whole YAML document,
+   * so a stamp step sitting in ANY other job satisfied them while `publish-npm`
+   * published unstamped -- or computed its checksums before a stamp that ran
+   * somewhere else entirely. Ordering only means anything inside one job.
+   */
+  function publishJob() {
+    const raw = readFileSync(
+      join(ROOT, '.github', 'workflows', 'release.yml'),
+      'utf8'
+    );
+    const lines = raw
+      .split(String.fromCharCode(10))
+      .map((line) => line.trimEnd());
+    const start = lines.indexOf('  publish-npm:');
+    expect(start).toBeGreaterThan(-1);
+    let end = lines.length;
+    for (let index = start + 1; index < lines.length; index += 1) {
+      const line = lines[index];
+      // The next top-level job key: two spaces of indent, and no more.
+      if (
+        line.startsWith('  ') &&
+        !line.startsWith('   ') &&
+        line.endsWith(':')
+      ) {
+        end = index;
+        break;
+      }
+    }
+    return lines.slice(start, end).join(String.fromCharCode(10));
+  }
 
   test('publish-npm runs the stamp', () => {
-    expect(workflow()).toContain('npm run stamp:version');
+    expect(publishJob()).toContain('npm run stamp:version');
   });
 
   test('after the drift check, so the check sees the committed tree', () => {
-    const text = workflow();
+    const text = publishJob();
     // Without this, a MISSING step passes every ordering test: indexOf returns
     // -1, and -1 is less than every real index. Caught by mutation.
     expect(text).toContain('npm run stamp:version');
@@ -176,7 +232,7 @@ describe('the release workflow applies it, in the only window that works', () =>
 
   test('before the checksums, which hash exactly what ships', () => {
     // A stamp applied after this point would ship files the checksums disown.
-    const text = workflow();
+    const text = publishJob();
     // Without this, a MISSING step passes every ordering test: indexOf returns
     // -1, and -1 is less than every real index. Caught by mutation.
     expect(text).toContain('npm run stamp:version');
@@ -186,11 +242,13 @@ describe('the release workflow applies it, in the only window that works', () =>
   });
 
   test('and before the publish itself', () => {
-    const text = workflow();
+    const text = publishJob();
     // Without this, a MISSING step passes every ordering test: indexOf returns
     // -1, and -1 is less than every real index. Caught by mutation.
     expect(text).toContain('npm run stamp:version');
-    expect(text.indexOf('npm run stamp:version')).toBeLessThan(text.indexOf('npm publish'));
+    expect(text.indexOf('npm run stamp:version')).toBeLessThan(
+      text.indexOf('npm publish')
+    );
   });
 });
 
@@ -219,15 +277,87 @@ describe('removing the stamp did not cost the version', () => {
   };
 
   test('resolves from the nearest manifest when nothing is stamped', () => {
-    withEnv({ TOKEN_OPTIMIZER_VERSION: undefined, npm_package_version: undefined }, () => {
-      const { version } = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
-      expect(serviceVersion()).toBe(version);
-    });
+    withEnv(
+      { TOKEN_OPTIMIZER_VERSION: undefined, npm_package_version: undefined },
+      () => {
+        const { version } = JSON.parse(
+          readFileSync(join(ROOT, 'package.json'), 'utf8')
+        );
+        expect(serviceVersion()).toBe(version);
+      }
+    );
   });
 
   test('the publish-time stamp still wins when present', () => {
     withEnv({ TOKEN_OPTIMIZER_VERSION: 'stamped-1.2.3' }, () => {
       expect(serviceVersion()).toBe('stamped-1.2.3');
     });
+  });
+});
+
+describe('a version is only reported when it is ours', () => {
+  // FOUND IN REVIEW. The walk used to accept the nearest package.json outright,
+  // so these hooks vendored into someone else's repository would have reported
+  // THAT project's version as the optimizer's. A wrong version is the failure
+  // this whole change exists to stop; 'unknown' is the correct answer here.
+  test("ignores a foreign manifest and says 'unknown'", async () => {
+    const foreign = mkdtempSync(join(tmpdir(), 'foreign-manifest-'));
+    try {
+      writeFileSync(
+        join(foreign, 'package.json'),
+        JSON.stringify({ name: 'someone-elses-project', version: '0.0.1' })
+      );
+      mkdirSync(join(foreign, 'vendored'));
+      const copy = join(foreign, 'vendored', 'observability.mjs');
+      cpSync(join(ROOT, 'hooks-core', 'observability.mjs'), copy);
+
+      const saved = {
+        version: process.env.TOKEN_OPTIMIZER_VERSION,
+        name: process.env.npm_package_name,
+        packageVersion: process.env.npm_package_version,
+      };
+      delete process.env.TOKEN_OPTIMIZER_VERSION;
+      delete process.env.npm_package_name;
+      delete process.env.npm_package_version;
+      try {
+        // Imported from the foreign tree, so its own walk starts there.
+        const module = await import(pathToFileURL(copy).href);
+        expect(module.serviceVersion()).toBe('unknown');
+      } finally {
+        if (saved.version !== undefined)
+          process.env.TOKEN_OPTIMIZER_VERSION = saved.version;
+        if (saved.name !== undefined) process.env.npm_package_name = saved.name;
+        if (saved.packageVersion !== undefined) {
+          process.env.npm_package_version = saved.packageVersion;
+        }
+      }
+    } finally {
+      rmSync(foreign, { recursive: true, force: true });
+    }
+  });
+
+  test('ignores npm_package_version when npm is running a different package', () => {
+    const saved = {
+      version: process.env.TOKEN_OPTIMIZER_VERSION,
+      name: process.env.npm_package_name,
+      packageVersion: process.env.npm_package_version,
+    };
+    delete process.env.TOKEN_OPTIMIZER_VERSION;
+    process.env.npm_package_name = 'someone-elses-project';
+    process.env.npm_package_version = '0.0.1';
+    try {
+      const { version } = JSON.parse(
+        readFileSync(join(ROOT, 'package.json'), 'utf8')
+      );
+      expect(serviceVersion()).toBe(version);
+    } finally {
+      if (saved.version !== undefined)
+        process.env.TOKEN_OPTIMIZER_VERSION = saved.version;
+      if (saved.name === undefined) delete process.env.npm_package_name;
+      else process.env.npm_package_name = saved.name;
+      if (saved.packageVersion === undefined)
+        delete process.env.npm_package_version;
+      else process.env.npm_package_version = saved.packageVersion;
+    }
   });
 });


### PR DESCRIPTION
npm has been stuck on **5.7.0** since 11 August. v5.7.1 and v5.8.0 both carry a version bump in git that never reached users, and the cause is one line that this repository has already removed once, from different files, after it cost two releases.

## What breaks

`scripts/sync-hook-core.mjs` and `scripts/generate-client-entries.mjs` both wrote `package.json`'s version into their output:

```js
process.env.TOKEN_OPTIMIZER_VERSION = '${PACKAGE_VERSION}';
```

That makes *"generated output == committed file"* an invariant that **cannot hold across a release**. release-please bumps `package.json` without regenerating, so the release commit is born drifted — all **48** generated files at once — and `publish-npm` fails at *"Verify generated configs match their generators"*.

It cannot be repaired afterwards either: `publish-npm` checks out the **tag**, so a fix landed on master never touches the tree the publish reads.

## This is the third time

The post-mortem is already written into `scripts/pin-mcp-version.mjs` and `scripts/generate-client-configs.mjs`, which removed the version from nine configs:

> the invariant "committed spec == package.json" cannot hold across a release, and the four mechanisms built to enforce it cost four releases: **v5.4.0 and v5.4.1 were tagged with GitHub Releases and neither reached npm**.

And the remedy, in the same comment:

> it is **pinning at publish time only, so the tarball carries an exact version while git carries none**. Nothing in git can then go stale.

The stamp was reintroduced by a different generator in #305, into 48 files, and v5.7.1 was tagged and never reached npm either. This does what that comment says.

## What changes

- The stamp moves behind a `--stamp` flag that **only `release.yml` passes**, after the drift check and before `Generate CHECKSUMS.sha256` — the only window where both hold, since the checksums hash exactly what ships.
- Git carries no version. All 48 generated files are regenerated without one.
- `observability.mjs` **resolves** a version instead of carrying a literal: env first, so the publish-time stamp and any host that sets it still win, then the nearest manifest. Inside the tarball that finds the package's own `package.json`; a marketplace plugin install finds `.claude-plugin/plugin.json`, which release-please keeps correct; a bare copy into a client hook directory reports `unknown`, which is honest and is what this reported before #305.

A lagging stamp would have been worse than none — the file exists to make failures correlatable, and `pin-mcp-version.mjs` already records what a pin that lags does.

## Verification

The decisive one: **package.json bumped to an unreleased version, exactly what release-please does.** `sync:hooks:check` passes. Before this change it failed for all 48 files.

Every claim mutation-tested:

| Mutation | Result |
|---|---|
| Stamp reintroduced unconditionally | 2 fail |
| Stamp step removed from release.yml | 4 fail |
| Stamp step moved below the checksums | 1 fails |
| `--stamp` made a no-op | 2 fail |
| Runtime manifest walk disabled | 3 fail |

**Two of my own tests were vacuous and mutation is what caught them:**

- The repository-wide scan for a reintroduced stamp reused `walk()` from `tests/fixtures/source-scan.mjs`, which **deliberately skips `lib` directories** — exactly where the eleven vendored `observability.mjs` copies live. It could never have seen the thing it was written to catch. It now uses a local walker that includes them.
- The three workflow-ordering tests passed with the step **entirely absent**: `indexOf` returns `-1`, and `-1` is less than every real index. Each now asserts the step exists first.

`tests/hooks/observability.test.mjs` asserted `serviceVersion === PACKAGE_VERSION` on spawned hooks, and only passed because the generated entry file overwrote the `TOKEN_OPTIMIZER_VERSION` the test itself injected. The assertion is unchanged; the child env no longer carries the variable, so the hook has to resolve its own version. That is strictly stronger, and it fails when the walk is disabled.

234 suites, 3038 passed, 5 skipped, 0 failed. `tsc --noEmit` clean, `lint` 0 errors, `format:check` clean, `sync:hooks:check` in sync, `validate` passes. Quality Gates run locally: `verify:clients` 253/253, `verify:certification`, `verify:harvest` 27/27, `verify:live-graph`, `verify:ui` 55/55, `verify:interactions` 64/64.

## Note on v5.8.0

Its tag would point at `0959941`, whose tree already carries the stale stamps, so it would fail to publish however this lands. The plan is to skip it and let the next release PR carry both this fix and the 5.8.0 changelog that is already in `CHANGELOG.md`.

Separately, and unrelated to this bug: the push of `0959941` created **zero** workflow runs — CI, Quality Gates, HOL Scanner and Release are all missing for that sha, with no path filter, no skip directive, and a web-UI merge. GitHub dropped the event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSFxBpREeR7mMkJXYb6wuX


---

## Review fixes (9e89a87)

Three findings, each with a mutation that fails without the fix.

- **A version was reported without proving it was ours.** The walk accepted the nearest `package.json` outright, so these hooks vendored into another repository would have reported *that* project's version, and `npm_package_version` came from whichever npm script was running. A wrong version is the failure this PR exists to prevent. Both are now checked against the package and plugin names and fall through to `unknown`. Tested by copying `observability.mjs` into a temp tree under a foreign manifest and importing it there, so the walk really starts in the foreign tree.
- **The stamp detector matched one exact spelling** — a reintroduced `TOKEN_OPTIMIZER_VERSION="1.2.3"` would have passed all three no-stamp assertions.
- **The ordering assertions read the whole YAML document**, so a stamp step in any other job satisfied them while `publish-npm` published unstamped. They now read only that job.

| Mutation | Result |
|---|---|
| Double-quoted stamp in a committed file | 1 fails |
| Stamp step moved into the `notify` job | 4 fail |
| Manifest ownership check removed | 1 fails |
| `npm_package_name` guard removed | 1 fails |

234 suites, 3040 passed, 5 skipped, 0 failed.
