### PR TITLE
perf(analysis): read each file once instead of two or three times

### DIFF
--- a/src/tools/code-analysis/smart-dependencies.ts
+++ b/src/tools/code-analysis/smart-dependencies.ts
@@ -13,7 +13,7 @@
  * Week 5 - Phase 2 Track 2A
  */
 
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, statSync } from 'fs';
 import { parse as parseTypescript } from '@typescript-eslint/typescript-estree';
 import { parse as parseBabel } from '@babel/parser';
 // glob v10+ is native ESM and has no default export; the CJS-style
@@ -164,6 +164,26 @@ export interface SmartDependenciesResult {
 }
 
 export class SmartDependenciesTool {
+  /**
+   * Token count per relative path, recorded while the file was open.
+   *
+   * Cleared at the start of every `analyze()` so it can never serve a count
+   * from a previous call's content -- the saving is skipping a redundant read
+   * WITHIN one analysis, not caching across them.
+   */
+  private fileTokenCounts = new Map<string, number>();
+
+  /**
+   * Whether a candidate module path is a file, remembered for one `analyze()`.
+   *
+   * Import resolution probes the same handful of candidates over and over --
+   * every file in a package resolving `./index` walks the identical extension
+   * list -- and each probe was its own `existsSync`. Measured 2026-08-28 after
+   * the read-once fix landed: 4.98 s, 14.6% of the run, and the single largest
+   * remaining cost. Cleared per call for the same reason as the token counts.
+   */
+  private pathExists = new Map<string, boolean>();
+
   constructor(
     private cache: CacheEngine,
     private tokenCounter: TokenCounter,
@@ -187,6 +207,8 @@ export class SmartDependenciesTool {
     options: SmartDependenciesOptions = {}
   ): Promise<SmartDependenciesResult> {
     const startTime = Date.now();
+    this.fileTokenCounts.clear();
+    this.pathExists.clear();
 
     // Default options
     const opts: Required<SmartDependenciesOptions> = {
@@ -491,6 +513,13 @@ export class SmartDependenciesTool {
       const ext = extname(filePath);
       const hash = hashFileMetadata(filePath);
       const relativePath = relative(cwd, filePath);
+
+      // Counted here, where the content is already in memory. See
+      // measureFullFileTokens for what this replaces.
+      this.fileTokenCounts.set(
+        relativePath,
+        this.tokenCounter.count(content).tokens
+      );
 
       const imports: DependencyImport[] = [];
       const exports: DependencyExport[] = [];
@@ -1171,36 +1200,59 @@ export class SmartDependenciesTool {
   /**
    * Utility: Resolve relative path
    */
+  /**
+   * Whether a candidate resolves to an actual FILE, asked once per analysis.
+   *
+   * `isFile()`, not `existsSync`. A directory satisfies `existsSync`, so
+   * `./foo` in a project holding a `foo/` directory resolved to the directory
+   * itself -- producing a graph edge to `src/foo`, which is not a node in the
+   * graph at all. Measured on a fixture holding both `foo.ts` and
+   * `foo/index.ts`: the recorded edge was `src\\main.ts -> src\\foo`, pointing
+   * at nothing, while Node resolves that import to `foo.ts`.
+   */
+  private candidateIsFile(candidate: string): boolean {
+    const remembered = this.pathExists.get(candidate);
+    if (remembered !== undefined) return remembered;
+    let isFile = false;
+    try {
+      isFile = statSync(candidate).isFile();
+    } catch {
+      isFile = false;
+    }
+    this.pathExists.set(candidate, isFile);
+    return isFile;
+  }
+
+  /**
+   * Resolve an import specifier to a path relative to `cwd`.
+   *
+   * Order matches Node: the path as written, then the extension candidates,
+   * then `index.*` inside a directory of that name. Each step returns on the
+   * first hit, so a later candidate can never overwrite an earlier one.
+   */
   private resolveRelativePath(
     source: string,
     fileDir: string,
     cwd: string
   ): string {
     const resolved = resolve(fileDir, source);
-    let relativePath = relative(cwd, resolved);
+    if (this.candidateIsFile(resolved)) return relative(cwd, resolved);
 
-    // Try common extensions if file doesn't exist
     const extensions = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
-    if (!existsSync(resolved)) {
-      for (const ext of extensions) {
-        const withExt = `${resolved}${ext}`;
-        if (existsSync(withExt)) {
-          relativePath = relative(cwd, withExt);
-          break;
-        }
-      }
 
-      // Try index files
-      const indexFiles = extensions.map((ext) => join(resolved, `index${ext}`));
-      for (const indexFile of indexFiles) {
-        if (existsSync(indexFile)) {
-          relativePath = relative(cwd, indexFile);
-          break;
-        }
-      }
+    for (const ext of extensions) {
+      const withExt = `${resolved}${ext}`;
+      if (this.candidateIsFile(withExt)) return relative(cwd, withExt);
     }
 
-    return relativePath;
+    for (const ext of extensions) {
+      const indexFile = join(resolved, `index${ext}`);
+      if (this.candidateIsFile(indexFile)) return relative(cwd, indexFile);
+    }
+
+    // Nothing on disk matches -- an unresolvable import is recorded as written
+    // rather than dropped, so the edge is visible instead of silently absent.
+    return relative(cwd, resolved);
   }
 
   /**
@@ -1265,6 +1317,20 @@ export class SmartDependenciesTool {
   private measureFullFileTokens(files: string[], cwd: string): number {
     let total = 0;
     for (const file of files) {
+      // ALREADY COUNTED WHILE THE FILE WAS OPEN. `analyzeFile` reads every file
+      // to parse it and records the count there, so this baseline used to read
+      // the entire project a SECOND time purely to produce a savings figure.
+      // Measured 2026-08-28 on 12,000 files: 19.58 s of readFileUtf8, 38% of a
+      // 51 s run, spent re-reading bytes the tool had just finished with.
+      //
+      // A miss still reads -- the cached-graph paths reach here without having
+      // analysed anything -- so this is a shortcut, never a different answer:
+      // the count comes from the same tokenizer over the same content.
+      const counted = this.fileTokenCounts.get(file);
+      if (counted !== undefined) {
+        total += counted;
+        continue;
+      }
       try {
         // RESOLVED AGAINST THE PROJECT, not the process. The graph is keyed by
         // paths relative to `cwd` (see analyzeFile), so reading them as-is

--- a/src/tools/code-analysis/smart-security.ts
+++ b/src/tools/code-analysis/smart-security.ts
@@ -16,6 +16,7 @@ import { createHash } from 'crypto';
 import { readFileSync, existsSync, statSync, readdirSync } from 'fs';
 import { join, relative, extname } from 'path';
 import { homedir } from 'os';
+import { hashFileMetadata } from '../shared/hash-utils.js';
 
 /**
  * Vulnerability severity levels
@@ -784,10 +785,21 @@ export class SmartSecurity {
    * Scan a single file for vulnerabilities
    */
   private async scanFile(filePath: string): Promise<FileScanResult | null> {
-    if (!existsSync(filePath)) return null;
+    // NO existsSync GUARD. It was a second syscall per file asking exactly what
+    // the read answers by failing -- 1.08 s across 12,000 files, on top of the
+    // read it was guarding. A file that vanished between discovery and scanning
+    // is ordinary and stays silent; anything else is still reported.
+    let content: string;
+    try {
+      content = readFileSync(filePath, 'utf-8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+        console.error(`Error reading file ${filePath}:`, error);
+      }
+      return null;
+    }
 
     try {
-      const content = readFileSync(filePath, 'utf-8');
       const lines = content.split('\n');
       const ext = extname(filePath);
       const findings: VulnerabilityFinding[] = [];
@@ -824,7 +836,9 @@ export class SmartSecurity {
 
       return {
         file: filePath,
-        hash: this.generateFileHash(filePath),
+        // The content is already in hand; hashing it costs nothing, whereas
+        // re-reading the file cost a third of this tool's runtime.
+        hash: this.generateFileHash(filePath, content),
         scannedAt: Date.now(),
         findings,
         linesScanned: lines.length,
@@ -1185,9 +1199,25 @@ export class SmartSecurity {
     // Sort files for consistent cache key
     const sortedFiles = [...files].sort();
 
+    // METADATA, NOT CONTENT. This hashed every file's CONTENT to decide whether
+    // a cached scan could be reused -- which meant reading the entire project
+    // before deciding whether to read the entire project. Measured 2026-08-28
+    // on 12,000 files: 17.75 s of readFileUtf8 plus 2.03 s of existsSync, 62%
+    // of a 32 s scan, spent on a question `stat` answers.
+    //
+    // Size-and-mtime is the same trade `smart_dependencies` already makes via
+    // this helper. It re-scans when a file is touched without changing (cheap,
+    // and correct), and it would reuse a cached scan if content changed while
+    // size AND mtime were both preserved -- which takes deliberate effort to
+    // arrange and is not something an editor does.
     for (const file of sortedFiles) {
-      const fileHash = this.generateFileHash(file);
-      hash.update(fileHash);
+      try {
+        hash.update(hashFileMetadata(file));
+      } catch {
+        // Unreadable or vanished between discovery and here. Contributing the
+        // path alone keeps the key stable and distinct rather than throwing.
+        hash.update(file);
+      }
     }
 
     return `${this.cacheNamespace}:${hash.digest('hex')}`;
@@ -1196,13 +1226,25 @@ export class SmartSecurity {
   /**
    * Generate hash for a single file
    */
-  private generateFileHash(filePath: string): string {
-    if (!existsSync(filePath)) return '';
-
-    const content = readFileSync(filePath, 'utf-8');
-    const hash = createHash('sha256');
-    hash.update(content);
-    return hash.digest('hex');
+  private generateFileHash(filePath: string, content?: string): string {
+    // CONTENT WHEN THE CALLER ALREADY HAS IT. `scanFile` reads the file, scans
+    // it, and then used to call this -- which read the very same file a second
+    // time purely to hash what it was already holding. Combined with the cache
+    // key's own pass that made three reads per file on a full scan.
+    //
+    // The `existsSync` guard is gone with it: it was a second syscall asking a
+    // question the read answers by failing, and the caller already treats a
+    // failure as "no result".
+    if (content !== undefined) {
+      return createHash('sha256').update(content).digest('hex');
+    }
+    try {
+      return createHash('sha256')
+        .update(readFileSync(filePath, 'utf-8'))
+        .digest('hex');
+    } catch {
+      return '';
+    }
   }
 
   /**

--- a/tests/unit/code-analysis/read-each-file-once.test.ts
+++ b/tests/unit/code-analysis/read-each-file-once.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Reading a file twice is not a slow answer, it is the same answer paid for twice.
+ *
+ * Profiled 2026-08-28 on a 12,000-file tree with `node --cpu-prof`, ranked by
+ * SELF time. Neither tool was slow because of traversal or because of the
+ * analysis it exists to do:
+ *
+ *   - smart_security spent 17.75 s hashing every file's CONTENT to build a
+ *     cache key -- reading the whole project to decide whether to read the
+ *     whole project -- plus 7.53 s reading it again to scan, plus a third read
+ *     inside `scanFile`'s own hash. Three reads per file; the vulnerability
+ *     regex was 3.9% of the run.
+ *   - smart_dependencies spent 19.58 s in `measureFullFileTokens` re-reading
+ *     every file purely to compute a "tokens saved" baseline, on top of the
+ *     10.67 s `analyzeFile` spent reading the same bytes to parse them.
+ *
+ * Measured after: smart_security 32.0 s -> 13.1 s, smart_dependencies
+ * 51.3 s -> 26.8 s, with identical outputs.
+ *
+ * WHAT THESE TESTS ARE FOR. The speed is measured by the benchmarks; what needs
+ * pinning is that nothing about the ANSWERS changed. Two of the fixes altered
+ * behaviour and had to be checked rather than assumed: the security cache key
+ * is now derived from file metadata instead of content, and import resolution
+ * returns on the first extension match instead of falling through.
+ */
+
+import { describe, it, expect, afterEach } from '@jest/globals';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { CacheEngine } from '../../../src/core/cache-engine.js';
+import { TokenCounter } from '../../../src/core/token-counter.js';
+import { MetricsCollector } from '../../../src/core/metrics.js';
+import { SmartSecurity } from '../../../src/tools/code-analysis/smart-security.js';
+import { SmartDependenciesTool } from '../../../src/tools/code-analysis/smart-dependencies.js';
+
+/**
+ * A detectable secret, assembled at runtime.
+ *
+ * Written as fragments for the same reason `security-finds-real-secrets`
+ * does it: a fixture holding a literal provider-shaped key is itself a
+ * scannable secret, and GitHub push protection rejected the first version
+ * of this file for exactly that -- correctly. This matches the tool's
+ * generic secret rule without resembling any real credential.
+ */
+const SECRET_LINE =
+  'const secret = "' +
+  ['abcdefghij', 'klmnopqrst', 'uvwxyz1234'].join('') +
+  '";\n';
+
+const dirs: string[] = [];
+const caches: CacheEngine[] = [];
+
+afterEach(() => {
+  while (caches.length) {
+    try {
+      caches.pop()?.close();
+    } catch {
+      /* already closed */
+    }
+  }
+  while (dirs.length) {
+    const dir = dirs.pop();
+    if (!dir) continue;
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* windows can hold a handle briefly */
+    }
+  }
+});
+
+function project(files: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), 'read-once-'));
+  dirs.push(root);
+  for (const [relative, body] of Object.entries(files)) {
+    const full = join(root, relative);
+    mkdirSync(join(full, '..'), { recursive: true });
+    writeFileSync(full, body);
+  }
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ name: 'read-once-fixture', version: '0.0.1' })
+  );
+  return root;
+}
+
+function newCache(root: string): CacheEngine {
+  const cache = new CacheEngine(join(root, `c-${caches.length}.db`), 100);
+  caches.push(cache);
+  return cache;
+}
+
+describe('smart_security reads each file once', () => {
+  it('still finds what it found before', async () => {
+    // The guard against making it fast by making it blind.
+    const root = project({
+      'src/leak.ts': SECRET_LINE,
+    });
+    const tool = new SmartSecurity(
+      newCache(root),
+      new TokenCounter(),
+      new MetricsCollector(),
+      root
+    );
+
+    const result = await tool.run({ force: true });
+
+    expect(result.summary.filesScanned).toBe(1);
+    expect(result.summary.totalFindings).toBeGreaterThan(0);
+  }, 120_000);
+
+  it('serves a second identical scan from cache', async () => {
+    const root = project({ 'src/a.ts': 'export const a = 1;\n' });
+    const cache = newCache(root);
+    const make = () =>
+      new SmartSecurity(cache, new TokenCounter(), new MetricsCollector(), root);
+
+    const first = await make().run({});
+    const second = await make().run({});
+
+    expect(first.summary.fromCache).toBe(false);
+    expect(second.summary.fromCache).toBe(true);
+  }, 120_000);
+
+  it('rescans exactly the file that changed, and nothing else', async () => {
+    // THE FILE HASH STILL HAS TO BE A CONTENT HASH. `scanFile` now hashes the
+    // content it is already holding instead of re-reading the file, and the
+    // stored hash is what `incrementalScan` compares against to decide whether
+    // a file needs rescanning. A mutation that hashed the PATH instead survived
+    // every other test here, because nothing exercised incremental mode -- the
+    // path never changes, so no edit would ever be noticed again.
+    const root = project({
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+    });
+    const tool = new SmartSecurity(
+      newCache(root),
+      new TokenCounter(),
+      new MetricsCollector(),
+      root
+    );
+
+    // Populate the per-file hashes.
+    const first = await tool.run({ targets: ['src'], force: true });
+    expect(first.summary.filesScanned).toBe(2);
+
+    // Nothing touched: the result cache answers before incremental mode is
+    // even reached, which is the cheaper correct behaviour rather than a bug.
+    const unchanged = await tool.run({ targets: ['src'] });
+    expect(unchanged.summary.fromCache).toBe(true);
+
+    writeFileSync(
+      join(root, 'src', 'b.ts'),
+      'export const b = 2;\n' + SECRET_LINE
+    );
+
+    const afterEdit = await tool.run({ targets: ['src'] });
+
+    expect(afterEdit.summary.filesScanned).toBe(1);
+    expect(afterEdit.summary.totalFindings).toBeGreaterThan(0);
+  }, 120_000);
+
+  it('still notices an edited file after the key stopped hashing content', async () => {
+    // THE ONE THAT MATTERS. The cache key is derived from size and mtime now
+    // rather than from a full read of every file. That is a real semantic
+    // change and it is only acceptable while an ordinary edit still
+    // invalidates -- so this asserts the invalidation directly rather than
+    // trusting the reasoning.
+    const root = project({ 'src/a.ts': 'export const a = 1;\n' });
+    const cache = newCache(root);
+    const make = () =>
+      new SmartSecurity(cache, new TokenCounter(), new MetricsCollector(), root);
+
+    await make().run({});
+    const cached = await make().run({});
+    expect(cached.summary.fromCache).toBe(true);
+
+    writeFileSync(
+      join(root, 'src', 'a.ts'),
+      'export const a = 1;\n' + SECRET_LINE
+    );
+
+    const afterEdit = await make().run({});
+
+    expect(afterEdit.summary.fromCache).toBe(false);
+    expect(afterEdit.summary.totalFindings).toBeGreaterThan(0);
+  }, 120_000);
+});
+
+describe('smart_dependencies reads each file once', () => {
+  it('reports the same graph and the same measured baseline', async () => {
+    // `measureFullFileTokens` now reads its counts from what `analyzeFile`
+    // recorded while the file was open. Same tokenizer, same content, so the
+    // baseline must be unchanged -- and it must not be zero, which is what a
+    // broken lookup would silently produce.
+    const root = project({
+      'src/a.ts': "import { b } from './b';\nexport const a = b;\n",
+      'src/b.ts': 'export const b = 2;\n',
+    });
+    const tool = new SmartDependenciesTool(
+      newCache(root),
+      new TokenCounter(),
+      new MetricsCollector()
+    );
+
+    const result = await tool.analyze({ cwd: root, useCache: false });
+
+    expect(result.success).toBe(true);
+    expect(result.metadata.totalFiles).toBe(2);
+    expect(result.metadata.originalTokenCount).toBeGreaterThan(0);
+  }, 120_000);
+
+  it('does not point an edge at a directory that is not a node', async () => {
+    // A CORRECTNESS BUG FOUND WHILE MAKING THIS FAST -- and not the one I first
+    // claimed. I asserted from reading the code that the index-file loop
+    // overwrote an extension match; the test disproved it. The real fault is
+    // that `existsSync` is TRUE FOR A DIRECTORY, so `./foo` in a project with a
+    // `foo/` directory resolved to `src/foo` and recorded an edge to a path
+    // that is not in the graph at all. Measured before the fix:
+    //   edges: [{ from: "src\\main.ts", to: "src\\foo" }]
+    // where the nodes were src\main.ts, src\foo.ts and src\foo\index.ts.
+    //
+    // Node resolves `./foo` to `foo.ts` when it exists, so that is what the
+    // edge must say.
+    const root = project({
+      'src/main.ts': "import { value } from './foo';\nexport const main = value;\n",
+      'src/foo.ts': 'export const value = 1;\n',
+      'src/foo/index.ts': 'export const value = 2;\n',
+    });
+    const tool = new SmartDependenciesTool(
+      newCache(root),
+      new TokenCounter(),
+      new MetricsCollector()
+    );
+
+    const result = await tool.analyze({ cwd: root, useCache: false });
+    const nodes = (result.graph?.nodes ?? []).map((n) => n.replace(/\\/g, '/'));
+    const targets = (result.graph?.edges ?? []).map((e) =>
+      e.to.replace(/\\/g, '/')
+    );
+
+    expect(result.success).toBe(true);
+    expect(targets).toContain('src/foo.ts');
+    // The invariant the old behaviour broke: every edge lands on a real node.
+    for (const target of targets) expect(nodes).toContain(target);
+  }, 120_000);
+
+  it('falls back to index.ts when only the directory exists', async () => {
+    // The other half of Node's rule, and the case the directory check must not
+    // break on its way to fixing the one above.
+    const root = project({
+      'src/main.ts': "import { value } from './foo';\nexport const main = value;\n",
+      'src/foo/index.ts': 'export const value = 2;\n',
+    });
+    const tool = new SmartDependenciesTool(
+      newCache(root),
+      new TokenCounter(),
+      new MetricsCollector()
+    );
+
+    const result = await tool.analyze({ cwd: root, useCache: false });
+    const targets = (result.graph?.edges ?? []).map((e) =>
+      e.to.replace(/\\/g, '/')
+    );
+
+    expect(result.success).toBe(true);
+    expect(targets).toContain('src/foo/index.ts');
+  }, 120_000);
+});


### PR DESCRIPTION
Closes the performance half of the "all the tools are slow" report.

Profiled on a 12,000-file tree with `node --cpu-prof`, each tool in its own process, ranked by **SELF** time. Neither tool was slow because of traversal, and neither was slow because of the analysis it exists to do. Both were reading the same bytes repeatedly.

## smart_security read every file three times

| Where | Cost |
|---|---|
| `generateCacheKey` → `generateFileHash` — hashing every file's **content** to decide whether a cached scan could be reused | **17.75 s** read + 2.03 s `existsSync` |
| `scanFile` — reading it again to actually scan | 7.53 s + 0.83 s |
| `scanFile`'s return → `generateFileHash` again — re-reading the file to hash what it was already holding | (inside the 17.75 s above) |
| the vulnerability regex all of that existed to feed | **3.9%** |

So it read the whole project to decide whether to read the whole project.

**Fixed:** the cache key comes from size and mtime — the same trade `smart_dependencies` already makes through `hashFileMetadata`. `scanFile` hashes the content it is holding. The `existsSync` before each read is gone: it was a second syscall asking exactly what the read answers by failing.

**32.0 s → 13.1 s.**

## smart_dependencies read every file twice

`measureFullFileTokens` re-read the entire project purely to compute the *"tokens saved"* baseline — **19.58 s**, 38% of the run — for bytes `analyzeFile` had just finished parsing (10.67 s).

**Fixed:** `analyzeFile` records the count while the content is in memory. A miss still reads, so the cached-graph paths are unaffected, and the number comes from the same tokenizer over the same content.

Removing that exposed the next cost, as it usually does: import resolution probing candidate paths, **4.98 s** of `existsSync`, now remembered for the duration of one analysis.

**51.3 s → 26.8 s.**

Both measured across three runs with tight variance, and both produce identical output (`filesScanned` / `totalFiles` unchanged at 12,000).

## A correctness bug found on the way — and not the one I first claimed

I asserted, from reading the code, that the index-file loop overwrote an extension match. **A test disproved it.** The real fault is that `existsSync` is **true for a directory**, so `./foo` in a project holding a `foo/` directory resolved to `src/foo` and recorded a graph edge to a path that is not a node at all:

```
nodes: ["src\\main.ts", "src\\foo.ts", "src\\foo\\index.ts"]
edges: [{ from: "src\\main.ts", to: "src\\foo" }]     <-- points at nothing
```

Resolution now requires a **file**, and follows Node's order — the path as written, then extensions, then `index.*` — returning on the first hit. Every edge lands on a real node, and `./foo` resolves to `foo.ts` when it exists and to `foo/index.ts` when only the directory does.

## Verification

Full suite **235 suites / 3050 passed / 0 failed**; `tsc` clean, `lint` 0 errors, `format:check` clean, `validate` passes.

Seven new tests, all mutation-verified — **5/5 caught**:

| Mutation | Result |
|---|---|
| cache key stops depending on the files at all | 2 fail |
| `scanFile` hashes the path instead of the content | 1 fails |
| recorded token count is zero | 1 fails |
| back to `existsSync`, so a directory satisfies resolution | 2 fail |
| index candidates tried before extensions | 1 fails |

Two notes on that, because the first pass was weaker than it looked:

- **The path-instead-of-content mutation survived initially.** Nothing exercised incremental mode, and the file hash is *only* used there — so hashing the path would have meant no edit was ever noticed again, with every test still green. There is a test for it now.
- **One mutation I wrote was meaningless and I removed it rather than count it.** Making the token lookup always miss falls back to reading and produces the *same answer*; it is a pure performance change, so no unit test can or should catch it. It is verified by the benchmark, and scoring it here would have been theatre.

The first push was also **rejected by GitHub push protection** — correctly. A fixture used a literal `sk_live_…` string, which scans as a real Stripe key. Fixtures are assembled from fragments now, matching the idiom already used in `security-finds-real-secrets`, and the commit was amended so the literal never enters history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
