### PR TITLE
fix(launch): let the served version be pinned, instead of the npx cache deciding

### DIFF
--- a/plugin/launch.mjs
+++ b/plugin/launch.mjs
@@ -118,8 +118,18 @@ const PINNED_VERSION = String(
  * which defeats a pin, because the value recorded would be the spec rather than
  * what actually installed. Prereleases and build metadata are allowed; a
  * leading `v` is not, so the value matches the directory name it becomes.
+ *
+ * THE OFFICIAL SEMVER GRAMMAR, not an approximation of it. A looser pattern
+ * accepted `01.2.3`, `1.02.3`, `1.2.3-01` and `1.2.3-alpha.` -- none of which
+ * are versions npm will ever publish, so each would pass validation here and
+ * then fail at install time with a registry error rather than the clear message
+ * this check exists to give. Leading zeros are rejected in the numeric
+ * identifiers, and a prerelease is dot-separated identifiers that are each
+ * either numeric-without-leading-zero or alphanumeric, which is what stops a
+ * trailing dot.
  */
-const EXACT_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+const EXACT_VERSION =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
 function numericEnv(name, fallback) {
   const raw = process.env[name];

--- a/plugin/launch.mjs
+++ b/plugin/launch.mjs
@@ -91,6 +91,25 @@ const REFRESH_INTERVAL_MS = numericEnv(
   6 * 60 * 60 * 1000
 );
 
+/**
+ * An exact version to serve, or '' for the normal @latest-tracking behaviour.
+ *
+ * Without this there is no way to say which build runs. `current` and the npx
+ * cache decide, and the npx cache is not a property of the install at all: on a
+ * cold runtime the shim serves whatever copy that cache happens to hold, so a
+ * machine with 6.0.2 installed was observed serving 6.0.0 on first launch.
+ * REFRESH_INTERVAL_MS could not prevent it -- that only throttles the
+ * background refresh, it does not choose what is served now.
+ *
+ * When set, this is authoritative: the npx cache is only accepted if it is the
+ * pinned version, no background refresh runs (a refresh exists to move off the
+ * current version, which is precisely what a pin forbids), and a missing
+ * pinned build is installed at that exact version rather than at latest.
+ */
+const PINNED_VERSION = String(
+  process.env.TOKEN_OPTIMIZER_VERSION || ''
+).trim();
+
 function numericEnv(name, fallback) {
   const raw = process.env[name];
   if (raw == null || raw === '') return fallback;
@@ -199,7 +218,7 @@ function atomicWrite(file, contents) {
  * entry path — WITHOUT flipping `current`. Returns null on any failure (offline,
  * registry down, install error) so callers fall back to what they already have.
  */
-function installLatest() {
+function installLatest(spec = 'latest') {
   mkdirSync(VERSIONS_DIR, { recursive: true });
   const staging = join(
     RUNTIME,
@@ -211,7 +230,7 @@ function installLatest() {
       NPM,
       [
         'install',
-        `${PACKAGE}@latest`,
+        `${PACKAGE}@${spec}`,
         '--prefix',
         staging,
         '--no-save',
@@ -601,6 +620,54 @@ function main() {
 
   if (process.argv.includes('--refresh')) {
     runRefresh();
+    return;
+  }
+
+  // A PIN SHORT-CIRCUITS EVERY OTHER SOURCE. Deliberately ahead of `current`
+  // and of the npx cache, because both of those are exactly what a pin exists
+  // to overrule, and no background refresh is started: a refresh's job is to
+  // move off the version being served, which is what the pin forbids.
+  if (PINNED_VERSION) {
+    let pinned = entryFor(join(VERSIONS_DIR, PINNED_VERSION));
+
+    if (!pinned) {
+      // The npx cache is acceptable only when it happens to hold the pinned
+      // version. Serving its newest copy is the unpinned behaviour, and is the
+      // bug this branch exists to prevent.
+      const cached = findCachedEntry();
+      if (cached && cached.version === PINNED_VERSION) pinned = cached.entry;
+    }
+
+    if (!pinned) {
+      log(`pinned to ${PINNED_VERSION}; installing that exact version…`);
+      if (acquireLock()) {
+        try {
+          pinned = installLatest(PINNED_VERSION);
+          if (pinned) atomicWrite(CURRENT_FILE, PINNED_VERSION);
+        } finally {
+          releaseLock();
+        }
+      } else {
+        for (let i = 0; i < 120 && !pinned; i++) {
+          sleepSync(500);
+          pinned = entryFor(join(VERSIONS_DIR, PINNED_VERSION));
+        }
+      }
+    }
+
+    if (!pinned) {
+      // FAIL LOUDLY RATHER THAN FALLING BACK. Someone who pinned a version and
+      // silently got a different one is worse off than someone who got an
+      // error: the whole point of the pin is knowing what ran.
+      log(
+        `could not obtain pinned version ${PINNED_VERSION}. ` +
+          `Unset TOKEN_OPTIMIZER_VERSION to track latest, or install it once: ` +
+          `npx -y ${PACKAGE}@${PINNED_VERSION}`
+      );
+      process.exit(1);
+    }
+
+    runServer(pinned);
     return;
   }
 

--- a/plugin/launch.mjs
+++ b/plugin/launch.mjs
@@ -110,6 +110,17 @@ const PINNED_VERSION = String(
   process.env.TOKEN_OPTIMIZER_VERSION || ''
 ).trim();
 
+/**
+ * An exact release, as opposed to anything npm would resolve for us.
+ *
+ * Ranges (`^9.0.0`), dist-tags (`latest`, `next`) and aliases are all valid
+ * `npm install` specs and all resolve to a version chosen by the registry --
+ * which defeats a pin, because the value recorded would be the spec rather than
+ * what actually installed. Prereleases and build metadata are allowed; a
+ * leading `v` is not, so the value matches the directory name it becomes.
+ */
+const EXACT_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
 function numericEnv(name, fallback) {
   const raw = process.env[name];
   if (raw == null || raw === '') return fallback;
@@ -645,12 +656,44 @@ function main() {
       if (cached) pinned = cached.entry;
     }
 
+    // A PIN MUST BE AN EXACT VERSION, checked before anything is installed.
+    // `npm install <pkg>@<spec>` also accepts ranges, dist-tags and aliases,
+    // and those resolve to whatever the registry decides -- so `^9.0.0` or
+    // `latest` would install one version while this code recorded the spec
+    // string as though it were the version. A pin whose value cannot be
+    // verified afterwards is not a pin.
+    if (!EXACT_VERSION.test(PINNED_VERSION)) {
+      log(
+        `TOKEN_OPTIMIZER_VERSION must be an exact version like 6.0.2, ` +
+          `not a range, dist-tag or alias (got "${PINNED_VERSION}"). ` +
+          `Unset it to track latest.`
+      );
+      process.exit(1);
+    }
+
     if (!pinned) {
       log(`pinned to ${PINNED_VERSION}; installing that exact version…`);
       if (acquireLock()) {
         try {
           pinned = installLatest(PINNED_VERSION);
-          if (pinned) atomicWrite(CURRENT_FILE, PINNED_VERSION);
+          // VERIFY WHAT ARRIVED rather than trusting the spec. npm can resolve
+          // a spec to a different manifest version; writing PINNED_VERSION into
+          // `current` without checking would make the marker claim a version
+          // that is not what sits in the directory.
+          if (pinned) {
+            const installed = pkgInfo(
+              join(VERSIONS_DIR, PINNED_VERSION, 'node_modules', PACKAGE)
+            );
+            if (installed?.version === PINNED_VERSION) {
+              atomicWrite(CURRENT_FILE, PINNED_VERSION);
+            } else {
+              log(
+                `install of ${PACKAGE}@${PINNED_VERSION} produced version ` +
+                  `${installed?.version ?? 'unknown'}; refusing to serve it`
+              );
+              pinned = null;
+            }
+          }
         } finally {
           releaseLock();
         }

--- a/plugin/launch.mjs
+++ b/plugin/launch.mjs
@@ -629,6 +629,33 @@ function runServer(entry) {
   });
 }
 
+/**
+ * Installs exactly PINNED_VERSION and returns its entry, or null.
+ *
+ * VERIFIES WHAT ARRIVED rather than trusting the spec: npm can resolve a spec
+ * to a different manifest version, and writing PINNED_VERSION into `current`
+ * without checking would make the marker claim a version that is not what sits
+ * in the directory. The caller must hold the lock.
+ */
+function installPinnedVersion() {
+  const entry = installLatest(PINNED_VERSION);
+  if (!entry) return null;
+
+  const installed = pkgInfo(
+    join(VERSIONS_DIR, PINNED_VERSION, 'node_modules', PACKAGE)
+  );
+  if (installed?.version !== PINNED_VERSION) {
+    log(
+      `install of ${PACKAGE}@${PINNED_VERSION} produced version ` +
+        `${installed?.version ?? 'unknown'}; refusing to serve it`
+    );
+    return null;
+  }
+
+  atomicWrite(CURRENT_FILE, PINNED_VERSION);
+  return entry;
+}
+
 function main() {
   // Ensure the runtime dir exists BEFORE anything else — runRefresh's lock is a
   // mkdir of RUNTIME/.refresh.lock, which fails (and silently no-ops the refresh)
@@ -673,35 +700,26 @@ function main() {
 
     if (!pinned) {
       log(`pinned to ${PINNED_VERSION}; installing that exact version…`);
-      if (acquireLock()) {
-        try {
-          pinned = installLatest(PINNED_VERSION);
-          // VERIFY WHAT ARRIVED rather than trusting the spec. npm can resolve
-          // a spec to a different manifest version; writing PINNED_VERSION into
-          // `current` without checking would make the marker claim a version
-          // that is not what sits in the directory.
-          if (pinned) {
-            const installed = pkgInfo(
-              join(VERSIONS_DIR, PINNED_VERSION, 'node_modules', PACKAGE)
-            );
-            if (installed?.version === PINNED_VERSION) {
-              atomicWrite(CURRENT_FILE, PINNED_VERSION);
-            } else {
-              log(
-                `install of ${PACKAGE}@${PINNED_VERSION} produced version ` +
-                  `${installed?.version ?? 'unknown'}; refusing to serve it`
-              );
-              pinned = null;
-            }
+
+      // RETRY THE LOCK, do not merely wait for the directory. The lock is
+      // shared with `runRefresh()`, which installs `latest` rather than this
+      // pin -- so a launch that only watched VERSIONS_DIR would sit through its
+      // entire budget and exit, even though the lock became free seconds in and
+      // the refresh was never going to produce the pinned version. Each pass
+      // therefore tries the lock first, and also notices a directory that
+      // another pinned launch may have produced in the meantime.
+      for (let i = 0; i < 120 && !pinned; i++) {
+        if (acquireLock()) {
+          try {
+            pinned = installPinnedVersion();
+          } finally {
+            releaseLock();
           }
-        } finally {
-          releaseLock();
+          break; // we held the lock and attempted the install; that is the answer
         }
-      } else {
-        for (let i = 0; i < 120 && !pinned; i++) {
-          sleepSync(500);
-          pinned = entryFor(join(VERSIONS_DIR, PINNED_VERSION));
-        }
+        pinned = entryFor(join(VERSIONS_DIR, PINNED_VERSION));
+        if (pinned) break;
+        sleepSync(500);
       }
     }
 

--- a/plugin/launch.mjs
+++ b/plugin/launch.mjs
@@ -173,7 +173,7 @@ function compareVersions(a, b) {
  * Computed from the default/env cache path (no `npm` spawn); any layout surprise
  * is swallowed and we simply fall through to a synchronous install.
  */
-function findCachedEntry() {
+function findCachedEntry(wantVersion = null) {
   const cacheRoot =
     process.env.npm_config_cache ||
     (IS_WIN
@@ -184,14 +184,21 @@ function findCachedEntry() {
   try {
     for (const hash of readdirSync(npxDir)) {
       const info = pkgInfo(join(npxDir, hash, 'node_modules', PACKAGE));
-      if (info && (!best || compareVersions(info.version, best.version) > 0)) {
-        best = info;
+      if (!info) continue;
+      // A PIN ASKS A DIFFERENT QUESTION THAN "what is newest here".
+      // Returning only the highest version meant a cache holding both 9.9.9 and
+      // 10.0.0 answered a 9.9.9 pin with 10.0.0, which the caller then declined
+      // -- so an offline launch failed with the requested build already on disk.
+      if (wantVersion) {
+        if (info.version === wantVersion) return info;
+        continue;
       }
+      if (!best || compareVersions(info.version, best.version) > 0) best = info;
     }
   } catch {
     /* no npx cache dir — fall through */
   }
-  return best;
+  return wantVersion ? null : best;
 }
 
 /** Resolve the currently-pointed entry, validating it exists. */
@@ -634,8 +641,8 @@ function main() {
       // The npx cache is acceptable only when it happens to hold the pinned
       // version. Serving its newest copy is the unpinned behaviour, and is the
       // bug this branch exists to prevent.
-      const cached = findCachedEntry();
-      if (cached && cached.version === PINNED_VERSION) pinned = cached.entry;
+      const cached = findCachedEntry(PINNED_VERSION);
+      if (cached) pinned = cached.entry;
     }
 
     if (!pinned) {

--- a/tests/hooks/launch-version-pin.test.mjs
+++ b/tests/hooks/launch-version-pin.test.mjs
@@ -123,6 +123,30 @@ describe('an explicit version pin decides what is served', () => {
     expect(r.stdout).not.toContain('SERVED 10.0.0');
   });
 
+  test.each([['^9.0.0'], ['~9.9.0'], ['latest'], ['next'], ['>=9.9.9'], ['v9.9.9']])(
+    'a pin of %s is rejected before anything is installed',
+    (spec) => {
+      // npm would happily accept all of these, and resolve each to whatever the
+      // registry decides -- so the recorded value would be the spec rather than
+      // the version that actually landed. A pin that cannot be verified
+      // afterwards is not a pin, so these fail up front rather than silently
+      // serving something else.
+      seedVersion(join(runtime, 'versions', '9.9.9'), '9.9.9');
+      const r = launch({ TOKEN_OPTIMIZER_VERSION: spec });
+      expect(r.status).toBe(1);
+      expect(r.stderr).toContain('must be an exact version');
+      expect(r.stdout).not.toContain('SERVED');
+    }
+  );
+
+  test('an exact pre-release pin is accepted', () => {
+    // The guard must reject ranges without also rejecting legitimate exact
+    // versions that merely look unusual.
+    seedVersion(join(runtime, 'versions', '9.9.9-rc.1'), '9.9.9-rc.1');
+    const r = launch({ TOKEN_OPTIMIZER_VERSION: '9.9.9-rc.1' });
+    expect(r.stdout).toContain('SERVED 9.9.9-rc.1');
+  });
+
   test('without a pin the runtime `current` marker still decides', () => {
     // Guards against over-correction: pinning is opt-in, and the default
     // resolution order must be untouched for everyone who sets nothing.

--- a/tests/hooks/launch-version-pin.test.mjs
+++ b/tests/hooks/launch-version-pin.test.mjs
@@ -19,7 +19,7 @@
  * network, so they assert the RESOLUTION RULE rather than npm's behaviour.
  */
 
-import { spawnSync } from 'node:child_process';
+import { spawnSync, spawn } from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -145,6 +145,46 @@ describe('an explicit version pin decides what is served', () => {
     seedVersion(join(runtime, 'versions', '9.9.9-rc.1'), '9.9.9-rc.1');
     const r = launch({ TOKEN_OPTIMIZER_VERSION: '9.9.9-rc.1' });
     expect(r.stdout).toContain('SERVED 9.9.9-rc.1');
+  });
+
+  test('a lock held by a refresh does not strand a pinned launch', () => {
+    // The lock is shared with runRefresh(), which installs `latest` rather than
+    // this pin. A launch that only watched for the pinned directory would sit
+    // through its whole 60s budget and exit, even though the refresh was never
+    // going to produce the pinned version. Here the directory appears partway
+    // through, standing in for another pinned launch finishing first, and this
+    // one must notice rather than block to the end.
+    mkdirSync(join(runtime, '.refresh.lock'), { recursive: true });
+
+    // A DETACHED PROCESS, not setTimeout: `launch()` uses spawnSync, which
+    // blocks this thread's event loop, so an in-process timer could never fire
+    // and the first version of this test waited the full 60s for a directory
+    // nothing was ever going to create.
+    const pkgDir = join(runtime, 'versions', '9.9.9', PACKAGE_DIR).replace(/\\/g, '/');
+    const helper = spawn(
+      process.execPath,
+      [
+        '-e',
+        `setTimeout(() => {
+           const fs = require('fs');
+           fs.mkdirSync(${JSON.stringify(pkgDir)}, { recursive: true });
+           fs.writeFileSync(${JSON.stringify(pkgDir)} + '/package.json',
+             JSON.stringify({ name: '@ooples/token-optimizer-mcp', version: '9.9.9', main: 'server.js' }));
+           fs.writeFileSync(${JSON.stringify(pkgDir)} + '/server.js',
+             "process.stdout.write('SERVED 9.9.9');");
+         }, 800);`,
+      ],
+      { detached: true, stdio: 'ignore' }
+    );
+    helper.unref();
+
+    const started = Date.now();
+    const r = launch({ TOKEN_OPTIMIZER_VERSION: '9.9.9' });
+
+    expect(r.stdout).toContain('SERVED 9.9.9');
+    // Well inside the 60s budget: proves it polled and noticed rather than
+    // waiting the loop out.
+    expect(Date.now() - started).toBeLessThan(20_000);
   });
 
   test('without a pin the runtime `current` marker still decides', () => {

--- a/tests/hooks/launch-version-pin.test.mjs
+++ b/tests/hooks/launch-version-pin.test.mjs
@@ -104,6 +104,25 @@ describe('an explicit version pin decides what is served', () => {
     expect(r.stdout).not.toContain('SERVED 9.9.7');
   });
 
+  test('the pin is found in the npx cache even when a newer copy is cached too', () => {
+    // findCachedEntry() returned only the HIGHEST cached version, so a pin that
+    // was present alongside a newer one was rejected rather than used: the
+    // lookup handed back 10.0.0, the pin declined it, and an offline launch
+    // failed with the requested build sitting right there in the cache.
+    const npxCache = mkdtempSync(join(tmpdir(), 'to-npx-'));
+    seedVersion(join(npxCache, '_npx', 'aaaa'), '9.9.9');
+    seedVersion(join(npxCache, '_npx', 'bbbb'), '10.0.0');
+
+    const r = launch({
+      TOKEN_OPTIMIZER_VERSION: '9.9.9',
+      npm_config_cache: npxCache,
+    });
+    rmSync(npxCache, { recursive: true, force: true });
+
+    expect(r.stdout).toContain('SERVED 9.9.9');
+    expect(r.stdout).not.toContain('SERVED 10.0.0');
+  });
+
   test('without a pin the runtime `current` marker still decides', () => {
     // Guards against over-correction: pinning is opt-in, and the default
     // resolution order must be untouched for everyone who sets nothing.

--- a/tests/hooks/launch-version-pin.test.mjs
+++ b/tests/hooks/launch-version-pin.test.mjs
@@ -1,0 +1,117 @@
+/**
+ * The launch shim must be pinnable to an exact version.
+ *
+ * Without a pin the shim resolves what to serve from two places that are
+ * outside anyone's control: `current` in the managed runtime, and -- when the
+ * runtime is cold -- whatever copy happens to sit in the npx cache. That second
+ * path is the damaging one. Observed on a machine with 6.0.2 installed
+ * globally, a cold runtime made the shim log
+ *
+ *   first run: serving npx-cached 6.0.0; populating managed runtime in the background
+ *
+ * and serve 6.0.0. The served version is therefore a property of the machine's
+ * npx cache rather than of the install, so a first session can silently run a
+ * build that is several releases old, and no environment variable could stop
+ * it: TOKEN_OPTIMIZER_REFRESH_INTERVAL_MS only throttles the BACKGROUND
+ * refresh, it does not choose what is served now.
+ *
+ * These tests are hermetic. They seed fake version trees and never reach the
+ * network, so they assert the RESOLUTION RULE rather than npm's behaviour.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const LAUNCH = join(HERE, '..', '..', 'plugin', 'launch.mjs');
+const PACKAGE_DIR = join('node_modules', '@ooples', 'token-optimizer-mcp');
+
+let runtime;
+
+/**
+ * Writes a fake installed copy of the package that announces which version it
+ * is and exits, so the test can read the served version off stdout.
+ */
+function seedVersion(root, version) {
+  const pkgDir = join(root, PACKAGE_DIR);
+  mkdirSync(pkgDir, { recursive: true });
+  writeFileSync(
+    join(pkgDir, 'package.json'),
+    JSON.stringify({
+      name: '@ooples/token-optimizer-mcp',
+      version,
+      main: 'server.js',
+    })
+  );
+  writeFileSync(
+    join(pkgDir, 'server.js'),
+    `process.stdout.write('SERVED ${version}');\n`
+  );
+}
+
+function launch(env) {
+  return spawnSync(process.execPath, [LAUNCH], {
+    encoding: 'utf8',
+    timeout: 60_000,
+    env: {
+      ...process.env,
+      TOKEN_OPTIMIZER_RUNTIME: runtime,
+      // Large enough that the background refresh can never be what makes a
+      // test pass or fail.
+      TOKEN_OPTIMIZER_REFRESH_INTERVAL_MS: '999999999999',
+      ...env,
+    },
+  });
+}
+
+beforeEach(() => {
+  runtime = mkdtempSync(join(tmpdir(), 'to-launch-'));
+  mkdirSync(join(runtime, 'versions'), { recursive: true });
+  // A recent marker, because refreshDueNow() treats an unreadable one as "due".
+  writeFileSync(join(runtime, '.last-refresh'), String(Date.now()));
+});
+
+afterEach(() => rmSync(runtime, { recursive: true, force: true }));
+
+describe('an explicit version pin decides what is served', () => {
+  test('the pin wins over the runtime `current` marker', () => {
+    seedVersion(join(runtime, 'versions', '9.9.8'), '9.9.8');
+    seedVersion(join(runtime, 'versions', '9.9.9'), '9.9.9');
+    writeFileSync(join(runtime, 'current'), '9.9.8');
+
+    const r = launch({ TOKEN_OPTIMIZER_VERSION: '9.9.9' });
+    expect(r.stdout).toContain('SERVED 9.9.9');
+  });
+
+  test('the pin wins over a newer copy in the npx cache', () => {
+    // The reported failure in miniature: a cold managed runtime plus a
+    // populated npx cache. The pinned build must win even though the cache
+    // holds a different version and would otherwise be served verbatim.
+    const npxCache = mkdtempSync(join(tmpdir(), 'to-npx-'));
+    seedVersion(join(npxCache, '_npx', 'deadbeef'), '9.9.7');
+    seedVersion(join(runtime, 'versions', '9.9.9'), '9.9.9');
+
+    const r = launch({
+      TOKEN_OPTIMIZER_VERSION: '9.9.9',
+      npm_config_cache: npxCache,
+    });
+    rmSync(npxCache, { recursive: true, force: true });
+
+    expect(r.stdout).toContain('SERVED 9.9.9');
+    expect(r.stdout).not.toContain('SERVED 9.9.7');
+  });
+
+  test('without a pin the runtime `current` marker still decides', () => {
+    // Guards against over-correction: pinning is opt-in, and the default
+    // resolution order must be untouched for everyone who sets nothing.
+    seedVersion(join(runtime, 'versions', '9.9.8'), '9.9.8');
+    seedVersion(join(runtime, 'versions', '9.9.9'), '9.9.9');
+    writeFileSync(join(runtime, 'current'), '9.9.8');
+
+    const r = launch({});
+    expect(r.stdout).toContain('SERVED 9.9.8');
+  });
+});

--- a/tests/hooks/launch-version-pin.test.mjs
+++ b/tests/hooks/launch-version-pin.test.mjs
@@ -123,7 +123,14 @@ describe('an explicit version pin decides what is served', () => {
     expect(r.stdout).not.toContain('SERVED 10.0.0');
   });
 
-  test.each([['^9.0.0'], ['~9.9.0'], ['latest'], ['next'], ['>=9.9.9'], ['v9.9.9']])(
+  // Invalid SemVer as well as ranges and tags. npm will never publish `01.2.3`
+  // or `1.2.3-alpha.`, so accepting them here only moved the failure to install
+  // time, where it surfaces as a registry error instead of the clear message
+  // this check exists to give.
+  test.each([
+    ['^9.0.0'], ['~9.9.0'], ['latest'], ['next'], ['>=9.9.9'], ['v9.9.9'],
+    ['01.2.3'], ['1.02.3'], ['9.9.9-01'], ['9.9.9-alpha.'], ['9.9.9-'],
+  ])(
     'a pin of %s is rejected before anything is installed',
     (spec) => {
       // npm would happily accept all of these, and resolve each to whatever the


### PR DESCRIPTION
Closes #358

## The bug

There was no way to say which build the launch shim serves.

Resolution came from `current` in the managed runtime and, when that is cold, from **whatever copy the npx cache happened to hold** — and that cache is not a property of the install at all.

Observed on a machine with **6.0.2** installed globally, against a cold runtime:

```
[token-optimizer/launch] first run: serving npx-cached 6.0.0; populating managed runtime in the background
```

It served **6.0.0**. So a user's first session can silently run a build several releases old, and *which* build depends on their machine rather than on what they installed.

## Why the existing env var did not help

`TOKEN_OPTIMIZER_REFRESH_INTERVAL_MS` throttles the **background refresh**. It does not choose what is served now, and it pins nothing on a fresh runtime because `refreshDueNow()` treats an unreadable `.last-refresh` as due:

```js
} catch {
  /* no record yet */
}
return true;
```

## The fix

`TOKEN_OPTIMIZER_VERSION` names an exact version and short-circuits every other source:

- ahead of `current`
- ahead of the npx cache, which is accepted **only** when it holds precisely the pinned version
- no background refresh runs — a refresh exists to move off the served version, which is what a pin forbids
- a missing pinned build is installed **at that exact version**, not at `latest`

It **fails loudly rather than falling back**. Someone who pinned a version and silently got a different one is worse off than someone who got an error, since knowing what ran is the entire point.

## Blast radius

Unpinned behaviour is unchanged, and a test asserts it — so this cannot quietly become the new default for anyone who sets nothing.

## Tests

`tests/hooks/launch-version-pin.test.mjs` — hermetic: seeds fake version trees, never reaches the network, so it asserts the *resolution rule* rather than npm's behaviour.

| test | asserts |
|---|---|
| the pin wins over the runtime `current` marker | pin beats `current` |
| the pin wins over a newer copy in the npx cache | **reproduces the reported failure**; red before this change |
| without a pin the runtime `current` marker still decides | no over-correction |

Verified red before (2 of 3 failing, the third passing to prove the tests discriminate), green after. Full hook suite: **92 suites, 1591 tests passing**.

## Why this surfaced

Found while building a reproducible Docker harness to run this project against the public THOL leaderboard: an image pinned to 6.0.1 measured 6.0.2, which made any benchmark result unattributable to a version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
