### PR TITLE
fix(cache): let a read diff against what a write just stored

### DIFF
--- a/src/tools/file-operations/smart-edit.ts
+++ b/src/tools/file-operations/smart-edit.ts
@@ -19,7 +19,8 @@ import { bumpFsGeneration } from '../../utils/fs-generation.js';
 import { writeBackup } from '../../utils/file-backup.js';
 import { TokenCounter } from '../../core/token-counter.js';
 import { MetricsCollector } from '../../core/metrics.js';
-import { generateCacheKey } from '../shared/hash-utils.js';
+import { generateCacheKey, lastWrittenKey } from '../shared/hash-utils.js';
+import { cacheSet } from '../../utils/cache-helper.js';
 import { generateUnifiedDiff } from '../shared/diff-utils.js';
 
 // Backups live in utils/file-backup.ts, shared with smart_write. They were
@@ -401,6 +402,12 @@ export class SmartEditTool {
           const cacheKey = generateCacheKey('file-edit', { path: filePath });
           const contentSize = Buffer.from(editedContent, 'utf-8').length;
           this.cache.set(cacheKey, editedContent, contentSize, contentSize);
+
+          // The entry above is a THIRD namespace no reader consults, stored raw
+          // where readers expect base64 gzip -- the same shape of gap smart_write
+          // had. This is the handoff the reader actually looks for, so a read
+          // after an edit reports the edit instead of resending the file.
+          cacheSet(this.cache, lastWrittenKey(filePath), editedContent);
         } catch {
           // The edit stands. The next read simply misses the cache.
         }

--- a/src/tools/file-operations/smart-read.ts
+++ b/src/tools/file-operations/smart-read.ts
@@ -16,7 +16,11 @@ import { CacheEngine } from '../../core/cache-engine.js';
 import { TokenCounter } from '../../core/token-counter.js';
 import { MetricsCollector } from '../../core/metrics.js';
 import { generateDiff, hasMeaningfulChanges } from '../shared/diff-utils.js';
-import { hashFile, generateCacheKey, lastWrittenKey } from '../shared/hash-utils.js';
+import {
+  hashFile,
+  generateCacheKey,
+  lastWrittenKey,
+} from '../shared/hash-utils.js';
 import { cacheGet, cacheSet } from '../../utils/cache-helper.js';
 import {
   chunkBySyntax,

--- a/src/tools/file-operations/smart-read.ts
+++ b/src/tools/file-operations/smart-read.ts
@@ -16,7 +16,7 @@ import { CacheEngine } from '../../core/cache-engine.js';
 import { TokenCounter } from '../../core/token-counter.js';
 import { MetricsCollector } from '../../core/metrics.js';
 import { generateDiff, hasMeaningfulChanges } from '../shared/diff-utils.js';
-import { hashFile, generateCacheKey } from '../shared/hash-utils.js';
+import { hashFile, generateCacheKey, lastWrittenKey } from '../shared/hash-utils.js';
 import { cacheGet, cacheSet } from '../../utils/cache-helper.js';
 import {
   chunkBySyntax,
@@ -140,8 +140,23 @@ export class SmartReadTool {
     });
 
     // Check cache
-    const cachedData = enableCache ? cacheGet(this.cache, cacheKey) : null;
-    const fromCache = cachedData !== null;
+    const ownCached = enableCache ? cacheGet(this.cache, cacheKey) : null;
+
+    // FALL BACK TO WHAT WAS LAST WRITTEN. Without this, the first read of a
+    // file always resends it in full even when this process wrote the file
+    // moments earlier -- the writer's entry lived under a different namespace,
+    // so it was never found. The fallback gives the diff a base on that first
+    // read; the entry is only ever a base, never the answer, so a stale one
+    // costs a diff rather than a wrong result.
+    const cachedData =
+      ownCached ??
+      (enableCache ? cacheGet(this.cache, lastWrittenKey(filePath)) : null);
+
+    // Deliberately NOT `cachedData !== null`. This flags "my own entry hit",
+    // which is what the metrics below report and what gates the re-seed further
+    // down -- so a read served off the fallback still populates its own key and
+    // the next read needs no fallback at all.
+    const fromCache = ownCached !== null;
 
     // Read file content
     const rawContent = readFileSync(filePath, encoding);

--- a/src/tools/file-operations/smart-write.ts
+++ b/src/tools/file-operations/smart-write.ts
@@ -25,7 +25,8 @@ import { bumpFsGeneration } from '../../utils/fs-generation.js';
 import { writeBackup } from '../../utils/file-backup.js';
 import { TokenCounter } from '../../core/token-counter.js';
 import { MetricsCollector } from '../../core/metrics.js';
-import { generateCacheKey } from '../shared/hash-utils.js';
+import { generateCacheKey, lastWrittenKey } from '../shared/hash-utils.js';
+import { cacheSet } from '../../utils/cache-helper.js';
 import { generateUnifiedDiff } from '../shared/diff-utils.js';
 import { detectFileType } from '../shared/syntax-utils.js';
 
@@ -261,6 +262,16 @@ export class SmartWriteTool {
         const cacheKey = generateCacheKey('file-write', { path: filePath });
         const contentSize = Buffer.from(finalContent, 'utf-8').length;
         this.cache.set(cacheKey, finalContent, contentSize, contentSize);
+
+        // TELL THE READER WHAT THE FILE NOW CONTAINS. The entry above is in a
+        // namespace no reader consults, and it is stored raw while every reader
+        // goes through `cacheGet`, which expects base64 gzip and treats a decode
+        // failure as a miss -- so it could not have been read back even under a
+        // matching key. This second entry is the handoff: one key derived from
+        // the path alone, written through the same helper the readers use, so
+        // the next smart_read diffs against what we just wrote instead of
+        // resending the whole file.
+        cacheSet(this.cache, lastWrittenKey(filePath), finalContent);
       }
 
       // Step 8: Record metrics

--- a/src/tools/shared/hash-utils.ts
+++ b/src/tools/shared/hash-utils.ts
@@ -58,6 +58,25 @@ export function hashFileMetadata(filePath: string): string {
 /**
  * Generate a cache key from namespace and parameters
  */
+/**
+ * The cache key for "the last content written to this path".
+ *
+ * ONE KEY BOTH SIDES AGREE ON, keyed on the path ALONE. The read key
+ * (`generateCacheKey('smart-read', { path, options })`) also hashes the read
+ * options, so an entry seeded under one set of options is invisible to a read
+ * that uses another -- which makes it useless as a handoff between a writer and
+ * a reader that never agreed on options. The write key
+ * (`generateCacheKey('file-write', { path })`) is a different namespace again,
+ * so a writer populating it taught the reader nothing.
+ *
+ * Anything written through this key must go through `cacheSet`, not
+ * `cache.set`: readers use `cacheGet`, which expects base64 gzip and treats a
+ * decode failure as a miss, so raw text stored here would read back as nothing.
+ */
+export function lastWrittenKey(path: string): string {
+  return generateCacheKey('file-content', { path });
+}
+
 export function generateCacheKey(
   namespace: string,
   params: Record<string, unknown>

--- a/tests/unit/file-operations/read-diffs-against-the-write.test.ts
+++ b/tests/unit/file-operations/read-diffs-against-the-write.test.ts
@@ -1,0 +1,169 @@
+/**
+ * A read that follows a write should report what changed, not resend the file.
+ *
+ * The two sides never shared a key. smart_write stored
+ * `generateCacheKey('file-write', { path })` while smart_read looked up
+ * `generateCacheKey('smart-read', { path, options })`, and generateCacheKey
+ * namespaces on its first argument -- so the first smart_read after a
+ * smart_write returned the whole file, exactly as it does with no cache at all.
+ *
+ * Two further mismatches sat behind that one, and both are covered here:
+ *
+ *   - the smart-read key hashes the READ OPTIONS as well as the path, so an
+ *     entry seeded under different options is invisible to a plain read;
+ *   - smart_write stored raw text with `cache.set` while every reader goes
+ *     through `cacheGet`, which expects base64 gzip and treats a decode failure
+ *     as a miss. Even a matching key would have read back nothing.
+ *
+ * So the fix is a shared last-written-content entry keyed on the path alone and
+ * written through the same compression helper the readers use.
+ *
+ * Assertions here are deliberately POSITIVE -- `content` equals a specific
+ * string, `isDiff` is true. An earlier draft asserted only that the full file
+ * was absent, which would have passed just as well if the call had thrown and
+ * returned an error object.
+ */
+
+import { mkdtempSync, writeFileSync, rmSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { CacheEngine } from '../../../src/core/cache-engine.js';
+import { TokenCounter } from '../../../src/core/token-counter.js';
+import { MetricsCollector } from '../../../src/core/metrics.js';
+import { SmartReadTool } from '../../../src/tools/file-operations/smart-read.js';
+import { SmartWriteTool } from '../../../src/tools/file-operations/smart-write.js';
+import { SmartEditTool } from '../../../src/tools/file-operations/smart-edit.js';
+
+let workspace: string;
+let cache: CacheEngine;
+let tokenCounter: TokenCounter;
+let metrics: MetricsCollector;
+
+// Deliberately under the 4000-character default chunkSize. At 200 lines this
+// fixture is ~5 KB and CHUNKS, so a plain read returns chunk 0 -- which made an
+// earlier control test pass for a reason that had nothing to do with the cache.
+const ORIGINAL = Array.from(
+  { length: 100 },
+  (_, i) => `export const value${i} = ${i};`
+).join('\n');
+
+// autoFormat defaults to true and would run prettier over the content, so the
+// bytes on disk would no longer be the bytes handed in and "nothing changed"
+// would be false for a reason that has nothing to do with the cache.
+const EXACT = { autoFormat: false } as const;
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), 'read-after-write-'));
+  cache = new CacheEngine();
+  tokenCounter = new TokenCounter();
+  metrics = new MetricsCollector();
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+describe('smart_read after smart_write', () => {
+  test('reports no changes instead of resending the file just written', async () => {
+    const file = join(workspace, 'generated.ts');
+    const writer = new SmartWriteTool(cache, tokenCounter, metrics);
+    const reader = new SmartReadTool(cache, tokenCounter, metrics);
+
+    await writer.write(file, ORIGINAL, EXACT);
+
+    // The premise: the bytes on disk are the bytes just written, so an honest
+    // reader has nothing to report.
+    expect(readFileSync(file, 'utf-8')).toBe(ORIGINAL);
+
+    const result = await reader.read(file);
+
+    expect(result.metadata.isDiff).toBe(true);
+    expect(result.content).toBe('// No changes');
+    expect(result.metadata.tokensSaved).toBeGreaterThan(0);
+  });
+
+  test('returns only the changed line when the file moved on after the write', async () => {
+    const file = join(workspace, 'moved.ts');
+    const writer = new SmartWriteTool(cache, tokenCounter, metrics);
+    const reader = new SmartReadTool(cache, tokenCounter, metrics);
+
+    await writer.write(file, ORIGINAL, EXACT);
+    writeFileSync(file, ORIGINAL.replace('value7 = 7;', 'value7 = 4242;'));
+
+    const result = await reader.read(file);
+
+    expect(result.metadata.isDiff).toBe(true);
+    expect(result.content).toContain('4242');
+    // The point of the diff is that it is not the file.
+    expect(result.content.length).toBeLessThan(ORIGINAL.length / 2);
+  });
+
+  test('a first read with no prior write still returns the file', async () => {
+    // Guards against over-correction: the fallback must not invent a base and
+    // start answering "no changes" to reads of files nobody has written.
+    const file = join(workspace, 'untouched.ts');
+    writeFileSync(file, ORIGINAL);
+
+    const reader = new SmartReadTool(cache, tokenCounter, metrics);
+    const result = await reader.read(file);
+
+    expect(result.metadata.isDiff).toBe(false);
+    expect(result.content).toContain('value99 = 99;');
+  });
+});
+
+describe('smart_read after smart_edit', () => {
+  test('reports the edit instead of resending the file', async () => {
+    // smart_edit had the same gap in a third namespace, `file-edit`, also
+    // stored raw. Fixing only smart_write would have left the more common
+    // writer -- editing an existing file -- still resending it on next read.
+    const file = join(workspace, 'edited.ts');
+    writeFileSync(file, ORIGINAL);
+
+    const editor = new SmartEditTool(cache, tokenCounter, metrics);
+    const reader = new SmartReadTool(cache, tokenCounter, metrics);
+
+    await editor.edit(
+      file,
+      { type: 'replace', startLine: 8, endLine: 8, content: 'export const value7 = 4242;' },
+      { createBackup: false }
+    );
+
+    const result = await reader.read(file);
+
+    // "No changes" is the CORRECT answer here, and the valuable one: the file
+    // on disk is exactly what the edit left, so the honest report is three
+    // tokens rather than a hundred lines. An earlier version of this test
+    // expected to see the edited line, which confused "what did I change" with
+    // "what changed since I changed it".
+    expect(result.metadata.isDiff).toBe(true);
+    expect(result.content).toBe('// No changes');
+    expect(result.metadata.tokensSaved).toBeGreaterThan(0);
+  });
+
+  test('returns a diff when the file moves on after the edit', async () => {
+    // Proves the edit really seeded a usable BASE, not merely a value equal to
+    // the file: a later external change has to diff against it.
+    const file = join(workspace, 'edited-then-changed.ts');
+    writeFileSync(file, ORIGINAL);
+
+    const editor = new SmartEditTool(cache, tokenCounter, metrics);
+    const reader = new SmartReadTool(cache, tokenCounter, metrics);
+
+    await editor.edit(
+      file,
+      { type: 'replace', startLine: 8, endLine: 8, content: 'export const value7 = 4242;' },
+      { createBackup: false }
+    );
+    writeFileSync(
+      file,
+      readFileSync(file, 'utf-8').replace('value9 = 9;', 'value9 = 7777;')
+    );
+
+    const result = await reader.read(file);
+
+    expect(result.metadata.isDiff).toBe(true);
+    expect(result.content).toContain('7777');
+    expect(result.content.length).toBeLessThan(ORIGINAL.length / 2);
+  });
+});


### PR DESCRIPTION
Part of #350 (in-process half; the built-in Write path is closed by #356).

Closes the in-process half of #350.

## The bug

`smart_write`, `smart_edit` and `smart_read` each used a **different cache namespace**:

| tool | key |
|---|---|
| `smart_write` | `generateCacheKey('file-write', { path })` |
| `smart_edit` | `generateCacheKey('file-edit', { path })` |
| `smart_read` | `generateCacheKey('smart-read', { path, options })` |

`generateCacheKey` namespaces on its first argument, so **no writer ever populated anything a reader consults**. The first `smart_read` after a write returned the whole file — exactly as it does with no cache at all.

Two further mismatches sat behind that one, and either alone would have defeated a naive fix:

1. The read key also hashes the read **options**, so an entry seeded under one set of options is invisible to a read using another.
2. Both writers stored **raw text** via `cache.set`, while every reader goes through `cacheGet`, which expects base64 gzip and treats a decode failure as a miss. Even a matching key would have read back nothing.

## The fix

One key derived from the **path alone** (`lastWrittenKey`), written by both writers through the same `cacheSet` helper the readers use, and consulted by `smart_read` **only as a diff base** when its own entry misses.

`fromCache` deliberately still means "my own entry hit", so metrics are unchanged and a read served off the fallback still seeds its own key — the next read needs no fallback.

## Behaviour

- read after a write → `// No changes` instead of the file
- read after a later change → only the diff
- first read of a file nobody wrote → still the file

That last one is asserted so the fallback can't start inventing a base and answering "no changes" to ordinary reads.

## Tests

`tests/unit/file-operations/read-diffs-against-the-write.test.ts`, 5 tests, covering both `smart_write` and `smart_edit` as writers.

Assertions are deliberately **positive** (`content` equals a specific string). An earlier draft asserted only that the full file was *absent*, which would have passed just as well had the call thrown and returned an error object.

Two fixture traps are documented in the test and worth knowing: `autoFormat` defaults to true and would rewrite the bytes, and a 200-line fixture exceeds the 4000-char default `chunkSize` and chunks — which made an earlier control test pass for the wrong reason.

## Verification

- `tsc --noEmit` clean
- eslint clean (2 warnings pre-existing, on untouched lines)
- **209 suites / 2748 tests passing**

One run showed a single failure in `wiki-routes-search.test.ts`; it passes 8/8 in isolation and a second full sweep was entirely green, so it is an ordering flake rather than a regression from this change.

## Not covered

The **built-in `Write`** path still resends on first read: `PostToolUse` stores a wiki-graph snapshot, a different store from the `CacheEngine` a hook cannot reach. That needs a `snapshotFor(dir, path)` export and a bridge in `smart-read.ts`, and stays open in #350 — it matters more now that #348 makes the built-in `Write` the common path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
