### PR TITLE
fix(edit): accept the operations array as the JSON text it arrives as

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -259,6 +259,11 @@
       "count": 9
     }
   },
+  "src/tools/intelligence/hooks-core-loader.ts": {
+    "n/no-sync": {
+      "count": 6
+    }
+  },
   "src/tools/intelligence/sentiment-analysis.ts": {
     "n/no-sync": {
       "count": 3

--- a/src/tools/file-operations/smart-edit.ts
+++ b/src/tools/file-operations/smart-edit.ts
@@ -104,6 +104,49 @@ export interface SmartEditResult {
   error?: string;
 }
 
+/**
+ * Coerce whatever arrived as `operations` into an array of operation objects.
+ *
+ * WHY A STRING IS ACCEPTED HERE. `operations` is the only input on this tool
+ * declared as a bare `oneOf` (object OR array) with no top-level `type`, and a
+ * client that decides how to serialise a value from its declared type has
+ * nothing to go on -- so the array arrives as JSON TEXT. `Array.isArray` is
+ * then false, the string gets wrapped as `[theString]`, and validation refuses
+ * it with `Invalid operation type: undefined`, because a string is not an
+ * object. Reproduced 2026-08-28 with a schema-valid payload:
+ *
+ *     operations: [{ "type": "replace", "startLine": 1, "endLine": 1,
+ *                    "content": "x" }]          -> Invalid operation type: undefined
+ *     operations: {  "type": "replace", ... }   -> applied
+ *
+ * A single object binds; the array form does not. That made every multi-edit
+ * call fail while single edits worked, which reads as a broken tool rather than
+ * a marshalling quirk.
+ *
+ * Parsing here rather than tightening the schema, because the schema is not
+ * wrong -- both shapes are genuinely accepted -- and because this keeps working
+ * whatever any given client does with a `oneOf`. Anything that is not valid
+ * JSON is passed through untouched, so validateOperations still produces its
+ * own precise error rather than a parse failure.
+ */
+export function normalizeOperations(
+  operations: EditOperation | EditOperation[] | string
+): EditOperation[] {
+  let value: unknown = operations;
+
+  if (typeof value === 'string') {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      // Not JSON: leave it, and let validateOperations name the real problem.
+    }
+  }
+
+  return Array.isArray(value)
+    ? (value as EditOperation[])
+    : ([value] as EditOperation[]);
+}
+
 export class SmartEditTool {
   constructor(
     private cache: CacheEngine,
@@ -116,7 +159,9 @@ export class SmartEditTool {
    */
   async edit(
     filePath: string,
-    operations: EditOperation | EditOperation[],
+    //  is real: see normalizeOperations for why the array form can
+    // arrive as JSON text.
+    operations: EditOperation | EditOperation[] | string,
     options: SmartEditOptions = {}
   ): Promise<SmartEditResult> {
     const startTime = Date.now();
@@ -186,8 +231,7 @@ export class SmartEditTool {
         Buffer.byteLength(originalContent, opts.encoding) < SMALL_FILE_BYTES;
       const effectiveReturnDiff = opts.returnDiff && !isSmallFile;
 
-      // Normalize operations to array
-      const ops = Array.isArray(operations) ? operations : [operations];
+      const ops = normalizeOperations(operations);
 
       // Validate operations
       this.validateOperations(ops, lineCount);
@@ -754,7 +798,7 @@ export function getSmartEditTool(
  */
 export async function runSmartEdit(
   filePath: string,
-  operations: EditOperation | EditOperation[],
+  operations: EditOperation | EditOperation[] | string,
   options: SmartEditOptions = {}
 ): Promise<SmartEditResult> {
   const cache = new CacheEngine(join(homedir(), '.hypercontext', 'cache'), 100);

--- a/tests/unit/file-operations/smart-edit-accepts-serialized-operations.test.ts
+++ b/tests/unit/file-operations/smart-edit-accepts-serialized-operations.test.ts
@@ -1,0 +1,126 @@
+/**
+ * A multi-edit call must work over MCP, not just in-process.
+ *
+ * ISSUE #339 reported this as "`wiki_write` rejects a valid `anchors` array",
+ * and diagnosed it as array-typed arguments being dropped during marshalling.
+ * That diagnosis is wrong -- `anchors` binds fine; `wikiWrite` validates it with
+ * `Array.isArray(...)` and a non-empty-string filter at the top of the function
+ * and a probe call gets past that check. What the issue caught the edge of is
+ * real though, and it lives here.
+ *
+ * `operations` is the only input on this tool declared as a bare `oneOf`
+ * (object OR array) with no top-level `type`. A client deciding how to
+ * serialise a value from its declared type has nothing to go on, and the array
+ * form arrives as JSON TEXT. `Array.isArray` is then false, the string is
+ * wrapped as `[theString]`, and validation refuses it -- correctly, since a
+ * string is not an operation -- with `Invalid operation type: undefined`.
+ *
+ * Measured over the real MCP transport on 2026-08-28, against a schema-valid
+ * payload:
+ *
+ *     operations: [{ type: 'replace', startLine: 1, ... }]  -> Invalid operation type
+ *     operations: {  type: 'replace', startLine: 1, ... }   -> applied
+ *
+ * So single edits worked and every multi-edit failed, which reads as a broken
+ * tool rather than a marshalling quirk. It is why a whole session's file edits
+ * were done with a hand-rolled script instead.
+ */
+
+import { describe, it, expect, afterEach } from '@jest/globals';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  normalizeOperations,
+  runSmartEdit,
+} from '../../../src/tools/file-operations/smart-edit.js';
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  while (dirs.length) {
+    const dir = dirs.pop();
+    if (!dir) continue;
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* windows can hold a handle briefly */
+    }
+  }
+});
+
+function fixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'edit-serialized-'));
+  dirs.push(dir);
+  const file = join(dir, 'a.txt');
+  writeFileSync(file, 'line one\nline two\nline three\n');
+  return file;
+}
+
+const OPS = [
+  { type: 'replace' as const, startLine: 1, endLine: 1, content: 'LINE ONE' },
+  { type: 'replace' as const, startLine: 3, endLine: 3, content: 'LINE THREE' },
+];
+
+describe('normalizeOperations', () => {
+  it('parses the JSON text an array arrives as', () => {
+    // THE BUG. Without this the string is wrapped as [theString] and every
+    // multi-edit call dies on "Invalid operation type: undefined".
+    expect(normalizeOperations(JSON.stringify(OPS))).toEqual(OPS);
+  });
+
+  it('leaves a real array alone', () => {
+    expect(normalizeOperations(OPS)).toEqual(OPS);
+  });
+
+  it('wraps a single operation, however it arrived', () => {
+    expect(normalizeOperations(OPS[0])).toEqual([OPS[0]]);
+    expect(normalizeOperations(JSON.stringify(OPS[0]))).toEqual([OPS[0]]);
+  });
+
+  it('passes non-JSON through rather than throwing', () => {
+    // Parsing must not become a second failure mode: validateOperations owns
+    // the error message, and it is a better one than a parse error.
+    expect(normalizeOperations('not json at all')).toEqual(['not json at all']);
+  });
+});
+
+describe('smart_edit end to end', () => {
+  it('applies every edit when operations arrive as JSON text', async () => {
+    const file = fixture();
+
+    const result = await runSmartEdit(file, JSON.stringify(OPS), {
+      createBackup: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.metadata.editsApplied).toBe(2);
+    expect(readFileSync(file, 'utf8')).toBe('LINE ONE\nline two\nLINE THREE\n');
+  }, 60_000);
+
+  it('still applies an array that arrives as an array', async () => {
+    const file = fixture();
+
+    const result = await runSmartEdit(file, OPS, { createBackup: false });
+
+    expect(result.success).toBe(true);
+    expect(result.metadata.editsApplied).toBe(2);
+  }, 60_000);
+
+  it('still refuses garbage, and leaves the file alone', async () => {
+    // The guard this fix must not weaken: an operation that is not an
+    // operation is refused with a precise error, not silently applied as
+    // nothing. Reported failure with the bytes already changed is the worst
+    // outcome, because the only sane response is a retry.
+    const file = fixture();
+    const before = readFileSync(file, 'utf8');
+
+    const result = await runSmartEdit(file, 'not json at all', {
+      createBackup: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid operation type');
+    expect(readFileSync(file, 'utf8')).toBe(before);
+  }, 60_000);
+});


### PR DESCRIPTION
Closes #339.

> **Stacked on #341**, which fixes master currently failing lint. Until that merges this branch carries its one-line commit; afterwards the diff here is just the `smart_edit` change.

## The issue's diagnosis is wrong, and the correction matters

#339 reports that `wiki_write` rejects a valid `anchors` array, and concludes that array-typed arguments are dropped during marshalling. **`anchors` binds correctly.**

`wikiWrite` validates it at the top of the function:

```ts
const anchors = Array.isArray(options?.anchors)
  ? options.anchors.filter((a) => typeof a === 'string' && a.trim())
  : [];
if (!anchors.length) { /* 'anchors are required: …' */ }
```

That is `src/tools/intelligence/wiki-write.ts:105`, and the `hooks-core` import is at line 189. A probe call carrying an `anchors` array **reaches line 189** — so it passed the `Array.isArray` check with a non-empty string element. If arrays were dropped it would have returned the anchors error instead.

The message the issue quotes — `wiki_write requires anchors (required: …)` — is the **server-level** required check in `src/server/tool-arguments.ts:116`, which fires only when a field is `undefined` in the payload, i.e. a malformed call rather than a marshalling fault.

The real blocker behind the failing harvest flow was different: `Cannot find module …/hooks-core/wiki.mjs`, because a background refresh had deleted the runtime the server was executing from. **That is fixed in #337.**

## What the issue did catch, and it is real

Its footnote — *"an unrelated array-typed input on a different MCP tool also failed to bind"* — is a genuine bug, reproduced over the real transport with a schema-valid payload:

```
operations: [{ type: 'replace', startLine: 1, endLine: 1, content: 'x' }]
  → Invalid operation type: undefined (expected replace, insert or delete)

operations: {  type: 'replace', startLine: 1, endLine: 1, content: 'x' }
  → applied
```

One-element and two-element arrays both failed. `validateOperations` refuses because `typeof op !== 'object'` — so `ops[0]` is a **string**: `Array.isArray` was false on the incoming JSON text and it was wrapped as `[theString]`.

**Why this input and not `anchors`:** `operations` is the only input on this tool declared as a bare `oneOf` (object **or** array) with no top-level `type`. A client deciding how to serialise a value from its declared type has nothing to go on. `anchors` is declared `{type: 'array', items: {type: 'string'}}` and binds fine.

So single edits worked and **every multi-edit failed**, which reads as a broken tool rather than a marshalling quirk. It is why an entire session's file edits went through a hand-rolled script instead of the tool that exists for them.

## The fix

Parse at the boundary rather than tighten the schema — the schema is not wrong, both shapes are genuinely accepted, and this keeps working whatever a given client does with a `oneOf`.

Two properties preserved deliberately:

- A string that is **not** JSON passes through untouched, so `validateOperations` still names the real problem instead of a parse failure replacing it.
- The guard refusing a non-operation is unchanged. **Garbage is still refused with the file untouched** — which matters, because the only sane response to "failed" with bytes already written is a retry, and retrying a line-based edit against an already-edited file corrupts it.

## Verification

Full suite **244 suites / 3129 passed / 0 failed**; `tsc` clean, `lint` 0 errors, `format:check` clean.

Seven new tests, and all three mutations caught:

| Mutation | Result |
|---|---|
| back to the old normalize, string never parsed | 1 fails |
| `JSON.parse` result ignored | 3 fail |
| parse failure throws instead of passing through | 2 fail |

Verified end to end against the built output, since the live MCP server runs a different installed runtime:

```
array (as an object)                success=true  applied=2
array (JSON text, what is sent)     success=true  applied=2   <- the fix
single object                       success=true  applied=1
garbage string                      success=false applied=0   file untouched
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
