### PR TITLE
fix(enforce): stop refusing Write, which cost a second copy of every file

### DIFF
--- a/hooks-core/decide.mjs
+++ b/hooks-core/decide.mjs
@@ -883,19 +883,38 @@ export function decide(payload, state, availableTools = undefined) {
     };
   }
 
-  if (tool === 'Write') {
-    if (!replacementAvailable(availableTools, 'smart_write')) return null;
-    const path = input.file_path;
-    const content = input.content || '';
-    if (!path || content.length < threshold) return null;
-    return {
-      key: `write:${path}`,
-      reason:
-        `You are writing ${KB(content.length)} KB to ${path}. Call the ` +
-        `token-optimizer MCP tool smart_write instead -- it stores the content ` +
-        `through the cache so later reads of this file diff against it.`,
-    };
-  }
+  // Write is deliberately NOT routed, and the asymmetry with Read is the reason.
+  //
+  // Every other redirection here refuses tokens that DO NOT EXIST YET: a Read's
+  // bytes, a Grep's match list and a Glob's path list are all produced by the
+  // tool, so refusing the call is what stops them entering context. The saving
+  // is real and the refusal pays for itself.
+  //
+  // A Write inverts that. Its `content` is authored by the model inside the very
+  // call being refused, so those tokens are already spent and unreclaimable by
+  // the time this function sees them. Refusing cannot un-spend them -- it can
+  // only demand an identical second copy through smart_write. The redirect
+  // therefore cost exactly one extra copy of the file, with certainty, every
+  // time, on a tool whose entire purpose is to reduce context spend.
+  //
+  // AND THE CACHE ENTRY IT CLAIMED TO BUY WAS NEVER BOUGHT. The refusal text
+  // promised smart_write would "store the content through the cache so later
+  // reads of this file diff against it". It does not: smart_write writes
+  // `generateCacheKey('file-write', {path})` while smart_read reads
+  // `generateCacheKey('smart-read', {path, options})` -- different namespaces,
+  // different keys. So the first smart_read after a smart_write already returned
+  // the whole file, exactly as it does after a built-in Write. Removing the
+  // redirect gives up nothing that was actually happening.
+  //
+  // Populating the smart-read cache after a write IS worth doing, and would
+  // make that first read a diff for the first time. It is deliberately not done
+  // here: the cache is a SQLite store owned by the MCP server process, and a
+  // PreToolUse hook cannot reach it without cross-process plumbing that does not
+  // belong in this change. Tracked in #350.
+  //
+  // Edit/MultiEdit above stay routed on purpose -- their inputs are a pair of
+  // small strings rather than the whole file, so this argument does not reach
+  // them.
 
   if (tool === 'Bash') {
     const command = input.command || '';

--- a/integrations/cline/hooks/token-optimizer/lib/decide.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/decide.mjs
@@ -885,19 +885,38 @@ export function decide(payload, state, availableTools = undefined) {
     };
   }
 
-  if (tool === 'Write') {
-    if (!replacementAvailable(availableTools, 'smart_write')) return null;
-    const path = input.file_path;
-    const content = input.content || '';
-    if (!path || content.length < threshold) return null;
-    return {
-      key: `write:${path}`,
-      reason:
-        `You are writing ${KB(content.length)} KB to ${path}. Call the ` +
-        `token-optimizer MCP tool smart_write instead -- it stores the content ` +
-        `through the cache so later reads of this file diff against it.`,
-    };
-  }
+  // Write is deliberately NOT routed, and the asymmetry with Read is the reason.
+  //
+  // Every other redirection here refuses tokens that DO NOT EXIST YET: a Read's
+  // bytes, a Grep's match list and a Glob's path list are all produced by the
+  // tool, so refusing the call is what stops them entering context. The saving
+  // is real and the refusal pays for itself.
+  //
+  // A Write inverts that. Its `content` is authored by the model inside the very
+  // call being refused, so those tokens are already spent and unreclaimable by
+  // the time this function sees them. Refusing cannot un-spend them -- it can
+  // only demand an identical second copy through smart_write. The redirect
+  // therefore cost exactly one extra copy of the file, with certainty, every
+  // time, on a tool whose entire purpose is to reduce context spend.
+  //
+  // AND THE CACHE ENTRY IT CLAIMED TO BUY WAS NEVER BOUGHT. The refusal text
+  // promised smart_write would "store the content through the cache so later
+  // reads of this file diff against it". It does not: smart_write writes
+  // `generateCacheKey('file-write', {path})` while smart_read reads
+  // `generateCacheKey('smart-read', {path, options})` -- different namespaces,
+  // different keys. So the first smart_read after a smart_write already returned
+  // the whole file, exactly as it does after a built-in Write. Removing the
+  // redirect gives up nothing that was actually happening.
+  //
+  // Populating the smart-read cache after a write IS worth doing, and would
+  // make that first read a diff for the first time. It is deliberately not done
+  // here: the cache is a SQLite store owned by the MCP server process, and a
+  // PreToolUse hook cannot reach it without cross-process plumbing that does not
+  // belong in this change. Tracked in #350.
+  //
+  // Edit/MultiEdit above stay routed on purpose -- their inputs are a pair of
+  // small strings rather than the whole file, so this argument does not reach
+  // them.
 
   if (tool === 'Bash') {
     const command = input.command || '';

--- a/integrations/codex/hooks/lib/decide.mjs
+++ b/integrations/codex/hooks/lib/decide.mjs
@@ -885,19 +885,38 @@ export function decide(payload, state, availableTools = undefined) {
     };
   }
 
-  if (tool === 'Write') {
-    if (!replacementAvailable(availableTools, 'smart_write')) return null;
-    const path = input.file_path;
-    const content = input.content || '';
-    if (!path || content.length < threshold) return null;
-    return {
-      key: `write:${path}`,
-      reason:
-        `You are writing ${KB(content.length)} KB to ${path}. Call the ` +
-        `token-optimizer MCP tool smart_write instead -- it stores the content ` +
-        `through the cache so later reads of this file diff against it.`,
-    };
-  }
+  // Write is deliberately NOT routed, and the asymmetry with Read is the reason.
+  //
+  // Every other redirection here refuses tokens that DO NOT EXIST YET: a Read's
+  // bytes, a Grep's match list and a Glob's path list are all produced by the
+  // tool, so refusing the call is what stops them entering context. The saving
+  // is real and the refusal pays for itself.
+  //
+  // A Write inverts that. Its `content` is authored by the model inside the very
+  // call being refused, so those tokens are already spent and unreclaimable by
+  // the time this function sees them. Refusing cannot un-spend them -- it can
+  // only demand an identical second copy through smart_write. The redirect
+  // therefore cost exactly one extra copy of the file, with certainty, every
+  // time, on a tool whose entire purpose is to reduce context spend.
+  //
+  // AND THE CACHE ENTRY IT CLAIMED TO BUY WAS NEVER BOUGHT. The refusal text
+  // promised smart_write would "store the content through the cache so later
+  // reads of this file diff against it". It does not: smart_write writes
+  // `generateCacheKey('file-write', {path})` while smart_read reads
+  // `generateCacheKey('smart-read', {path, options})` -- different namespaces,
+  // different keys. So the first smart_read after a smart_write already returned
+  // the whole file, exactly as it does after a built-in Write. Removing the
+  // redirect gives up nothing that was actually happening.
+  //
+  // Populating the smart-read cache after a write IS worth doing, and would
+  // make that first read a diff for the first time. It is deliberately not done
+  // here: the cache is a SQLite store owned by the MCP server process, and a
+  // PreToolUse hook cannot reach it without cross-process plumbing that does not
+  // belong in this change. Tracked in #350.
+  //
+  // Edit/MultiEdit above stay routed on purpose -- their inputs are a pair of
+  // small strings rather than the whole file, so this argument does not reach
+  // them.
 
   if (tool === 'Bash') {
     const command = input.command || '';

--- a/integrations/codex/plugin/hooks/lib/decide.mjs
+++ b/integrations/codex/plugin/hooks/lib/decide.mjs
@@ -885,19 +885,38 @@ export function decide(payload, state, availableTools = undefined) {
     };
   }
 
-  if (tool === 'Write') {
-    if (!replacementAvailable(availableTools, 'smart_write')) return null;
-    const path = input.file_path;
-    const content = input.content || '';
-    if (!path || content.length < threshold) return null;
-    return {
-      key: `write:${path}`,
-      reason:
-        `You are writing ${KB(content.length)} KB to ${path}. Call the ` +
-        `token-optimizer MCP tool smart_write instead -- it stores the content ` +
-        `through the cache so later reads of this file diff against it.`,
-    };
-  }
+  // Write is deliberately NOT routed, and the asymmetry with Read is the reason.
+  //
+  // Every other redirection here refuses tokens that DO NOT EXIST YET: a Read's
+  // bytes, a Grep's match list and a Glob's path list are all produced by the
+  // tool, so refusing the call is what stops them entering context. The saving
+  // is real and the refusal pays for itself.
+  //
+  // A Write inverts that. Its `content` is authored by the model inside the very
+  // call being refused, so those tokens are already spent and unreclaimable by
+  // the time this function sees them. Refusing cannot un-spend them -- it can
+  // only demand an identical second copy through smart_write. The redirect
+  // therefore cost exactly one extra copy of the file, with certainty, every
+  // time, on a tool whose entire purpose is to reduce context spend.
+  //
+  // AND THE CACHE ENTRY IT CLAIMED TO BUY WAS NEVER BOUGHT. The refusal text
+  // promised smart_write would "store the content through the cache so later
+  // reads of this file diff against it". It does not: smart_write writes
+  // `generateCacheKey('file-write', {path})` while smart_read reads
+  // `generateCacheKey('smart-read', {path, options})` -- different namespaces,
+  // different keys. So the first smart_read after a smart_write already returned
+  // the whole file, exactly as it does after a built-in Write. Removing the
+  // redirect gives up nothing that was actually happening.
+  //
+  // Populating the smart-read cache after a write IS worth doing, and would
+  // make that first read a diff for the first time. It is deliberately not done
+  // here: the cache is a SQLite store owned by the MCP server process, and a
+  // PreToolUse hook cannot reach it without cross-process plumbing that does not
+  // belong in this change. Tracked in #350.
+  //
+  // Edit/MultiEdit above stay routed on purpose -- their inputs are a pair of
+  // small strings rather than the whole file, so this argument does not reach
+  // them.
 
   if (tool === 'Bash') {
     const command = input.command || '';

--- a/integrations/copilot/.github/hooks/lib/decide.mjs
+++ b/integrations/copilot/.github/hooks/lib/decide.mjs
@@ -885,19 +885,38 @@ export function decide(payload, state, availableTools = undefined) {
     };
   }
 
-  if (tool === 'Write') {
-    if (!replacementAvailable(availableTools, 'smart_write')) return null;
-    const path = input.file_path;
-    const content = input.content || '';
-    if (!path || content.length < threshold) return null;
-    return {
-      key: `write:${path}`,
-      reason:
-        `You are writing ${KB(content.length)} KB to ${path}. Call the ` +
-        `token-optimizer MCP tool smart_write instead -- it stores the content ` +
-        `through the cache so later reads of this file diff against it.`,
-    };
-  }
+  // Write is deliberately NOT routed, and the asymmetry with Read is the reason.
+  //
+  // Every other redirection here refuses tokens that DO NOT EXIST YET: a Read's
+  // bytes, a Grep's match list and a Glob's path list are all produced by the
+  // tool, so refusing the call is what stops them entering context. The saving
+  // is real and the refusal pays for itself.
+  //
+  // A Write inverts that. Its `content` is authored by the model inside the very
+  // call being refused, so those tokens are already spent and unreclaimable by
+  // the time this function sees them. Refusing cannot un-spend them -- it can
+  // only demand an identical second copy through smart_write. The redirect
+  // therefore cost exactly one extra copy of the file, with certainty, every
+  // time, on a tool whose entire purpose is to reduce context spend.
+  //
+  // AND THE CACHE ENTRY IT CLAIMED TO BUY WAS NEVER BOUGHT. The refusal text
+  // promised smart_write would "store the content through the cache so later
+  // reads of this file diff against it". It does not: smart_write writes
+  // `generateCacheKey('file-write', {path})` while smart_read reads
+  // `generateCacheKey('smart-read', {path, options})` -- different namespaces,
+  // different keys. So the first smart_read after a smart_write already returned
+  // the whole file, exactly as it does after a built-in Write. Removing the
+  // redirect gives up nothing that was actually happening.
+  //
+  // Populating the smart-read cache after a write IS worth doing, and would
+  // make that first read a diff for the first time. It is deliberately not done
+  // here: the cache is a SQLite store owned by the MCP server process, and a
+  // PreToolUse hook cannot reach it without cross-process plumbing that does not
+  // belong in this change. Tracked in #350.
+  //
+  // Edit/MultiEdit above stay routed on purpose -- their inputs are a pair of
+  // small strings rather than the whole file, so this argument does not reach
+  // them.
 
   if (tool === 'Bash') {
     const command = input.command || '';

--- a/integrations/cursor/hooks/lib/decide.mjs
+++ b/integrations/cursor/hooks/lib/decide.mjs
@@ -885,19 +885,38 @@ export function decide(payload, state, availableTools = undefined) {
     };
   }
 
-  if (tool === 'Write') {
-    if (!replacementAvailable(availableTools, 'smart_write')) return null;
-    const path = input.file_path;
-    const content = input.content || '';
-    if (!path || content.length < threshold) return null;
-    return {
-      key: `write:${path}`,
-      reason:
-        `You are writing ${KB(content.length)} KB to ${path}. Call the ` +
-        `token-optimizer MCP tool smart_write instead -- it stores the content ` +
-        `through the cache so later reads of this file diff against it.`,
-    };
-  }
+  // Write is deliberately NOT routed, and the asymmetry with Read is the reason.
+  //
+  // Every other redirection here refuses tokens that DO NOT EXIST YET: a Read's
+  // bytes, a Grep's match list and a Glob's path list are all produced by the
+  // tool, so refusing the call is what stops them entering context. The saving
+  // is real and the refusal pays for itself.
+  //
+  // A Write inverts that. Its `content` is authored by the model inside the very
+  // call being refused, so those tokens are already spent and unreclaimable by
+  // the time this function sees them. Refusing cannot un-spend them -- it can
+  // only demand an identical second copy through smart_write. The redirect
+  // therefore cost exactly one extra copy of the file, with certainty, every
+  // time, on a tool whose entire purpose is to reduce context spend.
+  //
+  // AND THE CACHE ENTRY IT CLAIMED TO BUY WAS NEVER BOUGHT. The refusal text
+  // promised smart_write would "store the content through the cache so later
+  // reads of this file diff against it". It does not: smart_write writes
+  // `generateCacheKey('file-write', {path})` while smart_read reads
+  // `generateCacheKey('smart-read', {path, options})` -- different namespaces,
+  // different keys. So the first smart_read after a smart_write already returned
+  // the whole file, exactly as it does after a built-in Write. Removing the
+  // redirect gives up nothing that was actually happening.
+  //
+  // Populating the smart-read cache after a write IS worth doing, and would
+  // make that first read a diff for the first time. It is deliberately not done
+  // here: the cache is a SQLite store owned by the MCP server process, and a
+  // PreToolUse hook cannot reach it without cross-process plumbing that does not
+  // belong in this change. Tracked in #350.
+  //
+  // Edit/MultiEdit above stay routed on purpose -- their inputs are a pair of
+  // small strings rather than the whole file, so this argument does not reach
+  // them.
 
   if (tool === 'Bash') {
     const command = input.command || '';

--- a/integrations/gemini/hooks/lib/decide.mjs
+++ b/integrations/gemini/hooks/lib/decide.mjs
@@ -885,19 +885,38 @@ export function decide(payload, state, availableTools = undefined) {
     };
   }
 
-  if (tool === 'Write') {
-    if (!replacementAvailable(availableTools, 'smart_write')) return null;
-    const path = input.file_path;
-    const content = input.content || '';
-    if (!path || content.length < threshold) return null;
-    return {
-      key: `write:${path}`,
-      reason:
-        `You are writing ${KB(content.length)} KB to ${path}. Call the ` +
-        `token-optimizer MCP tool smart_write instead -- it stores the content ` +
-        `through the cache so later reads of this file diff against it.`,
-    };
-  }
+  // Write is deliberately NOT routed, and the asymmetry with Read is the reason.
+  //
+  // Every other redirection here refuses tokens that DO NOT EXIST YET: a Read's
+  // bytes, a Grep's match list and a Glob's path list are all produced by the
+  // tool, so refusing the call is what stops them entering context. The saving
+  // is real and the refusal pays for itself.
+  //
+  // A Write inverts that. Its `content` is authored by the model inside the very
+  // call being refused, so those tokens are already spent and unreclaimable by
+  // the time this function sees them. Refusing cannot un-spend them -- it can
+  // only demand an identical second copy through smart_write. The redirect
+  // therefore cost exactly one extra copy of the file, with certainty, every
+  // time, on a tool whose entire purpose is to reduce context spend.
+  //
+  // AND THE CACHE ENTRY IT CLAIMED TO BUY WAS NEVER BOUGHT. The refusal text
+  // promised smart_write would "store the content through the cache so later
+  // reads of this file diff against it". It does not: smart_write writes
+  // `generateCacheKey('file-write', {path})` while smart_read reads
+  // `generateCacheKey('smart-read', {path, options})` -- different namespaces,
+  // different keys. So the first smart_read after a smart_write already returned
+  // the whole file, exactly as it does after a built-in Write. Removing the
+  // redirect gives up nothing that was actually happening.
+  //
+  // Populating the smart-read cache after a write IS worth doing, and would
+  // make that first read a diff for the first time. It is deliberately not done
+  // here: the cache is a SQLite store owned by the MCP server process, and a
+  // PreToolUse hook cannot reach it without cross-process plumbing that does not
+  // belong in this change. Tracked in #350.
+  //
+  // Edit/MultiEdit above stay routed on purpose -- their inputs are a pair of
+  // small strings rather than the whole file, so this argument does not reach
+  // them.
 
   if (tool === 'Bash') {
     const command = input.command || '';

--- a/integrations/kilo/hooks/lib/decide.mjs
+++ b/integrations/kilo/hooks/lib/decide.mjs
@@ -885,19 +885,38 @@ export function decide(payload, state, availableTools = undefined) {
     };
   }
 
-  if (tool === 'Write') {
-    if (!replacementAvailable(availableTools, 'smart_write')) return null;
-    const path = input.file_path;
-    const content = input.content || '';
-    if (!path || content.length < threshold) return null;
-    return {
-      key: `write:${path}`,
-      reason:
-        `You are writing ${KB(content.length)} KB to ${path}. Call the ` +
-        `token-optimizer MCP tool smart_write instead -- it stores the content ` +
-        `through the cache so later reads of this file diff against it.`,
-    };
-  }
+  // Write is deliberately NOT routed, and the asymmetry with Read is the reason.
+  //
+  // Every other redirection here refuses tokens that DO NOT EXIST YET: a Read's
+  // bytes, a Grep's match list and a Glob's path list are all produced by the
+  // tool, so refusing the call is what stops them entering context. The saving
+  // is real and the refusal pays for itself.
+  //
+  // A Write inverts that. Its `content` is authored by the model inside the very
+  // call being refused, so those tokens are already spent and unreclaimable by
+  // the time this function sees them. Refusing cannot un-spend them -- it can
+  // only demand an identical second copy through smart_write. The redirect
+  // therefore cost exactly one extra copy of the file, with certainty, every
+  // time, on a tool whose entire purpose is to reduce context spend.
+  //
+  // AND THE CACHE ENTRY IT CLAIMED TO BUY WAS NEVER BOUGHT. The refusal text
+  // promised smart_write would "store the content through the cache so later
+  // reads of this file diff against it". It does not: smart_write writes
+  // `generateCacheKey('file-write', {path})` while smart_read reads
+  // `generateCacheKey('smart-read', {path, options})` -- different namespaces,
+  // different keys. So the first smart_read after a smart_write already returned
+  // the whole file, exactly as it does after a built-in Write. Removing the
+  // redirect gives up nothing that was actually happening.
+  //
+  // Populating the smart-read cache after a write IS worth doing, and would
+  // make that first read a diff for the first time. It is deliberately not done
+  // here: the cache is a SQLite store owned by the MCP server process, and a
+  // PreToolUse hook cannot reach it without cross-process plumbing that does not
+  // belong in this change. Tracked in #350.
+  //
+  // Edit/MultiEdit above stay routed on purpose -- their inputs are a pair of
+  // small strings rather than the whole file, so this argument does not reach
+  // them.
 
   if (tool === 'Bash') {
     const command = input.command || '';

--- a/integrations/opencode/hooks/lib/decide.mjs
+++ b/integrations/opencode/hooks/lib/decide.mjs
@@ -885,19 +885,38 @@ export function decide(payload, state, availableTools = undefined) {
     };
   }
 
-  if (tool === 'Write') {
-    if (!replacementAvailable(availableTools, 'smart_write')) return null;
-    const path = input.file_path;
-    const content = input.content || '';
-    if (!path || content.length < threshold) return null;
-    return {
-      key: `write:${path}`,
-      reason:
-        `You are writing ${KB(content.length)} KB to ${path}. Call the ` +
-        `token-optimizer MCP tool smart_write instead -- it stores the content ` +
-        `through the cache so later reads of this file diff against it.`,
-    };
-  }
+  // Write is deliberately NOT routed, and the asymmetry with Read is the reason.
+  //
+  // Every other redirection here refuses tokens that DO NOT EXIST YET: a Read's
+  // bytes, a Grep's match list and a Glob's path list are all produced by the
+  // tool, so refusing the call is what stops them entering context. The saving
+  // is real and the refusal pays for itself.
+  //
+  // A Write inverts that. Its `content` is authored by the model inside the very
+  // call being refused, so those tokens are already spent and unreclaimable by
+  // the time this function sees them. Refusing cannot un-spend them -- it can
+  // only demand an identical second copy through smart_write. The redirect
+  // therefore cost exactly one extra copy of the file, with certainty, every
+  // time, on a tool whose entire purpose is to reduce context spend.
+  //
+  // AND THE CACHE ENTRY IT CLAIMED TO BUY WAS NEVER BOUGHT. The refusal text
+  // promised smart_write would "store the content through the cache so later
+  // reads of this file diff against it". It does not: smart_write writes
+  // `generateCacheKey('file-write', {path})` while smart_read reads
+  // `generateCacheKey('smart-read', {path, options})` -- different namespaces,
+  // different keys. So the first smart_read after a smart_write already returned
+  // the whole file, exactly as it does after a built-in Write. Removing the
+  // redirect gives up nothing that was actually happening.
+  //
+  // Populating the smart-read cache after a write IS worth doing, and would
+  // make that first read a diff for the first time. It is deliberately not done
+  // here: the cache is a SQLite store owned by the MCP server process, and a
+  // PreToolUse hook cannot reach it without cross-process plumbing that does not
+  // belong in this change. Tracked in #350.
+  //
+  // Edit/MultiEdit above stay routed on purpose -- their inputs are a pair of
+  // small strings rather than the whole file, so this argument does not reach
+  // them.
 
   if (tool === 'Bash') {
     const command = input.command || '';

--- a/integrations/qwen/hooks/lib/decide.mjs
+++ b/integrations/qwen/hooks/lib/decide.mjs
@@ -885,19 +885,38 @@ export function decide(payload, state, availableTools = undefined) {
     };
   }
 
-  if (tool === 'Write') {
-    if (!replacementAvailable(availableTools, 'smart_write')) return null;
-    const path = input.file_path;
-    const content = input.content || '';
-    if (!path || content.length < threshold) return null;
-    return {
-      key: `write:${path}`,
-      reason:
-        `You are writing ${KB(content.length)} KB to ${path}. Call the ` +
-        `token-optimizer MCP tool smart_write instead -- it stores the content ` +
-        `through the cache so later reads of this file diff against it.`,
-    };
-  }
+  // Write is deliberately NOT routed, and the asymmetry with Read is the reason.
+  //
+  // Every other redirection here refuses tokens that DO NOT EXIST YET: a Read's
+  // bytes, a Grep's match list and a Glob's path list are all produced by the
+  // tool, so refusing the call is what stops them entering context. The saving
+  // is real and the refusal pays for itself.
+  //
+  // A Write inverts that. Its `content` is authored by the model inside the very
+  // call being refused, so those tokens are already spent and unreclaimable by
+  // the time this function sees them. Refusing cannot un-spend them -- it can
+  // only demand an identical second copy through smart_write. The redirect
+  // therefore cost exactly one extra copy of the file, with certainty, every
+  // time, on a tool whose entire purpose is to reduce context spend.
+  //
+  // AND THE CACHE ENTRY IT CLAIMED TO BUY WAS NEVER BOUGHT. The refusal text
+  // promised smart_write would "store the content through the cache so later
+  // reads of this file diff against it". It does not: smart_write writes
+  // `generateCacheKey('file-write', {path})` while smart_read reads
+  // `generateCacheKey('smart-read', {path, options})` -- different namespaces,
+  // different keys. So the first smart_read after a smart_write already returned
+  // the whole file, exactly as it does after a built-in Write. Removing the
+  // redirect gives up nothing that was actually happening.
+  //
+  // Populating the smart-read cache after a write IS worth doing, and would
+  // make that first read a diff for the first time. It is deliberately not done
+  // here: the cache is a SQLite store owned by the MCP server process, and a
+  // PreToolUse hook cannot reach it without cross-process plumbing that does not
+  // belong in this change. Tracked in #350.
+  //
+  // Edit/MultiEdit above stay routed on purpose -- their inputs are a pair of
+  // small strings rather than the whole file, so this argument does not reach
+  // them.
 
   if (tool === 'Bash') {
     const command = input.command || '';

--- a/integrations/windsurf/hooks/lib/decide.mjs
+++ b/integrations/windsurf/hooks/lib/decide.mjs
@@ -885,19 +885,38 @@ export function decide(payload, state, availableTools = undefined) {
     };
   }
 
-  if (tool === 'Write') {
-    if (!replacementAvailable(availableTools, 'smart_write')) return null;
-    const path = input.file_path;
-    const content = input.content || '';
-    if (!path || content.length < threshold) return null;
-    return {
-      key: `write:${path}`,
-      reason:
-        `You are writing ${KB(content.length)} KB to ${path}. Call the ` +
-        `token-optimizer MCP tool smart_write instead -- it stores the content ` +
-        `through the cache so later reads of this file diff against it.`,
-    };
-  }
+  // Write is deliberately NOT routed, and the asymmetry with Read is the reason.
+  //
+  // Every other redirection here refuses tokens that DO NOT EXIST YET: a Read's
+  // bytes, a Grep's match list and a Glob's path list are all produced by the
+  // tool, so refusing the call is what stops them entering context. The saving
+  // is real and the refusal pays for itself.
+  //
+  // A Write inverts that. Its `content` is authored by the model inside the very
+  // call being refused, so those tokens are already spent and unreclaimable by
+  // the time this function sees them. Refusing cannot un-spend them -- it can
+  // only demand an identical second copy through smart_write. The redirect
+  // therefore cost exactly one extra copy of the file, with certainty, every
+  // time, on a tool whose entire purpose is to reduce context spend.
+  //
+  // AND THE CACHE ENTRY IT CLAIMED TO BUY WAS NEVER BOUGHT. The refusal text
+  // promised smart_write would "store the content through the cache so later
+  // reads of this file diff against it". It does not: smart_write writes
+  // `generateCacheKey('file-write', {path})` while smart_read reads
+  // `generateCacheKey('smart-read', {path, options})` -- different namespaces,
+  // different keys. So the first smart_read after a smart_write already returned
+  // the whole file, exactly as it does after a built-in Write. Removing the
+  // redirect gives up nothing that was actually happening.
+  //
+  // Populating the smart-read cache after a write IS worth doing, and would
+  // make that first read a diff for the first time. It is deliberately not done
+  // here: the cache is a SQLite store owned by the MCP server process, and a
+  // PreToolUse hook cannot reach it without cross-process plumbing that does not
+  // belong in this change. Tracked in #350.
+  //
+  // Edit/MultiEdit above stay routed on purpose -- their inputs are a pair of
+  // small strings rather than the whole file, so this argument does not reach
+  // them.
 
   if (tool === 'Bash') {
     const command = input.command || '';

--- a/plugin/hooks/lib/decide.mjs
+++ b/plugin/hooks/lib/decide.mjs
@@ -885,19 +885,38 @@ export function decide(payload, state, availableTools = undefined) {
     };
   }
 
-  if (tool === 'Write') {
-    if (!replacementAvailable(availableTools, 'smart_write')) return null;
-    const path = input.file_path;
-    const content = input.content || '';
-    if (!path || content.length < threshold) return null;
-    return {
-      key: `write:${path}`,
-      reason:
-        `You are writing ${KB(content.length)} KB to ${path}. Call the ` +
-        `token-optimizer MCP tool smart_write instead -- it stores the content ` +
-        `through the cache so later reads of this file diff against it.`,
-    };
-  }
+  // Write is deliberately NOT routed, and the asymmetry with Read is the reason.
+  //
+  // Every other redirection here refuses tokens that DO NOT EXIST YET: a Read's
+  // bytes, a Grep's match list and a Glob's path list are all produced by the
+  // tool, so refusing the call is what stops them entering context. The saving
+  // is real and the refusal pays for itself.
+  //
+  // A Write inverts that. Its `content` is authored by the model inside the very
+  // call being refused, so those tokens are already spent and unreclaimable by
+  // the time this function sees them. Refusing cannot un-spend them -- it can
+  // only demand an identical second copy through smart_write. The redirect
+  // therefore cost exactly one extra copy of the file, with certainty, every
+  // time, on a tool whose entire purpose is to reduce context spend.
+  //
+  // AND THE CACHE ENTRY IT CLAIMED TO BUY WAS NEVER BOUGHT. The refusal text
+  // promised smart_write would "store the content through the cache so later
+  // reads of this file diff against it". It does not: smart_write writes
+  // `generateCacheKey('file-write', {path})` while smart_read reads
+  // `generateCacheKey('smart-read', {path, options})` -- different namespaces,
+  // different keys. So the first smart_read after a smart_write already returned
+  // the whole file, exactly as it does after a built-in Write. Removing the
+  // redirect gives up nothing that was actually happening.
+  //
+  // Populating the smart-read cache after a write IS worth doing, and would
+  // make that first read a diff for the first time. It is deliberately not done
+  // here: the cache is a SQLite store owned by the MCP server process, and a
+  // PreToolUse hook cannot reach it without cross-process plumbing that does not
+  // belong in this change. Tracked in #350.
+  //
+  // Edit/MultiEdit above stay routed on purpose -- their inputs are a pair of
+  // small strings rather than the whole file, so this argument does not reach
+  // them.
 
   if (tool === 'Bash') {
     const command = input.command || '';

--- a/tests/hooks/enforcement.test.mjs
+++ b/tests/hooks/enforcement.test.mjs
@@ -246,3 +246,55 @@ describe('fail-open', () => {
     expect(run(read(png, { session_id: 'bin-1' })).decision).toBe('allow');
   });
 });
+
+/**
+ * Enforcement is only ever worth issuing when the tokens it refuses have not
+ * been spent yet. That is true of Read, Grep and Glob, whose output does not
+ * exist until the tool runs -- and false of Write, whose `content` the model
+ * has ALREADY emitted in the very call being refused.
+ *
+ * Refusing a Write therefore cannot save the content: it has been paid for.
+ * What it does instead is force the model to emit an identical copy through
+ * smart_write, so the refusal costs exactly one extra copy of the file, every
+ * time, with certainty. The cache entry it was buying is obtainable for free
+ * from disk once the write lands, because the bytes are then a local file.
+ *
+ * This was observed live: a 39 KB Write was denied, and satisfying the refusal
+ * required re-sending all 39 KB from context -- a strict loss on a tool whose
+ * entire purpose is to reduce context spend.
+ */
+describe('a refusal must not cost more than the call it replaces', () => {
+  test('a large Write is allowed -- its content is already in context', () => {
+    const r = run({
+      session_id: 'write-net-loss-1',
+      tool_name: 'Write',
+      tool_input: {
+        file_path: join(workspace, 'generated.ts'),
+        content: 'x'.repeat(80_000),
+      },
+    });
+    expect(r.decision).toBe('allow');
+  });
+
+  test('the refusal reason never asks for a Write to be re-sent', () => {
+    const r = run({
+      session_id: 'write-net-loss-2',
+      tool_name: 'Write',
+      tool_input: {
+        file_path: join(workspace, 'generated2.ts'),
+        content: 'y'.repeat(80_000),
+      },
+    });
+    // An allowed call may carry no reason at all, which is the strongest form
+    // of passing -- hence the `|| ''` rather than asserting a reason exists.
+    expect(r.reason || '').not.toContain('smart_write');
+  });
+
+  test('a large Read is still denied -- those tokens are genuinely unspent', () => {
+    // Guards the fix against over-correction: the asymmetry is the point, so a
+    // change that silently disabled enforcement everywhere must fail here.
+    expect(run(read(big, { session_id: 'write-net-loss-3' })).decision).toBe(
+      'deny'
+    );
+  });
+});


### PR DESCRIPTION
## The bug

Enforcement is only worth issuing when the tokens it refuses **have not been spent yet**.

That holds for `Read`, `Grep` and `Glob`: their output does not exist until the tool runs, so refusing the call is exactly what keeps those tokens out of context. The refusal pays for itself.

`Write` is the opposite case. Its `content` is authored by the model *inside the very call being refused*, so those tokens are already spent and unreclaimable by the time the router sees them. The refusal cannot un-spend them — it can only demand an identical second copy through `smart_write`.

So the redirect cost **one extra copy of the file, with certainty, every time**, on a tool whose entire purpose is to reduce context spend.

## How it was found

Observed live while writing a 39 KB file: the `Write` was denied, and satisfying the refusal required re-sending all 39 KB from context.

## Why the cache entry did not justify it

The old reason string promised the content would be "stored through the cache so later reads of this file diff against it". That benefit never needed the re-send: once the built-in `Write` lands, the bytes are a local file, so any snapshot for later diffing can be taken from disk for free.

## Scope

- `Edit`/`MultiEdit` stay routed **deliberately** — their inputs are a pair of small strings rather than the whole file, so the argument does not reach them.
- A test asserts a large `Read` is **still denied**, so a later over-correction that disabled enforcement generally cannot pass silently.

## Tests

Three tests added to `tests/hooks/enforcement.test.mjs`, driving the real router over stdin:

| test | asserts |
|---|---|
| a large Write is allowed | the content is already in context |
| the refusal reason never asks for a Write to be re-sent | no `smart_write` redirect |
| a large Read is still denied | the asymmetry is preserved |

Verified red before the change (2 failures), green after. Full hook suite: **91 suites, 1591 tests passing**, including the vendored-core drift check.

## Propagation

Edited in `hooks-core/decide.mjs` (the source of truth) and propagated to all 11 client integrations via `scripts/sync-hook-core.mjs`. Editing the vendored copy alone fails `clients.test.mjs`'s drift check — which is how the mistake was caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)