### PR TITLE
fix(launch): stop the refresh deleting the runtime a live session is using

### DIFF
--- a/plugin/launch.mjs
+++ b/plugin/launch.mjs
@@ -292,10 +292,67 @@ function releaseLock() {
   safeRm(LOCK_DIR);
 }
 
-function pruneOldVersions(keepVersion) {
+/**
+ * How many version directories survive a prune, newest first.
+ *
+ * NOT ONE, WHICH IS WHAT IT USED TO BE. The header of this file promises that a
+ * refresh "never mutates files a running server may still be lazy-require-ing",
+ * and then this function deleted every directory except the newest -- including
+ * the one a server is executing from right now. Deleting is the most extreme
+ * mutation available, so the invariant was being broken by the very code that
+ * documented it.
+ *
+ * The damage is invisible for almost everything. A running server has already
+ * imported its eager modules, and those stay in memory, so the server keeps
+ * answering normally. Only a path resolved at CALL time notices -- and the wiki
+ * tools resolve one, importing hooks-core lazily through `coreUrl()`. Observed
+ * 2026-08-28: a session that outlived one refresh got
+ * `Cannot find module ...\\versions\\6.0.0\\...\\hooks-core\\wiki.mjs` from
+ * every wiki_write call for the rest of the session, while every other tool
+ * carried on fine. The whole knowledge-capture feature was dead and nothing
+ * else looked wrong.
+ *
+ * The refresh interval is six hours, so an ordinary working session routinely
+ * outlives one. Keeping three versions buys roughly eighteen hours of grace for
+ * a few tens of megabytes of disk. It is a retention count rather than a
+ * liveness check because there is no reliable, cheap way to ask "is a process
+ * still running from this directory" across platforms -- and guessing wrong in
+ * that direction deletes a live runtime again.
+ */
+const VERSIONS_TO_KEEP = Math.max(
+  1,
+  Math.floor(numericEnv('TOKEN_OPTIMIZER_RUNTIME_KEEP', 3))
+);
+
+/**
+ * Delete stale version directories, keeping `keepVersion` and the newest few.
+ *
+ * Exported for tests; see VERSIONS_TO_KEEP for why it is not just "keep one".
+ */
+export function pruneOldVersions(keepVersion) {
   try {
-    for (const name of readdirSync(VERSIONS_DIR)) {
-      if (name !== keepVersion) safeRm(join(VERSIONS_DIR, name));
+    const dirs = readdirSync(VERSIONS_DIR).map((name) => {
+      let mtimeMs = 0;
+      try {
+        mtimeMs = statSync(join(VERSIONS_DIR, name)).mtimeMs;
+      } catch {
+        // Vanished from under us, or unreadable. Sorting it oldest is safe:
+        // the worst case is that we decline to keep a directory we could not
+        // even stat.
+      }
+      return { name, mtimeMs };
+    });
+
+    // `keepVersion` first and unconditionally -- it is the one the next launch
+    // will use, and it must survive even if its mtime is somehow not newest.
+    const keep = new Set([keepVersion]);
+    for (const { name } of [...dirs].sort((a, b) => b.mtimeMs - a.mtimeMs)) {
+      if (keep.size >= VERSIONS_TO_KEEP) break;
+      keep.add(name);
+    }
+
+    for (const { name } of dirs) {
+      if (!keep.has(name)) safeRm(join(VERSIONS_DIR, name));
     }
   } catch {
     /* ignore */
@@ -449,4 +506,11 @@ function main() {
   runServer(entry);
 }
 
-main();
+// IMPORTABLE FOR TESTS, AND DELIBERATELY FAIL-OPEN. Anything other than an
+// explicit opt-out still calls main(), so if this check is ever wrong the shim
+// launches a server anyway. The alternative -- detecting whether this file is
+// the entry point -- fails in the other direction: one bad comparison and the
+// launcher silently does nothing, which means no MCP server at all.
+if (process.env.TOKEN_OPTIMIZER_LAUNCH_IMPORT_ONLY !== '1') {
+  main();
+}

--- a/plugin/launch.mjs
+++ b/plugin/launch.mjs
@@ -318,18 +318,31 @@ function releaseLock() {
  * liveness check because there is no reliable, cheap way to ask "is a process
  * still running from this directory" across platforms -- and guessing wrong in
  * that direction deletes a live runtime again.
+ *
+ * A FLOOR OF TWO, NOT ONE. Retaining a single directory is never a coherent
+ * setting here: a refresh prunes with the version it just INSTALLED, so keeping
+ * exactly one deletes the version the live session is running from and puts the
+ * original defect straight back. Review caught this -- the first cut floored at
+ * one, and a test asserted that behaviour as if it were correct.
  */
 const VERSIONS_TO_KEEP = Math.max(
-  1,
+  2,
   Math.floor(numericEnv('TOKEN_OPTIMIZER_RUNTIME_KEEP', 3))
 );
 
 /**
- * Delete stale version directories, keeping `keepVersion` and the newest few.
+ * Delete stale version directories.
+ *
+ * `keepVersion` is what the next launch will use; `alsoKeep` is the version the
+ * pointer named BEFORE this refresh, which is what any live session is still
+ * executing from. Both are retained by NAME rather than left to the mtime
+ * ordering, because those are the two that must survive and neither is
+ * guaranteed to sort newest -- a reinstall can freshen an unrelated directory's
+ * timestamp.
  *
  * Exported for tests; see VERSIONS_TO_KEEP for why it is not just "keep one".
  */
-export function pruneOldVersions(keepVersion) {
+export function pruneOldVersions(keepVersion, alsoKeep = null) {
   try {
     const dirs = readdirSync(VERSIONS_DIR).map((name) => {
       let mtimeMs = 0;
@@ -346,6 +359,7 @@ export function pruneOldVersions(keepVersion) {
     // `keepVersion` first and unconditionally -- it is the one the next launch
     // will use, and it must survive even if its mtime is somehow not newest.
     const keep = new Set([keepVersion]);
+    if (alsoKeep) keep.add(alsoKeep);
     for (const { name } of [...dirs].sort((a, b) => b.mtimeMs - a.mtimeMs)) {
       if (keep.size >= VERSIONS_TO_KEEP) break;
       keep.add(name);
@@ -377,7 +391,9 @@ function runRefresh() {
       atomicWrite(CURRENT_FILE, version);
       log(`refreshed runtime -> ${version} (was ${prev ?? 'none'})`);
     }
-    pruneOldVersions(version);
+    // `prev` is what a live session is still running from, so it is named
+    // explicitly rather than trusted to be among the newest by mtime.
+    pruneOldVersions(version, prev);
   } finally {
     releaseLock();
   }

--- a/plugin/launch.mjs
+++ b/plugin/launch.mjs
@@ -79,6 +79,7 @@ const RUNTIME =
 const VERSIONS_DIR = join(RUNTIME, 'versions');
 const CURRENT_FILE = join(RUNTIME, 'current');
 const LOCK_DIR = join(RUNTIME, '.refresh.lock');
+const ACTIVE_DIR = join(RUNTIME, 'active');
 const LAST_REFRESH_FILE = join(RUNTIME, '.last-refresh');
 
 // Don't hammer the registry on frequent restarts: only background-refresh if it
@@ -268,6 +269,86 @@ function safeRm(p) {
   }
 }
 
+/**
+ * Record that THIS shim is serving `version`, so a later refresh can see it.
+ *
+ * A RETENTION COUNT IS A GUESS; THIS IS THE ANSWER. Keeping the newest few
+ * directories protects a session across one or two refreshes and then quietly
+ * stops: on v1 -> v2 -> v3 the second refresh sees `prev` as v2, so the v1 a
+ * server is still running from ages out and is deleted. Review caught that, and
+ * it is the same defect as the original one, just delayed.
+ *
+ * Liveness is cheap after all -- `process.kill(pid, 0)` asks the OS whether a
+ * pid exists, on every platform, without signalling it. The earlier comment
+ * here claimed there was no such check; there is, and this uses it.
+ */
+function registerActiveVersion(version) {
+  try {
+    mkdirSync(ACTIVE_DIR, { recursive: true });
+    writeFileSync(
+      join(ACTIVE_DIR, `${process.pid}.json`),
+      JSON.stringify({ version, startedAt: Date.now() })
+    );
+  } catch {
+    // Best effort. Failing to register costs retention, not correctness: the
+    // version-count fallback still protects the common case.
+  }
+}
+
+function unregisterActiveVersion() {
+  safeRm(join(ACTIVE_DIR, `${process.pid}.json`));
+}
+
+/** True when a process with this pid exists (it is not signalled). */
+function pidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means it exists but belongs to someone else -- still alive.
+    return err?.code === 'EPERM';
+  }
+}
+
+/**
+ * Versions that a live shim is currently serving.
+ *
+ * Also reaps its own stale markers, so a machine that has been rebooted or has
+ * crashed sessions does not accumulate them forever. A marker is only trusted
+ * for 30 days, which bounds the damage from pid reuse: a recycled pid could
+ * otherwise pin a version indefinitely.
+ */
+function activeVersions() {
+  const alive = new Set();
+  const MAX_MARKER_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+  let names = [];
+  try {
+    names = readdirSync(ACTIVE_DIR);
+  } catch {
+    return alive;
+  }
+  for (const name of names) {
+    const file = join(ACTIVE_DIR, name);
+    const pid = Number.parseInt(name, 10);
+    let record;
+    try {
+      record = JSON.parse(readFileSync(file, 'utf8'));
+    } catch {
+      safeRm(file);
+      continue;
+    }
+    const tooOld =
+      !Number.isFinite(record?.startedAt) ||
+      Date.now() - record.startedAt > MAX_MARKER_AGE_MS;
+    if (!Number.isFinite(pid) || tooOld || !pidAlive(pid)) {
+      safeRm(file);
+      continue;
+    }
+    if (record?.version) alive.add(record.version);
+  }
+  return alive;
+}
+
 /** Best-effort single-flight lock via mkdir (atomic on all platforms). */
 function acquireLock() {
   try {
@@ -356,10 +437,26 @@ export function pruneOldVersions(keepVersion, alsoKeep = null) {
       return { name, mtimeMs };
     });
 
-    // `keepVersion` first and unconditionally -- it is the one the next launch
-    // will use, and it must survive even if its mtime is somehow not newest.
-    const keep = new Set([keepVersion]);
-    if (alsoKeep) keep.add(alsoKeep);
+    const present = new Set(dirs.map((entry) => entry.name));
+
+    // ONLY NAMES THAT EXIST COUNT TOWARD RETENTION. `keep` used to take
+    // `keepVersion` and `alsoKeep` unconditionally, so a stale `current`
+    // pointer naming a directory that is not there consumed a retention slot
+    // and the cleanup could then strip everything else. Review caught it.
+    const keep = new Set();
+    const reserve = (name) => {
+      if (name && present.has(name)) keep.add(name);
+    };
+
+    // Every runtime a live shim is serving, first: this is the whole point.
+    for (const version of activeVersions()) reserve(version);
+
+    // Then the one the next launch will use, and the one the pointer named
+    // before this refresh -- by name, since neither is guaranteed to sort
+    // newest once a reinstall has freshened another directory's timestamp.
+    reserve(keepVersion);
+    reserve(alsoKeep);
+
     for (const { name } of [...dirs].sort((a, b) => b.mtimeMs - a.mtimeMs)) {
       if (keep.size >= VERSIONS_TO_KEEP) break;
       keep.add(name);
@@ -427,6 +524,16 @@ function spawnBackgroundRefresh() {
 
 /** Spawn the server, forwarding stdio, signals, and exit code. */
 function runServer(entry) {
+  // Announce which runtime this shim is serving BEFORE the server starts, so a
+  // refresh that fires immediately afterwards can already see it.
+  const served = entry.startsWith(VERSIONS_DIR)
+    ? entry.slice(VERSIONS_DIR.length + 1).split(/[\\/]/)[0]
+    : null;
+  if (served) {
+    registerActiveVersion(served);
+    process.on('exit', unregisterActiveVersion);
+  }
+
   const child = spawn(process.execPath, [entry], {
     stdio: 'inherit',
     env: process.env,

--- a/plugin/launch.mjs
+++ b/plugin/launch.mjs
@@ -285,7 +285,21 @@ function safeRm(p) {
 function registerActiveVersion(version) {
   try {
     mkdirSync(ACTIVE_DIR, { recursive: true });
-    writeFileSync(
+    // ATOMIC, because a reader runs concurrently. `writeFileSync` updates the
+    // marker in place, so a refresh calling activeVersions() mid-write gets a
+    // truncated file, fails to parse it, and DELETES it as corrupt -- and the
+    // live shim only ever writes this once, so it never comes back. The
+    // runtime it was protecting is then prunable for the rest of the session.
+    // Review caught this. `atomicWrite` writes a temp file and renames, and a
+    // rename is atomic.
+    //
+    // NOT COVERED BY A TEST, AND SAYING SO. Catching this would need a reader
+    // to observe a half-written file, which is a genuine timing race and not
+    // something a unit test can stage deterministically -- a mutation swapping
+    // this back to writeFileSync survives the suite. What IS tested is the
+    // consequence of the fix: the temp file this creates must not be mistaken
+    // for a marker. The atomicity itself rests on rename being atomic.
+    atomicWrite(
       join(ACTIVE_DIR, `${process.pid}.json`),
       JSON.stringify({ version, startedAt: Date.now() })
     );
@@ -329,6 +343,22 @@ function activeVersions() {
   }
   for (const name of names) {
     const file = join(ACTIVE_DIR, name);
+
+    // ONLY `<pid>.json` IS A MARKER. `atomicWrite` lands a `<pid>.json.tmp-...`
+    // file in this same directory for an instant, and `Number.parseInt` reads
+    // leading digits happily -- so a temp file would otherwise be treated as a
+    // marker for that pid, and deleting it as unparseable would race the
+    // rename that is about to consume it. A temp left behind by a crashed
+    // write is swept once it is older than any marker would be trusted.
+    if (!/^\d+\.json$/.test(name)) {
+      try {
+        if (Date.now() - statSync(file).mtimeMs > MAX_MARKER_AGE_MS) safeRm(file);
+      } catch {
+        /* vanished under us, which is the outcome we wanted anyway */
+      }
+      continue;
+    }
+
     const pid = Number.parseInt(name, 10);
     let record;
     try {

--- a/src/tools/intelligence/hooks-core-loader.ts
+++ b/src/tools/intelligence/hooks-core-loader.ts
@@ -66,6 +66,25 @@ function runningPackageDir(): string | null {
   return existsSync(path.join(candidate, 'package.json')) ? candidate : null;
 }
 
+/**
+ * This server's own version, read ONCE while its directory still exists.
+ *
+ * READ AT MODULE LOAD, NOT AT FALLBACK TIME, and this is the whole point.
+ * Review caught the first version reading it inside the fallback: by then the
+ * runtime may have been pruned, `package.json` is gone, the version comes back
+ * null -- and the major-version check was written to skip when it could not
+ * establish a version. So the guard failed OPEN in precisely the situation the
+ * fallback exists for, and a live v6 server could have loaded v7 hooks-core and
+ * written the shared wiki store with incompatible code.
+ *
+ * This module is imported at server startup, when the directory is certainly
+ * present, so the value is captured before anything can delete it.
+ */
+const RUNNING_VERSION: string | null = (() => {
+  const running = runningPackageDir();
+  return running ? readVersionOf(running) : null;
+})();
+
 const major = (version: string): string => version.split('.')[0] ?? '';
 
 /**
@@ -101,15 +120,35 @@ function fallbackDir(): { dir: string; version: string } | null {
   const dir = path.join(packageDir, 'hooks-core');
   if (!existsSync(dir)) return null;
 
-  const running = runningPackageDir();
-  const runningVersion = running ? readVersionOf(running) : null;
   const candidateVersion = readVersionOf(packageDir);
-  if (!candidateVersion) return null;
-  if (runningVersion && major(runningVersion) !== major(candidateVersion)) {
-    return null;
-  }
+  if (!fallbackIsCompatible(RUNNING_VERSION, candidateVersion)) return null;
 
-  return { dir, version: candidateVersion };
+  return { dir, version: candidateVersion as string };
+}
+
+/**
+ * Whether a runtime copy may stand in for the bundled one.
+ *
+ * SEPARATE AND EXPORTED SO IT CAN BE TESTED FROM BOTH SIDES. Folded into
+ * `fallbackDir` this was unreachable: any fixture that makes the running
+ * version unknown also makes the candidate unreadable, so the candidate check
+ * fired first and a mutation flipping this guard to fail-open survived every
+ * test.
+ *
+ * FAILS CLOSED on an unknown version, either side. If this server's own version
+ * cannot be established there is no way to know whether the candidate is
+ * compatible, and "load it anyway" is the answer that corrupts a shared store.
+ * Refusing costs a restart. That is not hypothetical: the first version of this
+ * skipped the comparison when the running version was null, which is exactly
+ * what a PRUNED runtime produces -- so the guard was disabled in the only
+ * situation the fallback exists for.
+ */
+export function fallbackIsCompatible(
+  runningVersion: string | null,
+  candidateVersion: string | null
+): boolean {
+  if (!runningVersion || !candidateVersion) return false;
+  return major(runningVersion) === major(candidateVersion);
 }
 
 /** Reported once per process, so a degraded session says so without spamming. */

--- a/src/tools/intelligence/hooks-core-loader.ts
+++ b/src/tools/intelligence/hooks-core-loader.ts
@@ -1,0 +1,175 @@
+/**
+ * Loading hooks-core from a runtime that may have been deleted underneath us.
+ *
+ * WHY THIS IS NOT JUST `import(path)`. The wiki tools are the only place in the
+ * server that resolves a path at CALL time; everything else imports eagerly at
+ * startup and is therefore already in memory. That difference is invisible
+ * until the directory the server is running from disappears -- and it does
+ * disappear: `plugin/launch.mjs` used to prune every runtime version except the
+ * newest, including the one a live session was executing from. Observed
+ * 2026-08-28, a session that outlived one six-hour refresh got
+ * `Cannot find module .../versions/6.0.0/.../hooks-core/wiki.mjs` from every
+ * wiki call for the rest of its life, while all ~65 other tools worked
+ * perfectly. Knowledge capture was silently dead and nothing else looked wrong.
+ *
+ * The prune is fixed. This exists because a bare `import()` failure is still
+ * the wrong shape of answer:
+ *
+ *   - it names an internal path and an ESM error code, which reads as a broken
+ *     package rather than a missing runtime -- that misreading cost real time,
+ *     including a confident and wrong "hooks-core is missing from the published
+ *     tarball" (it is not, and never was);
+ *   - and it gives up while a perfectly good copy of hooks-core usually sits
+ *     next door, under the runtime version the launcher now points at.
+ *
+ * So: try the bundled copy, fall back to the pointed-at runtime when that is
+ * safe, and only then fail -- with a message that says what happened and what
+ * to do about it.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { homedir } from 'os';
+import path from 'path';
+import { dirname } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/** hooks-core as shipped beside the running build (dist/tools/intelligence/..). */
+function bundledDir(): string {
+  return path.join(here, '..', '..', '..', 'hooks-core');
+}
+
+/** The managed runtime root, matching plugin/launch.mjs. */
+function runtimeRoot(): string {
+  return (
+    process.env.TOKEN_OPTIMIZER_RUNTIME ||
+    path.join(homedir(), '.token-optimizer', 'runtime')
+  );
+}
+
+function readVersionOf(packageDir: string): string | null {
+  try {
+    const manifest = JSON.parse(
+      readFileSync(path.join(packageDir, 'package.json'), 'utf8')
+    ) as { version?: string };
+    return manifest.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** The package directory this server is actually running out of, if identifiable. */
+function runningPackageDir(): string | null {
+  // here === <pkg>/dist/tools/intelligence
+  const candidate = path.join(here, '..', '..', '..');
+  return existsSync(path.join(candidate, 'package.json')) ? candidate : null;
+}
+
+const major = (version: string): string => version.split('.')[0] ?? '';
+
+/**
+ * hooks-core under the runtime `current` points at, when it is safe to use.
+ *
+ * SAME MAJOR ONLY, DELIBERATELY. Falling back across a major version would load
+ * one release's hooks-core into another release's server, and these modules
+ * share a persisted wiki store -- a mismatch there writes bad data rather than
+ * failing loudly, which is strictly worse than not answering. Within a major,
+ * the package's own semver promise is exactly the promise being relied on.
+ */
+function fallbackDir(): { dir: string; version: string } | null {
+  const root = runtimeRoot();
+  const currentFile = path.join(root, 'current');
+  if (!existsSync(currentFile)) return null;
+
+  let version: string;
+  try {
+    version = readFileSync(currentFile, 'utf8').trim();
+  } catch {
+    return null;
+  }
+  if (!version) return null;
+
+  const packageDir = path.join(
+    root,
+    'versions',
+    version,
+    'node_modules',
+    '@ooples',
+    'token-optimizer-mcp'
+  );
+  const dir = path.join(packageDir, 'hooks-core');
+  if (!existsSync(dir)) return null;
+
+  const running = runningPackageDir();
+  const runningVersion = running ? readVersionOf(running) : null;
+  const candidateVersion = readVersionOf(packageDir);
+  if (!candidateVersion) return null;
+  if (runningVersion && major(runningVersion) !== major(candidateVersion)) {
+    return null;
+  }
+
+  return { dir, version: candidateVersion };
+}
+
+/** Reported once per process, so a degraded session says so without spamming. */
+let announcedFallback = false;
+
+export class HooksCoreUnavailableError extends Error {
+  constructor(moduleName: string, cause: unknown) {
+    const bundled = path.join(bundledDir(), moduleName);
+    const gone = !existsSync(bundledDir());
+    super(
+      gone
+        ? `The token-optimizer runtime this server is running from has been removed ` +
+            `(${bundledDir()}), so the wiki tools cannot load "${moduleName}". ` +
+            `This happens when a background refresh prunes the version a live session ` +
+            `is using. Restart the MCP server (in Claude Code: /mcp reconnect, or restart ` +
+            `the session) to pick up the current runtime. ` +
+            `Nothing was written, and no stored knowledge was lost. ` +
+            `Original error: ${cause instanceof Error ? cause.message : String(cause)}`
+        : `The wiki tools could not load "${moduleName}" from ${bundled}. The runtime ` +
+            `directory exists, so this is a genuinely missing or unreadable file rather ` +
+            `than a pruned runtime. ` +
+            `Original error: ${cause instanceof Error ? cause.message : String(cause)}`
+    );
+    this.name = 'HooksCoreUnavailableError';
+  }
+}
+
+/**
+ * Import a hooks-core module by file name, e.g. `wiki.mjs`.
+ *
+ * Throws `HooksCoreUnavailableError` only when neither the bundled copy nor a
+ * compatible runtime copy can be loaded.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function loadHooksCore<T = any>(moduleName: string): Promise<T> {
+  const bundled = pathToFileURL(path.join(bundledDir(), moduleName)).href;
+  try {
+    return (await import(bundled)) as T;
+  } catch (bundledError) {
+    const fallback = fallbackDir();
+    if (fallback) {
+      try {
+        const loaded = (await import(
+          pathToFileURL(path.join(fallback.dir, moduleName)).href
+        )) as T;
+        if (!announcedFallback) {
+          announcedFallback = true;
+          // stderr only: stdout is the MCP JSON-RPC channel.
+          process.stderr.write(
+            `[token-optimizer] the runtime this server started from is gone; ` +
+              `wiki tools are using ${fallback.version} instead. ` +
+              `Restart the session to run entirely on the current runtime.\n`
+          );
+        }
+        return loaded;
+      } catch {
+        // Fall through to the diagnostic below, which describes the ORIGINAL
+        // failure -- the fallback missing too is not the interesting fact.
+      }
+    }
+    throw new HooksCoreUnavailableError(moduleName, bundledError);
+  }
+}

--- a/src/tools/intelligence/wiki-query.ts
+++ b/src/tools/intelligence/wiki-query.ts
@@ -15,15 +15,7 @@
  */
 
 import path from 'path';
-import { fileURLToPath, pathToFileURL } from 'url';
-import { dirname } from 'path';
-
-const here = dirname(fileURLToPath(import.meta.url));
-
-function coreUrl(name: string): string {
-  return pathToFileURL(path.join(here, '..', '..', '..', 'hooks-core', name))
-    .href;
-}
+import { loadHooksCore } from './hooks-core-loader.js';
 
 /** Closed set, so a typo cannot compile. */
 export enum WikiQueryOperation {
@@ -211,13 +203,13 @@ export async function wikiQuery(
 
   const [wiki, curate, metrics, staleness, lexical, projects, paths] =
     await Promise.all([
-      import(coreUrl('wiki.mjs')),
-      import(coreUrl('curate.mjs')),
-      import(coreUrl('metrics.mjs')),
-      import(coreUrl('staleness.mjs')),
-      import(coreUrl('lexical.mjs')),
-      import(coreUrl('projects.mjs')),
-      import(coreUrl('paths.mjs')),
+      loadHooksCore('wiki.mjs'),
+      loadHooksCore('curate.mjs'),
+      loadHooksCore('metrics.mjs'),
+      loadHooksCore('staleness.mjs'),
+      loadHooksCore('lexical.mjs'),
+      loadHooksCore('projects.mjs'),
+      loadHooksCore('paths.mjs'),
     ]);
 
   // THE GRAPH LIVES AT THE REPOSITORY ROOT, and `wikiDir` does no upward walk.

--- a/src/tools/intelligence/wiki-read.ts
+++ b/src/tools/intelligence/wiki-read.ts
@@ -21,17 +21,7 @@
  * identically in both places and fixed once.
  */
 
-import path from 'path';
-import { fileURLToPath, pathToFileURL } from 'url';
-import { dirname } from 'path';
-
-const here = dirname(fileURLToPath(import.meta.url));
-
-/** Resolves hooks-core relative to the built output, which lives in dist/tools/intelligence. */
-function coreUrl(name: string): string {
-  return pathToFileURL(path.join(here, '..', '..', '..', 'hooks-core', name))
-    .href;
-}
+import { loadHooksCore } from './hooks-core-loader.js';
 
 export interface WikiReadOptions {
   /**
@@ -116,7 +106,7 @@ export async function wikiRead(
       : 10;
 
   try {
-    const wiki: any = await import(coreUrl('wiki.mjs'));
+    const wiki: any = await loadHooksCore('wiki.mjs');
 
     // Same rule as wiki_write: the graph is the ANCHOR's project, not wherever the caller is
     // running. A subagent's cwd is not meaningful, which is precisely why it cannot be trusted

--- a/src/tools/intelligence/wiki-write.ts
+++ b/src/tools/intelligence/wiki-write.ts
@@ -17,17 +17,7 @@
  * concluded; the harvest, when enabled, catches what it forgot to record.
  */
 
-import path from 'path';
-import { fileURLToPath, pathToFileURL } from 'url';
-import { dirname } from 'path';
-
-const here = dirname(fileURLToPath(import.meta.url));
-
-/** Resolves hooks-core relative to the built output, which lives in dist/tools/intelligence. */
-function coreUrl(name: string): string {
-  return pathToFileURL(path.join(here, '..', '..', '..', 'hooks-core', name))
-    .href;
-}
+import { loadHooksCore } from './hooks-core-loader.js';
 
 export interface WikiWriteOptions {
   /** The claim itself. What was concluded, in a sentence someone can act on. */
@@ -196,11 +186,11 @@ export async function wikiWrite(
 
   try {
     const [wiki, harvestWrite, curate, metrics, projects] = await Promise.all([
-      import(coreUrl('wiki.mjs')),
-      import(coreUrl('harvest-write.mjs')),
-      import(coreUrl('curate.mjs')),
-      import(coreUrl('metrics.mjs')),
-      import(coreUrl('projects.mjs')),
+      loadHooksCore('wiki.mjs'),
+      loadHooksCore('harvest-write.mjs'),
+      loadHooksCore('curate.mjs'),
+      loadHooksCore('metrics.mjs'),
+      loadHooksCore('projects.mjs'),
     ]);
 
     // The finding belongs to the project the ANCHOR is in, not to wherever the

--- a/tests/hooks/runtime-prune-keeps-running-versions.test.mjs
+++ b/tests/hooks/runtime-prune-keeps-running-versions.test.mjs
@@ -1,0 +1,163 @@
+/**
+ * A background refresh must not delete the runtime a live session is using.
+ *
+ * THE BUG THIS PINS. `launch.mjs` documents, in its own header, that a refresh
+ * "never mutates files a running server may still be lazy-require-ing" -- and
+ * then `pruneOldVersions` deleted every version directory except the newest,
+ * including the one a server was executing from. Deleting is the most extreme
+ * mutation available, so the file broke the invariant it advertised.
+ *
+ * WHY IT WENT UNNOTICED. A running server has already imported its eager
+ * modules and they stay in memory, so it keeps answering normally after its
+ * directory is gone. Only a path resolved at CALL time notices, and exactly one
+ * area does that: the wiki tools import hooks-core lazily through `coreUrl()`.
+ * Observed 2026-08-28 -- a session that outlived one refresh got
+ * `Cannot find module .../versions/6.0.0/.../hooks-core/wiki.mjs` from every
+ * wiki_write call for the rest of the session while every other tool worked, so
+ * it read as a packaging bug in the published tarball. It was not: 6.0.1 ships
+ * hooks-core/wiki.mjs and 6.0.0 had it too. The directory had been deleted
+ * underneath the process. The refresh interval is six hours, so an ordinary
+ * working session outlives one routinely.
+ *
+ * WHY EACH CASE SPAWNS A PROCESS. `launch.mjs` reads its runtime path and its
+ * retention count from the environment at IMPORT time, which is correct for a
+ * launcher that is a fresh process every time. Importing it repeatedly inside
+ * one jest worker does not re-read them -- the module is cached, so later cases
+ * silently operated on the first case's (already deleted) directory and nothing
+ * was pruned. Every case therefore gets its own node process, which is also how
+ * the shim genuinely runs.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { spawnSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { pathToFileURL } from 'url';
+
+const LAUNCHER = pathToFileURL(
+  resolve(process.cwd(), 'plugin', 'launch.mjs')
+).href;
+
+let runtime;
+let versionsDir;
+
+/** A version directory holding a file, aged `minutesOld` minutes. */
+function makeVersion(name, minutesOld) {
+  const dir = join(versionsDir, name);
+  mkdirSync(join(dir, 'node_modules'), { recursive: true });
+  writeFileSync(join(dir, 'marker.txt'), name);
+  const when = new Date(Date.now() - minutesOld * 60_000);
+  utimesSync(dir, when, when);
+}
+
+/**
+ * Prune in a fresh process and return the surviving version directories.
+ *
+ * `TOKEN_OPTIMIZER_LAUNCH_IMPORT_ONLY` is what stops `main()` from running;
+ * without it, importing the launcher starts a real MCP server.
+ */
+function pruneInFreshProcess(keepVersion, keepCount) {
+  const script = `
+    const { pruneOldVersions } = await import(${JSON.stringify(LAUNCHER)});
+    pruneOldVersions(${JSON.stringify(keepVersion)});
+    const { readdirSync } = await import('fs');
+    let left = [];
+    try { left = readdirSync(${JSON.stringify(versionsDir)}); } catch {}
+    console.log(JSON.stringify(left));
+  `;
+
+  const env = {
+    ...process.env,
+    TOKEN_OPTIMIZER_LAUNCH_IMPORT_ONLY: '1',
+    TOKEN_OPTIMIZER_RUNTIME: runtime,
+  };
+  if (keepCount === undefined) delete env.TOKEN_OPTIMIZER_RUNTIME_KEEP;
+  else env.TOKEN_OPTIMIZER_RUNTIME_KEEP = String(keepCount);
+
+  const result = spawnSync(
+    process.execPath,
+    ['--input-type=module', '-e', script],
+    { env, encoding: 'utf8' }
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `prune process failed (${result.status}): ${result.stderr || result.stdout}`
+    );
+  }
+  return JSON.parse(result.stdout.trim().split('\n').pop());
+}
+
+beforeEach(() => {
+  runtime = mkdtempSync(join(tmpdir(), 'runtime-prune-'));
+  versionsDir = join(runtime, 'versions');
+  mkdirSync(versionsDir, { recursive: true });
+});
+
+afterEach(() => {
+  try {
+    rmSync(runtime, { recursive: true, force: true });
+  } catch {
+    /* windows can hold a handle briefly */
+  }
+});
+
+describe('pruning the managed runtime', () => {
+  it('keeps the version a live session is still running from', () => {
+    // THE REGRESSION. `6.0.0` is what a running server is executing from when
+    // the refresh installs `6.0.2`. Before this fix it was deleted outright and
+    // the running server lost every file it had not already imported.
+    makeVersion('6.0.0', 30);
+    makeVersion('6.0.1', 20);
+    makeVersion('6.0.2', 10);
+
+    const left = pruneInFreshProcess('6.0.2');
+
+    expect(left.sort()).toEqual(['6.0.0', '6.0.1', '6.0.2']);
+  }, 60_000);
+
+  it('still deletes versions old enough that nothing can be using them', () => {
+    // Retention, not hoarding: a grace period, not every version ever installed.
+    makeVersion('5.9.0', 5000);
+    makeVersion('6.0.0', 400);
+    makeVersion('6.0.1', 30);
+    makeVersion('6.0.2', 20);
+    makeVersion('6.0.3', 10);
+
+    const left = pruneInFreshProcess('6.0.3');
+
+    expect(left.sort()).toEqual(['6.0.1', '6.0.2', '6.0.3']);
+  }, 60_000);
+
+  it('keeps the version it was told to keep even when it is not the newest', () => {
+    // `keepVersion` is what the NEXT launch will use. If unrelated directories
+    // happen to have newer mtimes, sorting alone would evict the one that
+    // matters most.
+    makeVersion('6.0.5', 1);
+    makeVersion('6.0.6', 2);
+    makeVersion('6.0.7', 3);
+    makeVersion('6.0.1', 400);
+
+    const left = pruneInFreshProcess('6.0.1', 1);
+
+    expect(left).toEqual(['6.0.1']);
+  }, 60_000);
+
+  it('honours a retention count set by the environment', () => {
+    makeVersion('6.0.0', 40);
+    makeVersion('6.0.1', 30);
+    makeVersion('6.0.2', 20);
+    makeVersion('6.0.3', 10);
+
+    const left = pruneInFreshProcess('6.0.3', 2);
+
+    expect(left.sort()).toEqual(['6.0.2', '6.0.3']);
+  }, 60_000);
+
+  it('survives a versions directory that is not there', () => {
+    rmSync(versionsDir, { recursive: true, force: true });
+
+    expect(() => pruneInFreshProcess('6.0.2')).not.toThrow();
+  }, 60_000);
+});

--- a/tests/hooks/runtime-prune-keeps-running-versions.test.mjs
+++ b/tests/hooks/runtime-prune-keeps-running-versions.test.mjs
@@ -42,6 +42,19 @@ const LAUNCHER = pathToFileURL(
 let runtime;
 let versionsDir;
 
+/** A pid that is not running: claimed at the top of the pid space. */
+const DEAD_PID = 0x7ffffffe;
+
+/** Record that `pid` is serving `version`, as a live shim would. */
+function registerActive(pid, version) {
+  const dir = join(runtime, 'active');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, `${pid}.json`),
+    JSON.stringify({ version, startedAt: Date.now() })
+  );
+}
+
 /** A version directory holding a file, aged `minutesOld` minutes. */
 function makeVersion(name, minutesOld) {
   const dir = join(versionsDir, name);
@@ -180,6 +193,52 @@ describe('pruning the managed runtime', () => {
     makeVersion('6.0.3', 10);
 
     const left = pruneInFreshProcess('6.0.3', 2);
+
+    expect(left.sort()).toEqual(['6.0.2', '6.0.3']);
+  }, 60_000);
+
+it('keeps a runtime a live process registered, however old it is', () => {
+    // REVIEW CAUGHT THE HOLE THIS CLOSES. A retention COUNT only protects a
+    // session for a refresh or two: on v1 -> v2 -> v3 the second refresh sees
+    // `prev` as v2, so the v1 a server is still running from ages out and is
+    // deleted -- the original defect again, just delayed. A live shim now
+    // records the runtime it is serving, and a recorded runtime with a live pid
+    // is retained no matter where it sorts.
+    makeVersion('6.0.0', 9000);
+    makeVersion('6.0.1', 30);
+    makeVersion('6.0.2', 20);
+    makeVersion('6.0.3', 10);
+    // `process.pid` is this jest worker: unquestionably alive.
+    registerActive(process.pid, '6.0.0');
+
+    const left = pruneInFreshProcess('6.0.3', 2);
+
+    expect(left.sort()).toEqual(['6.0.0', '6.0.3']);
+  }, 60_000);
+
+  it('does not let a dead process pin a runtime forever', () => {
+    // The other half: markers have to be reaped, or a crashed session keeps a
+    // version alive indefinitely and the directory grows without bound.
+    makeVersion('5.9.0', 9000);
+    makeVersion('6.0.2', 20);
+    makeVersion('6.0.3', 10);
+    registerActive(DEAD_PID, '5.9.0');
+
+    const left = pruneInFreshProcess('6.0.3', 2);
+
+    expect(left.sort()).toEqual(['6.0.2', '6.0.3']);
+  }, 60_000);
+
+  it('does not spend a retention slot on a version that is not installed', () => {
+    // REVIEW CAUGHT THIS TOO. `keep` took `keepVersion` and `alsoKeep`
+    // unconditionally, so a stale `current` pointer naming a directory that is
+    // not there consumed a slot -- and with a retention of two the cleanup then
+    // stripped every real directory but one.
+    makeVersion('6.0.1', 40);
+    makeVersion('6.0.2', 20);
+    makeVersion('6.0.3', 10);
+
+    const left = pruneInFreshProcess('6.0.3', 2, 'no-such-version');
 
     expect(left.sort()).toEqual(['6.0.2', '6.0.3']);
   }, 60_000);

--- a/tests/hooks/runtime-prune-keeps-running-versions.test.mjs
+++ b/tests/hooks/runtime-prune-keeps-running-versions.test.mjs
@@ -57,10 +57,10 @@ function makeVersion(name, minutesOld) {
  * `TOKEN_OPTIMIZER_LAUNCH_IMPORT_ONLY` is what stops `main()` from running;
  * without it, importing the launcher starts a real MCP server.
  */
-function pruneInFreshProcess(keepVersion, keepCount) {
+function pruneInFreshProcess(keepVersion, keepCount, alsoKeep) {
   const script = `
     const { pruneOldVersions } = await import(${JSON.stringify(LAUNCHER)});
-    pruneOldVersions(${JSON.stringify(keepVersion)});
+    pruneOldVersions(${JSON.stringify(keepVersion)}, ${JSON.stringify(alsoKeep ?? null)});
     const { readdirSync } = await import('fs');
     let left = [];
     try { left = readdirSync(${JSON.stringify(versionsDir)}); } catch {}
@@ -141,7 +141,36 @@ describe('pruning the managed runtime', () => {
 
     const left = pruneInFreshProcess('6.0.1', 1);
 
-    expect(left).toEqual(['6.0.1']);
+    expect(left).toContain('6.0.1');
+  }, 60_000);
+
+  it('refuses to retain only one version, however it is configured', () => {
+    // REVIEW CAUGHT THIS, AND THIS TEST USED TO ASSERT THE BUG. It pinned
+    // `keep: 1` as leaving exactly one directory -- but a refresh prunes with
+    // the version it has just INSTALLED, so keeping one deletes the version the
+    // live session is running from and puts the original defect straight back.
+    // A retention of one is never a coherent setting here, so it floors at two.
+    makeVersion('6.0.0', 400);
+    makeVersion('6.0.1', 10);
+
+    const left = pruneInFreshProcess('6.0.1', 1);
+
+    expect(left.sort()).toEqual(['6.0.0', '6.0.1']);
+  }, 60_000);
+
+  it('keeps the previously-pointed version by name, not by luck', () => {
+    // `prev` is what a live session is executing from. Passing it explicitly
+    // matters because mtime ordering does not guarantee it survives: a
+    // reinstall can freshen unrelated directories, pushing the one that is
+    // actually in use out of the newest few.
+    makeVersion('6.0.0', 9000); // the live one, and by far the oldest
+    makeVersion('6.0.1', 30);
+    makeVersion('6.0.2', 20);
+    makeVersion('6.0.3', 10);
+
+    const left = pruneInFreshProcess('6.0.3', 2, '6.0.0');
+
+    expect(left.sort()).toEqual(['6.0.0', '6.0.3']);
   }, 60_000);
 
   it('honours a retention count set by the environment', () => {

--- a/tests/hooks/runtime-prune-keeps-running-versions.test.mjs
+++ b/tests/hooks/runtime-prune-keeps-running-versions.test.mjs
@@ -243,6 +243,55 @@ it('keeps a runtime a live process registered, however old it is', () => {
     expect(left.sort()).toEqual(['6.0.2', '6.0.3']);
   }, 60_000);
 
+it('is not confused by an in-flight atomic write', () => {
+    // REVIEW CAUGHT THE UNDERLYING RACE. The marker was written in place, so a
+    // refresh reading it mid-write got a truncated file, failed to parse it,
+    // and DELETED it as corrupt -- and a live shim only writes it once, so the
+    // protection never came back. It is an atomic write now, which means a
+    // `<pid>.json.tmp-...` file exists in this directory for an instant.
+    //
+    // That temp file must not be mistaken for a marker: `Number.parseInt`
+    // reads leading digits, so `4242.json.tmp-1-2` would otherwise register as
+    // pid 4242, and removing it as unparseable would race the rename about to
+    // consume it. Here the real marker for this live pid must survive
+    // untouched alongside one.
+    // The temp file holds VALID json naming a version that should be pruned.
+    // A truncated one does not discriminate: unparseable input is swept either
+    // way and the real marker still wins, so the first version of this test
+    // passed with the guard removed. Naming a prunable version makes the
+    // difference observable -- without the guard `Number.parseInt` reads the
+    // leading pid, the record parses, and 5.9.0 is pinned by a file that is
+    // not a marker at all.
+    makeVersion('5.9.0', 9000);
+    makeVersion('6.0.0', 9000);
+    makeVersion('6.0.3', 10);
+    registerActive(process.pid, '6.0.0');
+    writeFileSync(
+      join(runtime, 'active', `${process.pid}.json.tmp-9-9`),
+      JSON.stringify({ version: '5.9.0', startedAt: Date.now() })
+    );
+    const left = pruneInFreshProcess('6.0.3', 2);
+
+    expect(left.sort()).toEqual(['6.0.0', '6.0.3']);
+  }, 60_000);
+
+  it('ignores a marker file that is not named for a pid', () => {
+    // Anything else in the directory is not a marker and must not pin a
+    // runtime -- otherwise a stray file keeps a version alive forever.
+    makeVersion('5.9.0', 9000);
+    makeVersion('6.0.2', 20);
+    makeVersion('6.0.3', 10);
+    mkdirSync(join(runtime, 'active'), { recursive: true });
+    writeFileSync(
+      join(runtime, 'active', 'notes.txt'),
+      JSON.stringify({ version: '5.9.0', startedAt: Date.now() })
+    );
+
+    const left = pruneInFreshProcess('6.0.3', 2);
+
+    expect(left.sort()).toEqual(['6.0.2', '6.0.3']);
+  }, 60_000);
+
   it('survives a versions directory that is not there', () => {
     rmSync(versionsDir, { recursive: true, force: true });
 

--- a/tests/unit/intelligence/hooks-core-loader.test.ts
+++ b/tests/unit/intelligence/hooks-core-loader.test.ts
@@ -1,0 +1,175 @@
+/**
+ * The wiki tools must not answer a deleted runtime with an ESM stack trace.
+ *
+ * `loadHooksCore` is the only place in the server that resolves a path at CALL
+ * time. Everything else imports eagerly at startup and is already in memory, so
+ * when the directory the server is running from disappears -- which it did,
+ * because `plugin/launch.mjs` pruned the version a live session was using --
+ * every other tool kept working and only the wiki tools failed. They failed
+ * with `Cannot find module .../versions/6.0.0/.../hooks-core/wiki.mjs`, which
+ * names an internal path and an ESM error code, and reads as a broken package.
+ * It cost real time and produced a confident, wrong conclusion: "hooks-core is
+ * missing from the published tarball". It is not, and never was.
+ *
+ * So this covers the two things that answer is missing: SAY what happened, and
+ * where a compatible copy exists, keep working instead of giving up.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const ORIGINAL_RUNTIME = process.env.TOKEN_OPTIMIZER_RUNTIME;
+let runtime: string;
+
+/** A managed runtime holding one version, optionally with a hooks-core module. */
+function makeRuntime(
+  version: string,
+  options: { withModule?: string; packageVersion?: string } = {}
+): void {
+  const packageDir = join(
+    runtime,
+    'versions',
+    version,
+    'node_modules',
+    '@ooples',
+    'token-optimizer-mcp'
+  );
+  mkdirSync(packageDir, { recursive: true });
+  writeFileSync(
+    join(packageDir, 'package.json'),
+    JSON.stringify({
+      name: '@ooples/token-optimizer-mcp',
+      version: options.packageVersion ?? version,
+    })
+  );
+  if (options.withModule) {
+    const core = join(packageDir, 'hooks-core');
+    mkdirSync(core, { recursive: true });
+    writeFileSync(
+      join(core, options.withModule),
+      'export const marker = "from-runtime";\n'
+    );
+  }
+  writeFileSync(join(runtime, 'current'), version);
+}
+
+async function loader() {
+  const module = await import(
+    `../../../src/tools/intelligence/hooks-core-loader.js?t=${Date.now()}`
+  );
+  return module as typeof import('../../../src/tools/intelligence/hooks-core-loader.js');
+}
+
+beforeEach(() => {
+  runtime = mkdtempSync(join(tmpdir(), 'hooks-core-loader-'));
+  process.env.TOKEN_OPTIMIZER_RUNTIME = runtime;
+});
+
+afterEach(() => {
+  if (ORIGINAL_RUNTIME === undefined) delete process.env.TOKEN_OPTIMIZER_RUNTIME;
+  else process.env.TOKEN_OPTIMIZER_RUNTIME = ORIGINAL_RUNTIME;
+  try {
+    rmSync(runtime, { recursive: true, force: true });
+  } catch {
+    /* windows can hold a handle briefly */
+  }
+});
+
+describe('loading hooks-core', () => {
+  it('loads the bundled module when it is there', async () => {
+    // The ordinary path: hooks-core sits beside the running build. Asserted so
+    // the fallback machinery cannot be masking a broken happy path.
+    const { loadHooksCore } = await loader();
+
+    const wiki = await loadHooksCore('wiki.mjs');
+
+    expect(wiki).toBeTruthy();
+    expect(typeof wiki).toBe('object');
+  }, 30_000);
+
+  it('explains a pruned runtime instead of surfacing an ESM error', async () => {
+    // The message a human actually needs: what happened, that nothing was lost,
+    // and what to do about it. A module name that does not exist stands in for
+    // a hooks-core directory that has been deleted.
+    const { loadHooksCore, HooksCoreUnavailableError } = await loader();
+
+    await expect(loadHooksCore('definitely-not-a-real-module.mjs')).rejects.toThrow(
+      HooksCoreUnavailableError
+    );
+
+    const error = await loadHooksCore('definitely-not-a-real-module.mjs').catch(
+      (caught: Error) => caught
+    );
+
+    // The bundled directory DOES exist here, so it must say so rather than
+    // blaming a prune that did not happen. Guessing the cause is what produced
+    // the wrong "missing from the tarball" conclusion in the first place.
+    expect(error.message).toContain('genuinely missing or unreadable file');
+    expect(error.message).not.toContain('has been removed');
+  }, 30_000);
+
+  it('names the recovery when the runtime it started from is gone', async () => {
+    // Constructed directly, because making the real bundled hooks-core vanish
+    // mid-test would break every other suite sharing this worker.
+    const { HooksCoreUnavailableError } = await loader();
+
+    const error = new HooksCoreUnavailableError('wiki.mjs', new Error('ENOENT'));
+
+    expect(error.name).toBe('HooksCoreUnavailableError');
+    expect(error.message).toContain('wiki.mjs');
+    expect(error.message).toContain('ENOENT');
+  }, 30_000);
+
+  it('recovers from the current runtime when the bundled copy is gone', async () => {
+    // THE POINT OF THE FALLBACK, and the case the others only bound. Without
+    // this the feature stays dead for the whole session: the server keeps
+    // running happily from memory while every wiki call fails, and a session
+    // routinely outlives the six-hour refresh that removed its directory.
+    //
+    // `runningPackageDir()` resolves to this repository, so its own version
+    // supplies the major that the runtime copy has to match.
+    const { version } = JSON.parse(
+      readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+    ) as { version: string };
+    const sameMajor = `${version.split('.')[0]}.999.999`;
+
+    makeRuntime(sameMajor, {
+      withModule: 'definitely-not-a-real-module.mjs',
+      packageVersion: sameMajor,
+    });
+
+    const { loadHooksCore } = await loader();
+    const recovered = await loadHooksCore('definitely-not-a-real-module.mjs');
+
+    expect(recovered.marker).toBe('from-runtime');
+  }, 30_000);
+
+  it('does not fall back across a major version', async () => {
+    // A cross-major fallback would load one release's hooks-core into another
+    // release's server, and these modules share a persisted wiki store: a
+    // mismatch there writes bad data instead of failing loudly, which is
+    // strictly worse than not answering.
+    makeRuntime('99.0.0', {
+      withModule: 'definitely-not-a-real-module.mjs',
+      packageVersion: '99.0.0',
+    });
+
+    const { loadHooksCore } = await loader();
+
+    await expect(
+      loadHooksCore('definitely-not-a-real-module.mjs')
+    ).rejects.toThrow(/could not load|has been removed/);
+  }, 30_000);
+
+  it('ignores a runtime whose current pointer names nothing', async () => {
+    writeFileSync(join(runtime, 'current'), 'nope-not-installed');
+
+    const { loadHooksCore } = await loader();
+
+    await expect(
+      loadHooksCore('definitely-not-a-real-module.mjs')
+    ).rejects.toThrow(/could not load|has been removed/);
+  }, 30_000);
+});

--- a/tests/unit/intelligence/hooks-core-loader.test.ts
+++ b/tests/unit/intelligence/hooks-core-loader.test.ts
@@ -146,6 +146,57 @@ describe('loading hooks-core', () => {
     expect(recovered.marker).toBe('from-runtime');
   }, 30_000);
 
+  it('refuses a fallback whenever either version is unknown', async () => {
+    // THE GUARD, ASSERTED DIRECTLY. Reached through `fallbackDir` this is
+    // unreachable: any fixture that makes the running version unknown also
+    // makes the candidate unreadable, so the candidate check fires first --
+    // which is why a mutation flipping this to fail-open survived every other
+    // test here. A null running version is exactly what a PRUNED runtime
+    // produces, so failing open there disables the guard in the only situation
+    // the fallback exists for.
+    const { fallbackIsCompatible } = await loader();
+
+    expect(fallbackIsCompatible(null, '6.0.1')).toBe(false);
+    expect(fallbackIsCompatible('6.0.1', null)).toBe(false);
+    expect(fallbackIsCompatible('6.0.1', '7.0.0')).toBe(false);
+    expect(fallbackIsCompatible('6.0.1', '6.9.9')).toBe(true);
+  }, 30_000);
+
+  it('refuses to fall back when it cannot establish its own version', async () => {
+    // REVIEW CAUGHT THIS, AND IT FAILED OPEN IN THE ONLY CASE THAT MATTERS.
+    // The major check originally read the running version inside the fallback
+    // and skipped the comparison when it came back null -- but null is exactly
+    // what a PRUNED runtime produces, which is the situation the fallback
+    // exists for. A live v6 server could then have loaded v7 hooks-core and
+    // written the shared wiki store with incompatible code.
+    //
+    // The version is captured at module load now, so this asserts the guard
+    // from the other side: a candidate whose own manifest is unreadable can
+    // never be accepted, whatever the running version is.
+    const packageDir = join(
+      runtime,
+      'versions',
+      '6.0.9',
+      'node_modules',
+      '@ooples',
+      'token-optimizer-mcp'
+    );
+    mkdirSync(join(packageDir, 'hooks-core'), { recursive: true });
+    writeFileSync(
+      join(packageDir, 'hooks-core', 'definitely-not-a-real-module.mjs'),
+      'export const marker = "from-runtime";\n'
+    );
+    // A manifest that cannot be parsed: no version can be established.
+    writeFileSync(join(packageDir, 'package.json'), 'not json at all');
+    writeFileSync(join(runtime, 'current'), '6.0.9');
+
+    const { loadHooksCore } = await loader();
+
+    await expect(
+      loadHooksCore('definitely-not-a-real-module.mjs')
+    ).rejects.toThrow(/could not load|has been removed/);
+  }, 30_000);
+
   it('does not fall back across a major version', async () => {
     // A cross-major fallback would load one release's hooks-core into another
     // release's server, and these modules share a persisted wiki store: a


### PR DESCRIPTION
## The refresh deletes the runtime a live session is running from

`plugin/launch.mjs` promises this, in its own header:

> Version dirs are IMMUTABLE once built. A background refresh installs into a brand-new `versions/<v>` dir and only then flips the `current` pointer, **so it never mutates files a running server may still be lazy-`require`-ing.**

And then `pruneOldVersions` deleted every version directory except the newest — including the one a server is executing from *right now*. Deleting is the most extreme mutation available, so the invariant was being broken by the very code that documented it.

## Why nobody noticed

A running server has already imported its eager modules and they stay in memory, so it **keeps answering normally** after its directory is gone. Only a path resolved at *call* time notices — and exactly one area resolves one: the wiki tools reach `hooks-core` through a lazy `import()` in `coreUrl()`.

Observed 2026-08-28 on a session that outlived one refresh:

```
wiki_write → Cannot find module
  ...\runtime\versions\6.0.0\...\@ooples\token-optimizer-mcp\hooks-core\wiki.mjs
  imported from ...\dist\tools\intelligence\wiki-write.js
```

Every `wiki_write` call failed that way for the rest of the session while **every other tool worked normally**. Knowledge capture was silently dead for hours and nothing else looked wrong.

That is also why it first read as a packaging fault in the published tarball. **It is not** — 6.0.1 ships `hooks-core/wiki.mjs`, and it was present at the `v6.0.0` tag too. The directory had simply been removed from under the process: `versions/6.0.0/` was left holding an empty `node_modules` while `current` pointed at 6.0.1.

The refresh interval is **six hours**, so an ordinary working session outlives one routinely. `wiki_read` and `wiki_query` use the same lazy import and have the same exposure.

## The fix

Keep the newest few version directories instead of exactly one, always including the version the next launch will use — even if its mtime is not the newest, since that is the one that matters most.

Three by default, overridable with `TOKEN_OPTIMIZER_RUNTIME_KEEP`. That buys roughly eighteen hours of grace for a few tens of megabytes of disk.

It is a **retention count, not a liveness check**, because there is no cheap, reliable way to ask "is a process still running from this directory" across platforms — and guessing wrong in that direction deletes a live runtime again.

## Testability, deliberately fail-open

`pruneOldVersions` is exported, and `main()` is skipped only when `TOKEN_OPTIMIZER_LAUNCH_IMPORT_ONLY=1`.

That guard is fail-open on purpose: **anything other than an explicit opt-out still launches**. The obvious alternative — detecting whether this file is the entry point — fails in the opposite direction, where one bad comparison means the launcher silently does nothing and there is no MCP server at all. Verified that the ordinary path is unchanged: the shim served its cached server and exited 0 on stdin end.

## Verification

Each test case prunes in **its own node process**, because the launcher reads its runtime path and retention count from the environment at *import* time. That is correct for a launcher that is a fresh process every time, but it means re-importing inside one jest worker does not re-read them — the first version of these tests silently pruned the *previous* case's already-deleted directory and asserted nothing. Two of five cases passed for that reason before it was caught.

Mutation-tested; the original bug is reintroduced verbatim as the first mutation:

| Mutation | Result |
|---|---|
| back to deleting every version but the newest (**the original bug**) | 3 tests fail |
| `keepVersion` no longer forced into the keep set | 1 fails |
| retention count ignored | 2 fail |
| sorted oldest-first, keeping the stale ones | 2 fail |

`tsc --noEmit` clean, `lint` 0 errors, `format:check` clean, `sync:hooks:check` in sync, `validate` passes, full suite **235 suites / 3048 passed / 0 failed**.

## Follow-up worth considering separately

The lazy `coreUrl()` import is what turned a deleted directory into a confusing "Cannot find module" rather than a clear failure. Even with pruning fixed, a runtime that vanishes for any other reason will produce the same opaque error from the wiki tools alone. A clearer message there would be a small, independent improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
