### PR TITLE
fix: bound file traversal so smart_glob and smart_grep cannot hang

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,86 @@
+name: Mutation Testing
+
+# WHY THIS IS SCHEDULED AND NOT A PR GATE.
+#
+# Measured 2026-08-28: 140 mutants against the traversal safety primitive, at
+# roughly a minute each with concurrency 2, is about 2h20m. Nothing that long
+# belongs on a pull request. The cost is not Stryker -- it is the 2,000-file
+# fixture that `beforeAll` rebuilds for every mutant.
+#
+# WHAT IT IS FOR. A passing test suite is evidence of nothing until you have
+# watched it go red. The bounded-traversal primitive is the code that decides
+# whether a search silently returns a partial answer, so its tests are exactly
+# the ones that must not be vacuous. This is the maintained replacement for a
+# hand-rolled harness that reported every mutation as SURVIVED (it could not
+# parse jest's summary line) and left mutations in the working tree whenever it
+# was killed.
+#
+# `incremental: true` in stryker.config.json means a rerun only re-tests mutants
+# whose code or tests changed, so after the first full run the nightly is short.
+# The incremental file is cached below rather than committed.
+
+on:
+  schedule:
+    # 04:17 UTC, off the hour so it does not pile up with everything else.
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Why this run was triggered by hand'
+        required: false
+        default: 'manual check'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  mutation:
+    name: Stryker on the traversal primitives
+    runs-on: ubuntu-latest
+    # Generous: the first run has no incremental cache to work from.
+    timeout-minutes: 240
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Restored, not committed: a stale incremental file only costs a slower
+      # run, whereas committing it would put a machine-generated cache into
+      # every diff.
+      - name: Restore the incremental mutation cache
+        uses: actions/cache@v4
+        with:
+          path: reports/mutation/stryker-incremental.json
+          key: stryker-incremental-${{ github.sha }}
+          restore-keys: |
+            stryker-incremental-
+
+      - name: Run Stryker
+        # jest needs the ESM flag; without it every suite fails to load and the
+        # dry run dies with an error that reads like a broken test rather than a
+        # missing flag.
+        env:
+          NODE_OPTIONS: --experimental-vm-modules
+        run: npm run mutation:run
+
+      - name: Upload the mutation report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-report
+          path: reports/mutation/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,8 @@ tests/benchmarks/results.json
 # a release-pipeline PR. Ignored so the next one cannot.
 .playwright-mcp/
 data/sessions.json
+
+# Mutation testing (Stryker). The temp tree and the JSON report are build
+# output; the incremental file is a cache that makes a nightly run resumable.
+.stryker-tmp/
+reports/mutation/

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -151,7 +151,7 @@
   },
   "src/tools/code-analysis/smart-dependencies.ts": {
     "n/no-sync": {
-      "count": 7
+      "count": 5
     }
   },
   "src/tools/code-analysis/smart-exports.ts": {
@@ -171,7 +171,7 @@
   },
   "src/tools/code-analysis/smart-security.ts": {
     "n/no-sync": {
-      "count": 7
+      "count": 5
     }
   },
   "src/tools/code-analysis/smart-symbols.ts": {

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,0 +1,302 @@
+{
+  "src/analytics/analytics-storage.ts": {
+    "n/no-sync": {
+      "count": 2
+    }
+  },
+  "src/analytics/native-provider-usage.ts": {
+    "n/no-sync": {
+      "count": 10
+    }
+  },
+  "src/analytics/optimization-storage.ts": {
+    "n/no-sync": {
+      "count": 2
+    }
+  },
+  "src/core/cache-engine.ts": {
+    "n/no-sync": {
+      "count": 7
+    }
+  },
+  "src/core/compression-engine.ts": {
+    "n/no-sync": {
+      "count": 2
+    }
+  },
+  "src/core/config.ts": {
+    "n/no-sync": {
+      "count": 6
+    }
+  },
+  "src/core/session-manager.ts": {
+    "n/no-sync": {
+      "count": 2
+    }
+  },
+  "src/server/daemon.ts": {
+    "n/no-sync": {
+      "count": 8
+    }
+  },
+  "src/server/dashboard-analytics.ts": {
+    "n/no-sync": {
+      "count": 2
+    }
+  },
+  "src/server/hook-diagnostics.ts": {
+    "n/no-sync": {
+      "count": 6
+    }
+  },
+  "src/server/index.ts": {
+    "n/no-sync": {
+      "count": 11
+    }
+  },
+  "src/server/mcp-diagnostics.ts": {
+    "n/no-sync": {
+      "count": 14
+    }
+  },
+  "src/server/session-log-parser.ts": {
+    "n/no-sync": {
+      "count": 1
+    }
+  },
+  "src/server/ucr-routes.ts": {
+    "n/no-sync": {
+      "count": 4
+    }
+  },
+  "src/server/ucr-tools.ts": {
+    "n/no-sync": {
+      "count": 3
+    }
+  },
+  "src/server/web-server.ts": {
+    "n/no-sync": {
+      "count": 7
+    }
+  },
+  "src/server/wiki-routes.ts": {
+    "n/no-sync": {
+      "count": 1
+    }
+  },
+  "src/tools/advanced-caching/cache-analytics.ts": {
+    "n/no-sync": {
+      "count": 1
+    }
+  },
+  "src/tools/advanced-caching/cache-benchmark.ts": {
+    "n/no-sync": {
+      "count": 1
+    }
+  },
+  "src/tools/advanced-caching/predictive-cache.ts": {
+    "n/no-sync": {
+      "count": 3
+    }
+  },
+  "src/tools/build-systems/run-node-bin.ts": {
+    "n/no-sync": {
+      "count": 4
+    }
+  },
+  "src/tools/build-systems/smart-build.ts": {
+    "n/no-sync": {
+      "count": 5
+    }
+  },
+  "src/tools/build-systems/smart-docker.ts": {
+    "n/no-sync": {
+      "count": 5
+    }
+  },
+  "src/tools/build-systems/smart-install.ts": {
+    "n/no-sync": {
+      "count": 9
+    }
+  },
+  "src/tools/build-systems/smart-lint.ts": {
+    "n/no-sync": {
+      "count": 4
+    }
+  },
+  "src/tools/build-systems/smart-logs.ts": {
+    "n/no-sync": {
+      "count": 4
+    }
+  },
+  "src/tools/build-systems/smart-test.ts": {
+    "n/no-sync": {
+      "count": 8
+    }
+  },
+  "src/tools/build-systems/smart-typecheck.ts": {
+    "n/no-sync": {
+      "count": 4
+    }
+  },
+  "src/tools/code-analysis/smart-ast-grep.ts": {
+    "n/no-sync": {
+      "count": 8
+    }
+  },
+  "src/tools/code-analysis/smart-complexity.ts": {
+    "n/no-sync": {
+      "count": 2
+    }
+  },
+  "src/tools/code-analysis/smart-dependencies.ts": {
+    "n/no-sync": {
+      "count": 7
+    }
+  },
+  "src/tools/code-analysis/smart-exports.ts": {
+    "n/no-sync": {
+      "count": 3
+    }
+  },
+  "src/tools/code-analysis/smart-imports.ts": {
+    "n/no-sync": {
+      "count": 5
+    }
+  },
+  "src/tools/code-analysis/smart-refactor.ts": {
+    "n/no-sync": {
+      "count": 2
+    }
+  },
+  "src/tools/code-analysis/smart-security.ts": {
+    "n/no-sync": {
+      "count": 7
+    }
+  },
+  "src/tools/code-analysis/smart-symbols.ts": {
+    "n/no-sync": {
+      "count": 4
+    }
+  },
+  "src/tools/code-analysis/smart-typescript.ts": {
+    "n/no-sync": {
+      "count": 8
+    }
+  },
+  "src/tools/configuration/smart-config-read.ts": {
+    "n/no-sync": {
+      "count": 3
+    }
+  },
+  "src/tools/configuration/smart-env.ts": {
+    "n/no-sync": {
+      "count": 2
+    }
+  },
+  "src/tools/configuration/smart-package-json.ts": {
+    "n/no-sync": {
+      "count": 7
+    }
+  },
+  "src/tools/configuration/smart-tsconfig.ts": {
+    "n/no-sync": {
+      "count": 2
+    }
+  },
+  "src/tools/configuration/smart-workflow.ts": {
+    "n/no-sync": {
+      "count": 8
+    }
+  },
+  "src/tools/file-operations/smart-branch.ts": {
+    "n/no-sync": {
+      "count": 7
+    }
+  },
+  "src/tools/file-operations/smart-diff.ts": {
+    "n/no-sync": {
+      "count": 4
+    }
+  },
+  "src/tools/file-operations/smart-edit.ts": {
+    "n/no-sync": {
+      "count": 3
+    }
+  },
+  "src/tools/file-operations/smart-glob.ts": {
+    "n/no-sync": {
+      "count": 3
+    }
+  },
+  "src/tools/file-operations/smart-grep.ts": {
+    "n/no-sync": {
+      "count": 3
+    }
+  },
+  "src/tools/file-operations/smart-log.ts": {
+    "n/no-sync": {
+      "count": 6
+    }
+  },
+  "src/tools/file-operations/smart-merge.ts": {
+    "n/no-sync": {
+      "count": 18
+    }
+  },
+  "src/tools/file-operations/smart-read.ts": {
+    "n/no-sync": {
+      "count": 7
+    }
+  },
+  "src/tools/file-operations/smart-status.ts": {
+    "n/no-sync": {
+      "count": 8
+    }
+  },
+  "src/tools/file-operations/smart-write.ts": {
+    "n/no-sync": {
+      "count": 9
+    }
+  },
+  "src/tools/intelligence/sentiment-analysis.ts": {
+    "n/no-sync": {
+      "count": 3
+    }
+  },
+  "src/tools/shared/compression-utils.ts": {
+    "n/no-sync": {
+      "count": 4
+    }
+  },
+  "src/tools/shared/hash-utils.ts": {
+    "n/no-sync": {
+      "count": 4
+    }
+  },
+  "src/tools/system-operations/smart-user.ts": {
+    "n/no-sync": {
+      "count": 4
+    }
+  },
+  "src/utils/file-backup.ts": {
+    "n/no-sync": {
+      "count": 4
+    }
+  },
+  "src/utils/gzip.ts": {
+    "n/no-sync": {
+      "count": 13
+    }
+  },
+  "src/utils/safe-exec.ts": {
+    "n/no-sync": {
+      "count": 1
+    }
+  },
+  "src/utils/search-scope.ts": {
+    "n/no-sync": {
+      "count": 1
+    }
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
 import tseslint from '@typescript-eslint/eslint-plugin';
 import tsparser from '@typescript-eslint/parser';
+import nodePlugin from 'eslint-plugin-n';
 import prettierConfig from 'eslint-config-prettier';
 
 export default [
@@ -37,6 +38,7 @@ export default [
     },
     plugins: {
       '@typescript-eslint': tseslint,
+      n: nodePlugin,
     },
     rules: {
       ...tseslint.configs.recommended.rules,
@@ -45,6 +47,27 @@ export default [
         'warn',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
       ],
+
+      // SYNCHRONOUS I/O IS THE DEFECT CLASS BEHIND #335, and this is the
+      // industry-standard detector for it rather than another bespoke test.
+      //
+      // A `*Sync` call blocks the event loop for its whole duration, so while
+      // one runs this server cannot answer a ping, a cancel, or anything else.
+      // That is why the reported hangs had to be KILLED rather than timing out:
+      // `globSync` over a large tree held the loop for 178 seconds. It is also
+      // why the cost compounds -- 12,000 serial `readFileSync` calls at ~2 ms
+      // each is 25 seconds that overlapping I/O would have hidden.
+      //
+      // ERROR, NOT WARN, because this codebase already carries ~538 warnings
+      // and one more would be invisible. The existing 63 call sites are
+      // recorded in `eslint-suppressions.json` instead, so they neither block
+      // the build nor quietly become permanent: `--prune-suppressions` fails
+      // once a suppressed site is fixed and not removed, which is what makes
+      // the list shrink-only.
+      //
+      // `allowAtRootLevel` permits module-initialisation reads, where blocking
+      // is the correct behaviour -- nothing is being served yet.
+      'n/no-sync': ['error', { allowAtRootLevel: true }],
     },
   },
   prettierConfig,

--- a/jest.mutation.config.js
+++ b/jest.mutation.config.js
@@ -1,0 +1,22 @@
+/**
+ * Jest, restricted to the tests that cover the traversal safety primitives.
+ *
+ * WHY A SEPARATE CONFIG. Stryker runs the test suite once as a dry run and then
+ * again per surviving mutant. Against the full suite -- 239 files, ~200 s -- the
+ * dry run alone exceeds Stryker's default timeout, and 140 mutants would take
+ * hours. Mutation testing is only affordable when the tests it runs are the ones
+ * that could actually kill the mutant, so this config names them.
+ *
+ * Keep this list in step with `mutate` in stryker.config.json: a mutant whose
+ * killing test is not listed here is scored as SURVIVED, which is a false alarm
+ * of exactly the kind that gets a gate switched off.
+ */
+import base from './jest.config.js';
+
+export default {
+  ...base,
+  testMatch: [
+    '<rootDir>/tests/unit/file-operations/bounded-traversal.test.ts',
+    '<rootDir>/tests/unit/code-analysis/analysis-traversal-is-bounded.test.ts',
+  ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,10 +29,11 @@
         "tiktoken": "^1.0.22",
         "typescript": "^5.9.3",
         "yaml": "^2.9.0",
-        "zod": ">=3.25.0 <5"
+        "zod": "^3.25.0"
       },
       "bin": {
         "token-optimizer-daemon": "dist/server/daemon.js",
+        "token-optimizer-diagnostics": "scripts/export-diagnostics.mjs",
         "token-optimizer-doctor": "scripts/doctor.mjs",
         "token-optimizer-install": "scripts/install-cli.mjs",
         "token-optimizer-mcp": "dist/server/index.js"
@@ -47,6 +48,8 @@
         "@semantic-release/github": "^11.0.0",
         "@semantic-release/npm": "^13.1.3",
         "@semantic-release/release-notes-generator": "^14.0.1",
+        "@stryker-mutator/core": "^10.0.0",
+        "@stryker-mutator/jest-runner": "^10.0.0",
         "@types/better-sqlite3": "^7.6.13",
         "@types/body-parser": "^1.19.6",
         "@types/conventional-commits-parser": "^5.0.1",
@@ -69,6 +72,7 @@
         "conventional-changelog-conventionalcommits": "^8.0.0",
         "eslint": "^9.38.0",
         "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-n": "^18.3.0",
         "fast-check": "^4.9.0",
         "jest": "^30.2.0",
         "npm": "^11.19.0",
@@ -298,7 +302,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -351,6 +354,53 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-8.0.0.tgz",
+      "integrity": "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
@@ -398,6 +448,153 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-8.0.0.tgz",
+      "integrity": "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/code-frame": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/generator": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/helper-globals": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+      "integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/template": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+      "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/traverse": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+      "integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-globals": "^8.0.0",
+        "@babel/parser": "^8.0.4",
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.4",
+        "obug": "^2.1.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
@@ -430,6 +627,53 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-8.0.0.tgz",
+      "integrity": "sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
@@ -439,6 +683,153 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-8.0.0.tgz",
+      "integrity": "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/code-frame": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/generator": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/helper-globals": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+      "integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/template": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+      "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/traverse": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+      "integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-globals": "^8.0.0",
+        "@babel/parser": "^8.0.4",
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.4",
+        "obug": "^2.1.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
@@ -1507,6 +1898,350 @@
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "license": "ISC"
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.3.tgz",
+      "integrity": "sha512-XEYX2WA8SBkLPczL6/yXPHLPCvDoptmh9v56Cy05BSV1Smk1vWy19bTC4qJBuIffw7+6l4CcaYYzGqG60RfW1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.0.tgz",
+      "integrity": "sha512-pZHXJImFtERmSNMBHcjwuz8Ck5vEFEYNUZnwbb8aJpjHv/TwGuFErNxF2Hp8+V+pNJs2EYPMlyWscvFEqO9jOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.1.0",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.1.tgz",
+      "integrity": "sha512-y43COoyVUjPWIobn2Qep/uI1drPS78aaZZZ9kVi94Tyu/GuW2N8d8Q4rifJXGAXCEAXCPTTMjD8gC1HyvM5ukA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/external-editor": "^3.0.4",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.3.tgz",
+      "integrity": "sha512-3NQJiXNJ/aj9wiAsr7pECdp5Qe9J0X9YUJCKsaFXS+ddOxfL6J4AIl3w3T4Gq3kK0WsQY5GMoDokK5X94m6lHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.4.tgz",
+      "integrity": "sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
+      "integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.4.tgz",
+      "integrity": "sha512-3xQkQrOvgOzpSN2ciTVdRDlg1FWMCA8l+0KfB6SNlILoTCGzJTzO/gc0Rwjcb3usuGyKdaGtI6OiyMdeMeLWkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.1.tgz",
+      "integrity": "sha512-5KaqwZNLRpUuWcoCrYghPP9TMaXL5v2Sk4xqePM7RCVegcJStoXdWibio60YIC1bec+z1fCyb67N6XPJIkZtGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.0.tgz",
+      "integrity": "sha512-CvVcW09emkBESEOW+4R8CjLNkP3fB3XrjeL8CDvfpjgrJN+V9oerXmJAXXM3l+4xqYPD5Yaujzy/Ph0PLOdDuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.0.tgz",
+      "integrity": "sha512-yQwBMYvpJ6jqrXtKiOwRD5XezjJoyt3VQvIyjsr5Arqb519nfIohOQymWVJ8/vEgg8xtZerrCsqlSaqt/LPC9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.2.3",
+        "@inquirer/confirm": "^6.3.0",
+        "@inquirer/editor": "^5.3.1",
+        "@inquirer/expand": "^5.1.3",
+        "@inquirer/input": "^5.1.4",
+        "@inquirer/number": "^4.2.1",
+        "@inquirer/password": "^5.2.0",
+        "@inquirer/rawlist": "^5.3.3",
+        "@inquirer/search": "^4.3.1",
+        "@inquirer/select": "^5.2.3"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.3.tgz",
+      "integrity": "sha512-Mu7WrtmDLaXBDEyrRLS70SZgX9ZSm4Up1w0ZxiH8C1OOp9oaVCn2k8q3QGgmlnhsKYUhuaU3zFWhAP6wxkVIMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.1.tgz",
+      "integrity": "sha512-0VWOvsHWI0rPj6CG70MoP4oXNCB6adcyN8bVFZXnh11eLDdPIK2f2XCmva78acPPDfJisfab7qNakwBh7hdBXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.3.tgz",
+      "integrity": "sha512-KuRTodDa6xBXX2noIpjuitpX/QT7Sfav7dIZ/OfUY54Hxg95nrGoshSzxx6Ey7qqLbImKdiGkSDt7KjPXjQgmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.0.tgz",
+      "integrity": "sha512-FMiJpuHUG3Dk0ex+UIXkre7i+i4OcwHWk9YdcVtZHFwb/r2rnrU2ipTCNAB7A+QOP0ryzIcqOfy76fRyyvOEAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -2140,7 +2875,6 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -2998,6 +3732,854 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@stryker-mutator/api": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-10.0.0.tgz",
+      "integrity": "sha512-ZtAJ0ZT3MVRCWJTBE2h90XB/6E+4lifHYtcTyNG6nU2nLekPgTo4gD5esjX6Okxo1b/JB4jJzyxYB54fwKAoJw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-metrics": "3.8.4",
+        "mutation-testing-report-schema": "3.8.4",
+        "tslib": "~2.8.0",
+        "typed-inject": "~5.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-10.0.0.tgz",
+      "integrity": "sha512-ZvMsRyaXQQ5e6Thcid9pkuODv6Fn9E3nrBQJUap+hcJuGJ4unm26afo3m6YKSjn8kinyxJ/3TXf0cTWRDaTxVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@inquirer/prompts": "^8.0.0",
+        "@stryker-mutator/api": "10.0.0",
+        "@stryker-mutator/instrumenter": "10.0.0",
+        "@stryker-mutator/util": "10.0.0",
+        "ajv": "~8.20.0",
+        "chalk": "~5.6.0",
+        "commander": "~14.0.0",
+        "diff-match-patch": "1.0.5",
+        "emoji-regex": "~10.6.0",
+        "execa": "~9.6.0",
+        "json-rpc-2.0": "^1.7.0",
+        "lodash.groupby": "~4.6.0",
+        "minimatch": "~10.2.4",
+        "mutation-server-protocol": "~0.4.0",
+        "mutation-testing-elements": "3.8.4",
+        "mutation-testing-metrics": "3.8.4",
+        "mutation-testing-report-schema": "3.8.4",
+        "npm-run-path": "~6.0.0",
+        "progress": "~2.0.3",
+        "rxjs": "~7.8.1",
+        "semver": "^7.6.3",
+        "source-map": "~0.7.4",
+        "tree-kill": "~1.2.2",
+        "tslib": "2.8.1",
+        "typed-inject": "~5.0.0",
+        "typed-rest-client": "~2.3.0"
+      },
+      "bin": {
+        "stryker": "bin/stryker.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/core/node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/core/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/instrumenter/-/instrumenter-10.0.0.tgz",
+      "integrity": "sha512-B7Wmn1KlEWyFeOz6D6oGvQGRfi5Xw3VemG6dEKvFQp4qLvxD9Mf4kcZghfxffgnYwXd3bFgqXsJ+ZGlhdfIOrQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "~8.0.0",
+        "@babel/generator": "~8.0.0",
+        "@babel/parser": "~8.0.0",
+        "@babel/plugin-proposal-decorators": "~8.0.0",
+        "@babel/plugin-transform-explicit-resource-management": "^8.0.0",
+        "@babel/preset-react": "~8.0.0",
+        "@babel/preset-typescript": "~8.0.0",
+        "@babel/traverse": "~8.0.4",
+        "@stryker-mutator/api": "10.0.0",
+        "@stryker-mutator/util": "10.0.0",
+        "angular-html-parser": "~10.11.0",
+        "semver": "~7.8.0",
+        "tslib": "2.8.1",
+        "weapon-regex": "~2.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/code-frame": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/compat-data": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+      "integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/core": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+      "integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-compilation-targets": "^8.0.0",
+        "@babel/helpers": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/template": "^8.0.0",
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@types/gensync": "^1.0.5",
+        "convert-source-map": "^2.0.0",
+        "empathic": "^2.0.1",
+        "gensync": "^1.0.0-beta.2",
+        "import-meta-resolve": "^4.2.0",
+        "json5": "^2.2.3",
+        "obug": "^2.1.1",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/generator": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-compilation-targets": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+      "integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^8.0.0",
+        "@babel/helper-validator-option": "^8.0.0",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^11.0.0",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-8.0.1.tgz",
+      "integrity": "sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-member-expression-to-functions": "^8.0.0",
+        "@babel/helper-optimise-call-expression": "^8.0.0",
+        "@babel/helper-replace-supers": "^8.0.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+        "@babel/traverse": "^8.0.0",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-globals": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+      "integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-module-imports": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-8.0.0.tgz",
+      "integrity": "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-module-transforms": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-8.0.1.tgz",
+      "integrity": "sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "@babel/traverse": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-plugin-utils": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+      "integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-replace-supers": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-8.0.1.tgz",
+      "integrity": "sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^8.0.0",
+        "@babel/helper-optimise-call-expression": "^8.0.0",
+        "@babel/traverse": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-validator-option": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+      "integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-proposal-decorators": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-8.0.2.tgz",
+      "integrity": "sha512-+C6O6KKXU7BBq1GNaIkFJxrALUVGRcr+WeWm4OcuRl3h+l/CmNfcTLMrT2Lm3uvGBimBH/8pEBRrXJFLoO67Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/plugin-syntax-decorators": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-syntax-decorators": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-8.0.1.tgz",
+      "integrity": "sha512-NI+0S/6MvR6GlcQFwjDZ+WIc2qvG6TXN534lYs9llNldwW4b7Dh6KTtk030FA0xWdYGs4t1lWo+OEWN8wGB+Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-syntax-jsx": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-8.0.1.tgz",
+      "integrity": "sha512-n0jtCOxEovhU7METqSQjcZO9pX53nu9uNIjMS+hEt+Nt9jA7oOZoBIgbCxhhASmF6T6rPDGge5UAvh6Z4eFz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-syntax-typescript": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-8.0.3.tgz",
+      "integrity": "sha512-jmTPwps7oSQSZaV1SxkQ3C12UWyufGysGc5OzDpZzvPAIX4mO7dJT3hoqkWVrSImvkcMiknir1iLN1SNV/CZzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-destructuring": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-8.0.1.tgz",
+      "integrity": "sha512-RtR8uLDl0QcCmqMNIkM8gmDeYZ3rS0ZH+sa+I6sfc09yFoqfp9AEPgBstq9KyfVb0lFCVSRFfJXCI70FIl5ccw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-explicit-resource-management": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-8.0.1.tgz",
+      "integrity": "sha512-VzDIYwBlLCpV6mJfloRdJm8HmYnMqs7O+bGha8yfg2kP7jAdxeCw6yZBVBeaKKQUThtSU52iy+3lB7DhYsbOBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/plugin-transform-destructuring": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-8.0.1.tgz",
+      "integrity": "sha512-PMuzulWrrzFNmY3lXSk/tV9NRb7y0eZZLJY4UEo2TKszroxvUZHAPPi+T9FDyrQhod+TQA+t+8/QYaaMpiEuhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-react-display-name": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-8.0.1.tgz",
+      "integrity": "sha512-soLishXlkyu6jcICPyO3HEP7A3GCzKEnn7XfvYrImuWEOwFAz93qShmWSYPf5ww0ZkO4By0zsN2bVIDF54fSdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-8.0.1.tgz",
+      "integrity": "sha512-NgkoF7Uq+30TmOPDdNUimT0Nta02uVjqJRFNlVWKrbOCu/CkzfHa4aMnIs0lMpkMmZmWA1e42Va+F04i/pY1zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-module-imports": "^8.0.0",
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/plugin-syntax-jsx": "^8.0.1",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-react-jsx-development": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-8.0.1.tgz",
+      "integrity": "sha512-Hb+HUZpV9KFHjm+F+P3aLDMi8QXU9l3ROCQv20z18Me2sGyW5nNNR5YTevNlgHvCpFek3BnAwhDGq/BRndXViw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-react-pure-annotations": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-8.0.1.tgz",
+      "integrity": "sha512-7/8UwU8hoPBurXa9tUiTTC8aACTRy5tCqLUtqikHp2eGiWoEB57AduOdbQ71OOMTEvawKrGhv3WfzkDpI+/oSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-typescript": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-8.0.1.tgz",
+      "integrity": "sha512-0Svqp3413Eg0GElldykF/T7SNsxQO5YVGD70fZyAdZTnX8WRgcopmbiU7GTa5xY5ZnJcEpNbfns8/GjX+/1yeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-create-class-features-plugin": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+        "@babel/plugin-syntax-typescript": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/preset-react": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-8.0.1.tgz",
+      "integrity": "sha512-jrFuPp/pTddFZbtmWhdLNAYc6UMcpboeUPnw0BBrm4nOmcAko/1TRcFi1PzWCeOFRU+VaSiKmat87W1HvR7mIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-validator-option": "^8.0.0",
+        "@babel/plugin-transform-react-display-name": "^8.0.1",
+        "@babel/plugin-transform-react-jsx": "^8.0.1",
+        "@babel/plugin-transform-react-jsx-development": "^8.0.1",
+        "@babel/plugin-transform-react-pure-annotations": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/preset-typescript": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-8.0.1.tgz",
+      "integrity": "sha512-qrPhQIN1NLrPmzgazF9XKQqXrOcp/WJly+K+6ReFonn24FZqRJO7clxOJo6Ni75L+2vAqI3cHVU2OJLBxoPp5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-validator-option": "^8.0.0",
+        "@babel/plugin-transform-modules-commonjs": "^8.0.1",
+        "@babel/plugin-transform-typescript": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/template": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+      "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/traverse": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+      "integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-globals": "^8.0.0",
+        "@babel/parser": "^8.0.4",
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.4",
+        "obug": "^2.1.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/jest-runner": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/jest-runner/-/jest-runner-10.0.0.tgz",
+      "integrity": "sha512-WgUU/rk9qL+LXuOYZmNYJDu4JaQ6GIl5/xUkUEyYBvZa2eBVZypHa5rxzFTKiZXq3mqxEkgZ5xYXXzXPI8E51Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stryker-mutator/api": "10.0.0",
+        "@stryker-mutator/util": "10.0.0",
+        "semver": "~7.8.0",
+        "tslib": "~2.8.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@stryker-mutator/core": "10.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/util": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-10.0.0.tgz",
+      "integrity": "sha512-LzOpHiJaCp2ABQgnPMlrQQcsK43bd5Vo/2FGL78aN62yDoeRQ+4j3tzeuXxK5OAHdC3fUz6TDoy4IsoAuLAd3w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -3137,6 +4719,13 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/gensync": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.5.tgz",
+      "integrity": "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -3182,6 +4771,13 @@
         "pretty-format": "^30.0.0"
       }
     },
+    "node_modules/@types/jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3202,7 +4798,6 @@
       "integrity": "sha512-/NbVmcGTP+lj5oa4yiYxxeBjRivKQ5Ns1eSZeB99ExsEQ6rX5XYU1Zy/gGxY/ilqtD4Etx9mKyrPxZRetiahhA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.14.0"
       }
@@ -3338,7 +4933,6 @@
       "integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.1",
         "@typescript-eslint/types": "8.46.1",
@@ -4103,7 +5697,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4200,6 +5793,16 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/angular-html-parser": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/angular-html-parser/-/angular-html-parser-10.11.0.tgz",
+      "integrity": "sha512-3vERzJ65UFDr3C7uozLJwsNcQS3FS784dSh583oDgDTTZMgXe3/pdyXgKndxiP5R2lvYRfW6gSl145Hnyf2OFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -4485,22 +6088,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/body-parser/node_modules/iconv-lite": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
-      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/bottleneck": {
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
@@ -4553,7 +6140,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.44",
         "caniuse-lite": "^1.0.30001806",
@@ -4702,6 +6288,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/chart.js": {
       "version": "4.4.0",
@@ -4935,6 +6528,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -5048,6 +6651,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/compare-func": {
       "version": "2.0.0",
@@ -5243,7 +6856,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -5448,6 +7060,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -5476,6 +7099,13 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -5605,6 +7235,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -5612,6 +7252,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/env-ci": {
@@ -5854,7 +7508,6 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5909,6 +7562,22 @@
         }
       }
     },
+    "node_modules/eslint-compat-utils": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
+      "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
     "node_modules/eslint-config-prettier": {
       "version": "10.1.8",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
@@ -5923,6 +7592,87 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-es-x": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
+      "integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/ota-meshi",
+        "https://opencollective.com/eslint"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.11.0",
+        "eslint-compat-utils": "^0.5.1"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-n": {
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-18.3.0.tgz",
+      "integrity": "sha512-cPVguuDe6DrIPb/qUXHf8P89MaVTUmiYWwpt5gX5AILsvRIiZAxMFXcFR6QHYBksqKJpjfUBlL/RleCJUWcD7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.5.0",
+        "enhanced-resolve": "^5.17.1",
+        "eslint-plugin-es-x": "^7.8.0",
+        "get-tsconfig": "^4.8.1",
+        "globals": "^15.11.0",
+        "globrex": "^0.1.2",
+        "ignore": "^5.3.2",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.57.1",
+        "ts-declaration-location": "^1.0.6",
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-declaration-location": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/eslint-scope": {
@@ -6224,7 +7974,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6388,6 +8137,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
@@ -6403,6 +8169,16 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -6778,6 +8554,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.3.tgz",
+      "integrity": "sha512-++QEw4DIY7WGoukz+/+A/8dGYPT9l9yIadnmSgZ8Rjr3YVSVDipQSO9CdnJo9ePqFqUUqh+wk9uIaoiAwsiPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/git-log-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.1.tgz",
@@ -6925,6 +8714,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -7030,7 +8826,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
       "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7134,9 +8929,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -7583,7 +9378,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -8314,6 +10108,13 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8375,6 +10176,13 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-rpc-2.0": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-2.0/-/json-rpc-2.0-1.8.0.tgz",
+      "integrity": "sha512-4nw+XlJbk5XokA7BtqHGu+0PEiUPfAkRzXXd1Cgjy1c3F2UI/3Gy7yr76wyJEv3X1F1SRGGF8xPAPPhelBiGmA==",
       "dev": true,
       "license": "MIT"
     },
@@ -8579,6 +10387,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -8704,7 +10519,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -8897,6 +10711,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -8937,6 +10758,63 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mutation-server-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mutation-server-protocol/-/mutation-server-protocol-0.4.1.tgz",
+      "integrity": "sha512-SBGK0j8hLDne7bktgThKI8kGvGTx3rY3LAeQTmOKZ5bVnL/7TorLMvcVF7dIPJCu5RNUWhkkuF53kurygYVt3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^4.1.12"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mutation-server-protocol/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/mutation-testing-elements": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/mutation-testing-elements/-/mutation-testing-elements-3.8.4.tgz",
+      "integrity": "sha512-5CF1SNa7at5ZH33vEr+21wNebTSrtNIVvnzaUlxortHajOrIPaSLczIWvg6sI/fsExekQ7jookwf2cHftkckqQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/mutation-testing-metrics": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/mutation-testing-metrics/-/mutation-testing-metrics-3.8.4.tgz",
+      "integrity": "sha512-DZcmndJBH6nrNs3tpiB3OcMVq9KkG2cHCpJSnDxSxPwi9qrafRmoec40xjhkbzOoX1n7/4UkDqg5tIj4A6nvCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-report-schema": "3.8.4"
+      }
+    },
+    "node_modules/mutation-testing-report-schema": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/mutation-testing-report-schema/-/mutation-testing-report-schema-3.8.4.tgz",
+      "integrity": "sha512-s4G71R6Lt/PpZ0cqeglIcgyBdzLM8E+SeCHZAPg1wkSsPtRBa4XfPzAozYKdiJk/TLbNEEb7En9t0/bveuPuxA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -10897,7 +12775,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11016,6 +12893,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/on-finished": {
@@ -11351,7 +13242,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11611,6 +13501,16 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/proto-list": {
       "version": "1.2.4",
@@ -11879,6 +13779,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -11930,6 +13840,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -11962,7 +13882,6 @@
       "integrity": "sha512-bxve7csK0/Txr++CkfrmV+X1r4jqiSOw2WsSad9E2S68R+ZfLBwDn8IceM8WfiOmKQIHgsQc1cNA8Dzg7U75pg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -12483,9 +14402,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -13162,6 +15081,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/temp-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
@@ -13458,6 +15391,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -13619,12 +15562,54 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/typed-inject": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/typed-inject/-/typed-inject-5.0.0.tgz",
+      "integrity": "sha512-0Ql2ORqBORLMdAW89TQKZsb1PQkFGImFfVmncXWe7a+AA3+7dh7Se9exxZowH4kbnlvKEFkMxUYdHUpjYWFJaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.3.1.tgz",
+      "integrity": "sha512-k4kX5Up6qA68D0Cby2AK+6+vM5k3qTxe+/3FqhnHRExjY5cfbOnzjQZbP/LXleF8hVoDvDqxlgk9KK83HoBZlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "6.15.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.13.8"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/typed-rest-client/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13646,6 +15631,13 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.29.0",
@@ -13866,6 +15858,13 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
+    },
+    "node_modules/weapon-regex": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/weapon-regex/-/weapon-regex-2.0.4.tgz",
+      "integrity": "sha512-ubuhY5Lo4phWcMsJqe8j62m9uhsuo/VpfK5XsSgYGRGDSt10hwVwOBTriPRd0dac+KYbGNXOrfXjM6xCp2NUKg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -14154,7 +16153,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -158,6 +158,8 @@
     "@semantic-release/github": "^11.0.0",
     "@semantic-release/npm": "^13.1.3",
     "@semantic-release/release-notes-generator": "^14.0.1",
+    "@stryker-mutator/core": "^10.0.0",
+    "@stryker-mutator/jest-runner": "^10.0.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/body-parser": "^1.19.6",
     "@types/conventional-commits-parser": "^5.0.1",
@@ -180,6 +182,7 @@
     "conventional-changelog-conventionalcommits": "^8.0.0",
     "eslint": "^9.38.0",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-n": "^18.3.0",
     "fast-check": "^4.9.0",
     "jest": "^30.2.0",
     "npm": "^11.19.0",
@@ -208,7 +211,7 @@
     "tiktoken": "^1.0.22",
     "typescript": "^5.9.3",
     "yaml": "^2.9.0",
-    "zod": ">=3.25.0 <5"
+    "zod": "^3.25.0"
   },
   "overrides": {
     "brace-expansion": "5.0.9",

--- a/src/tools/api-database/smart-api-fetch.ts
+++ b/src/tools/api-database/smart-api-fetch.ts
@@ -747,6 +747,11 @@ Perfect for:
         type: 'boolean',
         description: 'Parse response as JSON (default: true)',
       },
+      includeFullResponse: {
+        type: 'boolean',
+        description:
+          'Return the full response body alongside the compacted summary (default: false)',
+      },
     },
     required: ['method', 'url'],
   },

--- a/src/tools/build-systems/smart-build.ts
+++ b/src/tools/build-systems/smart-build.ts
@@ -211,8 +211,11 @@ export class SmartBuild {
     const duration = Date.now() - startTime;
     result.duration = duration;
 
-    // Cache the result
-    if (!watch) {
+    // Cache the result -- but never a truncated file count. The key hashes
+    // tsconfig and package.json, NOT which files were reached, so a partial
+    // count stored here is replayed for every later build until one of those
+    // two files changes. Found by the bounded-tools guard, not by hand.
+    if (!watch && !result.filesCompiledTruncatedBy) {
       this.cacheResult(cacheKey, result);
     }
 

--- a/src/tools/build-systems/smart-build.ts
+++ b/src/tools/build-systems/smart-build.ts
@@ -12,10 +12,15 @@ import { CacheEngine } from '../../core/cache-engine.js';
 import { TokenCounter } from '../../core/token-counter.js';
 import { MetricsCollector } from '../../core/metrics.js';
 import { createHash } from 'crypto';
-import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { spawnNodeBin } from './run-node-bin.js';
+import {
+  boundedWalk,
+  traversalDeadlineMs,
+  type TruncationReason,
+} from '../shared/bounded-traversal.js';
 
 interface BuildError {
   file: string;
@@ -33,6 +38,11 @@ interface BuildResult {
   duration: number;
   filesCompiled: number;
   timestamp: number;
+  /**
+   * Set when `filesCompiled` came from a walk that was cut short, which makes
+   * it a FLOOR rather than a count.
+   */
+  filesCompiledTruncatedBy?: TruncationReason;
 }
 
 interface SmartBuildOptions {
@@ -65,6 +75,16 @@ interface SmartBuildOptions {
    * Maximum cache age in seconds (default: 3600 = 1 hour)
    */
   maxCacheAge?: number;
+
+  /**
+   * Wall-clock budget in ms for the source-file count fallback.
+   *
+   * When tsc's output carries no "Found N errors" line there is nothing to
+   * count files from, so the tool walked `src` itself -- recursively, with a
+   * `statSync` per entry, following junctions, and with no way to stop.
+   * Defaults to 10 s.
+   */
+  deadlineMs?: number;
 }
 
 interface SmartBuildOutput {
@@ -78,6 +98,18 @@ interface SmartBuildOutput {
     errorCount: number;
     warningCount: number;
     fromCache: boolean;
+    /**
+     * Set when `filesCompiled` is a FLOOR rather than a count, because the
+     * fallback walk that produced it hit its deadline.
+     *
+     * There is no honest cap for this number: unlike a search, the answer here
+     * IS the total, so any bound that stops early makes it wrong. Saying so is
+     * the only thing that keeps it usable -- as a lower bound it still
+     * supports the "more than 50 files" test below, which can only err by
+     * withholding a suggestion.
+     */
+    filesCompiledPartial?: boolean;
+    filesCompiledNote?: string;
   };
 
   /**
@@ -150,6 +182,7 @@ export class SmartBuild {
       includeWarnings = false,
       maxCacheAge = 3600,
     } = options;
+    const deadlineMs = traversalDeadlineMs(options.deadlineMs);
 
     const startTime = Date.now();
 
@@ -172,6 +205,7 @@ export class SmartBuild {
       tsconfig,
       watch,
       incremental: !force,
+      deadlineMs,
     });
 
     const duration = Date.now() - startTime;
@@ -201,6 +235,7 @@ export class SmartBuild {
     tsconfig: string;
     watch: boolean;
     incremental: boolean;
+    deadlineMs: number;
   }): Promise<BuildResult> {
     const args = ['--project', options.tsconfig];
 
@@ -212,7 +247,7 @@ export class SmartBuild {
       args.push('--incremental');
     }
 
-    return new Promise((resolve, reject) => {
+    return new Promise<BuildResult>((resolve, reject) => {
       let stdout = '';
       let stderr = '';
 
@@ -241,14 +276,23 @@ export class SmartBuild {
         const output = stdout + stderr;
         const errors = this.parseCompilerOutput(output);
 
-        resolve({
-          success: code === 0,
-          errors: errors.filter((e) => e.severity === 'error'),
-          warnings: errors.filter((e) => e.severity === 'warning'),
-          duration: 0, // Set by caller
-          filesCompiled: this.countCompiledFiles(output),
-          timestamp: Date.now(),
-        });
+        // The count can now require a filesystem walk, which is async, so the
+        // handler resolves from a promise chain rather than inline. `reject`
+        // is wired up because a walk that throws must surface as a failed
+        // build, not as a promise that never settles.
+        this.countCompiledFiles(output, options.deadlineMs).then(
+          (counted) =>
+            resolve({
+              success: code === 0,
+              errors: errors.filter((e) => e.severity === 'error'),
+              warnings: errors.filter((e) => e.severity === 'warning'),
+              duration: 0, // Set by caller
+              filesCompiled: counted.count,
+              filesCompiledTruncatedBy: counted.truncatedBy,
+              timestamp: Date.now(),
+            }),
+          reject
+        );
       });
 
       tsc.on('error', (err) => {
@@ -287,7 +331,10 @@ export class SmartBuild {
   /**
    * Count files compiled from output
    */
-  private countCompiledFiles(output: string): number {
+  private async countCompiledFiles(
+    output: string,
+    deadlineMs: number
+  ): Promise<{ count: number; truncatedBy?: TruncationReason }> {
     // Look for "Found X errors" message which indicates compilation happened
     const match = output.match(/Found (\d+) error/);
     if (match) {
@@ -300,38 +347,20 @@ export class SmartBuild {
           files.add(fileMatch[1]);
         }
       }
-      return files.size;
+      return { count: files.size };
     }
 
     // Fallback: count .ts files in src
-    return this.countSourceFiles();
+    return this.countSourceFiles(deadlineMs);
   }
 
   /**
    * Count TypeScript source files
    */
-  private countSourceFiles(): number {
-    const srcDir = join(this.projectRoot, 'src');
-    if (!existsSync(srcDir)) {
-      return 0;
-    }
-
-    let count = 0;
-    const walk = (dir: string) => {
-      const files = readdirSync(dir);
-      for (const file of files) {
-        const fullPath = join(dir, file);
-        const stat = statSync(fullPath);
-        if (stat.isDirectory()) {
-          walk(fullPath);
-        } else if (file.endsWith('.ts')) {
-          count++;
-        }
-      }
-    };
-
-    walk(srcDir);
-    return count;
+  private async countSourceFiles(
+    deadlineMs: number
+  ): Promise<{ count: number; truncatedBy?: TruncationReason }> {
+    return countTypeScriptSources(join(this.projectRoot, 'src'), deadlineMs);
   }
 
   /**
@@ -500,6 +529,13 @@ export class SmartBuild {
         errorCount: result.errors.length,
         warningCount: result.warnings.length,
         fromCache,
+        ...(result.filesCompiledTruncatedBy
+          ? {
+              filesCompiledPartial: true,
+              filesCompiledNote:
+                'tsc reported no error summary to count from, so this number came from walking `src` -- and that walk hit its traversal deadline. Treat `filesCompiled` as a LOWER BOUND, not a count.',
+            }
+          : {}),
       },
       errors: allErrors,
       suggestions,
@@ -736,6 +772,49 @@ export const SMART_BUILD_TOOL_DEFINITION = {
         description: 'Maximum cache age in seconds (default: 3600)',
         default: 3600,
       },
+      deadlineMs: {
+        type: 'number',
+        description:
+          'Wall-clock budget in ms for the fallback source-file count (default 10000). On expiry filesCompiled is reported as a lower bound with summary.filesCompiledPartial set.',
+      },
     },
   },
 };
+
+/**
+ * Count `.ts` files under a directory, bounded.
+ *
+ * A MODULE FUNCTION RATHER THAN A METHOD so the bound can be exercised
+ * directly. Reaching it through `run()` requires a real `tsc` invocation that
+ * produces no "Found N errors" line, which is a five-second subprocess to test
+ * a walk -- and a bound nobody can test is a bound nobody will keep.
+ */
+export async function countTypeScriptSources(
+  srcDir: string,
+  deadlineMs?: number
+): Promise<{ count: number; truncatedBy?: TruncationReason }> {
+  if (!existsSync(srcDir)) {
+    return { count: 0 };
+  }
+
+  // NO CAP HERE, WHICH IS NOT THE SAME CHOICE `smart_glob` MAKES. A cap is
+  // legitimate when the caller asked for N results, because stopping at N is
+  // the answer. Here the answer IS the total, so a cap does not shorten it,
+  // it replaces it with the cap -- and nothing downstream could tell.
+  //
+  // The deadline can also make the number a floor, so when it fires the
+  // number is reported AS a floor rather than as a count. That is still
+  // useful: the only consumer is a "more than 50 files" heuristic, and a
+  // floor can only ever err by withholding a suggestion.
+  //
+  // The old walk used `statSync` per entry and therefore FOLLOWED junctions,
+  // which on Windows is how a shared `node_modules` turns a count into an
+  // endless loop. `boundedWalk` reads types from the directory entry, so a
+  // junction is simply not descended.
+  const walk = await boundedWalk(srcDir, {
+    accept: (_fullPath, fileName) => fileName.endsWith('.ts'),
+    deadlineMs,
+  });
+
+  return { count: walk.items.length, truncatedBy: walk.truncatedBy };
+}

--- a/src/tools/build-systems/smart-processes.ts
+++ b/src/tools/build-systems/smart-processes.ts
@@ -864,6 +864,18 @@ export const SMART_PROCESSES_TOOL_DEFINITION = {
         description: 'Compare with previous snapshot',
         default: true,
       },
+      useCache: {
+        type: 'boolean',
+        description:
+          'Reuse the cached snapshot so the run can report what changed since it (default: true)',
+        default: true,
+      },
+      maxCacheAge: {
+        type: 'number',
+        description:
+          'Oldest cached snapshot still worth comparing against, in seconds (default: 60)',
+        default: 60,
+      },
     },
   },
 };

--- a/src/tools/code-analysis/smart-ast-grep.ts
+++ b/src/tools/code-analysis/smart-ast-grep.ts
@@ -16,12 +16,17 @@ import {
   resolveBinScript,
   resolveNpmScript,
 } from '../build-systems/run-node-bin.js';
-import { existsSync, statSync, readdirSync } from 'fs';
+import { existsSync, statSync } from 'fs';
 import { join, relative } from 'path';
 import { CacheEngine } from '../../core/cache-engine.js';
 import { TokenCounter } from '../../core/token-counter.js';
 import { MetricsCollector } from '../../core/metrics.js';
 import { hashFile } from '../shared/hash-utils.js';
+import {
+  boundedWalk,
+  traversalDeadlineMs,
+  type TruncationReason,
+} from '../shared/bounded-traversal.js';
 
 /**
  * The ast-grep CLI package, pinned by name.
@@ -65,6 +70,16 @@ export interface SmartAstGrepOptions {
   // Performance options
   respectGitignore?: boolean;
   incrementalIndexing?: boolean;
+
+  /**
+   * Wall-clock budget in ms for discovering the files to index.
+   *
+   * Discovery was a recursive `readdirSync` that enumerated every entry and
+   * only then tested it against the exclusions -- so `node_modules` was read
+   * in full before being thrown away, on the event loop, with no point at
+   * which the walk could give up and answer. Defaults to 10 s.
+   */
+  deadlineMs?: number;
 }
 
 export interface AstMatch {
@@ -99,6 +114,18 @@ export interface SmartAstGrepResult {
       reindexedFiles: number;
       cachedFiles: number;
     };
+    /**
+     * Set when a bound stopped file discovery, so the index covers only part
+     * of the project and a missing match may simply be an unvisited file.
+     *
+     * Neither the index nor the pattern result is cached while this is set:
+     * the index key is derived from the project path and language, not from
+     * the file set, so a partial index stored under it would be served in
+     * answer to every later search.
+     */
+    searchTruncated?: boolean;
+    searchTruncatedBy?: TruncationReason;
+    searchNote?: string;
   };
   suggestions?: string[];
 }
@@ -171,6 +198,8 @@ export class SmartAstGrepTool {
       respectGitignore = true,
       incrementalIndexing = true,
     } = options;
+    const deadlineMs = traversalDeadlineMs(options.deadlineMs);
+    let searchTruncatedBy: TruncationReason | undefined;
 
     // Validate project path
     if (!existsSync(projectPath)) {
@@ -217,17 +246,24 @@ export class SmartAstGrepTool {
 
     if (!index || !enableCache) {
       // Create new index
-      index = await this.createIndex(
+      const created = await this.createIndex(
         projectPath,
         detectedLanguage,
         filePattern,
         excludePatterns,
-        respectGitignore
+        respectGitignore,
+        deadlineMs
       );
+      index = created.index;
+      searchTruncatedBy = created.truncatedBy;
       reindexedFiles = index.files.size;
 
-      // Cache the index
-      if (enableCache) {
+      // A PARTIAL INDEX IS NEVER CACHED. The index key is derived from the
+      // project path and language, NOT from the file set, so a partial index
+      // stored under it would be served to every later search of this project
+      // for the whole TTL -- silently answering "no matches" for files that
+      // were never walked.
+      if (enableCache && !searchTruncatedBy) {
         this.cacheIndex(indexKey, index, ttl);
       }
     } else if (incrementalIndexing) {
@@ -238,13 +274,16 @@ export class SmartAstGrepTool {
         detectedLanguage,
         filePattern,
         excludePatterns,
-        respectGitignore
+        respectGitignore,
+        deadlineMs
       );
       reindexedFiles = updates.reindexed;
       cachedFiles = updates.cached;
+      searchTruncatedBy = updates.truncatedBy;
 
-      // Update cache if files changed
-      if (reindexedFiles > 0 && enableCache) {
+      // Update cache if files changed -- but never with a partial walk, for
+      // the same reason as above.
+      if (reindexedFiles > 0 && enableCache && !searchTruncatedBy) {
         this.cacheIndex(indexKey, index, ttl);
       }
     }
@@ -302,8 +341,21 @@ export class SmartAstGrepTool {
       suggestions: suggestions.length > 0 ? suggestions : undefined,
     };
 
-    // Cache pattern result
-    if (enableCache && !fromPatternCache) {
+    if (searchTruncatedBy) {
+      result.metadata.searchTruncated = true;
+      result.metadata.searchTruncatedBy = searchTruncatedBy;
+      result.metadata.searchNote =
+        'File discovery stopped at the ' +
+        deadlineMs +
+        'ms traversal deadline after indexing ' +
+        index.files.size +
+        ' file(s), so parts of the project were never searched and an absent match may just be an unvisited file. Narrow `projectPath`/`excludePatterns`, or raise TOKEN_OPTIMIZER_TRAVERSAL_DEADLINE_MS.';
+    }
+
+    // Cache pattern result -- but not one produced from a partial walk. The
+    // pattern key does not encode which files were reached, so caching it
+    // would answer every later identical search with the short version.
+    if (enableCache && !fromPatternCache && !searchTruncatedBy) {
       this.cachePatternResult(patternKey, result, ttl);
     }
 
@@ -321,15 +373,18 @@ export class SmartAstGrepTool {
     language: string,
     filePattern?: string,
     excludePatterns: string[] = [],
-    respectGitignore: boolean = true
-  ): Promise<AstIndex> {
-    const files = this.findSourceFiles(
+    respectGitignore: boolean = true,
+    deadlineMs?: number
+  ): Promise<{ index: AstIndex; truncatedBy?: TruncationReason }> {
+    const discovery = await this.findSourceFiles(
       projectPath,
       language,
       filePattern,
       excludePatterns,
-      respectGitignore
+      respectGitignore,
+      deadlineMs
     );
+    const files = discovery.files;
 
     const index: AstIndex = {
       version: SmartAstGrepTool.INDEX_VERSION,
@@ -356,7 +411,7 @@ export class SmartAstGrepTool {
       index.files.set(file, entry);
     }
 
-    return index;
+    return { index, truncatedBy: discovery.truncatedBy };
   }
 
   /**
@@ -368,15 +423,22 @@ export class SmartAstGrepTool {
     language: string,
     filePattern?: string,
     excludePatterns: string[] = [],
-    respectGitignore: boolean = true
-  ): Promise<{ reindexed: number; cached: number }> {
-    const files = this.findSourceFiles(
+    respectGitignore: boolean = true,
+    deadlineMs?: number
+  ): Promise<{
+    reindexed: number;
+    cached: number;
+    truncatedBy?: TruncationReason;
+  }> {
+    const discovery = await this.findSourceFiles(
       projectPath,
       language,
       filePattern,
       excludePatterns,
-      respectGitignore
+      respectGitignore,
+      deadlineMs
     );
+    const files = discovery.files;
     let reindexed = 0;
     let cached = 0;
 
@@ -587,50 +649,40 @@ export class SmartAstGrepTool {
   /**
    * Find source files in project
    */
-  private findSourceFiles(
+  private async findSourceFiles(
     projectPath: string,
     language: string,
     _filePattern?: string,
     excludePatterns: string[] = [],
-    respectGitignore: boolean = true
-  ): string[] {
+    respectGitignore: boolean = true,
+    deadlineMs?: number
+  ): Promise<{ files: string[]; truncatedBy?: TruncationReason }> {
     const extensions = this.getExtensionsForLanguage(language);
-    const files: string[] = [];
 
-    const walk = (dir: string) => {
-      try {
-        const entries = readdirSync(dir, { withFileTypes: true });
+    const excluded = (fullPath: string): boolean =>
+      this.shouldExclude(
+        relative(projectPath, fullPath),
+        excludePatterns,
+        respectGitignore
+      );
 
-        for (const entry of entries) {
-          const fullPath = join(dir, entry.name);
-          const relativePath = relative(projectPath, fullPath);
+    // PRUNED, NOT FILTERED. `shouldExclude` was consulted per entry AFTER the
+    // directory had been enumerated, so a project with `node_modules` paid to
+    // read the whole of it and then dropped the results one at a time. Pruning
+    // is exactly equivalent, not stricter: `shouldExclude` is a substring test
+    // on the relative path, and a child's relative path contains its parent's.
+    const walk = await boundedWalk(projectPath, {
+      prune: (_name, fullPath) => excluded(fullPath),
+      accept: (fullPath, fileName) =>
+        !excluded(fullPath) &&
+        extensions.includes(fileName.substring(fileName.lastIndexOf('.'))),
+      // NO CAP. A file missing from the index is a match missing from the
+      // answer, and nothing in the output would distinguish that from the
+      // pattern genuinely not occurring.
+      deadlineMs,
+    });
 
-          // Skip excluded patterns
-          if (
-            this.shouldExclude(relativePath, excludePatterns, respectGitignore)
-          ) {
-            continue;
-          }
-
-          if (entry.isDirectory()) {
-            walk(fullPath);
-          } else if (entry.isFile()) {
-            // Check extension
-            const ext = entry.name.substring(entry.name.lastIndexOf('.'));
-            if (extensions.includes(ext)) {
-              files.push(fullPath);
-            }
-          }
-        }
-      } catch (error) {
-        // Skip directories we can't read
-        return;
-      }
-    };
-
-    walk(projectPath);
-
-    return files;
+    return { files: walk.items, truncatedBy: walk.truncatedBy };
   }
 
   /**
@@ -1030,6 +1082,11 @@ export const SMART_AST_GREP_TOOL_DEFINITION = {
         description:
           'Reindex only files changed since the last run instead of the whole project',
         default: true,
+      },
+      deadlineMs: {
+        type: 'number',
+        description:
+          'Wall-clock budget in ms for discovering the files to index (default 10000). On expiry the search reports what it reached with metadata.searchTruncated set and caches nothing, instead of walking until the calling tool times out.',
       },
     },
     required: ['pattern', 'projectPath'],

--- a/src/tools/code-analysis/smart-dependencies.ts
+++ b/src/tools/code-analysis/smart-dependencies.ts
@@ -16,17 +16,17 @@
 import { readFileSync, existsSync, statSync } from 'fs';
 import { parse as parseTypescript } from '@typescript-eslint/typescript-estree';
 import { parse as parseBabel } from '@babel/parser';
-// glob v10+ is native ESM and has no default export; the CJS-style
-// `import pkg from 'glob'` threw "does not provide an export named 'default'"
-// at import time, which is why this module could never be loaded. Every other
-// file in this codebase already imports it the working way.
-import { globSync } from 'glob';
 import { relative, resolve, dirname, extname, join } from 'path';
 import { CacheEngine } from '../../core/cache-engine.js';
 import { measured, unmeasured } from '../shared/savings.js';
 import { TokenCounter } from '../../core/token-counter.js';
 import { MetricsCollector } from '../../core/metrics.js';
 import { hashFileMetadata, generateCacheKey } from '../shared/hash-utils.js';
+import {
+  boundedGlob,
+  traversalDeadlineMs,
+  type TruncationReason,
+} from '../shared/bounded-traversal.js';
 
 /**
  * Represents an import in a file
@@ -117,6 +117,16 @@ export interface SmartDependenciesOptions {
   // Output options
   format?: 'compact' | 'detailed'; // Output format
   includeMetadata?: boolean; // Include file metadata
+
+  /**
+   * Wall-clock budget in ms for discovering the files to analyse.
+   *
+   * File discovery here was `globSync` over every source file in the tree,
+   * which is the same unbounded walk issue #335 reported: on a large tree it
+   * blocks the event loop until it finishes, and there was no point at which
+   * it could give up and answer. Defaults to 10 s.
+   */
+  deadlineMs?: number;
 }
 
 /** JSON-safe shape of the dependency graph. */
@@ -141,6 +151,14 @@ export interface SmartDependenciesResult {
     duration: number;
     cacheHit: boolean;
     incrementalUpdate: boolean;
+    /**
+     * Set when a bound stopped file discovery, so the graph describes only
+     * part of the tree. Absent means the walk ran to completion -- the
+     * difference between "no cycles" and "no cycles among what I looked at".
+     */
+    searchTruncated?: boolean;
+    searchTruncatedBy?: TruncationReason;
+    searchNote?: string;
   };
   /**
    * The dependency graph, as data JSON can carry.
@@ -232,6 +250,7 @@ export class SmartDependenciesTool {
       ttl: options.ttl ?? 7,
       format: options.format ?? 'compact',
       includeMetadata: options.includeMetadata ?? false,
+      deadlineMs: traversalDeadlineMs(options.deadlineMs),
     };
 
     try {
@@ -264,6 +283,18 @@ export class SmartDependenciesTool {
         default:
           result = this.transformGraphOutput(graph, opts, startTime);
           break;
+      }
+
+      // Truncation is a property of the WALK, but each mode handler builds its
+      // own metadata from the finished graph, so the flag is dropped on three
+      // of the four paths unless it is re-applied here. A `circular` result
+      // that quietly loses it reads as "no cycles" rather than "no cycles in
+      // the part of the tree I actually reached".
+      if (graphResult.metadata.searchTruncated) {
+        result.metadata.searchTruncated = true;
+        result.metadata.searchTruncatedBy =
+          graphResult.metadata.searchTruncatedBy;
+        result.metadata.searchNote = graphResult.metadata.searchNote;
       }
 
       // Record metrics
@@ -432,10 +463,14 @@ export class SmartDependenciesTool {
     }
 
     // Build graph from scratch
-    const graph = await this.buildFullGraph(opts);
+    const { graph, truncatedBy } = await this.buildFullGraph(opts);
 
-    // Cache the graph
-    if (opts.useCache) {
+    // A PARTIAL GRAPH IS NEVER CACHED. Storing one would outlive the call that
+    // knew it was partial: every later request would hit the cache, report
+    // `cacheHit: true` with no truncation flag at all, and answer "unused" for
+    // files whose importers were simply never walked. Paying for a rebuild is
+    // cheaper than a fast wrong answer that persists for the TTL.
+    if (opts.useCache && !truncatedBy) {
       this.cacheGraph(cacheKey, graph, opts.ttl);
     }
 
@@ -462,6 +497,13 @@ export class SmartDependenciesTool {
         duration: 0,
         cacheHit: false,
         incrementalUpdate: false,
+        ...(truncatedBy
+          ? {
+              searchTruncated: true,
+              searchTruncatedBy: truncatedBy,
+              searchNote: `File discovery stopped at the ${opts.deadlineMs}ms traversal deadline, so this graph covers only part of the tree and anything derived from it -- unused imports, cycles, impact -- may be missing entries. The partial graph was NOT cached. Narrow \`files\`/\`exclude\`, or raise TOKEN_OPTIMIZER_TRAVERSAL_DEADLINE_MS.`,
+            }
+          : {}),
       },
     };
   }
@@ -471,17 +513,38 @@ export class SmartDependenciesTool {
    */
   private async buildFullGraph(
     opts: Required<SmartDependenciesOptions>
-  ): Promise<Map<string, DependencyNode>> {
+  ): Promise<{
+    graph: Map<string, DependencyNode>;
+    truncatedBy?: TruncationReason;
+  }> {
+    // ONE budget for the whole call, not one per pattern. `files` defaults to a
+    // single pattern but accepts a list, and giving each its own 10 s deadline
+    // would turn a five-pattern request into a fifty-second one -- which is the
+    // caller's tool timeout, the thing this bound exists to stay under.
+    const expiresAt = Date.now() + opts.deadlineMs;
+    const remainingMs = () => Math.max(1, expiresAt - Date.now());
+
     // Find all files to analyze
     let files: string[] = [];
+    let truncatedBy: TruncationReason | undefined;
+
     for (const pattern of opts.files) {
-      const matches = globSync(pattern, {
+      if (truncatedBy) break;
+      const walk = await boundedGlob(pattern, {
         cwd: opts.cwd,
         absolute: true,
         ignore: opts.exclude,
         nodir: true,
+        deadlineMs: remainingMs(),
       });
-      files.push(...matches);
+      files.push(...walk.items);
+      // NO CAP, DELIBERATELY. Every mode here answers a whole-graph question --
+      // what imports what, which cycles exist, what is unused -- and a cap does
+      // not shorten that answer, it falsifies it: dropping a node also drops
+      // the `importedBy` edges of nodes that were KEPT, so a file that IS
+      // imported comes back reported as unused. The deadline is the only bound
+      // that can be reported honestly, because what it reports is "partial".
+      if (walk.truncated) truncatedBy = walk.truncatedBy;
     }
 
     // Remove duplicates
@@ -501,7 +564,7 @@ export class SmartDependenciesTool {
     // Build reverse dependencies (importedBy)
     this.buildReverseDependencies(graph, opts.cwd);
 
-    return graph;
+    return { graph, truncatedBy };
   }
 
   /**
@@ -1526,6 +1589,11 @@ export const SMART_DEPENDENCIES_TOOL_DEFINITION = {
         description:
           'Include per-package version and resolution detail, not just the edges',
         default: false,
+      },
+      deadlineMs: {
+        type: 'number',
+        description:
+          'Wall-clock budget in ms for discovering the files to analyse (default 10000). On expiry the graph comes back partial with metadata.searchTruncated set and is NOT cached, instead of walking until the calling tool times out.',
       },
     },
   },

--- a/src/tools/code-analysis/smart-exports.ts
+++ b/src/tools/code-analysis/smart-exports.ts
@@ -9,12 +9,17 @@
 
 import * as ts from 'typescript';
 import { createHash } from 'crypto';
-import { join } from 'path';
+import { join, relative, dirname } from 'path';
 import { homedir } from 'os';
-import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { CacheEngine } from '../../core/cache-engine.js';
 import { MetricsCollector } from '../../core/metrics.js';
 import { TokenCounter } from '../../core/token-counter.js';
+import {
+  boundedWalk,
+  traversalDeadlineMs,
+  type TruncationReason,
+} from '../shared/bounded-traversal.js';
 
 /**
  * Export statement information
@@ -107,6 +112,15 @@ export interface SmartExportsResult {
     reexports: number;
     unusedCount: number;
     dependencyCount: number;
+    /**
+     * Set when a bound stopped the usage scan, so `unusedExports` is a list of
+     * exports whose importers were not FOUND, which is not the same as exports
+     * that have none. Acting on the first as if it were the second deletes
+     * live code. Absent means the scan completed.
+     */
+    searchTruncated?: boolean;
+    searchTruncatedBy?: TruncationReason;
+    searchNote?: string;
   };
   /** Cache metadata */
   cached: boolean;
@@ -131,6 +145,15 @@ export interface SmartExportsOptions {
   checkUsage?: boolean;
   /** Scan depth for checking usage (number of directories) */
   scanDepth?: number;
+
+  /**
+   * Wall-clock budget in ms for the usage scan.
+   *
+   * `scanDepth` bounds how DEEP the walk goes but not how WIDE, so a shallow
+   * scan of a broad monorepo was still unbounded -- and it ran `statSync` per
+   * entry on the event loop. Defaults to 10 s.
+   */
+  deadlineMs?: number;
 }
 
 /**
@@ -170,6 +193,7 @@ export class SmartExportsTool {
       checkUsage = false,
       scanDepth = 3,
     } = options;
+    const deadlineMs = traversalDeadlineMs(options.deadlineMs);
 
     // Get file content
     let content: string;
@@ -225,10 +249,17 @@ export class SmartExportsTool {
 
     // Analyze exports
     const exports = this.extractExports(sourceFile);
-    const dependencies =
+    const usage =
       checkUsage && filePath
-        ? this.findExportDependencies(filePath, exports, projectRoot, scanDepth)
-        : [];
+        ? await this.findExportDependencies(
+            filePath,
+            exports,
+            projectRoot,
+            scanDepth,
+            deadlineMs
+          )
+        : { dependencies: [], truncatedBy: undefined };
+    const dependencies = usage.dependencies;
     const unusedExports = checkUsage
       ? this.detectUnusedExports(exports, dependencies)
       : [];
@@ -247,6 +278,16 @@ export class SmartExportsTool {
         reexports: exports.filter((e) => e.type === 'reexport').length,
         unusedCount: unusedExports.length,
         dependencyCount: dependencies.length,
+        ...(usage.truncatedBy
+          ? {
+              searchTruncated: true,
+              searchTruncatedBy: usage.truncatedBy,
+              searchNote:
+                'The usage scan stopped at the ' +
+                deadlineMs +
+                'ms traversal deadline, so `unusedExports` lists exports whose importers were NOT FOUND rather than exports that have none -- do not delete on this result. Lower `scanDepth`, or raise TOKEN_OPTIMIZER_TRAVERSAL_DEADLINE_MS.',
+            }
+          : {}),
       },
       cached: false,
     };
@@ -257,8 +298,13 @@ export class SmartExportsTool {
     const originalTokens = this.tokenCounter.count(fullOutput).tokens;
     const compactedTokens = this.tokenCounter.count(compactOutput).tokens;
 
-    // Cache result
-    this.cacheResult(cacheKey, result, originalTokens, compactedTokens);
+    // A PARTIAL USAGE SCAN IS NEVER CACHED. The key is derived from the file's
+    // content and the scan settings, NOT from which files were reached, so a
+    // truncated "nothing imports this" would be replayed for the whole cache
+    // window -- and it is the exact answer someone acts on by deleting code.
+    if (!usage.truncatedBy) {
+      this.cacheResult(cacheKey, result, originalTokens, compactedTokens);
+    }
 
     // Record metrics
     const duration = Date.now() - startTime;
@@ -448,16 +494,25 @@ export class SmartExportsTool {
   /**
    * Find files that import these exports
    */
-  private findExportDependencies(
+  private async findExportDependencies(
     filePath: string,
     exports: ExportInfo[],
     projectRoot: string,
-    scanDepth: number
-  ): ExportDependency[] {
+    scanDepth: number,
+    deadlineMs: number
+  ): Promise<{
+    dependencies: ExportDependency[];
+    truncatedBy?: TruncationReason;
+  }> {
     const dependencies: ExportDependency[] = [];
 
     // Scan project files
-    const filesToScan = this.scanProjectFiles(projectRoot, scanDepth);
+    const scan = await this.scanProjectFiles(
+      projectRoot,
+      scanDepth,
+      deadlineMs
+    );
+    const filesToScan = scan.files;
 
     for (const file of filesToScan) {
       if (file === filePath) continue;
@@ -491,55 +546,42 @@ export class SmartExportsTool {
       }
     }
 
-    return dependencies;
+    return { dependencies, truncatedBy: scan.truncatedBy };
   }
 
   /**
    * Scan project files up to specified depth
    */
-  private scanProjectFiles(
+  private async scanProjectFiles(
     dir: string,
     depth: number,
-    currentDepth = 0
-  ): string[] {
-    if (currentDepth >= depth) {
-      return [];
-    }
+    deadlineMs: number
+  ): Promise<{ files: string[]; truncatedBy?: TruncationReason }> {
+    // The old walk called `statSync` on every entry to decide file-vs-directory
+    // -- one blocking syscall per entry, on the event loop, on top of the
+    // recursion. `withFileTypes` answers the same question from the directory
+    // read that already happened, and also stops a Windows junction (which
+    // stats as a directory but is not one) from turning the walk into a loop.
+    const skipped = (name: string): boolean =>
+      name === 'node_modules' || name === '.git' || name.startsWith('.');
 
-    const files: string[] = [];
+    // DEPTH IS PRESERVED EXACTLY, not approximated. The recursive version
+    // listed `dir` at currentDepth 0 and refused to recurse once currentDepth
+    // reached `depth`, so a directory whose path is `depth` segments below the
+    // root was never opened. `relative` counts those segments.
+    const tooDeep = (fullPath: string): boolean =>
+      relative(dir, fullPath).split(/[\\/]/).length >= depth;
 
-    try {
-      const entries = readdirSync(dir);
+    const walk = await boundedWalk(dir, {
+      prune: (name, fullPath) => skipped(name) || tooDeep(fullPath),
+      accept: (_fullPath, fileName) =>
+        !skipped(fileName) && /\.(ts|tsx|js|jsx)$/.test(fileName),
+      // NO CAP. Usage is proved by FINDING an importer, so a short walk turns
+      // "I did not look everywhere" into "nothing uses this, delete it".
+      deadlineMs,
+    });
 
-      for (const entry of entries) {
-        // Skip node_modules, .git, etc.
-        if (
-          entry === 'node_modules' ||
-          entry === '.git' ||
-          entry.startsWith('.')
-        ) {
-          continue;
-        }
-
-        const fullPath = join(dir, entry);
-        const stat = statSync(fullPath);
-
-        if (stat.isDirectory()) {
-          files.push(
-            ...this.scanProjectFiles(fullPath, depth, currentDepth + 1)
-          );
-        } else if (stat.isFile()) {
-          // Only TypeScript/JavaScript files
-          if (/\.(ts|tsx|js|jsx)$/.test(entry)) {
-            files.push(fullPath);
-          }
-        }
-      }
-    } catch {
-      // Skip directories we can't read
-    }
-
-    return files;
+    return { files: walk.items, truncatedBy: walk.truncatedBy };
   }
 
   /**
@@ -619,33 +661,60 @@ export class SmartExportsTool {
     targetFilePath: string
   ): boolean {
     // Handle relative imports
-    if (importPath.startsWith('.')) {
-      const importingDir = importingFile.substring(
-        0,
-        importingFile.lastIndexOf('/') || importingFile.lastIndexOf('\\')
-      );
-      let resolved = join(importingDir, importPath);
+    if (!importPath.startsWith('.')) return false;
 
-      // Try different extensions
-      const extensions = [
-        '',
-        '.ts',
-        '.tsx',
-        '.js',
-        '.jsx',
-        '/index.ts',
-        '/index.tsx',
-        '/index.js',
-        '/index.jsx',
-      ];
+    // `dirname`, not a hand-rolled `lastIndexOf`. The previous version read
+    // `lastIndexOf('/') || lastIndexOf('\\')`, and `||` yields the FIRST
+    // truthy operand -- which for a path containing no forward slash is the
+    // -1 the failed search returned, and `substring(0, -1)` clamps to ''.
+    //
+    // MEASURED, NOT ASSUMED: that is LATENT here, not live. `importingFile` is
+    // `sourceFile.fileName`, and TypeScript normalises it to forward slashes --
+    // `C:/Users/.../src/uses.ts` even on Windows, while the target path passed
+    // in alongside it keeps its backslashes. So the '/' search always finds a
+    // real index and the fallback never runs. It would bite the moment this is
+    // called with a path that did not come through TypeScript.
+    //
+    // Fixed anyway, because the expression is wrong on its own terms -- but no
+    // test here can observe the difference, and a mutation reverting this line
+    // survives. That is the honest result, recorded rather than papered over.
+    const importingDir = dirname(importingFile);
+
+    // A NodeNext specifier names the EMITTED file: `./helper.js` is how you
+    // import `helper.ts`, and it is the style this repository itself uses
+    // throughout. Candidate extensions were appended to the specifier AS
+    // WRITTEN, so such an import was only ever tried as `helper.js`,
+    // `helper.js.ts`, `helper.js.tsx` ... and never as `helper.ts`. Every one
+    // of them failed to resolve, so every export reached only through one came
+    // back in `unusedExports` -- which is the single output of this tool that
+    // someone acts on by deleting live code.
+    const specifiers = [importPath];
+    const emitted = /\.(js|jsx|mjs|cjs)$/.exec(importPath);
+    if (emitted) specifiers.push(importPath.slice(0, -emitted[0].length));
+
+    const extensions = [
+      '',
+      '.ts',
+      '.tsx',
+      '.js',
+      '.jsx',
+      '/index.ts',
+      '/index.tsx',
+      '/index.js',
+      '/index.jsx',
+    ];
+
+    // Compared with one separator spelling on both sides. `join` produces
+    // backslashes on Windows while the `/index.*` candidates carry a forward
+    // slash, so a raw string comparison misses on exactly the platform this
+    // runs on.
+    const normalised = (path: string): string => path.replace(/\\/g, '/');
+    const target = normalised(targetFilePath);
+
+    for (const specifier of specifiers) {
+      const resolved = join(importingDir, specifier);
       for (const ext of extensions) {
-        const withExt = resolved + ext;
-        if (
-          withExt === targetFilePath ||
-          withExt.replace(/\\/g, '/') === targetFilePath.replace(/\\/g, '/')
-        ) {
-          return true;
-        }
+        if (normalised(resolved + ext) === target) return true;
       }
     }
 
@@ -924,6 +993,11 @@ export const SMART_EXPORTS_TOOL_DEFINITION = {
         type: 'number',
         description: 'Directory depth to scan when checking usage (default: 3)',
         default: 3,
+      },
+      deadlineMs: {
+        type: 'number',
+        description:
+          'Wall-clock budget in ms for the usage scan (default 10000). On expiry the result comes back with summary.searchTruncated set and is NOT cached, instead of walking until the calling tool times out.',
       },
     },
   },

--- a/src/tools/code-analysis/smart-security.ts
+++ b/src/tools/code-analysis/smart-security.ts
@@ -13,10 +13,15 @@ import { CacheEngine } from '../../core/cache-engine.js';
 import { MetricsCollector } from '../../core/metrics.js';
 import { TokenCounter } from '../../core/token-counter.js';
 import { createHash } from 'crypto';
-import { readFileSync, existsSync, statSync, readdirSync } from 'fs';
+import { readFileSync, existsSync, statSync } from 'fs';
 import { join, relative, extname } from 'path';
 import { homedir } from 'os';
 import { hashFileMetadata } from '../shared/hash-utils.js';
+import {
+  boundedWalk,
+  traversalDeadlineMs,
+  type TruncationReason,
+} from '../shared/bounded-traversal.js';
 
 /**
  * Vulnerability severity levels
@@ -85,6 +90,26 @@ interface FileScanResult {
 /**
  * Complete security scan result
  */
+/**
+ * The file types the pattern rules below actually know how to read.
+ *
+ * Hoisted out of the walk so the accept test is a lookup rather than an array
+ * literal rebuilt once per directory entry.
+ */
+const SCANNABLE_EXTENSIONS = [
+  '.js',
+  '.ts',
+  '.jsx',
+  '.tsx',
+  '.py',
+  '.java',
+  '.cs',
+  '.go',
+  '.rb',
+  '.php',
+  '.html',
+];
+
 interface SecurityScanResult {
   success: boolean;
   filesScanned: string[];
@@ -134,6 +159,16 @@ export interface SmartSecurityOptions {
    * Include low-severity findings
    */
   includeLowSeverity?: boolean;
+
+  /**
+   * Wall-clock budget in ms for discovering the files to scan.
+   *
+   * Discovery was a recursive `readdirSync` that enumerated every entry and
+   * only THEN tested it against `exclude` -- so a project with `node_modules`
+   * paid the full cost of reading the thing it was excluding, on the event
+   * loop, with no point at which it could give up. Defaults to 10 s.
+   */
+  deadlineMs?: number;
 }
 
 /**
@@ -155,6 +190,15 @@ export interface SmartSecurityOutput {
     duration: number;
     fromCache: boolean;
     incrementalMode: boolean;
+    /**
+     * Set when a bound stopped file discovery, so files were never opened.
+     *
+     * This flag is the whole difference between "no vulnerabilities" and "no
+     * vulnerabilities in the files I got to". Absent means the walk completed.
+     */
+    searchTruncated?: boolean;
+    searchTruncatedBy?: TruncationReason;
+    searchNote?: string;
   };
 
   /**
@@ -599,9 +643,11 @@ export class SmartSecurity {
     } = options;
 
     const startTime = Date.now();
+    const deadlineMs = traversalDeadlineMs(options.deadlineMs);
 
     // Determine files to scan
-    const filesToScan = await this.discoverFiles(targets, exclude);
+    const discovery = await this.discoverFiles(targets, exclude, deadlineMs);
+    const filesToScan = discovery.files;
 
     // Generate cache key
     const cacheKey = await this.generateCacheKey(filesToScan);
@@ -650,7 +696,20 @@ export class SmartSecurity {
     // Transform to compact output
     const output = this.transformOutput(scanResults, incrementalMode);
 
-    // Cache the result
+    if (discovery.truncatedBy) {
+      output.summary.searchTruncated = true;
+      output.summary.searchTruncatedBy = discovery.truncatedBy;
+      output.summary.searchNote =
+        'File discovery stopped at the ' +
+        deadlineMs +
+        'ms traversal deadline after finding ' +
+        filesToScan.length +
+        ' file(s), so parts of the project were never scanned and a clean result does NOT mean there is nothing there. Narrow `targets`, widen `exclude`, or raise TOKEN_OPTIMIZER_TRAVERSAL_DEADLINE_MS.';
+    }
+
+    // Cached under a key derived from the DISCOVERED FILE SET, so a partial
+    // scan can never be served in answer to a complete one: a different set of
+    // files hashes to a different key.
     this.cacheResult(cacheKey, output);
 
     // Record metrics
@@ -672,58 +731,56 @@ export class SmartSecurity {
    */
   private async discoverFiles(
     targets: string[],
-    exclude: string[]
-  ): Promise<string[]> {
-    const files: string[] = [];
+    exclude: string[],
+    deadlineMs: number
+  ): Promise<{ files: string[]; truncatedBy?: TruncationReason }> {
+    // ONE budget for the whole call. `targets` is a list, and a per-target
+    // deadline would multiply the ceiling by however many the caller passed.
+    const expiresAt = Date.now() + deadlineMs;
+    const remainingMs = () => Math.max(1, expiresAt - Date.now());
 
-    const scanDirectory = (dir: string) => {
+    const isExcluded = (fullPath: string): boolean => {
+      const relativePath = relative(this.projectRoot, fullPath);
+      return exclude.some((pattern) => relativePath.includes(pattern));
+    };
+
+    const files: string[] = [];
+    let truncatedBy: TruncationReason | undefined;
+
+    const scanDirectory = async (dir: string) => {
       if (!existsSync(dir)) return;
 
-      const entries = readdirSync(dir, { withFileTypes: true });
-
-      for (const entry of entries) {
-        const fullPath = join(dir, entry.name);
-        const relativePath = relative(this.projectRoot, fullPath);
-
-        // Skip excluded patterns
-        if (exclude.some((pattern) => relativePath.includes(pattern))) {
-          continue;
-        }
-
-        if (entry.isDirectory()) {
-          scanDirectory(fullPath);
-        } else if (entry.isFile()) {
-          const ext = extname(entry.name);
-          // Only scan source code files
-          if (
-            [
-              '.js',
-              '.ts',
-              '.jsx',
-              '.tsx',
-              '.py',
-              '.java',
-              '.cs',
-              '.go',
-              '.rb',
-              '.php',
-              '.html',
-            ].includes(ext)
-          ) {
-            files.push(fullPath);
-          }
-        }
-      }
+      // PRUNED, NOT FILTERED. The exclusion ran after enumerating each entry,
+      // so `node_modules` was read in full and then discarded directory by
+      // directory -- paying the entire cost of the thing being excluded.
+      // Pruning is exactly equivalent to the old test rather than a tightening
+      // of it: a child's relative path contains its parent's, so everything
+      // under an excluded directory already failed the same substring check.
+      const walk = await boundedWalk(dir, {
+        prune: (_name, fullPath) => isExcluded(fullPath),
+        accept: (fullPath, fileName) =>
+          !isExcluded(fullPath) &&
+          SCANNABLE_EXTENSIONS.includes(extname(fileName)),
+        // NO CAP, DELIBERATELY. A file that was never opened is
+        // indistinguishable in this output from a file with no
+        // vulnerabilities, so a cap converts "I stopped looking" into "this
+        // project is clean" -- the most dangerous wrong answer this server can
+        // produce. A deadline is reportable, so it never makes that claim.
+        deadlineMs: remainingMs(),
+      });
+      files.push(...walk.items);
+      if (walk.truncated) truncatedBy = walk.truncatedBy;
     };
 
     if (targets.length > 0) {
       // Scan specific targets
       for (const target of targets) {
+        if (truncatedBy) break;
         const fullPath = join(this.projectRoot, target);
         if (existsSync(fullPath)) {
           const stat = statSync(fullPath);
           if (stat.isDirectory()) {
-            scanDirectory(fullPath);
+            await scanDirectory(fullPath);
           } else if (stat.isFile()) {
             files.push(fullPath);
           }
@@ -731,10 +788,10 @@ export class SmartSecurity {
       }
     } else {
       // Full project scan
-      scanDirectory(this.projectRoot);
+      await scanDirectory(this.projectRoot);
     }
 
-    return files;
+    return { files, truncatedBy };
   }
 
   /**
@@ -1436,6 +1493,11 @@ export const SMART_SECURITY_TOOL_DEFINITION = {
         items: {
           type: 'string',
         },
+      },
+      deadlineMs: {
+        type: 'number',
+        description:
+          'Wall-clock budget in ms for discovering the files to scan (default 10000). On expiry the scan reports what it reached with summary.searchTruncated set, instead of walking until the calling tool times out.',
       },
       exclude: {
         type: 'array',

--- a/src/tools/file-operations/smart-edit.ts
+++ b/src/tools/file-operations/smart-edit.ts
@@ -340,10 +340,26 @@ export class SmartEditTool {
       bumpFsGeneration();
 
       // Update cache
+      //
+      // ISOLATED, BECAUSE THE WRITE ABOVE ALREADY HAPPENED. This ran inside the
+      // method's single try/catch, so a cache failure after a successful write
+      // was reported as `success: false, operation: 'failed', editsApplied: 0`
+      // while the file on disk was already edited. Observed live: the SQLite
+      // cache returned "database or disk is full" and smart_edit reported a
+      // failed edit it had in fact completed.
+      //
+      // The caller's only sane response to a reported failure is to retry, and
+      // retrying a LINE-BASED edit against an already-edited file corrupts it.
+      // A refreshed cache is a nicety; a truthful report of what happened to
+      // the file is not.
       if (opts.updateCache) {
-        const cacheKey = generateCacheKey('file-edit', { path: filePath });
-        const contentSize = Buffer.from(editedContent, 'utf-8').length;
-        this.cache.set(cacheKey, editedContent, contentSize, contentSize);
+        try {
+          const cacheKey = generateCacheKey('file-edit', { path: filePath });
+          const contentSize = Buffer.from(editedContent, 'utf-8').length;
+          this.cache.set(cacheKey, editedContent, contentSize, contentSize);
+        } catch {
+          // The edit stands. The next read simply misses the cache.
+        }
       }
 
       // Record metrics

--- a/src/tools/file-operations/smart-glob.ts
+++ b/src/tools/file-operations/smart-glob.ts
@@ -11,8 +11,12 @@
  * Target: 75% reduction vs listing all files with content
  */
 
-import { globSync } from 'glob';
 import { statSync, readFileSync } from 'fs';
+import {
+  boundedGlob,
+  traversalDeadlineMs,
+  type TruncationReason,
+} from '../shared/bounded-traversal.js';
 import { relative, basename, extname, join, isAbsolute } from 'path';
 import { homedir } from 'os';
 import { CacheEngine } from '../../core/cache-engine.js';
@@ -97,6 +101,14 @@ export interface SmartGlobOptions {
    */
   useCache?: boolean;
   ttl?: number; // Cache TTL in seconds (default: 300)
+  /**
+   * Wall-clock budget for the whole call, in ms.
+   *
+   * Defaults to TOKEN_OPTIMIZER_TRAVERSAL_DEADLINE_MS, then to 10 s. The
+   * search returns what it found and says it was cut short, rather than
+   * running until the caller's own tool timeout kills it.
+   */
+  deadlineMs?: number;
 }
 
 export interface SmartGlobResult {
@@ -118,6 +130,19 @@ export interface SmartGlobResult {
     ignoredMatches?: number;
     /** Plain-language explanation of what was withheld and how to see it. */
     ignoreNote?: string;
+    /**
+     * True when a BOUND stopped the walk, so the tree was not fully searched.
+     *
+     * Distinct from `truncated`, which means "more matches exist than this page
+     * returned" and says nothing about coverage. A caller can page through a
+     * `truncated` result and see everything; a `searchTruncated` result has
+     * matches that were never looked for.
+     */
+    searchTruncated?: boolean;
+    /** Which bound stopped it: a result cap, or the wall-clock deadline. */
+    searchTruncatedBy?: TruncationReason;
+    /** What to do about it, in the caller's terms. */
+    searchNote?: string;
   };
   files?: Array<string | FileMetadata>;
   error?: string;
@@ -217,6 +242,7 @@ export class SmartGlobTool {
         sortOrder: options.sortOrder ?? 'asc',
         useCache: options.useCache ?? false,
         ttl: options.ttl ?? 300,
+        deadlineMs: traversalDeadlineMs(options.deadlineMs),
       };
 
       // Check cache first
@@ -250,36 +276,81 @@ export class SmartGlobTool {
         }
       }
 
-      // Perform glob search
+      // ONE BUDGET FOR THE WHOLE CALL.
       //
+      // Both walks share a single wall-clock deadline. Two independent
+      // ten-second budgets is a twenty-second call, and the bound a caller
+      // cares about is on the tool, not on its internals.
+      const expiresAt = startTime + opts.deadlineMs;
+      const remainingMs = () => Math.max(1, expiresAt - Date.now());
+
+      // WHEN THE CAP MAY STOP THE WALK EARLY.
+      //
+      // Short-circuiting is what makes a narrow search on a huge tree instant,
+      // but it changes WHICH matches come back, so it is only allowed where
+      // that cannot silently produce a wrong answer:
+      //
+      //   - Sorting by size or mtime asks for the top N of the whole set. Stop
+      //     early and "largest" quietly becomes "largest among the first
+      //     found", which is a wrong answer wearing a right answer's clothes.
+      //   - The size and date filters need a `statSync` this walk does not do,
+      //     so a cap counted before them gets spent on files that are then
+      //     filtered out -- returning fewer than asked for while more existed.
+      //   - `onlyDirectories` is decided after the walk for the same reason.
+      //
+      // Extension filters are exempt: they are decided from the path alone, so
+      // they run INSIDE both walks and the cap counts only keepers.
+      const filtersNeedStat =
+        opts.minSize > 0 ||
+        opts.maxSize !== Infinity ||
+        opts.modifiedAfter.getTime() > 0 ||
+        opts.modifiedBefore.getTime() < 8640000000000000 ||
+        opts.onlyDirectories;
+      const mayShortCircuit =
+        opts.sortBy === 'path' &&
+        opts.sortOrder === 'asc' &&
+        !filtersNeedStat &&
+        Number.isFinite(opts.limit);
+
+      // Applied to BOTH walks. Filtering only the primary would inflate the
+      // difference below and invent withheld matches that never existed.
+      const acceptsExtension = (candidate: string): boolean => {
+        const ext = extname(candidate);
+        if (opts.extensions.length > 0 && !opts.extensions.includes(ext)) {
+          return false;
+        }
+        return !opts.excludeExtensions.includes(ext);
+      };
+
       // Narrowed to the scoped file when `path` named one -- the glob ran from
       // that file's PARENT, so without this it would also return the parent's
       // other matches and quietly widen the scope the caller asked for.
-      const matches = limitToScopedFile(
-        globSync(pattern, {
-          cwd: opts.cwd,
-          absolute: opts.absolute,
-          // ALWAYS_IGNORED REACHES THIS WALK TOO.
-          //
-          // It used to apply only to the comparison walk, so a caller-supplied
-          // ignore list left `.git` enumerated HERE and excluded THERE. The
-          // primary walk then returned more matches than the comparison, the
-          // difference went negative, and `ignoredMatches` clamped to zero --
-          // telling the caller nothing had been withheld while their own
-          // pattern was withholding a file. The two walks only mean anything
-          // relative to each other, so they have to be scoped identically.
-          ignore: withAlwaysIgnored(opts.ignore),
-          nodir: opts.onlyFiles,
-          // `.github/`, `.claude/`, `.husky/` and every dotfile are ordinary
-          // project content, but glob skips anything dot-prefixed unless told
-          // otherwise. Measured in a real checkout: ten .yml files existed, all
-          // under .github/workflows, and a repo-wide search returned ZERO while
-          // reporting success over 654 files searched. Exclusion is the ignore
-          // list's job -- .git and node_modules are still excluded by it.
-          dot: true,
-        }),
-        scope
-      );
+      const primaryWalk = await boundedGlob(pattern, {
+        cwd: opts.cwd,
+        absolute: opts.absolute,
+        // ALWAYS_IGNORED REACHES THIS WALK TOO.
+        //
+        // It used to apply only to the comparison walk, so a caller-supplied
+        // ignore list left `.git` enumerated HERE and excluded THERE. The
+        // primary walk then returned more matches than the comparison, the
+        // difference went negative, and `ignoredMatches` clamped to zero --
+        // telling the caller nothing had been withheld while their own
+        // pattern was withholding a file. The two walks only mean anything
+        // relative to each other, so they have to be scoped identically.
+        ignore: withAlwaysIgnored(opts.ignore),
+        nodir: opts.onlyFiles,
+        // `.github/`, `.claude/`, `.husky/` and every dotfile are ordinary
+        // project content, but glob skips anything dot-prefixed unless told
+        // otherwise. Measured in a real checkout: ten .yml files existed, all
+        // under .github/workflows, and a repo-wide search returned ZERO while
+        // reporting success over 654 files searched. Exclusion is the ignore
+        // list's job -- .git and node_modules are still excluded by it.
+        dot: true,
+        deadlineMs: remainingMs(),
+        cap: mayShortCircuit ? opts.offset + opts.limit : undefined,
+        accept: acceptsExtension,
+      });
+      const matches = limitToScopedFile(primaryWalk.items, scope);
 
       // Whether the exclusions in force are OURS or the caller's -- the note
       // below names them, and naming them wrongly misdirects anyone hunting a
@@ -291,8 +362,8 @@ export class SmartGlobTool {
       //
       // With `ignore: []` there is nothing to withhold and `matches` is
       // already the unignored set, so the second walk would traverse the whole
-      // tree synchronously to rediscover a list we are holding -- pure cost on
-      // the exact call that opted out of filtering.
+      // tree to rediscover a list we are holding -- pure cost on the exact
+      // call that opted out of filtering.
       //
       // BOTH WALKS ARE SCOPED THE SAME WAY. Narrowing only the first one made
       // the difference between them look like suppressed matches: a file-scoped
@@ -300,29 +371,45 @@ export class SmartGlobTool {
       // returned 2, so the response reported that 1 file "matched but were
       // excluded by the ignore patterns" when nothing had been excluded at all.
       // A number invented to explain an absence is worse than no number.
-      const ignoredMatches =
-        opts.ignore.length === 0
-          ? 0
-          : Math.max(
-              0,
-              limitToScopedFile(
-                globSync(pattern, {
-                  cwd: opts.cwd,
-                  absolute: opts.absolute,
-                  nodir: opts.onlyFiles,
-                  // Same reason as above; both walks must agree.
-                  dot: true,
-                  // NOT an empty ignore list, now that `dot` is on. This walk
-                  // deliberately drops the caller's ignores to count what they
-                  // withheld -- but with dots visible that would enumerate
-                  // `.git/objects`, which on a real repository is enormous and
-                  // is pure cost: nobody's glob was "withheld" by git's object
-                  // store. Infrastructure stays excluded in both walks.
-                  ignore: ALWAYS_IGNORED,
-                }),
-                scope
-              ).length - matches.length
-            );
+      //
+      // AND IT IS SKIPPED WHENEVER EITHER WALK WAS BOUNDED, for that same
+      // reason: a difference between two walks that stopped in different places
+      // measures where they stopped, not what the ignore patterns withheld. The
+      // negative would clamp to zero and report "nothing was withheld" -- the
+      // one answer worse than admitting we do not know.
+      let ignoredMatches: number | undefined;
+      let ignoreUncounted = false;
+      if (opts.ignore.length === 0) {
+        ignoredMatches = 0;
+      } else if (primaryWalk.truncated) {
+        ignoreUncounted = true;
+      } else {
+        const comparisonWalk = await boundedGlob(pattern, {
+          cwd: opts.cwd,
+          absolute: opts.absolute,
+          nodir: opts.onlyFiles,
+          // Same reason as above; both walks must agree.
+          dot: true,
+          // NOT an empty ignore list, now that `dot` is on. This walk
+          // deliberately drops the caller's ignores to count what they
+          // withheld -- but with dots visible that would enumerate
+          // `.git/objects`, which on a real repository is enormous and
+          // is pure cost: nobody's glob was "withheld" by git's object
+          // store. Infrastructure stays excluded in both walks.
+          ignore: ALWAYS_IGNORED,
+          deadlineMs: remainingMs(),
+          accept: acceptsExtension,
+        });
+        if (comparisonWalk.truncated) {
+          ignoreUncounted = true;
+        } else {
+          ignoredMatches = Math.max(
+            0,
+            limitToScopedFile(comparisonWalk.items, scope).length -
+              matches.length
+          );
+        }
+      }
 
       // Filter and collect file info
       let files: Array<{ path: string; metadata?: FileMetadata }> = [];
@@ -462,9 +549,30 @@ export class SmartGlobTool {
           savingsClassification: 'unmeasured',
           savingsReason:
             'No comparable unoptimized glob response was materialized; caller-requested pagination is not optimizer-created savings.',
+          // Coverage, reported separately from pagination. Only present when
+          // the walk really was cut short, so an ordinary search stays quiet.
+          ...(primaryWalk.truncated
+            ? {
+                searchTruncated: true,
+                searchTruncatedBy: primaryWalk.truncatedBy,
+                searchNote:
+                  primaryWalk.truncatedBy === 'deadline'
+                    ? `Search stopped at the ${expiresAt - startTime}ms traversal deadline, so the tree was not fully searched and matches may be missing. Narrow \`path\` or \`pattern\`, or raise TOKEN_OPTIMIZER_TRAVERSAL_DEADLINE_MS.`
+                    : `Search stopped after collecting ${opts.offset + opts.limit} match(es), so the tree was not fully searched. Raise \`limit\` or narrow \`pattern\` to see more.`,
+              }
+            : {}),
+          // The withheld count is unknowable once a walk was bounded, and a
+          // number invented to explain an absence is worse than no number.
+          ...(ignoreUncounted
+            ? {
+                ignoreNote:
+                  'The search stopped at a bound before it finished, so how many matches the ' +
+                  'ignore patterns withheld is unknown. It is not being reported as zero.',
+              }
+            : {}),
           // Only present when something was actually withheld, so a normal
           // search stays as quiet as it was.
-          ...(ignoredMatches > 0
+          ...(ignoredMatches !== undefined && ignoredMatches > 0
             ? {
                 ignoredMatches,
                 // "default" only when they ARE the defaults. A caller who
@@ -701,6 +809,11 @@ export const SMART_GLOB_TOOL_DEFINITION = {
         description:
           'Return absolute paths instead of paths relative to the search root',
         default: false,
+      },
+      deadlineMs: {
+        type: 'number',
+        description:
+          'Wall-clock budget in ms for the whole search (default 10000). On expiry the search returns what it found with metadata.searchTruncated set, instead of running until the calling tool times out.',
       },
       ignore: {
         type: 'array',

--- a/src/tools/file-operations/smart-grep.ts
+++ b/src/tools/file-operations/smart-grep.ts
@@ -12,7 +12,12 @@
  */
 
 import { readFileSync, statSync } from 'fs';
-import { globSync } from 'glob';
+import {
+  boundedGlobStream,
+  traversalDeadlineMs,
+  type StreamState,
+  type TruncationReason,
+} from '../shared/bounded-traversal.js';
 import { relative, join } from 'path';
 import { homedir } from 'os';
 import { CacheEngine } from '../../core/cache-engine.js';
@@ -33,6 +38,25 @@ import { resolveSearchScope } from '../../utils/search-scope.js';
  * through it with `offset`.
  */
 const MAX_RESPONSE_TOKENS = 8_000;
+
+/**
+ * Ceilings that hold even when the caller sets no limit at all.
+ *
+ * Every match record carries its whole LINE, so a dense file multiplies two
+ * unbounded quantities together: one 50,000-character line searched for a
+ * character it repeats produced 50,000 records each holding that same 50,000
+ * characters -- 2.5 GB of string, which threw `Invalid string length` out of
+ * the response-budget `JSON.stringify` and failed the entire search with
+ * `success: false, filesSearched: 0` after 5.3 s.
+ *
+ * THE CEILING IS ON THE LINE, NOT ON THE MATCH COUNT. Capping matches per file
+ * was the first attempt and it was wrong: an existing test pins a file holding
+ * 130,000 matches, and short lines at that count are perfectly fine. The line
+ * text is what gets duplicated per match, so that is where the bound belongs.
+ * A match record is a locator anyway; a 50,000-character line in one is a file
+ * dump wearing a search result's clothes.
+ */
+const MAX_MATCH_LINE_CHARS = 2_000;
 
 export interface GrepMatch {
   file: string; // File path
@@ -98,6 +122,14 @@ export interface SmartGrepOptions {
 
   // Performance options
   maxFileSize?: number; // Skip files larger than this (bytes)
+  /**
+   * Wall-clock budget for discovery AND reading, in ms.
+   *
+   * Defaults to TOKEN_OPTIMIZER_TRAVERSAL_DEADLINE_MS, then to 10 s. The
+   * search returns what it found and says it was cut short, rather than
+   * running until the caller's own tool timeout kills it.
+   */
+  deadlineMs?: number;
   encoding?: BufferEncoding; // File encoding (default: utf-8)
 }
 
@@ -107,6 +139,16 @@ export interface SmartGrepResult {
   metadata: {
     totalMatches: number;
     filesSearched: number;
+    /**
+     * True when a BOUND stopped the search, so the tree was not fully
+     * covered. Distinct from `truncated`, which only means more matches
+     * exist than this page returned.
+     */
+    searchTruncated?: boolean;
+    /** Which bound stopped it: a result cap, or the wall-clock deadline. */
+    searchTruncatedBy?: TruncationReason;
+    /** What to do about it, in the caller's terms. */
+    searchNote?: string;
     filesWithMatches: number;
     returnedMatches: number;
     truncated: boolean;
@@ -241,6 +283,7 @@ export class SmartGrepTool {
         useCache: options.useCache ?? false,
         ttl: options.ttl ?? 300,
         maxFileSize: options.maxFileSize ?? 10 * 1024 * 1024, // 10MB default
+        deadlineMs: traversalDeadlineMs(options.deadlineMs),
         encoding: options.encoding ?? 'utf-8',
       };
 
@@ -278,32 +321,26 @@ export class SmartGrepTool {
       // Build search pattern
       const searchPattern = this.buildPattern(pattern, opts);
 
-      // Find files to search
-      let filesToSearch: string[] = [];
-      for (const filePattern of opts.files) {
-        const matches = globSync(filePattern, {
-          cwd: opts.cwd,
-          absolute: true,
-          ignore: opts.ignore,
-          nodir: true,
-          // `.github/`, `.claude/`, `.husky/` and every dotfile are ordinary
-          // project content, but glob skips anything dot-prefixed unless told
-          // otherwise -- so every CI workflow in the repository was invisible.
-          // Measured: searching a tree returned 0 matches over 654 files while
-          // reporting success, and naming `.github` explicitly in `path` returned
-          // 7 matches in 4 files. This is the third shape of the same defect in
-          // this tool, and the worst: the other two reported `filesSearched: 0`,
-          // whereas this one looks like a thorough search that found nothing.
-          // What is excluded stays the ignore list's job.
-          dot: true,
-        });
-        appendAll(filesToSearch, matches);
-      }
+      // ONE BUDGET FOR THE WHOLE CALL: discovery and reading share it, because
+      // the bound a caller cares about is on the tool, not on its phases.
+      const expiresAt = startTime + opts.deadlineMs;
+      const remainingMs = () => Math.max(1, expiresAt - Date.now());
+      let searchTruncatedBy: TruncationReason | undefined;
 
-      // Filter files by extension and size
-      filesToSearch = filesToSearch.filter((file) => {
+      // DISCOVERY IS STREAMED INTO THE READ, not completed before it.
+      //
+      // Collecting every path first meant a `limit: 5` grep still paid for
+      // enumerating the whole tree: measured on 12,000 files, 5,985 ms against
+      // 10,266 ms exhaustive, for five matches that were all in the first
+      // handful of files. The issue asks for the cap to "short-circuit
+      // traversal, not post-filter a full enumeration", and only reading as
+      // paths arrive delivers that -- the decision to stop comes from matches
+      // found, which cannot be known until files are actually read.
+      const streamState: StreamState = { truncated: false };
+
+      /** Path-and-stat filters, applied per file as it arrives. */
+      const passesFilters = (file: string): boolean => {
         try {
-          // Extension filter
           if (opts.extensions.length > 0) {
             const hasAllowedExt = opts.extensions.some((ext) =>
               file.endsWith(ext)
@@ -316,20 +353,29 @@ export class SmartGrepTool {
           );
           if (hasExcludedExt) return false;
 
-          // Size filter
           const stats = statSync(file);
           if (stats.size > opts.maxFileSize) return false;
 
-          // Binary file filter
           if (opts.skipBinary && this.isBinaryFile(file)) return false;
 
           return true;
         } catch {
           return false;
         }
-      });
+      };
 
-      const filesSearched = filesToSearch.length;
+      // Counted as files are actually opened, NOT as they are discovered.
+      // A run that stops at a bound would otherwise report having searched
+      // files it never read -- coverage it did not have, which is the same
+      // confident-wrong-answer shape this tool family keeps producing.
+      let filesSearched = 0;
+
+      // Stop reading once the caller's page is filled. There is no sort here,
+      // so the first N matches in walk order ARE the first N -- unlike
+      // smart_glob, where a cap could silently reorder a sorted answer.
+      const matchCap = Number.isFinite(opts.limit)
+        ? opts.offset + opts.limit
+        : Infinity;
 
       // Search files
       const allMatches: GrepMatch[] = [];
@@ -343,72 +389,115 @@ export class SmartGrepTool {
       const regexProbe = this.buildRegexProbe(pattern, opts);
       let regexWouldMatch = false;
 
-      for (const file of filesToSearch) {
-        try {
-          const content = readFileSync(file, opts.encoding);
-          const lines = content.split('\n');
-          const fileMatches: GrepMatch[] = [];
-
-          // PER LINE, because that is how the search itself matches.
-          //
-          // Testing whole file contents disagreed with the search in both
-          // directions: `^TOKEN$` is false against a multi-line string -- `^`
-          // and `$` anchor to the ends of the WHOLE string without the `m`
-          // flag -- so the hint went missing for exactly the anchored patterns
-          // someone reaching for regex is most likely to write; and a pattern
-          // spanning a newline matched the file while matching no line, which
-          // would have promised a `regex: true` result that does not exist.
-          if (
-            regexProbe &&
-            !regexWouldMatch &&
-            lines.some((l) => regexProbe.test(l))
-          ) {
-            regexWouldMatch = true;
+      for (const filePattern of opts.files) {
+        if (searchTruncatedBy) break;
+        for await (const file of boundedGlobStream(
+          filePattern,
+          {
+            cwd: opts.cwd,
+            absolute: true,
+            ignore: opts.ignore,
+            nodir: true,
+            deadlineMs: remainingMs(),
+            // `.github/`, `.claude/`, `.husky/` and every dotfile are ordinary
+            // project content, but glob skips anything dot-prefixed unless told
+            // otherwise -- so every CI workflow in the repository was invisible.
+            // Measured: searching a tree returned 0 matches over 654 files while
+            // reporting success, and naming `.github` explicitly in `path`
+            // returned 7 matches in 4 files. What is excluded stays the ignore
+            // list's job.
+            dot: true,
+          },
+          streamState
+        )) {
+          if (Date.now() >= expiresAt) {
+            searchTruncatedBy = 'deadline';
+            break;
           }
+          if (allMatches.length >= matchCap) {
+            searchTruncatedBy = 'cap';
+            break;
+          }
+          if (!passesFilters(file)) continue;
+          try {
+            filesSearched++;
+            const content = readFileSync(file, opts.encoding);
+            const lines = content.split('\n');
+            const fileMatches: GrepMatch[] = [];
 
-          for (let i = 0; i < lines.length; i++) {
-            const line = lines[i];
-            const matches = [...line.matchAll(searchPattern)];
-
-            for (const match of matches) {
-              if (fileMatches.length >= opts.maxMatchesPerFile) break;
-
-              const grepMatch: GrepMatch = {
-                file: relative(opts.cwd, file),
-                lineNumber: i + 1, // 1-based
-                line: line,
-                match: match[0],
-              };
-
-              // Add column if requested
-              if (opts.includeColumn && match.index !== undefined) {
-                grepMatch.column = match.index;
-              }
-
-              // Add context if requested
-              if (opts.includeContext) {
-                if (opts.contextBefore > 0) {
-                  const start = Math.max(0, i - opts.contextBefore);
-                  grepMatch.before = lines.slice(start, i);
-                }
-                if (opts.contextAfter > 0) {
-                  const end = Math.min(lines.length, i + opts.contextAfter + 1);
-                  grepMatch.after = lines.slice(i + 1, end);
-                }
-              }
-
-              fileMatches.push(grepMatch);
+            // PER LINE, because that is how the search itself matches.
+            //
+            // Testing whole file contents disagreed with the search in both
+            // directions: `^TOKEN$` is false against a multi-line string -- `^`
+            // and `$` anchor to the ends of the WHOLE string without the `m`
+            // flag -- so the hint went missing for exactly the anchored patterns
+            // someone reaching for regex is most likely to write; and a pattern
+            // spanning a newline matched the file while matching no line, which
+            // would have promised a `regex: true` result that does not exist.
+            if (
+              regexProbe &&
+              !regexWouldMatch &&
+              lines.some((l) => regexProbe.test(l))
+            ) {
+              regexWouldMatch = true;
             }
-          }
 
-          if (fileMatches.length > 0) {
-            filesWithMatches.add(relative(opts.cwd, file));
-            matchCounts.set(relative(opts.cwd, file), fileMatches.length);
-            appendAll(allMatches, fileMatches);
+            for (let i = 0; i < lines.length; i++) {
+              const line = lines[i];
+              const matches = [...line.matchAll(searchPattern)];
+
+              for (const match of matches) {
+                if (fileMatches.length >= opts.maxMatchesPerFile) break;
+
+                const grepMatch: GrepMatch = {
+                  file: relative(opts.cwd, file),
+                  lineNumber: i + 1, // 1-based
+                  // A match record is a LOCATOR, not a file dump. An
+                  // unbounded line here is what turned dense matches into
+                  // gigabytes of duplicated text.
+                  line:
+                    line.length > MAX_MATCH_LINE_CHARS
+                      ? line.slice(0, MAX_MATCH_LINE_CHARS) + '...'
+                      : line,
+                  match: match[0],
+                };
+
+                // Add column if requested
+                if (opts.includeColumn && match.index !== undefined) {
+                  grepMatch.column = match.index;
+                }
+
+                // Add context if requested
+                if (opts.includeContext) {
+                  if (opts.contextBefore > 0) {
+                    const start = Math.max(0, i - opts.contextBefore);
+                    grepMatch.before = lines.slice(start, i);
+                  }
+                  if (opts.contextAfter > 0) {
+                    const end = Math.min(
+                      lines.length,
+                      i + opts.contextAfter + 1
+                    );
+                    grepMatch.after = lines.slice(i + 1, end);
+                  }
+                }
+
+                fileMatches.push(grepMatch);
+              }
+            }
+
+            if (fileMatches.length > 0) {
+              filesWithMatches.add(relative(opts.cwd, file));
+              matchCounts.set(relative(opts.cwd, file), fileMatches.length);
+              appendAll(allMatches, fileMatches);
+            }
+          } catch {
+            // Skip files we can't read
+            continue;
           }
-        } catch {
-          // Skip files we can't read
-          continue;
+        }
+        if (streamState.truncated && !searchTruncatedBy) {
+          searchTruncatedBy = streamState.truncatedBy;
         }
       }
 
@@ -496,6 +585,16 @@ export class SmartGrepTool {
         metadata: {
           totalMatches,
           filesSearched,
+          ...(searchTruncatedBy
+            ? {
+                searchTruncated: true,
+                searchTruncatedBy,
+                searchNote:
+                  searchTruncatedBy === 'deadline'
+                    ? `Search stopped at the ${opts.deadlineMs}ms deadline after reading ${filesSearched} file(s), so files were left unsearched and matches may be missing. Narrow \`path\`/\`files\`, or raise TOKEN_OPTIMIZER_TRAVERSAL_DEADLINE_MS.`
+                    : `Search stopped once ${matchCap} match(es) were collected, so files were left unsearched. Raise \`limit\` to search further.`,
+              }
+            : {}),
           filesWithMatches: filesWithMatches.size,
           returnedMatches:
             opts.count || opts.filesWithMatches ? 0 : paginatedMatches.length,
@@ -843,6 +942,11 @@ export const SMART_GREP_TOOL_DEFINITION = {
         type: 'boolean',
         description: 'Skip files that look binary',
         default: true,
+      },
+      deadlineMs: {
+        type: 'number',
+        description:
+          'Wall-clock budget in ms for the whole search (default 10000). On expiry the search returns what it found with metadata.searchTruncated set, instead of running until the calling tool times out.',
       },
       ignore: {
         type: 'array',

--- a/src/tools/shared/bounded-traversal.ts
+++ b/src/tools/shared/bounded-traversal.ts
@@ -4,7 +4,7 @@
  * WHY THIS EXISTS. Every traversal in this server used `globSync` or a recursive
  * `readdirSync`, enumerated the entire tree, and only then applied `limit`. On a
  * real machine that is not a slow path, it is an unbounded one: measured on
- * 2026-08-28, a default-ignore glob of `C:/Users/cheat` ran **178 seconds
+ * 2026-08-28, a default-ignore glob of a Windows user profile directory ran **178 seconds
  * without completing** and had to be killed, while the same walk capped at 50
  * matches returned in **27 ms**. The tools are advertised as bounded
  * replacements for the built-in `Glob`/`grep`, and the routing policy DENIES the

--- a/src/tools/shared/bounded-traversal.ts
+++ b/src/tools/shared/bounded-traversal.ts
@@ -1,0 +1,308 @@
+/**
+ * File discovery that is bounded DURING the walk, not after it.
+ *
+ * WHY THIS EXISTS. Every traversal in this server used `globSync` or a recursive
+ * `readdirSync`, enumerated the entire tree, and only then applied `limit`. On a
+ * real machine that is not a slow path, it is an unbounded one: measured on
+ * 2026-08-28, a default-ignore glob of `C:/Users/cheat` ran **178 seconds
+ * without completing** and had to be killed, while the same walk capped at 50
+ * matches returned in **27 ms**. The tools are advertised as bounded
+ * replacements for the built-in `Glob`/`grep`, and the routing policy DENIES the
+ * built-ins -- so a tool that hangs where `dir` is instant does not merely
+ * perform badly, it strands the caller with no way to do the thing at all.
+ *
+ * TWO BOUNDS, BECAUSE ONE IS NOT ENOUGH. They fail in different places and
+ * neither covers the other:
+ *
+ *   - The **cap** short-circuits: stop walking once enough matches are in hand.
+ *     It is what makes a narrow search on a huge tree instant. It does nothing
+ *     when matches are rare, because it is only ever checked on a match.
+ *   - The **deadline** is a hard wall-clock stop delivered by `AbortSignal`.
+ *     It is what covers `**' + '/*.csproj` over `node_modules`, where the walk
+ *     can spend minutes yielding NOTHING and a between-matches check would never
+ *     run. Verified: an abort fired at 2 s on a pattern that matched nothing.
+ *
+ * SYNCHRONOUS TRAVERSAL WAS ITS OWN BUG. `globSync` blocks the event loop, so
+ * the server could not answer a cancel, a ping, or anything else while walking.
+ * That is why the reported hangs had to be killed rather than timing out. These
+ * helpers are async so the loop stays live and the abort can actually be
+ * delivered.
+ *
+ * NOTHING HERE INVENTS A NUMBER. When a bound is hit the result says so and
+ * names which one. A caller that gets `truncated: true` knows the set is
+ * partial; a caller that gets `false` knows the walk completed.
+ */
+
+import { globIterate } from 'glob';
+import { readdir } from 'fs/promises';
+import { join } from 'path';
+
+/**
+ * The default wall-clock budget for one traversal.
+ *
+ * Chosen against the measurements above rather than by feel: the whole point is
+ * to return before the caller's own tool timeout, which is 120 s. Ten seconds
+ * completes every in-repository walk measured here (the largest, a 116k-file
+ * tree, took 8.6 s) while cutting the pathological home-directory walk short by
+ * more than seventeen times over.
+ */
+export const DEFAULT_TRAVERSAL_DEADLINE_MS = 10_000;
+
+/** Why a traversal stopped early. Absent when it ran to completion. */
+export type TruncationReason = 'cap' | 'deadline';
+
+export interface BoundedResult<T> {
+  items: T[];
+  /** True when a bound stopped the walk, so `items` is a partial set. */
+  truncated: boolean;
+  /** Which bound stopped it. Absent when `truncated` is false. */
+  truncatedBy?: TruncationReason;
+  elapsedMs: number;
+}
+
+/**
+ * The traversal budget, overridable per deployment.
+ *
+ * A machine with a slow network drive may legitimately need longer, and a
+ * caller under a tighter timeout may need less. Invalid values fall back rather
+ * than throwing: a malformed environment variable must not break file search.
+ */
+export function traversalDeadlineMs(override?: number): number {
+  if (
+    typeof override === 'number' &&
+    Number.isFinite(override) &&
+    override > 0
+  ) {
+    return override;
+  }
+  const fromEnv = Number(process.env.TOKEN_OPTIMIZER_TRAVERSAL_DEADLINE_MS);
+  if (Number.isFinite(fromEnv) && fromEnv > 0) return fromEnv;
+  return DEFAULT_TRAVERSAL_DEADLINE_MS;
+}
+
+export interface BoundedGlobOptions {
+  cwd: string;
+  absolute?: boolean;
+  ignore?: string[];
+  nodir?: boolean;
+  dot?: boolean;
+  /**
+   * Stop after this many ACCEPTED paths.
+   *
+   * Counted after `accept`, not before, so a caller filtering by extension gets
+   * `cap` files it wanted rather than `cap` candidates it mostly discards.
+   */
+  cap?: number;
+  deadlineMs?: number;
+  /** Applied during the walk so filtering cannot be defeated by the cap. */
+  accept?: (path: string) => boolean;
+}
+
+/**
+ * `glob`, bounded.
+ *
+ * An abort is a RESULT, not an error: the caller asked for what could be found
+ * in the time allowed, and partial-with-a-flag is the answer. Any other failure
+ * still throws, because a permissions error or a bad pattern is not a bound
+ * being hit and must not be disguised as one.
+ */
+export async function boundedGlob(
+  pattern: string,
+  options: BoundedGlobOptions
+): Promise<BoundedResult<string>> {
+  const started = Date.now();
+  const cap = options.cap ?? Infinity;
+  const deadline = traversalDeadlineMs(options.deadlineMs);
+  const accept = options.accept;
+
+  const items: string[] = [];
+  let truncatedBy: TruncationReason | undefined;
+
+  const controller = new AbortController();
+  // `unref` so a pending deadline can never hold the process open on its own;
+  // the `clearTimeout` below is what normally retires it.
+  const timer = setTimeout(() => controller.abort(), deadline);
+  timer.unref?.();
+
+  try {
+    for await (const entry of globIterate(pattern, {
+      cwd: options.cwd,
+      absolute: options.absolute,
+      ignore: options.ignore,
+      nodir: options.nodir,
+      dot: options.dot,
+      signal: controller.signal,
+    })) {
+      const path = String(entry);
+      if (accept && !accept(path)) continue;
+      items.push(path);
+      if (items.length >= cap) {
+        truncatedBy = 'cap';
+        break;
+      }
+    }
+  } catch (error) {
+    if (!isAbort(error)) throw error;
+    truncatedBy = 'deadline';
+  } finally {
+    clearTimeout(timer);
+  }
+
+  return {
+    items,
+    truncated: truncatedBy !== undefined,
+    truncatedBy,
+    elapsedMs: Date.now() - started,
+  };
+}
+
+/** Mutable truncation state for a streaming walk, since a generator cannot return one. */
+export interface StreamState {
+  truncated: boolean;
+  truncatedBy?: TruncationReason;
+}
+
+/**
+ * The same walk, yielded one path at a time.
+ *
+ * WHY A STREAM AND NOT JUST A CAP. `boundedGlob` collects before returning, so a
+ * consumer that stops early still paid for the whole discovery. `smart_grep`
+ * does exactly that -- it must decide whether to stop from the MATCHES it finds
+ * while reading, which it cannot know until it has read. Measured on a 12,000
+ * file tree: a `limit: 5` grep took 5,985 ms against 10,266 ms exhaustive,
+ * because discovery ran to completion before the first file was opened. Reading
+ * as paths arrive makes the cap actually short-circuit.
+ *
+ * Truncation is reported through `state` because a generator's return value is
+ * not observable from `for await`.
+ */
+export async function* boundedGlobStream(
+  pattern: string,
+  options: BoundedGlobOptions,
+  state: StreamState
+): AsyncGenerator<string> {
+  const deadline = traversalDeadlineMs(options.deadlineMs);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), deadline);
+  timer.unref?.();
+
+  try {
+    for await (const entry of globIterate(pattern, {
+      cwd: options.cwd,
+      absolute: options.absolute,
+      ignore: options.ignore,
+      nodir: options.nodir,
+      dot: options.dot,
+      signal: controller.signal,
+    })) {
+      const path = String(entry);
+      if (options.accept && !options.accept(path)) continue;
+      yield path;
+    }
+  } catch (error) {
+    if (!isAbort(error)) throw error;
+    state.truncated = true;
+    state.truncatedBy = 'deadline';
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * An abort, however the runtime chose to spell it.
+ *
+ * Node reports this as an `AbortError` with code `ABORT_ERR`, but `glob` passes
+ * the signal down to `path-scurry` and the surfaced shape has changed across
+ * versions. Matching on several spellings is deliberate: mistaking an abort for
+ * a real failure would turn a bounded partial result into a thrown error, which
+ * is the failure mode this whole module exists to remove.
+ */
+function isAbort(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const candidate = error as { name?: unknown; code?: unknown };
+  return (
+    candidate.name === 'AbortError' ||
+    candidate.code === 'ABORT_ERR' ||
+    candidate.name === 'DOMException'
+  );
+}
+
+export interface BoundedWalkOptions {
+  /** Directory names never descended into. Pruned, not filtered afterwards. */
+  prune?: (directoryName: string, fullPath: string) => boolean;
+  /** Files kept. Called once per file; the cap counts only what it accepts. */
+  accept?: (fullPath: string, fileName: string) => boolean;
+  cap?: number;
+  deadlineMs?: number;
+}
+
+/**
+ * A recursive directory walk with the same two bounds.
+ *
+ * For the tools that hand-roll `readdirSync` recursion rather than using `glob`.
+ * PRUNING IS THE POINT: skipping a directory after enumerating it still paid for
+ * enumerating it, and `node_modules` is where that bill comes due.
+ *
+ * Breadth-first via an explicit queue rather than recursion, so a deep or
+ * symlink-looped tree cannot exhaust the stack -- and `withFileTypes` keeps
+ * symlinked directories from being descended, which is what turns a junction
+ * into an infinite walk on Windows.
+ */
+export async function boundedWalk(
+  root: string,
+  options: BoundedWalkOptions = {}
+): Promise<BoundedResult<string>> {
+  const started = Date.now();
+  const cap = options.cap ?? Infinity;
+  const deadline = traversalDeadlineMs(options.deadlineMs);
+  const expiresAt = started + deadline;
+
+  const items: string[] = [];
+  let truncatedBy: TruncationReason | undefined;
+  const queue: string[] = [root];
+
+  while (queue.length > 0) {
+    if (Date.now() >= expiresAt) {
+      truncatedBy = 'deadline';
+      break;
+    }
+
+    const dir = queue.shift() as string;
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      // An unreadable directory is not a reason to abandon the search.
+      continue;
+    }
+
+    for (const entry of entries) {
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (options.prune?.(entry.name, fullPath)) continue;
+        queue.push(fullPath);
+        continue;
+      }
+      // Anything that is not a real file or directory -- a symlink, a junction,
+      // a device -- is not followed. On Windows a junction reports as a
+      // directory to `stat` but not to `withFileTypes`, and following one is how
+      // a shared `node_modules` turns a walk into a loop.
+      if (!entry.isFile()) continue;
+      if (options.accept && !options.accept(fullPath, entry.name)) continue;
+      items.push(fullPath);
+      if (items.length >= cap) {
+        truncatedBy = 'cap';
+        break;
+      }
+    }
+
+    if (truncatedBy) break;
+  }
+
+  return {
+    items,
+    truncated: truncatedBy !== undefined,
+    truncatedBy,
+    elapsedMs: Date.now() - started,
+  };
+}

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "_why": "Mutation testing for the traversal safety primitives. A green suite is evidence of nothing until you have watched it go red; this makes that automatic instead of a hand-rolled script that gets rebuilt, and re-debugged, every time. The previous bespoke harness reported every mutation as SURVIVED because it could not parse jest's summary, and left mutations in the working tree when it was killed.",
+  "_why_not_a_pr_gate": "Measured 2026-08-28: 140 mutants against the traversal tests, ~1 minute each at concurrency 2, is roughly 2h20m. That is a scheduled job, not a blocking check. The cost is dominated by the 2,000-file fixture rebuilt in beforeAll for every mutant, not by Stryker.",
+  "_no_break_threshold_yet": "`thresholds.break` is deliberately absent until a first full run establishes the real score. Picking a number before measuring would either fail the first nightly for no reason or be set so low it asserts nothing.",
+  "_scope": "Only the shared primitive is mutated. Widening `mutate` without also widening jest.mutation.config.js scores mutants as SURVIVED because their killing tests were never run -- a false alarm of exactly the kind that gets a gate switched off.",
+  "packageManager": "npm",
+  "testRunner": "jest",
+  "jest": {
+    "projectType": "custom",
+    "configFile": "jest.mutation.config.js",
+    "enableFindRelatedTests": false
+  },
+  "mutate": [
+    "src/tools/shared/bounded-traversal.ts"
+  ],
+  "reporters": [
+    "clear-text",
+    "progress",
+    "json"
+  ],
+  "jsonReporter": {
+    "fileName": "reports/mutation/mutation.json"
+  },
+  "coverageAnalysis": "off",
+  "concurrency": 2,
+  "timeoutMS": 120000,
+  "dryRunTimeoutMinutes": 15,
+  "incremental": true,
+  "incrementalFile": "reports/mutation/stryker-incremental.json",
+  "thresholds": {
+    "high": 90,
+    "low": 80
+  }
+}

--- a/tests/benchmarks/traversal.bench.ts
+++ b/tests/benchmarks/traversal.bench.ts
@@ -1,0 +1,137 @@
+/**
+ * Wall-clock ceilings for every tool that walks the filesystem.
+ *
+ * WHY THIS EXISTS RATHER THAN A UNIT TEST. Issue #335 was not a wrong answer,
+ * it was an unbounded one: `smart_glob` and `smart_grep` enumerated a whole
+ * tree before applying `limit`, and on a real home directory that ran **178
+ * seconds without completing**. Nothing in the suite could fail for that,
+ * because every existing test ran against a handful of fixture files where an
+ * unbounded walk is indistinguishable from a bounded one. A defect that only
+ * appears at scale needs a test that runs at scale.
+ *
+ * WHAT THESE ASSERT, and what they deliberately do not. The ceilings are
+ * generous and shaped like "bounded, on a shared CI runner, under contention" --
+ * not millisecond budgets, which would flake and then be deleted. The
+ * interesting signal is the RATIO: a capped search must be dramatically cheaper
+ * than an exhaustive one over the same tree. That relationship is what breaks
+ * when someone reintroduces enumerate-then-filter, and it holds regardless of
+ * how slow the machine is.
+ *
+ * The tree is built once and is deliberately wider than any fixture in the unit
+ * suite, because that width is the entire point.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { SmartGlobTool } from '../../src/tools/file-operations/smart-glob.js';
+import { SmartGrepTool } from '../../src/tools/file-operations/smart-grep.js';
+import { CacheEngine } from '../../src/core/cache-engine.js';
+import { TokenCounter } from '../../src/core/token-counter.js';
+import { MetricsCollector } from '../../src/core/metrics.js';
+
+/** A tree big enough that enumerate-then-filter is visibly different. */
+const DIRECTORIES = 120;
+const FILES_PER_DIRECTORY = 100; // 12,000 files
+const CEILING_MS = 30_000;
+
+let root: string;
+let cache: CacheEngine;
+let glob: SmartGlobTool;
+let grep: SmartGrepTool;
+
+const report: Array<{ operation: string; ms: number }> = [];
+
+const timed = async <T>(operation: string, run: () => Promise<T>) => {
+  const started = Date.now();
+  const value = await run();
+  const ms = Date.now() - started;
+  report.push({ operation, ms });
+  return { value, ms };
+};
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), 'traversal-bench-'));
+  for (let d = 0; d < DIRECTORIES; d++) {
+    const sub = join(root, `pkg-${String(d).padStart(4, '0')}`);
+    mkdirSync(sub, { recursive: true });
+    for (let f = 0; f < FILES_PER_DIRECTORY; f++) {
+      writeFileSync(
+        join(sub, `file-${String(f).padStart(4, '0')}.ts`),
+        'export const NEEDLE = 1;\n'
+      );
+    }
+  }
+  cache = new CacheEngine(join(root, 'cache.db'), 100);
+  glob = new SmartGlobTool(cache, new TokenCounter(), new MetricsCollector());
+  grep = new SmartGrepTool(cache, new TokenCounter(), new MetricsCollector());
+}, 300_000);
+
+afterAll(() => {
+  // eslint-disable-next-line no-console
+  console.log(
+    '\nTraversal benchmarks (' +
+      DIRECTORIES * FILES_PER_DIRECTORY +
+      ' files):\n' +
+      report
+        .map((r) => `  ${String(r.ms).padStart(7)} ms  ${r.operation}`)
+        .join('\n')
+  );
+  try {
+    cache.close?.();
+  } catch {
+    /* ignore */
+  }
+  try {
+    rmSync(root, { recursive: true, force: true });
+  } catch {
+    /* windows can hold a handle briefly */
+  }
+});
+
+describe('traversal stays bounded at scale', () => {
+  it('smart_glob: an exhaustive search finishes inside its ceiling', async () => {
+    const { value, ms } = await timed('smart_glob exhaustive', () =>
+      glob.glob('**/*.ts', { cwd: root })
+    );
+    expect(value.success).toBe(true);
+    expect(ms).toBeLessThan(CEILING_MS);
+  }, 120_000);
+
+  it('smart_glob: a capped search is far cheaper than an exhaustive one', async () => {
+    // THE REGRESSION THIS CATCHES. Enumerate-then-filter makes these two cost
+    // the same, because the cap is applied to a list that was already built.
+    const exhaustive = await timed('smart_glob exhaustive (ratio base)', () =>
+      glob.glob('**/*.ts', { cwd: root })
+    );
+    const capped = await timed('smart_glob limit=10', () =>
+      glob.glob('**/*.ts', { cwd: root, limit: 10 })
+    );
+    expect(capped.value.files).toHaveLength(10);
+    expect(capped.ms).toBeLessThan(CEILING_MS);
+    // Generous factor: the claim is "short-circuits", not a speed record.
+    expect(capped.ms).toBeLessThanOrEqual(Math.max(250, exhaustive.ms / 2));
+  }, 180_000);
+
+  it('smart_grep: a capped search is far cheaper than an exhaustive one', async () => {
+    const exhaustive = await timed('smart_grep exhaustive (ratio base)', () =>
+      grep.grep('NEEDLE', { cwd: root })
+    );
+    const capped = await timed('smart_grep limit=5', () =>
+      grep.grep('NEEDLE', { cwd: root, limit: 5 })
+    );
+    expect(capped.ms).toBeLessThan(CEILING_MS);
+    expect(capped.ms).toBeLessThanOrEqual(Math.max(250, exhaustive.ms / 2));
+  }, 180_000);
+
+  it('a tight deadline is honoured rather than ignored', async () => {
+    // The bound that covers the case a cap cannot: a walk that matches nothing
+    // for a long time. Without it there is no ceiling at all on a wide tree.
+    const { value, ms } = await timed('smart_glob deadline=250ms', () =>
+      glob.glob('**/*.no-such-extension', { cwd: root, deadlineMs: 250 })
+    );
+    expect(value.success).toBe(true);
+    expect(ms).toBeLessThan(CEILING_MS);
+  }, 120_000);
+});

--- a/tests/unit/bounded-tools-report-their-bounds.test.ts
+++ b/tests/unit/bounded-tools-report-their-bounds.test.ts
@@ -1,0 +1,215 @@
+/**
+ * The invariants a linter cannot see.
+ *
+ * `n/no-sync` catches the mechanical half of #335 -- a blocking `*Sync` call --
+ * and `eslint-suppressions.json` keeps the 306 existing ones from growing. What
+ * no linter can check is whether a tool that CAN return a partial answer
+ * actually SAYS so, and whether it refuses to cache one. Those are semantic,
+ * they are where every real defect in this area was found, and they are the
+ * reason this file exists rather than another lint rule.
+ *
+ * Each of the three rules below failed on real code before it was written:
+ *
+ *   - `deadlineMs` accepted but undeclared. The server spreads the caller's
+ *     whole argument object into options, so an undeclared option WORKS while
+ *     being undiscoverable -- and a caller who guesses a neighbouring name gets
+ *     silence. smart_build shipped exactly this during #335 and the schema
+ *     ratchet could not see it, because its options interface is not exported.
+ *
+ *   - A bounded walk whose result says nothing. `success: true` with a short
+ *     file list is indistinguishable from a complete search; the caller acts on
+ *     "no findings" and "nothing imports this" as though the tool had looked
+ *     everywhere.
+ *
+ *   - A partial result written to the cache. This is the one that outlives the
+ *     call: the keys are derived from cwd, or project path plus language, or
+ *     file content -- never from WHICH FILES WERE REACHED -- so a truncated
+ *     walk stored under one is served to every later call for the whole TTL,
+ *     reporting `cacheHit: true` with no truncation flag at all. Three tools
+ *     had this and all three tests failed before the guards were added.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative } from 'path';
+import { acceptedOptions, declaredProperties } from './helpers/schema-source.js';
+
+const ROOT = process.cwd();
+const TOOLS = join(ROOT, 'src', 'tools');
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) out.push(full);
+  }
+  return out;
+}
+
+interface BoundedTool {
+  file: string;
+  text: string;
+}
+
+/** Every tool that walks the filesystem through the bounded primitives. */
+function boundedTools(): BoundedTool[] {
+  const found: BoundedTool[] = [];
+  for (const file of walk(TOOLS)) {
+    const text = readFileSync(file, 'utf8');
+    if (!text.includes('bounded-traversal.js')) continue;
+    if (!text.includes('_TOOL_DEFINITION')) continue;
+    found.push({ file: relative(ROOT, file).replace(/\\/g, '/'), text });
+  }
+  return found;
+}
+
+const tools = boundedTools();
+
+/**
+ * Tools whose cache key already encodes which files were reached, so a partial
+ * result cannot be served in answer to a complete one.
+ *
+ * AN EXEMPTION HERE NEEDS A REASON THAT IS TRUE OF THE KEY, not a note that the
+ * author checked. smart_security hashes the discovered file set itself
+ * (`generateCacheKey(files)`), so a truncated scan hashes differently and lands
+ * under a different key -- the poisoning this rule prevents is impossible by
+ * construction rather than by a guard.
+ */
+const KEY_ENCODES_COMPLETENESS: Record<string, string> = {
+  'src/tools/code-analysis/smart-security.ts':
+    'generateCacheKey hashes the discovered file set, so a partial scan gets its own key',
+};
+
+/**
+ * Individual cache writes that cannot store a partial result, with the argument
+ * for why -- matched on the call text so a rewrite invalidates the exemption
+ * rather than silently carrying it forward.
+ *
+ * A whole-file exemption would be wrong for these: the same file has other
+ * writes that DO need the guard, and blinding the rule to the file would take
+ * those with it.
+ */
+const CACHE_WRITES_THAT_CANNOT_TRUNCATE: Record<string, string> = {
+  'this.cacheGraph(cacheKey, updatedGraph, opts.ttl);':
+    'the incremental path. `incrementalGraphUpdate` re-analyses only files ' +
+    'already IN the graph and never walks the tree, so its result is exactly ' +
+    'as complete as its input -- and its input came from the cache, which the ' +
+    'guard on the full-build path keeps free of partial graphs. Safe by ' +
+    'induction on that guard, so it breaks if the other one is ever removed; ' +
+    'the full-build write is still checked.',
+};
+
+describe('every tool that can answer partially says so', () => {
+  it('finds the bounded tools at all, so this file cannot pass by matching nothing', () => {
+    // The failure mode of every guard in this repo: the scanner rots, finds
+    // nothing, and the suite goes green while asserting about an empty set.
+    expect(tools.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('declares deadlineMs in the published schema, not just accepts it', () => {
+    const undeclared: string[] = [];
+    for (const tool of tools) {
+      if (!acceptedOptions(tool.text).includes('deadlineMs')) {
+        undeclared.push(`${tool.file}: does not accept deadlineMs at all`);
+        continue;
+      }
+      const declared = declaredProperties(tool.text);
+      if (!declared || !declared.includes('deadlineMs')) {
+        undeclared.push(`${tool.file}: accepts deadlineMs but does not declare it`);
+      }
+    }
+
+    expect(undeclared).toEqual([]);
+  });
+
+  it('surfaces truncation in its result rather than returning a quiet partial', () => {
+    // A bounded walk that reports nothing is worse than a timeout: the caller
+    // cannot tell it from a complete answer, so it acts on the short one.
+    //
+    // LOOKS FOR THE ASSIGNMENT, NOT THE WORD. This first checked
+    // `text.includes('searchTruncated')`, which a mutation walked straight
+    // through: deleting the block that SETS the flag left the identifier behind
+    // in the interface declaration and a comment, so the tool reported nothing
+    // while the test stayed green. Mentioning a flag is not setting one.
+    const reports = /(searchTruncated|filesCompiledPartial)\s*[:=]\s*true/;
+    const silent = tools
+      .filter((tool) => !reports.test(tool.text))
+      .map((tool) => tool.file);
+
+    expect(silent).toEqual([]);
+  });
+
+  it('never writes a bounded result into a cache', () => {
+    // THE DEFECT THAT OUTLIVES THE CALL. Every cache write in a tool that can
+    // truncate must be guarded by a truncation check, unless the key itself
+    // encodes which files were reached.
+    const unguarded: string[] = [];
+
+    for (const tool of tools) {
+      if (KEY_ENCODES_COMPLETENESS[tool.file]) continue;
+
+      const lines = tool.text.split(/\r?\n/);
+      lines.forEach((line, index) => {
+        if (!/\bthis\.cache[A-Z]\w*\s*\(/.test(line)) return;
+        if (CACHE_WRITES_THAT_CANNOT_TRUNCATE[line.trim()]) return;
+
+        // The guard may be the enclosing `if`, so look back a few lines rather
+        // than only at the call itself.
+        const context = lines.slice(Math.max(0, index - 6), index + 1).join('\n');
+        const guarded =
+          /!\s*\w*[Tt]runcatedBy|!\s*\w+\.\w*[Tt]runcatedBy/.test(context);
+        if (!guarded) {
+          unguarded.push(`${tool.file}:${index + 1}  ${line.trim()}`);
+        }
+      });
+    }
+
+    expect(unguarded).toEqual([]);
+  });
+
+  it('records an exemption only for a tool that actually exists', () => {
+    // Stops the exemption list rotting into an allowlist that outlives the
+    // problem, exactly as KNOWN_GAPS is prevented from doing.
+    const stale = Object.keys(KEY_ENCODES_COMPLETENESS).filter(
+      (file) => !tools.some((tool) => tool.file === file)
+    );
+
+    expect(stale).toEqual([]);
+  });
+
+  it('records a per-call exemption only for a call that is still there', () => {
+    // Same rule for the narrower list. An exemption whose call has been renamed
+    // or rewritten is no longer an argument about this code, and leaving it
+    // would exempt whatever takes that text next.
+    const everyLine = tools
+      .flatMap((tool) => tool.text.split(/\r?\n/))
+      .map((line) => line.trim());
+    const stale = Object.keys(CACHE_WRITES_THAT_CANNOT_TRUNCATE).filter(
+      (call) => !everyLine.includes(call)
+    );
+
+    expect(stale).toEqual([]);
+  });
+});
+
+describe('the unbounded traversal APIs stay out of the tools', () => {
+  it('uses no globSync anywhere under src/tools', () => {
+    // `n/no-sync` does not catch this one: `globSync` is a bare import, not an
+    // `fs.*Sync` member call, so the rule that covers the rest of the class
+    // steps straight past the API that caused the original 178-second hang.
+    const offenders: string[] = [];
+    for (const file of walk(TOOLS)) {
+      const text = readFileSync(file, 'utf8');
+      text.split(/\r?\n/).forEach((line, index) => {
+        const code = line.trim();
+        if (code.startsWith('*') || code.startsWith('//')) return;
+        if (/\bglobSync\s*\(|\bglob\.sync\s*\(/.test(code)) {
+          offenders.push(`${relative(ROOT, file).replace(/\\/g, '/')}:${index + 1}`);
+        }
+      });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/unit/code-analysis/analysis-traversal-is-bounded.test.ts
+++ b/tests/unit/code-analysis/analysis-traversal-is-bounded.test.ts
@@ -1,0 +1,440 @@
+/**
+ * The whole-project tools walk the filesystem under a bound, and say when it bit.
+ *
+ * ISSUE #335 was reported against `smart_glob` and `smart_grep`, but those two
+ * were only where it was NOTICED -- they are the tools the routing policy forces
+ * callers into. Every tool that answers a question about "the project" carried
+ * the identical defect: `globSync` or a recursive `readdirSync` that enumerated
+ * the entire tree, blocked the event loop while doing it, and had no point at
+ * which it could give up and answer.
+ *
+ * WHY NONE OF THESE TOOLS GETS A CAP, WHICH IS THE OPPOSITE OF `smart_glob`.
+ * A cap is legitimate there because the caller passed `limit: N` -- "give me N
+ * files" -- so stopping at N IS the answer. Nothing here takes a limit. Each one
+ * answers a question about the whole tree, and for those a cap does not shorten
+ * the answer, it falsifies it while leaving it looking complete:
+ *
+ *   - smart_dependencies: dropping a node also drops the `importedBy` edges of
+ *     nodes that were KEPT, so a file that is imported is reported as unused.
+ *   - smart_security: a file not scanned is indistinguishable from a file with
+ *     no vulnerabilities. "No findings" is the most dangerous wrong answer this
+ *     server can produce.
+ *   - smart_exports: usage is proved by finding an importer, so a short walk
+ *     turns "I did not look" into "nothing uses this, delete it".
+ *   - smart_ast_grep: a missing file is a missing match.
+ *   - smart_build: it is a COUNT. Any bound makes the number wrong.
+ *
+ * So the deadline is the only bound applied, and every tool has to REPORT it.
+ * A partial answer that admits it is partial is useful; a partial answer wearing
+ * a complete one's clothes is worse than a timeout, because the caller acts on
+ * it.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { CacheEngine } from '../../../src/core/cache-engine.js';
+import { TokenCounter } from '../../../src/core/token-counter.js';
+import { MetricsCollector } from '../../../src/core/metrics.js';
+import { SmartDependenciesTool } from '../../../src/tools/code-analysis/smart-dependencies.js';
+import { SmartSecurity } from '../../../src/tools/code-analysis/smart-security.js';
+import { SmartAstGrepTool } from '../../../src/tools/code-analysis/smart-ast-grep.js';
+import { SmartExportsTool } from '../../../src/tools/code-analysis/smart-exports.js';
+import { countTypeScriptSources } from '../../../src/tools/build-systems/smart-build.js';
+
+/**
+ * Wide enough that a 1 ms deadline lands mid-walk rather than after it. The
+ * bound cannot be observed on a tree small enough to finish instantly, which is
+ * exactly why the unit suite never caught #335.
+ */
+const DIRECTORIES = 30;
+const FILES_PER_DIRECTORY = 40; // 1,200 files
+const SOURCE_FILES = DIRECTORIES * FILES_PER_DIRECTORY;
+
+/**
+ * The one planted file that is legitimately in scope.
+ *
+ * Two importers are planted outside `src` to make the skip lists observable
+ * (see the fixture). `node_modules/sneaky.ts` is excluded by every tool here.
+ * `.hidden/sneaky.ts` is NOT: only smart_exports skips dotted directories --
+ * smart_security and smart_ast_grep exclude by name list, and neither list
+ * mentions it. Counting it is correct, so the expected totals say so out loud
+ * rather than quietly rounding to the tidier number.
+ */
+const PLANTED_IN_SCOPE = 1;
+
+let root: string;
+const caches: CacheEngine[] = [];
+
+const newCache = (): CacheEngine => {
+  const cache = new CacheEngine(
+    join(root, `cache-${caches.length}.db`),
+    100
+  );
+  caches.push(cache);
+  return cache;
+};
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), 'analysis-bounded-'));
+  for (let d = 0; d < DIRECTORIES; d++) {
+    const sub = join(root, 'src', `pkg-${String(d).padStart(3, '0')}`);
+    mkdirSync(sub, { recursive: true });
+    // file-000 is the only exporter; every sibling imports the SAME named
+    // symbol from it. The usage scan proves a dependency by matching an
+    // imported name against an exported one, so the two names have to agree.
+    // With `export const value` on one side and `import { helper }` on the
+    // other, every file was importable and nothing was ever found importing
+    // it -- which reads exactly like a broken depth bound.
+    writeFileSync(join(sub, 'file-000.ts'), 'export const helper = 1;\n');
+    for (let f = 1; f < FILES_PER_DIRECTORY; f++) {
+      writeFileSync(
+        join(sub, `file-${String(f).padStart(3, '0')}.ts`),
+        // EXTENSIONLESS ON PURPOSE. `resolveImportPath` appends candidate
+        // extensions to the specifier as written, so a NodeNext-style
+        // './file-000.js' is only ever tried as 'file-000.js', 'file-000.js.ts'
+        // and so on -- it never reaches the '.ts' source. That is a real defect
+        // in smart_exports and it is NOT what these tests are about, so the
+        // fixture avoids it rather than encoding it.
+        `import { helper } from './file-000';\nexport const value${f} = helper;\n`
+      );
+    }
+  }
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ name: 'bounded-fixture', version: '0.0.1' })
+  );
+
+  // The directory every default `exclude` list names. It exists to prove that
+  // excluded trees are PRUNED rather than enumerated and discarded: before this
+  // change a project paid the full cost of reading the thing it excluded.
+  const vendored = join(root, 'node_modules', 'left-pad', 'lib');
+  mkdirSync(vendored, { recursive: true });
+  for (let f = 0; f < 300; f++) {
+    writeFileSync(join(vendored, `dep-${f}.js`), 'module.exports = 1;\n');
+  }
+
+  // TWO PLANTS THAT MAKE THE SKIP LIST OBSERVABLE. Counting files cannot catch
+  // a lost skip, because the accept filter rejects the same paths a second
+  // time -- so both of these IMPORT the target symbol. If `node_modules` or a
+  // dotted directory is ever walked, the usage scan finds them and the
+  // dependency count goes up by exactly two.
+  const importsTarget =
+    "import { helper } from '../src/pkg-000/file-000';\nexport const sneak = helper;\n";
+  writeFileSync(join(root, 'node_modules', 'sneaky.ts'), importsTarget);
+  mkdirSync(join(root, '.hidden'), { recursive: true });
+  writeFileSync(join(root, '.hidden', 'sneaky.ts'), importsTarget);
+});
+
+afterAll(() => {
+  while (caches.length) {
+    try {
+      caches.pop()?.close();
+    } catch {
+      /* a cache that will not close must not fail the suite */
+    }
+  }
+  try {
+    rmSync(root, { recursive: true, force: true });
+  } catch {
+    /* windows can hold a handle briefly */
+  }
+});
+
+describe('smart_ast_grep', () => {
+  it('stops at the deadline, says so, and caches nothing', async () => {
+    // THE CACHE IS THE DANGEROUS PART. The index key is derived from the
+    // project path and language, NOT from the file set, so a partial index
+    // stored under it is served in answer to every later search of this
+    // project for the whole TTL -- reporting "no matches" for files that were
+    // never walked, long after whatever made the walk slow is gone.
+    const cache = newCache();
+    const tool = new SmartAstGrepTool(
+      cache,
+      new TokenCounter(),
+      new MetricsCollector()
+    );
+
+    const truncated = await tool.grep('const $NAME = $VALUE', {
+      pattern: 'const $NAME = $VALUE',
+      projectPath: root,
+      language: 'ts',
+      deadlineMs: 1,
+    });
+    expect(truncated.metadata.searchTruncated).toBe(true);
+    expect(truncated.metadata.searchTruncatedBy).toBe('deadline');
+    expect(truncated.metadata.searchNote).toContain('unvisited file');
+
+    // `incrementalIndexing: false` IS WHAT MAKES THIS TEST ABLE TO FAIL, and it
+    // took a surviving mutation to notice. With incremental indexing on, a
+    // poisoned cache is indistinguishable from a clean one from the outside:
+    // the second call finds the partial index, takes the update path, reindexes
+    // everything missing from it, and arrives at exactly the same
+    // `filesScanned` AND the same `reindexedFiles` as a fresh build. Both of
+    // those assertions passed with the no-cache guard deleted.
+    //
+    // Turning incremental indexing off removes the repair step, so a stored
+    // partial index is used AS-IS -- and then it can only answer for the
+    // handful of files the 1 ms walk reached. A clean cache has nothing to
+    // load, so it builds the index from scratch and sees the whole tree.
+    const full = await tool.grep('const $NAME = $VALUE', {
+      pattern: 'const $NAME = $VALUE',
+      projectPath: root,
+      language: 'ts',
+      incrementalIndexing: false,
+    });
+    expect(full.metadata.searchTruncated).toBeUndefined();
+    expect(full.metadata.fromCache).toBe(false);
+    expect(full.metadata.filesScanned).toBe(SOURCE_FILES + PLANTED_IN_SCOPE);
+  }, 300_000);
+});
+
+describe('smart_exports', () => {
+  it('does not call an export unused when it simply stopped looking', async () => {
+    // `unusedExports` is computed from the dependencies the scan FOUND, so a
+    // truncated scan produces exactly the output that gets acted on by
+    // deleting live code. It must be flagged, and it must not be cached: the
+    // key is the file content plus the scan settings, so the short answer
+    // would be replayed for every later call on an unchanged file.
+    const cache = newCache();
+    const tool = new SmartExportsTool(
+      cache,
+      new TokenCounter(),
+      new MetricsCollector(),
+      root
+    );
+    const target = join(root, 'src', 'pkg-000', 'file-000.ts');
+
+    const truncated = await tool.run({
+      filePath: target,
+      projectRoot: root,
+      checkUsage: true,
+      scanDepth: 5,
+      deadlineMs: 1,
+    });
+    expect(truncated.summary.searchTruncated).toBe(true);
+    expect(truncated.summary.searchTruncatedBy).toBe('deadline');
+    expect(truncated.summary.searchNote).toContain('do not delete');
+
+    const full = await tool.run({
+      filePath: target,
+      projectRoot: root,
+      checkUsage: true,
+      scanDepth: 5,
+    });
+    expect(full.cached).toBe(false);
+    expect(full.summary.searchTruncated).toBeUndefined();
+  }, 300_000);
+
+  it('scans exactly as deep as scanDepth said, and no deeper', async () => {
+    // The old walk refused to recurse once `currentDepth` reached `depth`.
+    // Depth now comes from counting path segments instead, and getting that
+    // off by one would silently change which files are considered -- widening
+    // the scan, or narrowing it into false "unused" reports.
+    const tool = new SmartExportsTool(
+      newCache(),
+      new TokenCounter(),
+      new MetricsCollector(),
+      root
+    );
+    // BOTH SIDES MUST TARGET THE FILE THAT IS ACTUALLY IMPORTED. Pointing the
+    // shallow half at `file-001` made its "zero dependencies" true for the
+    // wrong reason -- nothing imports `value1` at any depth -- so the
+    // assertion held even with the depth bound deliberately broken.
+    const target = join(root, 'src', 'pkg-000', 'file-000.ts');
+
+    // Fixture layout is root/src/pkg-NNN/file-NNN.ts. At depth 2 the walk may
+    // open `src` but not `src/pkg-000`, so no importer is reachable.
+    const shallow = await tool.run({
+      filePath: target,
+      projectRoot: root,
+      checkUsage: true,
+      scanDepth: 2,
+      force: true,
+    });
+    expect(shallow.summary.dependencyCount).toBe(0);
+
+    // At depth 3 the siblings are reachable, and only pkg-000's resolve to
+    // this target -- every other package's importers point at their own
+    // file-000. An exact count, so a walk that goes too wide fails too.
+    const deep = await tool.run({
+      filePath: target,
+      projectRoot: root,
+      checkUsage: true,
+      scanDepth: 3,
+      force: true,
+    });
+    expect(deep.summary.dependencyCount).toBe(FILES_PER_DIRECTORY - 1);
+  }, 300_000);
+
+  it('never walks into node_modules or a dotted directory', async () => {
+    // Both plants import the target symbol, so a lost skip shows up as a
+    // dependency count that is too HIGH -- which counting files could never
+    // reveal, since the accept filter rejects the same paths a second time.
+    const tool = new SmartExportsTool(
+      newCache(),
+      new TokenCounter(),
+      new MetricsCollector(),
+      root
+    );
+    const result = await tool.run({
+      filePath: join(root, 'src', 'pkg-000', 'file-000.ts'),
+      projectRoot: root,
+      checkUsage: true,
+      scanDepth: 6,
+      force: true,
+    });
+
+    expect(result.summary.dependencyCount).toBe(FILES_PER_DIRECTORY - 1);
+    expect(
+      result.dependencies.some((d) => d.importingFile.includes('node_modules'))
+    ).toBe(false);
+    expect(
+      result.dependencies.some((d) => d.importingFile.includes('.hidden'))
+    ).toBe(false);
+  }, 300_000);
+});
+
+describe('smart_build', () => {
+  it('counts every source file when nothing stops the walk', async () => {
+    const counted = await countTypeScriptSources(join(root, 'src'));
+    expect(counted.count).toBe(SOURCE_FILES);
+    expect(counted.truncatedBy).toBeUndefined();
+  }, 120_000);
+
+  it('reports a floor rather than a wrong count when the deadline fires', async () => {
+    // Unlike a search, the answer here IS the total, so any bound that stops
+    // early does not shorten the answer -- it replaces it. Saying which one
+    // happened is what keeps the number usable.
+    const counted = await countTypeScriptSources(join(root, 'src'), 1);
+    expect(counted.truncatedBy).toBe('deadline');
+    expect(counted.count).toBeLessThan(SOURCE_FILES);
+  }, 120_000);
+
+  it('answers zero for a directory that is not there', async () => {
+    const counted = await countTypeScriptSources(join(root, 'no-such-dir'));
+    expect(counted).toEqual({ count: 0 });
+  });
+});
+
+describe('smart_security', () => {
+  it('never returns files from a pruned directory', async () => {
+    // Pruning has to be equivalent to the old post-hoc filter, not a
+    // tightening of it: a child's relative path contains its parent's, so
+    // everything under an excluded directory already failed the same test.
+    const tool = new SmartSecurity(
+      newCache(),
+      new TokenCounter(),
+      new MetricsCollector(),
+      root
+    );
+    const result = await tool.run({ force: true });
+
+    expect(result.summary.searchTruncated).toBeUndefined();
+    expect(result.summary.filesScanned).toBe(SOURCE_FILES + PLANTED_IN_SCOPE);
+  }, 180_000);
+
+  it('stops at the deadline and refuses to imply the project is clean', async () => {
+    // "No findings" and "I never opened the files" are the same output without
+    // this flag, and a security tool that silently means the second one while
+    // appearing to mean the first is worse than one that times out.
+    const tool = new SmartSecurity(
+      newCache(),
+      new TokenCounter(),
+      new MetricsCollector(),
+      root
+    );
+    const started = Date.now();
+    const result = await tool.run({ force: true, deadlineMs: 1 });
+
+    expect(Date.now() - started).toBeLessThan(15_000);
+    expect(result.summary.searchTruncated).toBe(true);
+    expect(result.summary.searchTruncatedBy).toBe('deadline');
+    expect(result.summary.searchNote).toContain('does NOT mean');
+  }, 180_000);
+});
+
+describe('smart_dependencies', () => {
+  it('completes an unbounded walk without claiming truncation', async () => {
+    const tool = new SmartDependenciesTool(
+      newCache(),
+      new TokenCounter(),
+      new MetricsCollector()
+    );
+    const result = await tool.analyze({ cwd: root, useCache: false });
+
+    expect(result.success).toBe(true);
+    expect(result.metadata.searchTruncated).toBeUndefined();
+    // No `+ PLANTED_IN_SCOPE`: glob does not match dotted paths unless asked,
+    // so the planted `.hidden` importer is out of scope for this tool.
+    expect(result.metadata.totalFiles).toBe(SOURCE_FILES);
+  }, 120_000);
+
+  it('stops at the deadline and reports the graph as partial', async () => {
+    const tool = new SmartDependenciesTool(
+      newCache(),
+      new TokenCounter(),
+      new MetricsCollector()
+    );
+    const started = Date.now();
+    const result = await tool.analyze({
+      cwd: root,
+      useCache: false,
+      deadlineMs: 1,
+    });
+
+    expect(result.success).toBe(true);
+    expect(Date.now() - started).toBeLessThan(15_000);
+    expect(result.metadata.searchTruncated).toBe(true);
+    expect(result.metadata.searchTruncatedBy).toBe('deadline');
+    expect(result.metadata.searchNote).toContain('only part of the tree');
+  }, 120_000);
+
+  it('never caches a partial graph', async () => {
+    // THE REGRESSION THIS EXISTS FOR. Caching a truncated graph outlives the
+    // call that knew it was truncated: every later request hits the cache,
+    // reports `cacheHit: true` with no truncation flag, and answers "unused"
+    // for files whose importers were never walked. The bad answer would then
+    // persist for the TTL, long after the slow tree was gone.
+    const cache = newCache();
+    const tool = new SmartDependenciesTool(
+      cache,
+      new TokenCounter(),
+      new MetricsCollector()
+    );
+
+    const truncated = await tool.analyze({
+      cwd: root,
+      useCache: true,
+      deadlineMs: 1,
+    });
+    expect(truncated.metadata.searchTruncated).toBe(true);
+
+    const second = await tool.analyze({ cwd: root, useCache: true });
+    expect(second.metadata.cacheHit).toBe(false);
+    expect(second.metadata.totalFiles).toBe(SOURCE_FILES);
+  }, 120_000);
+
+  it('carries the truncation flag into a mode that rebuilds its own metadata', async () => {
+    // `circular`, `unused` and `impact` each construct metadata from the
+    // finished graph, so the flag is dropped on three of the four paths unless
+    // it is re-applied after the mode switch. A `circular` result that loses it
+    // reads as "no cycles" rather than "no cycles in the part I reached".
+    const tool = new SmartDependenciesTool(
+      newCache(),
+      new TokenCounter(),
+      new MetricsCollector()
+    );
+    const result = await tool.analyze({
+      cwd: root,
+      useCache: false,
+      mode: 'circular',
+      deadlineMs: 1,
+    });
+
+    expect(result.mode).toBe('circular');
+    expect(result.metadata.searchTruncated).toBe(true);
+    expect(result.metadata.searchTruncatedBy).toBe('deadline');
+  }, 120_000);
+});

--- a/tests/unit/code-analysis/exports-resolves-nodenext-imports.test.ts
+++ b/tests/unit/code-analysis/exports-resolves-nodenext-imports.test.ts
@@ -1,0 +1,137 @@
+/**
+ * An export used through a `./foo.js` import is USED.
+ *
+ * `smart_exports` proves an export is used by finding a file that imports it,
+ * and `resolveImportPath` decides whether an import points at the file being
+ * analysed. It appended candidate extensions to the specifier AS WRITTEN, so a
+ * NodeNext import -- `./helper.js`, naming the emitted file, which is the style
+ * this repository uses in every one of its own modules -- was only ever tried
+ * as `helper.js`, then `helper.js.ts`, then `helper.js.tsx`. It never reached
+ * `helper.ts`.
+ *
+ * WHY THAT IS WORSE THAN A MISSING FEATURE. The failure is silent and it points
+ * the wrong way: an import that cannot be resolved is not reported as
+ * unresolved, it is simply not counted, so the export it uses lands in
+ * `unusedExports`. That is the one field of this tool's output that someone
+ * acts on by DELETING code. On a NodeNext project it listed every export.
+ *
+ * Found while writing the traversal tests for #335: a fixture whose files
+ * imported `'./file-000.js'` reported zero dependents at every scan depth,
+ * which reads exactly like a broken depth bound and is not one.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { CacheEngine } from '../../../src/core/cache-engine.js';
+import { TokenCounter } from '../../../src/core/token-counter.js';
+import { MetricsCollector } from '../../../src/core/metrics.js';
+import { SmartExportsTool } from '../../../src/tools/code-analysis/smart-exports.js';
+
+let root: string;
+let cache: CacheEngine;
+
+const analyse = () =>
+  new SmartExportsTool(
+    cache,
+    new TokenCounter(),
+    new MetricsCollector(),
+    root
+  ).run({
+    filePath: join(root, 'src', 'helper.ts'),
+    projectRoot: root,
+    checkUsage: true,
+    scanDepth: 4,
+    force: true,
+  });
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), 'exports-nodenext-'));
+  mkdirSync(join(root, 'src', 'nested'), { recursive: true });
+
+  writeFileSync(
+    join(root, 'src', 'helper.ts'),
+    'export const helper = 1;\nexport const neverUsed = 2;\n'
+  );
+  // The NodeNext spelling: names the emitted `.js`, resolves to the `.ts`.
+  writeFileSync(
+    join(root, 'src', 'uses-emitted-name.ts'),
+    "import { helper } from './helper.js';\nexport const a = helper;\n"
+  );
+  // The extensionless spelling, which already worked and must keep working.
+  writeFileSync(
+    join(root, 'src', 'uses-extensionless.ts'),
+    "import { helper } from './helper';\nexport const b = helper;\n"
+  );
+  // A relative import from one directory down, so the importing directory has
+  // to be computed correctly rather than coming out empty.
+  writeFileSync(
+    join(root, 'src', 'nested', 'uses-from-nested.ts'),
+    "import { helper } from '../helper.js';\nexport const c = helper;\n"
+  );
+  // Same-named file in another directory: must NOT be counted, or the fix has
+  // simply made the matcher promiscuous.
+  writeFileSync(
+    join(root, 'src', 'nested', 'helper.ts'),
+    'export const helper = 99;\n'
+  );
+  writeFileSync(
+    join(root, 'src', 'nested', 'uses-its-own-helper.ts'),
+    "import { helper } from './helper.js';\nexport const d = helper;\n"
+  );
+
+  cache = new CacheEngine(join(root, 'c.db'), 100);
+});
+
+afterAll(() => {
+  try {
+    cache.close?.();
+  } catch {
+    /* a cache that will not close must not fail the suite */
+  }
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('smart_exports resolves the imports projects actually write', () => {
+  it('counts an importer that names the emitted .js file', async () => {
+    const result = await analyse();
+    const importers = result.dependencies.map((d) =>
+      d.importingFile.replace(/^.*[\\/]/, '')
+    );
+
+    expect(importers).toContain('uses-emitted-name.ts');
+    expect(importers).toContain('uses-from-nested.ts');
+  }, 120_000);
+
+  it('still counts the extensionless spelling', async () => {
+    const result = await analyse();
+    const importers = result.dependencies.map((d) =>
+      d.importingFile.replace(/^.*[\\/]/, '')
+    );
+
+    expect(importers).toContain('uses-extensionless.ts');
+  }, 120_000);
+
+  it('does not claim an import of a DIFFERENT file with the same name', async () => {
+    // The guard against fixing this by making the comparison loose. `nested/`
+    // has its own `helper.ts`, and `nested/uses-its-own-helper.ts` imports
+    // that one -- resolving on basename alone would count it.
+    const result = await analyse();
+    const importers = result.dependencies.map((d) =>
+      d.importingFile.replace(/^.*[\\/]/, '')
+    );
+
+    expect(importers).not.toContain('uses-its-own-helper.ts');
+    expect(new Set(importers).size).toBe(3);
+  }, 120_000);
+
+  it('reports an export nothing imports as unused, and one that is imported as used', async () => {
+    // The whole point: `unusedExports` is what a caller deletes on.
+    const result = await analyse();
+    const unused = result.unusedExports.map((e) => e.name);
+
+    expect(unused).toContain('neverUsed');
+    expect(unused).not.toContain('helper');
+  }, 120_000);
+});

--- a/tests/unit/file-operations/bounded-traversal.test.ts
+++ b/tests/unit/file-operations/bounded-traversal.test.ts
@@ -1,0 +1,311 @@
+/**
+ * File discovery is bounded DURING the walk, not after it.
+ *
+ * ISSUE #335. `smart_glob` and `smart_grep` enumerated an entire tree with
+ * `globSync` and only then applied `limit`, so on a real machine they did not
+ * merely run slowly, they ran unbounded. Measured on 2026-08-28: a
+ * default-ignore glob of `C:/Users/cheat` ran **178 seconds without
+ * completing** and had to be killed, past the caller's 120 s tool timeout,
+ * while `dir` and `rg` answered the same question instantly. Because the
+ * routing policy DENIES the built-in `Glob`/`grep`, a tool that hangs there
+ * does not degrade the workflow, it removes it.
+ *
+ * TWO BOUNDS, TESTED SEPARATELY, because each covers a case the other cannot:
+ * the cap is only ever checked on a match, so it does nothing while a walk
+ * grinds through `node_modules` finding none; the deadline is delivered by
+ * `AbortSignal` and fires regardless.
+ *
+ * AND A CORRECTNESS GUARD. Stopping early changes WHICH matches come back, so
+ * the cap must not engage where that would silently produce a wrong answer --
+ * `sortBy: 'size'` with a limit asks for the largest files in the tree, and
+ * "largest among the first few found" is a wrong answer that looks right.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  boundedGlob,
+  boundedWalk,
+  traversalDeadlineMs,
+  DEFAULT_TRAVERSAL_DEADLINE_MS,
+} from '../../../src/tools/shared/bounded-traversal.js';
+import { SmartGlobTool } from '../../../src/tools/file-operations/smart-glob.js';
+import { SmartGrepTool } from '../../../src/tools/file-operations/smart-grep.js';
+import { CacheEngine } from '../../../src/core/cache-engine.js';
+import { TokenCounter } from '../../../src/core/token-counter.js';
+import { MetricsCollector } from '../../../src/core/metrics.js';
+
+let dir: string;
+let cache: CacheEngine;
+let tool: SmartGlobTool;
+let grep: SmartGrepTool;
+
+/** Wide enough that a cap is meaningfully cheaper than a full enumeration. */
+const DIRECTORIES = 40;
+const FILES_PER_DIRECTORY = 50; // 2000 files
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'bounded-traversal-'));
+  for (let d = 0; d < DIRECTORIES; d++) {
+    const sub = join(dir, `pkg-${String(d).padStart(3, '0')}`);
+    mkdirSync(sub, { recursive: true });
+    for (let f = 0; f < FILES_PER_DIRECTORY; f++) {
+      writeFileSync(join(sub, `file-${String(f).padStart(3, '0')}.ts`), 'x');
+    }
+  }
+  // A directory the ignore patterns are expected to keep out of the walk.
+  const heavy = join(dir, 'node_modules', 'dep');
+  mkdirSync(heavy, { recursive: true });
+  for (let f = 0; f < 200; f++) {
+    writeFileSync(join(heavy, `dep-${f}.ts`), 'x');
+  }
+  // One unmistakably largest file, for the sort-correctness guard. It lives in
+  // the LAST directory walked, so a capped walk would never reach it.
+  // Filled with 'y', not 'x': the grep tests search for 'x', and 50,000
+  // matches on ONE line of ONE file swamped those runs entirely.
+  writeFileSync(join(dir, `pkg-039`, 'zzz-largest.ts'), 'y'.repeat(50_000));
+
+  cache = new CacheEngine(join(dir, 'cache.db'), 100);
+  tool = new SmartGlobTool(cache, new TokenCounter(), new MetricsCollector());
+  grep = new SmartGrepTool(cache, new TokenCounter(), new MetricsCollector());
+});
+
+afterAll(() => {
+  try {
+    cache.close?.();
+  } catch {
+    /* a cache that will not close must not fail the suite */
+  }
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('boundedGlob', () => {
+  it('stops at the cap and says so', async () => {
+    const result = await boundedGlob('**/*.ts', { cwd: dir, cap: 25 });
+    expect(result.items).toHaveLength(25);
+    expect(result.truncated).toBe(true);
+    expect(result.truncatedBy).toBe('cap');
+  });
+
+  it('reports completion honestly when nothing stopped it', async () => {
+    const result = await boundedGlob('pkg-000/*.ts', { cwd: dir });
+    expect(result.items).toHaveLength(FILES_PER_DIRECTORY);
+    expect(result.truncated).toBe(false);
+    expect(result.truncatedBy).toBeUndefined();
+  });
+
+  it('stops at the deadline even when the pattern matches nothing', async () => {
+    // THE CASE THE CAP CANNOT COVER. A cap is only checked on a match, so a
+    // walk that yields nothing for minutes would never consult it. This is the
+    // shape of the reported hang: `**/*.csproj` over a tree of `node_modules`.
+    const result = await boundedGlob('**/*.no-such-extension', {
+      cwd: dir,
+      deadlineMs: 1,
+    });
+    expect(result.truncated).toBe(true);
+    expect(result.truncatedBy).toBe('deadline');
+  });
+
+  it('counts the cap AFTER the accept filter, not before', async () => {
+    // Otherwise a cap of 10 is spent on candidates that are then discarded and
+    // the caller gets 2 results while thousands more existed.
+    const result = await boundedGlob('**/*.ts', {
+      cwd: dir,
+      cap: 10,
+      accept: (p) => p.includes('file-000'),
+    });
+    expect(result.items).toHaveLength(10);
+    expect(result.items.every((p) => p.includes('file-000'))).toBe(true);
+  });
+
+  it('does not disguise a real failure as a bound', async () => {
+    // An abort is a result; anything else must still throw, or a permissions
+    // error becomes an empty "successful" search.
+    await expect(
+      boundedGlob('**/*.ts', {
+        cwd: dir,
+        accept: () => {
+          throw new Error('boom');
+        },
+      })
+    ).rejects.toThrow('boom');
+  });
+});
+
+describe('boundedWalk', () => {
+  it('prunes directories instead of enumerating and discarding them', async () => {
+    const seen: string[] = [];
+    const result = await boundedWalk(dir, {
+      prune: (name) => {
+        seen.push(name);
+        return name === 'node_modules';
+      },
+      accept: (_full, name) => name.endsWith('.ts'),
+    });
+    expect(seen).toContain('node_modules');
+    expect(result.items.some((p) => p.includes('node_modules'))).toBe(false);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('stops at the cap', async () => {
+    const result = await boundedWalk(dir, { cap: 12 });
+    expect(result.items).toHaveLength(12);
+    expect(result.truncatedBy).toBe('cap');
+  });
+
+  it('stops at the deadline', async () => {
+    const result = await boundedWalk(dir, { deadlineMs: 1, cap: Infinity });
+    expect(result.truncatedBy).toBe('deadline');
+  });
+});
+
+describe('the traversal budget', () => {
+  it('falls back rather than throwing on a malformed environment value', () => {
+    const previous = process.env.TOKEN_OPTIMIZER_TRAVERSAL_DEADLINE_MS;
+    process.env.TOKEN_OPTIMIZER_TRAVERSAL_DEADLINE_MS = 'not-a-number';
+    try {
+      expect(traversalDeadlineMs()).toBe(DEFAULT_TRAVERSAL_DEADLINE_MS);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.TOKEN_OPTIMIZER_TRAVERSAL_DEADLINE_MS;
+      } else {
+        process.env.TOKEN_OPTIMIZER_TRAVERSAL_DEADLINE_MS = previous;
+      }
+    }
+  });
+
+  it('an explicit override wins over the environment', () => {
+    expect(traversalDeadlineMs(1234)).toBe(1234);
+  });
+});
+
+describe('smart_glob is bounded end to end', () => {
+  it('returns under its deadline instead of running to completion', async () => {
+    const started = Date.now();
+    const result = await tool.glob('**/*.ts', { cwd: dir, deadlineMs: 200 });
+    expect(result.success).toBe(true);
+    // Generous: the assertion is "bounded", not a millisecond count on a
+    // shared runner. Unbounded, the reported failure ran past 120_000.
+    expect(Date.now() - started).toBeLessThan(15_000);
+  });
+
+  it('flags a capped search as incomplete rather than reporting it as whole', async () => {
+    const result = await tool.glob('**/*.ts', { cwd: dir, limit: 5 });
+    expect(result.files).toHaveLength(5);
+    expect(result.metadata.searchTruncated).toBe(true);
+    expect(result.metadata.searchTruncatedBy).toBe('cap');
+    expect(result.metadata.searchNote).toContain('not fully searched');
+  });
+
+  it('does NOT report a withheld count it can no longer justify', async () => {
+    // `ignoredMatches` is the difference between two walks. Once either walk
+    // stops early that difference measures where they stopped, and the
+    // clamped negative would claim "nothing was withheld" -- the one answer
+    // worse than admitting the number is unknown.
+    const result = await tool.glob('**/*.ts', { cwd: dir, limit: 5 });
+    expect(result.metadata.searchTruncated).toBe(true);
+    expect(result.metadata.ignoredMatches).toBeUndefined();
+    expect(result.metadata.ignoreNote).toContain('unknown');
+  });
+
+  it('still counts withheld matches when the walk completed', async () => {
+    const result = await tool.glob('**/*.ts', { cwd: dir });
+    expect(result.metadata.searchTruncated).toBeUndefined();
+    // node_modules holds 200 real matches the default ignore list withholds.
+    expect(result.metadata.ignoredMatches).toBe(200);
+  });
+
+  it('never short-circuits a sorted search, because that would answer wrongly', async () => {
+    // THE GUARD. `sortBy: 'size'` with a limit asks for the largest files in
+    // the whole tree. A cap would return the largest among the first walked,
+    // which is a wrong answer that looks exactly like a right one. The largest
+    // file is deliberately placed in the last directory a capped walk reaches.
+    const result = await tool.glob('**/*.ts', {
+      cwd: dir,
+      limit: 1,
+      sortBy: 'size',
+      sortOrder: 'desc',
+      includeMetadata: true,
+    });
+    const [largest] = result.files as Array<{ path: string; size: number }>;
+    expect(largest.path).toContain('zzz-largest');
+    expect(result.metadata.searchTruncated).toBeUndefined();
+  });
+});
+
+describe('smart_grep is bounded end to end', () => {
+  it('returns under its deadline instead of running to completion', async () => {
+    const started = Date.now();
+    const result = await grep.grep('x', { cwd: dir, deadlineMs: 200 });
+    expect(result.success).toBe(true);
+    expect(Date.now() - started).toBeLessThan(15_000);
+  });
+
+  it('stops reading once the requested page is filled, and says so', async () => {
+    const result = await grep.grep('x', { cwd: dir, limit: 3 });
+    expect(result.metadata.searchTruncated).toBe(true);
+    expect(result.metadata.searchTruncatedBy).toBe('cap');
+    expect(result.metadata.searchNote).toContain('left unsearched');
+  });
+
+  it('counts files it actually OPENED, not files it discovered', async () => {
+    // THE HONESTY HALF OF THE FIX. `filesSearched` was the discovered count, so
+    // a run that stopped early still reported having searched every file it had
+    // listed -- coverage it never had. Every one of this tool's previous
+    // defects had the same shape: a confident number describing work that did
+    // not happen.
+    const capped = await grep.grep('x', { cwd: dir, limit: 3 });
+    const whole = await grep.grep('x', { cwd: dir });
+    expect(whole.success).toBe(true);
+    expect(capped.metadata.searchTruncated).toBe(true);
+    expect(capped.metadata.filesSearched).toBeLessThan(
+      whole.metadata.filesSearched
+    );
+    expect(capped.metadata.filesSearched).toBeGreaterThan(0);
+  });
+
+  it('reports a complete search as complete', async () => {
+    const result = await grep.grep('x', { cwd: dir, files: ['pkg-000/*.ts'] });
+    expect(result.metadata.searchTruncated).toBeUndefined();
+  });
+});
+
+describe('smart_grep survives a dense file', () => {
+  it('does not fail the whole search on 50,000 matches in one line', async () => {
+    // FOUND WHILE WRITING THE TESTS ABOVE, not from the issue. `limit` defaults
+    // to Infinity and every match record carries its whole LINE, so 50,000
+    // matches on one 50,000-character line built 2.5 GB of string and threw
+    // `Invalid string length` out of the response-budget JSON.stringify --
+    // returning `success: false, filesSearched: 0, totalMatches: 0` after 5.3 s.
+    // Minified bundles, lock files and embedded data all have this shape.
+    const dense = mkdtempSync(join(tmpdir(), 'dense-match-'));
+    const denseCache = new CacheEngine(join(dense, 'cache.db'), 100);
+    try {
+      // NOT `.min.js`: that extension is in the documented default
+      // `excludeExtensions`, so the file would be skipped by design and the
+      // test would pass without ever exercising the dense-match path.
+      writeFileSync(join(dense, 'bundle.js'), 'x'.repeat(50_000));
+      const tool = new SmartGrepTool(
+        denseCache,
+        new TokenCounter(),
+        new MetricsCollector()
+      );
+      const result = await tool.grep('x', { cwd: dense });
+      expect(result.success).toBe(true);
+      expect(result.metadata.filesSearched).toBe(1);
+      expect(result.metadata.totalMatches).toBeGreaterThan(0);
+      // The stored line is a locator, not a copy of the file.
+      const [first] = (result.matches ?? []) as Array<{ line: string }>;
+      if (first) expect(first.line.length).toBeLessThanOrEqual(2_100);
+    } finally {
+      try {
+        denseCache.close?.();
+      } catch {
+        /* ignore */
+      }
+      rmSync(dense, { recursive: true, force: true });
+    }
+  }, 120_000);
+});

--- a/tests/unit/file-operations/bounded-traversal.test.ts
+++ b/tests/unit/file-operations/bounded-traversal.test.ts
@@ -4,7 +4,7 @@
  * ISSUE #335. `smart_glob` and `smart_grep` enumerated an entire tree with
  * `globSync` and only then applied `limit`, so on a real machine they did not
  * merely run slowly, they ran unbounded. Measured on 2026-08-28: a
- * default-ignore glob of `C:/Users/cheat` ran **178 seconds without
+ * default-ignore glob of a Windows user profile directory ran **178 seconds without
  * completing** and had to be killed, past the caller's 120 s tool timeout,
  * while `dir` and `rg` answered the same question instantly. Because the
  * routing policy DENIES the built-in `Glob`/`grep`, a tool that hangs there
@@ -147,6 +147,29 @@ describe('boundedWalk', () => {
     expect(seen).toContain('node_modules');
     expect(result.items.some((p) => p.includes('node_modules'))).toBe(false);
     expect(result.truncated).toBe(false);
+  });
+
+  it('never looks at a single file inside a pruned directory', async () => {
+    // THE PRECISE PRUNE CONTRACT, and the one assertion that separates pruning
+    // from filtering-afterwards. The test above shows no pruned path comes
+    // BACK, which a post-hoc filter also satisfies -- it enumerates the whole
+    // of `node_modules` and then discards it one entry at a time, which is the
+    // exact cost this module exists to stop paying.
+    //
+    // Every tool that excludes a directory delegates to this, and none of them
+    // can assert it for themselves: their accept filters re-reject the same
+    // paths, so their output is identical either way and only the work differs.
+    const offered: string[] = [];
+    await boundedWalk(dir, {
+      prune: (name) => name === 'node_modules',
+      accept: (fullPath) => {
+        offered.push(fullPath);
+        return fullPath.endsWith('.ts');
+      },
+    });
+
+    expect(offered.length).toBeGreaterThan(0);
+    expect(offered.some((p) => p.includes('node_modules'))).toBe(false);
   });
 
   it('stops at the cap', async () => {

--- a/tests/unit/file-operations/smart-edit-reports-the-write.test.ts
+++ b/tests/unit/file-operations/smart-edit-reports-the-write.test.ts
@@ -1,0 +1,72 @@
+/**
+ * A completed write is reported as completed, whatever the cache does.
+ *
+ * FOUND WHILE FIXING #335, by using the tool: `smart_edit` returned
+ * `success: false, operation: 'failed', editsApplied: 0` with
+ * `error: 'database or disk is full'` -- and BOTH edits were already on disk.
+ * The cache update ran inside the method's single try/catch, after
+ * `writeFileSync`, so a SQLite failure rewrote the report of an edit that had
+ * already happened.
+ *
+ * WHY THAT IS WORSE THAN A SLOW TOOL. The only sane response to "your edit
+ * failed, 0 applied" is to retry it, and retrying a line-based edit against an
+ * already-edited file does not fail -- it applies the change twice, to the
+ * wrong lines. A stale cache costs one re-read; a false failure report costs
+ * the file.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { SmartEditTool } from '../../../src/tools/file-operations/smart-edit.js';
+import { CacheEngine } from '../../../src/core/cache-engine.js';
+import { TokenCounter } from '../../../src/core/token-counter.js';
+import { MetricsCollector } from '../../../src/core/metrics.js';
+
+describe('smart_edit reports what actually happened to the file', () => {
+  it('still reports success when the cache write throws', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'edit-report-'));
+    const file = join(dir, 'target.ts');
+    writeFileSync(file, ['one', 'two', 'three'].join('\n'));
+
+    const cache = new CacheEngine(join(dir, 'cache.db'), 100);
+    // The exact failure observed live, from the exact call that produced it.
+    cache.set = () => {
+      throw new Error('database or disk is full');
+    };
+
+    const tool = new SmartEditTool(
+      cache,
+      new TokenCounter(),
+      new MetricsCollector()
+    );
+
+    try {
+      const result = await tool.edit(file, {
+        type: 'replace',
+        startLine: 2,
+        endLine: 2,
+        content: 'TWO',
+      });
+
+      // The file changed, so the report must say the file changed.
+      expect(readFileSync(file, 'utf-8')).toContain('TWO');
+      expect(result.success).toBe(true);
+      expect(result.metadata.editsApplied).toBe(1);
+      expect(result.operation).not.toBe('failed');
+    } finally {
+      try {
+        cache.close?.();
+      } catch {
+        /* ignore */
+      }
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // Windows can still hold the sqlite handle; the assertions above are
+        // the point, not the tidiness of the temp directory.
+      }
+    }
+  });
+});

--- a/tests/unit/helpers/schema-source.ts
+++ b/tests/unit/helpers/schema-source.ts
@@ -179,13 +179,49 @@ export function interfaceFields(text: string, name: string): InterfaceField[] {
   return match ? fieldsFrom(text, text.indexOf('{', match.index)) : [];
 }
 
+/**
+ * Every `*Options` interface in the file, EXPORTED OR NOT.
+ *
+ * THE `export` KEYWORD WAS NEVER THE POINT, and requiring it put a hole in this
+ * guard that nobody could see. 15 of the tools declare their options interface
+ * without `export` -- smart_build, smart_test, smart_lint, smart_install,
+ * smart_docker, smart_typecheck and the rest -- and the server hands the
+ * caller's whole argument object to the implementation regardless. So every one
+ * of those tools was exempt from the audit while appearing to pass it, which is
+ * the worst state for a ratchet to be in: a new undeclared option added to any
+ * of them was reported as clean. That is how a `deadlineMs` added to
+ * smart_build during #335 slipped past silently.
+ *
+ * NESTED DATA SHAPES ARE NOT TOOL OPTIONS, and widening the search brings them
+ * in. `TsConfigCompilerOptions` in smart-tsconfig describes the contents of a
+ * tsconfig FILE -- `target`, `module`, `strict` -- and no caller ever sends
+ * those as MCP arguments; the tool takes `compilerOptions` as a single field
+ * and `nestedShape` is what checks inside it. The discriminator is structural
+ * rather than a name list: a shape that appears as the TYPE OF A FIELD of some
+ * other interface in the same file is nested by construction. A tool's own
+ * options interface is passed to a method, never held as a field, so it is
+ * never excluded by this -- and the "audits a meaningful number of tools" test
+ * is what fails if that ever stops being true.
+ */
 function interfaceFieldsMatching(
   text: string,
   pattern: RegExp
 ): InterfaceField[] {
+  const declarations = [...text.matchAll(/(?:export\s+)?interface\s+(\w+)\s*\{/g)];
+
+  const usedAsFieldType = new Set<string>();
+  for (const m of declarations) {
+    for (const field of fieldsFrom(text, text.indexOf('{', m.index))) {
+      for (const identifier of field.type.matchAll(/[A-Za-z_$][\w$]*/g)) {
+        usedAsFieldType.add(identifier[0]);
+      }
+    }
+  }
+
   const out: InterfaceField[] = [];
-  for (const m of text.matchAll(/export interface\s+(\w+)\s*\{/g)) {
+  for (const m of declarations) {
     if (!pattern.test(m[1])) continue;
+    if (usedAsFieldType.has(m[1])) continue;
     out.push(...fieldsFrom(text, text.indexOf('{', m.index)));
   }
 

--- a/tests/unit/tool-schemas-declare-what-they-accept.test.ts
+++ b/tests/unit/tool-schemas-declare-what-they-accept.test.ts
@@ -169,6 +169,47 @@ describe('every tool declares the options it accepts', () => {
     expect(audited).toBeGreaterThan(40);
   });
 
+  it('audits a tool whose options interface is not exported', () => {
+    // THE HOLE THIS CLOSES, AND WHY THE COUNT ABOVE DID NOT CATCH IT. The
+    // extractor once required `export interface`, so the 15 tools that declare
+    // their options without it -- smart_build, smart_test, smart_lint,
+    // smart_install, smart_docker, smart_typecheck among them -- were exempt
+    // while appearing to pass. `audited` still cleared 40, because the count is
+    // of FILES reached, and those files were reached; it was their options that
+    // were invisible. A `deadlineMs` added to smart_build slipped through
+    // exactly that way.
+    //
+    // Asserting on a specific non-exported interface is what makes the fix
+    // self-protecting: narrowing the extractor back turns this red instead of
+    // quietly re-exempting a sixth of the surface.
+    const build = readFileSync(
+      join(SRC, 'build-systems', 'smart-build.ts'),
+      'utf8'
+    );
+    expect(/\n\s*interface SmartBuildOptions/.test(build)).toBe(true);
+    expect(build).not.toContain('export interface SmartBuildOptions');
+    expect(acceptedOptions(build)).toContain('deadlineMs');
+  });
+
+  it('does not mistake a nested data shape for a tool option', () => {
+    // Widening the search brings in every `*Options` interface in the file, and
+    // not all of them are arguments. `TsConfigCompilerOptions` describes the
+    // contents of a tsconfig FILE -- `target`, `module`, `strict` -- which no
+    // caller ever sends as MCP arguments; the tool accepts `compilerOptions` as
+    // one field, and `nestedShape` is what looks inside it. Counting its 16
+    // keys as undeclared options would be 16 false alarms, and false alarms are
+    // how a ratchet gets switched off.
+    const tsconfig = readFileSync(
+      join(SRC, 'configuration', 'smart-tsconfig.ts'),
+      'utf8'
+    );
+    const accepted = acceptedOptions(tsconfig);
+
+    expect(accepted).toContain('configPath');
+    expect(accepted).not.toContain('esModuleInterop');
+    expect(accepted).not.toContain('skipLibCheck');
+  });
+
   it('drops function-valued options, which cannot arrive over MCP', () => {
     const sample = `
       export interface XOptions {


### PR DESCRIPTION
Closes #335.

## The bug was unboundedness, not slowness

`smart_glob` and `smart_grep` enumerated the whole tree with `globSync` and applied `limit` afterwards. Reproduced the reported case exactly:

| | |
|---|---|
| Default-ignore glob of a Windows user profile directory | **178 s, never completed**, killed |
| Same walk, capped at 50 matches | **27 ms** |
| Tool timeout it has to beat | 120 s |

The routing policy **denies** the built-in `Glob`/`grep` and sends callers here, so a tool that hangs where `dir` is instant doesn't degrade the workflow — it removes it.

`globSync` also blocks the event loop, which is why the hangs had to be **killed** rather than timing out: the server couldn't answer anything while walking.

## Two bounds, because neither covers the other

- **Cap** — short-circuits the walk. Only ever checked *on a match*, so it does nothing while a walk grinds through `node_modules` finding none.
- **Deadline** — an `AbortSignal`. Covers exactly that case. Verified firing at 2 s on a pattern matching nothing.

Both helpers are async so the loop stays live and the abort can be delivered. One budget covers the whole call — two independent 10 s budgets is a 20 s call.

## The cap is not allowed to change the answer

Stopping early changes *which* matches return, so it only engages where that can't produce a wrong answer:

- `sortBy: 'size'` with a limit asks for the largest files **in the tree**. Capped, "largest" silently becomes "largest among the first found" — a wrong answer wearing a right answer's clothes.
- Size/date filters need a `stat` the walk doesn't do, so a cap counted before them returns fewer than asked for while more existed.
- Extension filters are exempt — decided from the path alone, so they run *inside* the walk and the cap counts only keepers.

`ignoredMatches` is now **withheld** whenever either walk was bounded. It's the difference between two walks; once they stop in different places that difference measures where they stopped, and the clamped negative would report *"nothing was withheld"* — the one answer worse than admitting we don't know.

## smart_grep streams discovery into the read

Collecting every path first meant a `limit: 5` grep still paid for the whole tree. The issue asks for the cap to *"short-circuit traversal, not post-filter a full enumeration"*, and only reading as paths arrive delivers it. `filesSearched` now counts files actually **opened**; it was the discovered count, so a bounded run reported coverage it never had.

## Two more defects in the first pass

**Dense files failed the entire search.** Every match record carries its LINE, so 50,000 matches on one 50,000-character line built 2.5 GB of string, threw `Invalid string length`, and returned `success: false, filesSearched: 0` after 5.3 s. Minified bundles and lock files have this shape. Now `success: true`, 2.0 s. The ceiling belongs on the **line**, not the match count — an existing test pins a file holding **130,000 matches**, and short lines at that count are fine.

**`smart_edit` reported a completed write as a failure.** The cache update ran inside the method's single `try/catch` *after* `writeFileSync`, so a SQLite error returned `success: false, operation: 'failed', editsApplied: 0` with the edits already on disk. The only sane response to that report is to retry — and retrying a line-based edit against an already-edited file corrupts it.

## Benchmarks, which is how the grep gap was found

The unit tests were already green when the benchmark showed capped grep at 5,985 ms against 10,266 ms exhaustive — barely short-circuiting at all.

| Operation (12,000 files) | Before | After |
|---|---|---|
| `smart_glob` limit=10 | — | **15 ms** (vs 1,234 ms exhaustive) |
| `smart_grep` limit=5 | 5,985 ms | **303 ms** (vs 10,353 ms exhaustive) |
| `smart_glob` deadline=250 ms, no matches | unbounded | **692 ms** |

They assert the *ratio*, not millisecond budgets — that survives a slow CI runner, and it's the relationship that breaks if enumerate-then-filter returns.

---

# The remaining five tools (second pass)

`smart_dependencies`, `smart_exports`, `smart_security`, `smart_ast_grep` and `smart_build` carried the identical defect: `globSync` or a recursive `readdirSync`, on the event loop, with no point at which the walk could give up and answer. All five are now wired.

## None of them gets a cap, which is the opposite of `smart_glob`

A cap is legitimate there because the caller passed `limit: N` — "give me N files" — so stopping at N *is* the answer. Nothing here takes a limit. Each answers a question about the whole tree, and for those a cap does not shorten the answer, it falsifies it while leaving it looking complete:

| Tool | Why a cap would produce a wrong answer |
|---|---|
| `smart_dependencies` | Dropping a node also drops the `importedBy` edges of nodes that were **kept**, so a file that *is* imported is reported unused. |
| `smart_security` | A file never opened is indistinguishable from a file with no vulnerabilities. "No findings" is the most dangerous wrong answer this server can give. |
| `smart_exports` | Usage is proved by *finding* an importer, so a short walk turns "I did not look" into "nothing uses this, delete it". |
| `smart_ast_grep` | A missing file is a missing match. |
| `smart_build` | It is a **count**. Any bound makes the number wrong. |

So the deadline is the only bound, plus pruning — which is free, because it only skips directories whose contents were being discarded anyway.

This corrects the earlier plan, which proposed `boundedWalk` **with a `cap`** for `smart_build`. That would have silently replaced the file count with the cap. It reports a **floor** instead (`summary.filesCompiledPartial`), which is still sound for its only consumer — a `filesCompiled > 50` heuristic that can then only err by withholding a suggestion.

## Three cache-poisoning defects, which is what makes a partial answer dangerous

Bounding the walk is the easy half. The half a naive fix gets wrong is that **three of these would have cached the partial result**, and none of their keys encode which files were reached:

- `smart_dependencies` keys the graph on `cwd`.
- `smart_ast_grep` keys the index on project path + language, and the pattern result on the pattern.
- `smart_exports` keys on file content + scan settings.

A truncated walk would then be served to **every later call for the whole TTL**, reporting `cacheHit: true` with no truncation flag — answering "unused" for files whose importers were never walked, long after whatever made the walk slow was gone. All three now refuse to cache a bounded result; each has a test that fails if the guard is removed. `smart_security` was already safe: its key derives from the discovered file set.

## Two further defects, both found by using the tools

**`smart_exports` reported every export as unused on any NodeNext project.** `resolveImportPath` appended candidate extensions to the specifier *as written*, so `./helper.js` — how you import `helper.ts`, and the style this repository uses in every one of its own modules — was only ever tried as `helper.js`, `helper.js.ts`, `helper.js.tsx`. It never reached `helper.ts`. The failure is silent and points the wrong way: an unresolvable import isn't reported as unresolved, it's simply not counted, so the export lands in `unusedExports` — the one field a caller acts on by *deleting code*. Found because a traversal fixture importing `'./file-000.js'` reported zero dependents at every scan depth, which reads exactly like a broken depth bound and is not one.

**The tool-schema ratchet was blind to 15 of the tools.** It audited only `export interface *Options`, and 15 tools — `smart_build`, `smart_test`, `smart_lint`, `smart_install`, `smart_docker`, `smart_typecheck` among them — declare theirs without `export`. They were exempt while appearing to pass, which is the worst state for a ratchet: a new undeclared option was reported clean. That is exactly how the `deadlineMs` this PR adds to `smart_build` slipped past it. Widening the extractor surfaced three genuinely undeclared options (`smart_api_fetch: includeFullResponse`, `smart_processes: useCache, maxCacheAge`), now declared. Widening also drags in nested *data* shapes — `TsConfigCompilerOptions` describes the contents of a tsconfig file, not MCP arguments — so shapes used as the **type of a field** of another interface are excluded structurally rather than by a name list. Two new tests make the fix self-protecting.

## Verification

`tsc --noEmit` clean, `lint` 0 errors, `format:check` clean, `sync:hooks:check` in sync. Full suite green.

Every claim mutation-tested. Three things about that are worth recording, because each produced confident, wrong evidence first:

- **The harness's summary parser could not see failures.** jest prints `Tests: 1 failed, 3 passed, 4 total`, so the failure count shares a comma-part with the `Tests:` label; splitting on commas and reading token 0 yields `"Tests:"` → 0. Every mutation scored "0 failed" and was reported **SURVIVED** — i.e. "all your tests are vacuous", the most alarming possible false signal.
- **A `finally` does not survive a kill.** Two runs were killed and each left its mutation in the source; one then produced a test that failed identically five times running, which reads exactly like a real defect. The harness now writes a disk sentinel before touching a file and refuses to start while a stale one exists, and an interrupted run is followed by auditing the full `git diff` rather than grepping for expected patterns.
- **A mutation that does not compile is INVALID, not "survived."** Three mutations tripped `noUnusedLocals` or lost a null-narrowing purely as a side effect of how the defect was expressed; rewritten so they compile, all three were then caught.

Six mutations survived the first full pass. All six were gaps in the tests, not the code, and are closed — including two that could not be closed at the tool level at all: pruning does not change the *answer* (the accept filter re-rejects the same paths), so no assertion about a tool's output can distinguish a pruning walk from an enumerate-then-discard one. That contract is asserted where it lives, on `boundedWalk`, by proving `accept` is never offered a single path inside a pruned directory.

**One survivor is left deliberately, and documented in the source.** The `dirname()` correction in `resolveImportPath` replaces `lastIndexOf('/') || lastIndexOf('\\')`, which yields the first *truthy* operand — the `-1` of a failed search. Measured rather than assumed: that is **latent, not live**, because TypeScript normalises `sourceFile.fileName` to forward slashes, so the fallback never runs. The expression is wrong on its own terms and is fixed, but no test here can observe the difference, and saying so is better than inventing a test that passes for the wrong reason.

## Measured, but deliberately not fixed here

Profiling on a 12,000-file tree (`node --cpu-prof`, ranked by **self/leaf** time, each tool in its own process) shows the remaining slowness is **not traversal**:

| Tool | Time | Dominant cost |
|---|---|---|
| `smart_dependencies` | 51.3 s | `measureFullFileTokens` re-reads every file only to compute the "tokens saved" baseline — **19.6 s (38%)** — on top of `analyzeFile`'s own 10.7 s read |
| `smart_security` | 32.0 s | `generateFileHash` re-reads every file to build the cache key — **19.8 s (62%)** — on top of `scanFile`'s own 8.4 s read. The vulnerability regex is 3.9%. |
| `smart_grep` | 10.7 s | 73% sync `open`+`read`, but only **one** read per file — needs concurrency, not deduplication |
| `smart_glob` | 1.3 s | traversal only — fine |

Two tools do literally twice the file I/O they need, and both redundant reads cost more than the work they support. That is a different defect class with a different risk profile, and it gets its own issue and PR rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Catching these classes before review, not after

The five tools above were fixed because someone listed them. The *classes* they belonged to were never censused, so this adds the checks that would have found them — and the census that says how much is left.

## Census, across the whole tool surface

| Class | Sites | Files |
|---|---|---|
| `globSync` unbounded traversal | **0** | eliminated by this PR |
| recursive `readdirSync` | **1** (`analytics/native-provider-usage.ts`) | the rest are single-level, bounded by construction |
| `existsSync` immediately before `readFileSync` | 37 | 25 |
| `readFileSync` inside a loop | 12 | 9 |
| `statSync` inside a loop | 13 | 7 |

## `n/no-sync`, as an error, with a shrink-only baseline

`eslint-plugin-n`'s `n/no-sync` is the standard detector for the mechanical half of #335 — a blocking `*Sync` call. It runs as an **error**, not a warning, because this codebase already carries ~538 warnings and one more would be invisible.

The 306 existing call sites across 60 files are recorded with **ESLint's own bulk suppressions** rather than fixed here, so the gate lands today and the debt is measured instead of guessed. The list is shrink-only by construction: fixing a suppressed site and leaving its entry behind exits 2 with *"there are suppressions left that do not occur anymore"*. Verified in both directions before being trusted — a new sync call errors, a fixed one fails the run. No workflow change was needed; CI already runs `npm run lint` on every PR.

## An architecture test for what a linter cannot see

Whether a tool that *can* answer partially actually **says so**, and whether it refuses to **cache** the partial answer, are semantic — and they are where every real defect in this area was found. Four rules: every bounded tool declares `deadlineMs` in its published schema, reports truncation, never writes a bounded result into a cache, and no `globSync` returns to `src/tools` (which `n/no-sync` misses, because it is a bare import rather than an `fs.*Sync` member call).

**It found two more sites the moment it existed.** `smart_build` cached a truncated file count under a key that hashes tsconfig rather than the file set, so the wrong number was replayed until tsconfig changed — fixed. The incremental path in `smart_dependencies` is exempt with the argument written down: `incrementalGraphUpdate` re-analyses only files already in the graph and never walks, so its output is as complete as its input, and its input came from a cache the other guard keeps free of partial graphs. Both exemption lists fail if they name something that no longer exists.

**Every rule was mutation-tested** by reintroducing, verbatim, a defect found by hand in this PR — five caught that way, the sixth by hand because reintroducing `globSync` needs an import added, and a mutation that does not compile proves nothing. One rule was itself vacuous when written: it checked `text.includes('searchTruncated')`, which a deletion walked straight through, since the identifier survived in the interface declaration and in a comment. It asserts on the assignment now.

## Stryker, scheduled rather than gating

Stryker replaces the scratch harness. It runs nightly rather than on pull requests because it was **measured at ~2h20m for 140 mutants** — the cost being the 2,000-file fixture rebuilt for every mutant, not Stryker. `thresholds.break` is deliberately absent until a first full run establishes a real score, rather than inventing one that either fails the first night or asserts nothing.

## A landmine found on the way

`package.json` declared `zod: ">=3.25.0 <5"` while `src/validation/tool-schemas.ts` uses the **v3-only** single-argument `z.record(z.any())` in five places. So any `npm install` re-resolved 3.25.76 → 4.4.3 and broke `tsc` in a file the contributor never touched — while `npm ci` hid it, because the lockfile pins 3.25.76. Reproduced twice and isolated by restoring the manifest and reinstalling. The range is narrowed to what the code actually supports.

## Still open, deliberately

- The 306 baselined sync sites are **detected, not triaged**. They get fixed by measurement, starting with the two double-read tools already measured at 62% and 38% of runtime — not by churning 30 files on speculation.
- The redundant double reads themselves are a separate PR.

---

## Rebased onto master, and re-measured because of it

#338 (read-each-file-once) merged first and rewrote the same two files this PR touches, so this branch was rebased onto it. The conflict itself was import-only — both sides additive — but `smart-dependencies.ts` auto-merged silently, which is where a semantic loss would hide, so both feature sets were verified present rather than assumed: `fileTokenCounts` / `pathExists` / `candidateIsFile` from #338, and `boundedGlob` / `searchTruncated` / the no-cache-when-truncated guard from this PR.

Two consequences worth stating:

- **The lint ratchet caught its own baseline going stale.** #338 removed four sync calls, so `npm run lint` exited 2 with *"there are suppressions left that do not occur anymore"* — exactly the shrink-only property it exists for. Pruned **306 → 302**.
- **The mutation score had to be re-measured.** It was taken before #338 merged, on files #338 then rewrote, so it no longer described this branch. Re-run on the rebased code: **23 of 24 caught, 0 survived unexplained.** The single survivor is the `dirname` correction in `resolveImportPath`, which is documented in the source as unobservable — TypeScript normalises `sourceFile.fileName` to forward slashes, so the `||` fallback it fixes never actually runs.

A generated baseline announces when it has rotted; a number written in a PR body never does. That is the only reason the second one was caught.

Full suite after the rebase: **241 suites / 3102 passed / 0 failed.** Perf re-checked on the merged result to confirm it kept both properties — bounded *and* fast: `smart_security` ~13.4 s, `smart_dependencies` ~27.5 s, matching #338's own numbers.
