### PR TITLE
fix(install): run the hook installer in argv mode instead of a shell string

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -259,6 +259,11 @@
       "count": 9
     }
   },
+  "src/tools/intelligence/hooks-core-loader.ts": {
+    "n/no-sync": {
+      "count": 6
+    }
+  },
   "src/tools/intelligence/sentiment-analysis.ts": {
     "n/no-sync": {
       "count": 3

--- a/scripts/postinstall.cjs
+++ b/scripts/postinstall.cjs
@@ -5,7 +5,7 @@
  * Runs the appropriate platform-specific installer
  */
 
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
@@ -34,7 +34,8 @@ try {
   const packageRoot = path.resolve(__dirname, '..');
 
   let installScript;
-  let command;
+  let runner;
+  let runnerArgs;
 
   if (platform === 'win32') {
     installScript = path.join(packageRoot, 'install-hooks.ps1');
@@ -52,7 +53,8 @@ try {
       process.exit(0);
     }
 
-    command = `powershell -ExecutionPolicy Bypass -File "${installScript}"`;
+    runner = 'powershell';
+    runnerArgs = ['-ExecutionPolicy', 'Bypass', '-File', installScript];
   } else {
     installScript = path.join(packageRoot, 'install-hooks.sh');
 
@@ -66,7 +68,8 @@ try {
       );
     }
 
-    command = `bash "${installScript}"`;
+    runner = 'bash';
+    runnerArgs = [installScript];
   }
 
   // Check if install script exists
@@ -81,8 +84,17 @@ try {
 
   console.log('[token-optimizer-mcp] Running hook installer...');
 
-  // Run the installer
-  execSync(command, {
+  // Run the installer in ARGV MODE, not through a shell.
+  //
+  // This built a shell string by interpolating installScript, which is
+  // derived from the package's own directory -- so it is trusted and this was
+  // never exploitable. It is still worth removing: it runs on npm install,
+  // the highest-consequence moment in a package's life, and a global prefix
+  // path containing a quote or a command substitution would break out of the
+  // quoting. Argv
+  // mode makes the question not arise, whatever the install directory is
+  // called. Raised by the mcpaudit static audit in #343.
+  execFileSync(runner, runnerArgs, {
     stdio: 'inherit',
     cwd: packageRoot,
   });


### PR DESCRIPTION
Addresses the one actionable item in the mcpaudit static audit, #343.

> **Stacked on #341**, which fixes master currently failing lint.

## The finding

`scripts/postinstall.cjs` built a shell command by interpolation and handed it to `execSync`:

```js
command = `bash "${installScript}"`;
execSync(command, { stdio: 'inherit', cwd: packageRoot });
```

**It was never exploitable, and the report says so.** `installScript` is `path.join(packageRoot, …)` where `packageRoot` is the package's own directory, and the script already exits early unless the install is global, interactive and not CI — I verified both guards.

It is still worth removing. It runs on `npm install`, the highest-consequence moment in a package's life, and a global prefix path containing a quote or a command substitution would break out of the quoting. Argv mode makes the question not arise, whatever the install directory happens to be called.

```js
execFileSync(runner, runnerArgs, { stdio: 'inherit', cwd: packageRoot });
```

The remaining `execSync` is a literal probe for PowerShell's presence with no interpolation, so it stays.

## Verified

The early-exit guard still fires on a local install (`node scripts/postinstall.cjs` → "Skipping automatic hook installation", exit 0), `node --check` clean, `lint` 0 errors, `format:check` clean, `tsc` clean, full suite **243 suites / 3122 passed**.

## Credit

This came from an unsolicited third-party audit by @allenwu-blip using [mcpaudit](https://github.com/allenwu-blip/mcpaudit) — 937 files, every hit read by hand, and six precision bugs in his own scanner fixed as a result. The report is unusually careful about what it does *not* establish (no taint tracking, no cross-file resolution, one file skipped) and it separated 247 raw findings down to 130 distinct ones by hashing byte-identical generated copies. Worth reading in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)