### PR TITLE
feat(policy): add assist, the posture that runs the graph without refusals

### DIFF
--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -23,6 +23,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
+  MODE_ASSIST,
   refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
@@ -676,14 +677,28 @@ export function policyText(
         : registrationProven
           ? 'The host supplied a proven empty optimizer MCP inventory for this session.'
           : 'This hook received no positive evidence that optimizer MCP tools are registered in this session.';
-  const routing = routes.length
-    ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
-    : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
-  const enforcement = routes.length
-    ? canDeny && refusalsEnabled()
-      ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
-      : '\n\nThese are recommendations; the built-in tools remain available.'
-    : '';
+  // ASSIST SAYS NOTHING ABOUT ROUTING. The routing list plus its "these are
+  // recommendations" tail cost ~800 bytes of context in every session, and
+  // under assist they advise about a mechanism that is switched off -- which is
+  // precisely the per-session overhead assist exists to remove. Measured: 813
+  // bytes emitted under assist against 898 under enforce, where the advice is
+  // at least true.
+  //
+  // The graph guidance below is deliberately NOT suppressed: retrieval and
+  // harvest are what assist keeps, so telling the model how to record findings
+  // still earns its place.
+  const advertiseRouting = mode() !== MODE_ASSIST;
+  const routing = !advertiseRouting
+    ? ''
+    : routes.length
+      ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
+      : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
+  const enforcement =
+    advertiseRouting && routes.length
+      ? canDeny && refusalsEnabled()
+        ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
+        : '\n\nThese are recommendations; the built-in tools remain available.'
+      : '';
   const utilities = [
     tools.has('optimize_session')
       ? 'When the context window gets tight, call optimize_session.'

--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -23,7 +23,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
-  MODE_ADVISE,
+  refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
   withEscape,
@@ -680,7 +680,7 @@ export function policyText(
     ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
     : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
   const enforcement = routes.length
-    ? canDeny && mode() !== MODE_ADVISE
+    ? canDeny && refusalsEnabled()
       ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
       : '\n\nThese are recommendations; the built-in tools remain available.'
     : '';
@@ -1308,7 +1308,7 @@ async function runHook(clientName, event, invocation) {
       client.canDeny &&
       event === 'pre-tool' &&
       !repeat &&
-      mode() !== MODE_ADVISE &&
+      refusalsEnabled() &&
       // Codex code mode presents orchestration as one outer `functions.exec`.
       // Refuse only when it contains one shell call; a multi-operation envelope
       // can include unrelated safe work that must not be discarded wholesale.

--- a/hooks-core/policy.mjs
+++ b/hooks-core/policy.mjs
@@ -51,7 +51,39 @@ import { noteHookOutput } from './observability.mjs';
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
 export const MODE_ADVISE = 'advise';
+/**
+ * Refusals off, everything else on.
+ *
+ * THE POSTURE THAT WAS MISSING. `off` is not "enforcement disabled" -- it exits
+ * the hook process (see adapter.mjs and stop-harvest.mjs), taking retrieval,
+ * injection and harvest with it. The experiment arms cannot express this either:
+ * they are cumulative, and every arm carrying retrieval also carries routing.
+ *
+ * So there was no way to run the knowledge graph without also refusing tool
+ * calls -- which is exactly the configuration a benchmark needed, since the
+ * enforcing default measured 1.687x vanilla Claude Code while `off` measured
+ * 0.904 with most of the product switched off.
+ *
+ * Quieter than `advise`: no refusal AND no routing advisory, because an
+ * advisory still spends context on every matched call.
+ */
+export const MODE_ASSIST = 'assist';
 export const MODE_OFF = 'off';
+
+/**
+ * Whether this posture may refuse a tool call.
+ *
+ * A PREDICATE RATHER THAN A THIRD `!==` COMPARISON. Two call sites in
+ * adapter.mjs previously excluded only `advise` -- one gating whether a refusal
+ * is emitted, one choosing between "a built-in call is denied" and "these are
+ * recommendations" in the session-start guidance. Adding a mode without
+ * updating both would have left assist telling the model its calls would be
+ * denied while allowing every one of them, and the next mode would have to
+ * find all the sites again.
+ */
+export function refusalsEnabled() {
+  return mode() === MODE_ENFORCE;
+}
 
 /**
  * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
@@ -62,6 +94,7 @@ export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
+  if (raw === MODE_ASSIST) return MODE_ASSIST;
   return MODE_ENFORCE;
 }
 
@@ -728,7 +761,10 @@ export function advise(context) {
  */
 export function enforce(reason, deniedBefore) {
   const current = mode();
-  if (current === MODE_OFF) allow();
+  // assist allows SILENTLY, like off and unlike advise: an advisory still
+  // spends context on every matched call, which is the cost assist exists to
+  // avoid while keeping the graph running.
+  if (current === MODE_OFF || current === MODE_ASSIST) allow();
   if (current === MODE_ADVISE || deniedBefore) advise(reason);
   deny(reason);
 }

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -25,7 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
-  MODE_ADVISE,
+  refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
   withEscape,
@@ -682,7 +682,7 @@ export function policyText(
     ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
     : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
   const enforcement = routes.length
-    ? canDeny && mode() !== MODE_ADVISE
+    ? canDeny && refusalsEnabled()
       ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
       : '\n\nThese are recommendations; the built-in tools remain available.'
     : '';
@@ -1310,7 +1310,7 @@ async function runHook(clientName, event, invocation) {
       client.canDeny &&
       event === 'pre-tool' &&
       !repeat &&
-      mode() !== MODE_ADVISE &&
+      refusalsEnabled() &&
       // Codex code mode presents orchestration as one outer `functions.exec`.
       // Refuse only when it contains one shell call; a multi-operation envelope
       // can include unrelated safe work that must not be discarded wholesale.

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -25,6 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
+  MODE_ASSIST,
   refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
@@ -678,14 +679,28 @@ export function policyText(
         : registrationProven
           ? 'The host supplied a proven empty optimizer MCP inventory for this session.'
           : 'This hook received no positive evidence that optimizer MCP tools are registered in this session.';
-  const routing = routes.length
-    ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
-    : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
-  const enforcement = routes.length
-    ? canDeny && refusalsEnabled()
-      ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
-      : '\n\nThese are recommendations; the built-in tools remain available.'
-    : '';
+  // ASSIST SAYS NOTHING ABOUT ROUTING. The routing list plus its "these are
+  // recommendations" tail cost ~800 bytes of context in every session, and
+  // under assist they advise about a mechanism that is switched off -- which is
+  // precisely the per-session overhead assist exists to remove. Measured: 813
+  // bytes emitted under assist against 898 under enforce, where the advice is
+  // at least true.
+  //
+  // The graph guidance below is deliberately NOT suppressed: retrieval and
+  // harvest are what assist keeps, so telling the model how to record findings
+  // still earns its place.
+  const advertiseRouting = mode() !== MODE_ASSIST;
+  const routing = !advertiseRouting
+    ? ''
+    : routes.length
+      ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
+      : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
+  const enforcement =
+    advertiseRouting && routes.length
+      ? canDeny && refusalsEnabled()
+        ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
+        : '\n\nThese are recommendations; the built-in tools remain available.'
+      : '';
   const utilities = [
     tools.has('optimize_session')
       ? 'When the context window gets tight, call optimize_session.'

--- a/integrations/cline/hooks/token-optimizer/lib/policy.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/policy.mjs
@@ -53,7 +53,39 @@ import { noteHookOutput } from './observability.mjs';
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
 export const MODE_ADVISE = 'advise';
+/**
+ * Refusals off, everything else on.
+ *
+ * THE POSTURE THAT WAS MISSING. `off` is not "enforcement disabled" -- it exits
+ * the hook process (see adapter.mjs and stop-harvest.mjs), taking retrieval,
+ * injection and harvest with it. The experiment arms cannot express this either:
+ * they are cumulative, and every arm carrying retrieval also carries routing.
+ *
+ * So there was no way to run the knowledge graph without also refusing tool
+ * calls -- which is exactly the configuration a benchmark needed, since the
+ * enforcing default measured 1.687x vanilla Claude Code while `off` measured
+ * 0.904 with most of the product switched off.
+ *
+ * Quieter than `advise`: no refusal AND no routing advisory, because an
+ * advisory still spends context on every matched call.
+ */
+export const MODE_ASSIST = 'assist';
 export const MODE_OFF = 'off';
+
+/**
+ * Whether this posture may refuse a tool call.
+ *
+ * A PREDICATE RATHER THAN A THIRD `!==` COMPARISON. Two call sites in
+ * adapter.mjs previously excluded only `advise` -- one gating whether a refusal
+ * is emitted, one choosing between "a built-in call is denied" and "these are
+ * recommendations" in the session-start guidance. Adding a mode without
+ * updating both would have left assist telling the model its calls would be
+ * denied while allowing every one of them, and the next mode would have to
+ * find all the sites again.
+ */
+export function refusalsEnabled() {
+  return mode() === MODE_ENFORCE;
+}
 
 /**
  * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
@@ -64,6 +96,7 @@ export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
+  if (raw === MODE_ASSIST) return MODE_ASSIST;
   return MODE_ENFORCE;
 }
 
@@ -730,7 +763,10 @@ export function advise(context) {
  */
 export function enforce(reason, deniedBefore) {
   const current = mode();
-  if (current === MODE_OFF) allow();
+  // assist allows SILENTLY, like off and unlike advise: an advisory still
+  // spends context on every matched call, which is the cost assist exists to
+  // avoid while keeping the graph running.
+  if (current === MODE_OFF || current === MODE_ASSIST) allow();
   if (current === MODE_ADVISE || deniedBefore) advise(reason);
   deny(reason);
 }

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -25,7 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
-  MODE_ADVISE,
+  refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
   withEscape,
@@ -682,7 +682,7 @@ export function policyText(
     ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
     : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
   const enforcement = routes.length
-    ? canDeny && mode() !== MODE_ADVISE
+    ? canDeny && refusalsEnabled()
       ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
       : '\n\nThese are recommendations; the built-in tools remain available.'
     : '';
@@ -1310,7 +1310,7 @@ async function runHook(clientName, event, invocation) {
       client.canDeny &&
       event === 'pre-tool' &&
       !repeat &&
-      mode() !== MODE_ADVISE &&
+      refusalsEnabled() &&
       // Codex code mode presents orchestration as one outer `functions.exec`.
       // Refuse only when it contains one shell call; a multi-operation envelope
       // can include unrelated safe work that must not be discarded wholesale.

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -25,6 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
+  MODE_ASSIST,
   refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
@@ -678,14 +679,28 @@ export function policyText(
         : registrationProven
           ? 'The host supplied a proven empty optimizer MCP inventory for this session.'
           : 'This hook received no positive evidence that optimizer MCP tools are registered in this session.';
-  const routing = routes.length
-    ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
-    : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
-  const enforcement = routes.length
-    ? canDeny && refusalsEnabled()
-      ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
-      : '\n\nThese are recommendations; the built-in tools remain available.'
-    : '';
+  // ASSIST SAYS NOTHING ABOUT ROUTING. The routing list plus its "these are
+  // recommendations" tail cost ~800 bytes of context in every session, and
+  // under assist they advise about a mechanism that is switched off -- which is
+  // precisely the per-session overhead assist exists to remove. Measured: 813
+  // bytes emitted under assist against 898 under enforce, where the advice is
+  // at least true.
+  //
+  // The graph guidance below is deliberately NOT suppressed: retrieval and
+  // harvest are what assist keeps, so telling the model how to record findings
+  // still earns its place.
+  const advertiseRouting = mode() !== MODE_ASSIST;
+  const routing = !advertiseRouting
+    ? ''
+    : routes.length
+      ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
+      : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
+  const enforcement =
+    advertiseRouting && routes.length
+      ? canDeny && refusalsEnabled()
+        ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
+        : '\n\nThese are recommendations; the built-in tools remain available.'
+      : '';
   const utilities = [
     tools.has('optimize_session')
       ? 'When the context window gets tight, call optimize_session.'

--- a/integrations/codex/hooks/lib/policy.mjs
+++ b/integrations/codex/hooks/lib/policy.mjs
@@ -53,7 +53,39 @@ import { noteHookOutput } from './observability.mjs';
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
 export const MODE_ADVISE = 'advise';
+/**
+ * Refusals off, everything else on.
+ *
+ * THE POSTURE THAT WAS MISSING. `off` is not "enforcement disabled" -- it exits
+ * the hook process (see adapter.mjs and stop-harvest.mjs), taking retrieval,
+ * injection and harvest with it. The experiment arms cannot express this either:
+ * they are cumulative, and every arm carrying retrieval also carries routing.
+ *
+ * So there was no way to run the knowledge graph without also refusing tool
+ * calls -- which is exactly the configuration a benchmark needed, since the
+ * enforcing default measured 1.687x vanilla Claude Code while `off` measured
+ * 0.904 with most of the product switched off.
+ *
+ * Quieter than `advise`: no refusal AND no routing advisory, because an
+ * advisory still spends context on every matched call.
+ */
+export const MODE_ASSIST = 'assist';
 export const MODE_OFF = 'off';
+
+/**
+ * Whether this posture may refuse a tool call.
+ *
+ * A PREDICATE RATHER THAN A THIRD `!==` COMPARISON. Two call sites in
+ * adapter.mjs previously excluded only `advise` -- one gating whether a refusal
+ * is emitted, one choosing between "a built-in call is denied" and "these are
+ * recommendations" in the session-start guidance. Adding a mode without
+ * updating both would have left assist telling the model its calls would be
+ * denied while allowing every one of them, and the next mode would have to
+ * find all the sites again.
+ */
+export function refusalsEnabled() {
+  return mode() === MODE_ENFORCE;
+}
 
 /**
  * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
@@ -64,6 +96,7 @@ export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
+  if (raw === MODE_ASSIST) return MODE_ASSIST;
   return MODE_ENFORCE;
 }
 
@@ -730,7 +763,10 @@ export function advise(context) {
  */
 export function enforce(reason, deniedBefore) {
   const current = mode();
-  if (current === MODE_OFF) allow();
+  // assist allows SILENTLY, like off and unlike advise: an advisory still
+  // spends context on every matched call, which is the cost assist exists to
+  // avoid while keeping the graph running.
+  if (current === MODE_OFF || current === MODE_ASSIST) allow();
   if (current === MODE_ADVISE || deniedBefore) advise(reason);
   deny(reason);
 }

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -25,7 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
-  MODE_ADVISE,
+  refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
   withEscape,
@@ -682,7 +682,7 @@ export function policyText(
     ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
     : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
   const enforcement = routes.length
-    ? canDeny && mode() !== MODE_ADVISE
+    ? canDeny && refusalsEnabled()
       ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
       : '\n\nThese are recommendations; the built-in tools remain available.'
     : '';
@@ -1310,7 +1310,7 @@ async function runHook(clientName, event, invocation) {
       client.canDeny &&
       event === 'pre-tool' &&
       !repeat &&
-      mode() !== MODE_ADVISE &&
+      refusalsEnabled() &&
       // Codex code mode presents orchestration as one outer `functions.exec`.
       // Refuse only when it contains one shell call; a multi-operation envelope
       // can include unrelated safe work that must not be discarded wholesale.

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -25,6 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
+  MODE_ASSIST,
   refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
@@ -678,14 +679,28 @@ export function policyText(
         : registrationProven
           ? 'The host supplied a proven empty optimizer MCP inventory for this session.'
           : 'This hook received no positive evidence that optimizer MCP tools are registered in this session.';
-  const routing = routes.length
-    ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
-    : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
-  const enforcement = routes.length
-    ? canDeny && refusalsEnabled()
-      ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
-      : '\n\nThese are recommendations; the built-in tools remain available.'
-    : '';
+  // ASSIST SAYS NOTHING ABOUT ROUTING. The routing list plus its "these are
+  // recommendations" tail cost ~800 bytes of context in every session, and
+  // under assist they advise about a mechanism that is switched off -- which is
+  // precisely the per-session overhead assist exists to remove. Measured: 813
+  // bytes emitted under assist against 898 under enforce, where the advice is
+  // at least true.
+  //
+  // The graph guidance below is deliberately NOT suppressed: retrieval and
+  // harvest are what assist keeps, so telling the model how to record findings
+  // still earns its place.
+  const advertiseRouting = mode() !== MODE_ASSIST;
+  const routing = !advertiseRouting
+    ? ''
+    : routes.length
+      ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
+      : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
+  const enforcement =
+    advertiseRouting && routes.length
+      ? canDeny && refusalsEnabled()
+        ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
+        : '\n\nThese are recommendations; the built-in tools remain available.'
+      : '';
   const utilities = [
     tools.has('optimize_session')
       ? 'When the context window gets tight, call optimize_session.'

--- a/integrations/codex/plugin/hooks/lib/policy.mjs
+++ b/integrations/codex/plugin/hooks/lib/policy.mjs
@@ -53,7 +53,39 @@ import { noteHookOutput } from './observability.mjs';
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
 export const MODE_ADVISE = 'advise';
+/**
+ * Refusals off, everything else on.
+ *
+ * THE POSTURE THAT WAS MISSING. `off` is not "enforcement disabled" -- it exits
+ * the hook process (see adapter.mjs and stop-harvest.mjs), taking retrieval,
+ * injection and harvest with it. The experiment arms cannot express this either:
+ * they are cumulative, and every arm carrying retrieval also carries routing.
+ *
+ * So there was no way to run the knowledge graph without also refusing tool
+ * calls -- which is exactly the configuration a benchmark needed, since the
+ * enforcing default measured 1.687x vanilla Claude Code while `off` measured
+ * 0.904 with most of the product switched off.
+ *
+ * Quieter than `advise`: no refusal AND no routing advisory, because an
+ * advisory still spends context on every matched call.
+ */
+export const MODE_ASSIST = 'assist';
 export const MODE_OFF = 'off';
+
+/**
+ * Whether this posture may refuse a tool call.
+ *
+ * A PREDICATE RATHER THAN A THIRD `!==` COMPARISON. Two call sites in
+ * adapter.mjs previously excluded only `advise` -- one gating whether a refusal
+ * is emitted, one choosing between "a built-in call is denied" and "these are
+ * recommendations" in the session-start guidance. Adding a mode without
+ * updating both would have left assist telling the model its calls would be
+ * denied while allowing every one of them, and the next mode would have to
+ * find all the sites again.
+ */
+export function refusalsEnabled() {
+  return mode() === MODE_ENFORCE;
+}
 
 /**
  * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
@@ -64,6 +96,7 @@ export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
+  if (raw === MODE_ASSIST) return MODE_ASSIST;
   return MODE_ENFORCE;
 }
 
@@ -730,7 +763,10 @@ export function advise(context) {
  */
 export function enforce(reason, deniedBefore) {
   const current = mode();
-  if (current === MODE_OFF) allow();
+  // assist allows SILENTLY, like off and unlike advise: an advisory still
+  // spends context on every matched call, which is the cost assist exists to
+  // avoid while keeping the graph running.
+  if (current === MODE_OFF || current === MODE_ASSIST) allow();
   if (current === MODE_ADVISE || deniedBefore) advise(reason);
   deny(reason);
 }

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -25,7 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
-  MODE_ADVISE,
+  refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
   withEscape,
@@ -682,7 +682,7 @@ export function policyText(
     ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
     : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
   const enforcement = routes.length
-    ? canDeny && mode() !== MODE_ADVISE
+    ? canDeny && refusalsEnabled()
       ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
       : '\n\nThese are recommendations; the built-in tools remain available.'
     : '';
@@ -1310,7 +1310,7 @@ async function runHook(clientName, event, invocation) {
       client.canDeny &&
       event === 'pre-tool' &&
       !repeat &&
-      mode() !== MODE_ADVISE &&
+      refusalsEnabled() &&
       // Codex code mode presents orchestration as one outer `functions.exec`.
       // Refuse only when it contains one shell call; a multi-operation envelope
       // can include unrelated safe work that must not be discarded wholesale.

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -25,6 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
+  MODE_ASSIST,
   refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
@@ -678,14 +679,28 @@ export function policyText(
         : registrationProven
           ? 'The host supplied a proven empty optimizer MCP inventory for this session.'
           : 'This hook received no positive evidence that optimizer MCP tools are registered in this session.';
-  const routing = routes.length
-    ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
-    : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
-  const enforcement = routes.length
-    ? canDeny && refusalsEnabled()
-      ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
-      : '\n\nThese are recommendations; the built-in tools remain available.'
-    : '';
+  // ASSIST SAYS NOTHING ABOUT ROUTING. The routing list plus its "these are
+  // recommendations" tail cost ~800 bytes of context in every session, and
+  // under assist they advise about a mechanism that is switched off -- which is
+  // precisely the per-session overhead assist exists to remove. Measured: 813
+  // bytes emitted under assist against 898 under enforce, where the advice is
+  // at least true.
+  //
+  // The graph guidance below is deliberately NOT suppressed: retrieval and
+  // harvest are what assist keeps, so telling the model how to record findings
+  // still earns its place.
+  const advertiseRouting = mode() !== MODE_ASSIST;
+  const routing = !advertiseRouting
+    ? ''
+    : routes.length
+      ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
+      : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
+  const enforcement =
+    advertiseRouting && routes.length
+      ? canDeny && refusalsEnabled()
+        ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
+        : '\n\nThese are recommendations; the built-in tools remain available.'
+      : '';
   const utilities = [
     tools.has('optimize_session')
       ? 'When the context window gets tight, call optimize_session.'

--- a/integrations/copilot/.github/hooks/lib/policy.mjs
+++ b/integrations/copilot/.github/hooks/lib/policy.mjs
@@ -53,7 +53,39 @@ import { noteHookOutput } from './observability.mjs';
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
 export const MODE_ADVISE = 'advise';
+/**
+ * Refusals off, everything else on.
+ *
+ * THE POSTURE THAT WAS MISSING. `off` is not "enforcement disabled" -- it exits
+ * the hook process (see adapter.mjs and stop-harvest.mjs), taking retrieval,
+ * injection and harvest with it. The experiment arms cannot express this either:
+ * they are cumulative, and every arm carrying retrieval also carries routing.
+ *
+ * So there was no way to run the knowledge graph without also refusing tool
+ * calls -- which is exactly the configuration a benchmark needed, since the
+ * enforcing default measured 1.687x vanilla Claude Code while `off` measured
+ * 0.904 with most of the product switched off.
+ *
+ * Quieter than `advise`: no refusal AND no routing advisory, because an
+ * advisory still spends context on every matched call.
+ */
+export const MODE_ASSIST = 'assist';
 export const MODE_OFF = 'off';
+
+/**
+ * Whether this posture may refuse a tool call.
+ *
+ * A PREDICATE RATHER THAN A THIRD `!==` COMPARISON. Two call sites in
+ * adapter.mjs previously excluded only `advise` -- one gating whether a refusal
+ * is emitted, one choosing between "a built-in call is denied" and "these are
+ * recommendations" in the session-start guidance. Adding a mode without
+ * updating both would have left assist telling the model its calls would be
+ * denied while allowing every one of them, and the next mode would have to
+ * find all the sites again.
+ */
+export function refusalsEnabled() {
+  return mode() === MODE_ENFORCE;
+}
 
 /**
  * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
@@ -64,6 +96,7 @@ export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
+  if (raw === MODE_ASSIST) return MODE_ASSIST;
   return MODE_ENFORCE;
 }
 
@@ -730,7 +763,10 @@ export function advise(context) {
  */
 export function enforce(reason, deniedBefore) {
   const current = mode();
-  if (current === MODE_OFF) allow();
+  // assist allows SILENTLY, like off and unlike advise: an advisory still
+  // spends context on every matched call, which is the cost assist exists to
+  // avoid while keeping the graph running.
+  if (current === MODE_OFF || current === MODE_ASSIST) allow();
   if (current === MODE_ADVISE || deniedBefore) advise(reason);
   deny(reason);
 }

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -25,7 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
-  MODE_ADVISE,
+  refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
   withEscape,
@@ -682,7 +682,7 @@ export function policyText(
     ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
     : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
   const enforcement = routes.length
-    ? canDeny && mode() !== MODE_ADVISE
+    ? canDeny && refusalsEnabled()
       ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
       : '\n\nThese are recommendations; the built-in tools remain available.'
     : '';
@@ -1310,7 +1310,7 @@ async function runHook(clientName, event, invocation) {
       client.canDeny &&
       event === 'pre-tool' &&
       !repeat &&
-      mode() !== MODE_ADVISE &&
+      refusalsEnabled() &&
       // Codex code mode presents orchestration as one outer `functions.exec`.
       // Refuse only when it contains one shell call; a multi-operation envelope
       // can include unrelated safe work that must not be discarded wholesale.

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -25,6 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
+  MODE_ASSIST,
   refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
@@ -678,14 +679,28 @@ export function policyText(
         : registrationProven
           ? 'The host supplied a proven empty optimizer MCP inventory for this session.'
           : 'This hook received no positive evidence that optimizer MCP tools are registered in this session.';
-  const routing = routes.length
-    ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
-    : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
-  const enforcement = routes.length
-    ? canDeny && refusalsEnabled()
-      ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
-      : '\n\nThese are recommendations; the built-in tools remain available.'
-    : '';
+  // ASSIST SAYS NOTHING ABOUT ROUTING. The routing list plus its "these are
+  // recommendations" tail cost ~800 bytes of context in every session, and
+  // under assist they advise about a mechanism that is switched off -- which is
+  // precisely the per-session overhead assist exists to remove. Measured: 813
+  // bytes emitted under assist against 898 under enforce, where the advice is
+  // at least true.
+  //
+  // The graph guidance below is deliberately NOT suppressed: retrieval and
+  // harvest are what assist keeps, so telling the model how to record findings
+  // still earns its place.
+  const advertiseRouting = mode() !== MODE_ASSIST;
+  const routing = !advertiseRouting
+    ? ''
+    : routes.length
+      ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
+      : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
+  const enforcement =
+    advertiseRouting && routes.length
+      ? canDeny && refusalsEnabled()
+        ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
+        : '\n\nThese are recommendations; the built-in tools remain available.'
+      : '';
   const utilities = [
     tools.has('optimize_session')
       ? 'When the context window gets tight, call optimize_session.'

--- a/integrations/cursor/hooks/lib/policy.mjs
+++ b/integrations/cursor/hooks/lib/policy.mjs
@@ -53,7 +53,39 @@ import { noteHookOutput } from './observability.mjs';
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
 export const MODE_ADVISE = 'advise';
+/**
+ * Refusals off, everything else on.
+ *
+ * THE POSTURE THAT WAS MISSING. `off` is not "enforcement disabled" -- it exits
+ * the hook process (see adapter.mjs and stop-harvest.mjs), taking retrieval,
+ * injection and harvest with it. The experiment arms cannot express this either:
+ * they are cumulative, and every arm carrying retrieval also carries routing.
+ *
+ * So there was no way to run the knowledge graph without also refusing tool
+ * calls -- which is exactly the configuration a benchmark needed, since the
+ * enforcing default measured 1.687x vanilla Claude Code while `off` measured
+ * 0.904 with most of the product switched off.
+ *
+ * Quieter than `advise`: no refusal AND no routing advisory, because an
+ * advisory still spends context on every matched call.
+ */
+export const MODE_ASSIST = 'assist';
 export const MODE_OFF = 'off';
+
+/**
+ * Whether this posture may refuse a tool call.
+ *
+ * A PREDICATE RATHER THAN A THIRD `!==` COMPARISON. Two call sites in
+ * adapter.mjs previously excluded only `advise` -- one gating whether a refusal
+ * is emitted, one choosing between "a built-in call is denied" and "these are
+ * recommendations" in the session-start guidance. Adding a mode without
+ * updating both would have left assist telling the model its calls would be
+ * denied while allowing every one of them, and the next mode would have to
+ * find all the sites again.
+ */
+export function refusalsEnabled() {
+  return mode() === MODE_ENFORCE;
+}
 
 /**
  * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
@@ -64,6 +96,7 @@ export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
+  if (raw === MODE_ASSIST) return MODE_ASSIST;
   return MODE_ENFORCE;
 }
 
@@ -730,7 +763,10 @@ export function advise(context) {
  */
 export function enforce(reason, deniedBefore) {
   const current = mode();
-  if (current === MODE_OFF) allow();
+  // assist allows SILENTLY, like off and unlike advise: an advisory still
+  // spends context on every matched call, which is the cost assist exists to
+  // avoid while keeping the graph running.
+  if (current === MODE_OFF || current === MODE_ASSIST) allow();
   if (current === MODE_ADVISE || deniedBefore) advise(reason);
   deny(reason);
 }

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -25,7 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
-  MODE_ADVISE,
+  refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
   withEscape,
@@ -682,7 +682,7 @@ export function policyText(
     ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
     : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
   const enforcement = routes.length
-    ? canDeny && mode() !== MODE_ADVISE
+    ? canDeny && refusalsEnabled()
       ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
       : '\n\nThese are recommendations; the built-in tools remain available.'
     : '';
@@ -1310,7 +1310,7 @@ async function runHook(clientName, event, invocation) {
       client.canDeny &&
       event === 'pre-tool' &&
       !repeat &&
-      mode() !== MODE_ADVISE &&
+      refusalsEnabled() &&
       // Codex code mode presents orchestration as one outer `functions.exec`.
       // Refuse only when it contains one shell call; a multi-operation envelope
       // can include unrelated safe work that must not be discarded wholesale.

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -25,6 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
+  MODE_ASSIST,
   refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
@@ -678,14 +679,28 @@ export function policyText(
         : registrationProven
           ? 'The host supplied a proven empty optimizer MCP inventory for this session.'
           : 'This hook received no positive evidence that optimizer MCP tools are registered in this session.';
-  const routing = routes.length
-    ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
-    : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
-  const enforcement = routes.length
-    ? canDeny && refusalsEnabled()
-      ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
-      : '\n\nThese are recommendations; the built-in tools remain available.'
-    : '';
+  // ASSIST SAYS NOTHING ABOUT ROUTING. The routing list plus its "these are
+  // recommendations" tail cost ~800 bytes of context in every session, and
+  // under assist they advise about a mechanism that is switched off -- which is
+  // precisely the per-session overhead assist exists to remove. Measured: 813
+  // bytes emitted under assist against 898 under enforce, where the advice is
+  // at least true.
+  //
+  // The graph guidance below is deliberately NOT suppressed: retrieval and
+  // harvest are what assist keeps, so telling the model how to record findings
+  // still earns its place.
+  const advertiseRouting = mode() !== MODE_ASSIST;
+  const routing = !advertiseRouting
+    ? ''
+    : routes.length
+      ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
+      : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
+  const enforcement =
+    advertiseRouting && routes.length
+      ? canDeny && refusalsEnabled()
+        ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
+        : '\n\nThese are recommendations; the built-in tools remain available.'
+      : '';
   const utilities = [
     tools.has('optimize_session')
       ? 'When the context window gets tight, call optimize_session.'

--- a/integrations/gemini/hooks/lib/policy.mjs
+++ b/integrations/gemini/hooks/lib/policy.mjs
@@ -53,7 +53,39 @@ import { noteHookOutput } from './observability.mjs';
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
 export const MODE_ADVISE = 'advise';
+/**
+ * Refusals off, everything else on.
+ *
+ * THE POSTURE THAT WAS MISSING. `off` is not "enforcement disabled" -- it exits
+ * the hook process (see adapter.mjs and stop-harvest.mjs), taking retrieval,
+ * injection and harvest with it. The experiment arms cannot express this either:
+ * they are cumulative, and every arm carrying retrieval also carries routing.
+ *
+ * So there was no way to run the knowledge graph without also refusing tool
+ * calls -- which is exactly the configuration a benchmark needed, since the
+ * enforcing default measured 1.687x vanilla Claude Code while `off` measured
+ * 0.904 with most of the product switched off.
+ *
+ * Quieter than `advise`: no refusal AND no routing advisory, because an
+ * advisory still spends context on every matched call.
+ */
+export const MODE_ASSIST = 'assist';
 export const MODE_OFF = 'off';
+
+/**
+ * Whether this posture may refuse a tool call.
+ *
+ * A PREDICATE RATHER THAN A THIRD `!==` COMPARISON. Two call sites in
+ * adapter.mjs previously excluded only `advise` -- one gating whether a refusal
+ * is emitted, one choosing between "a built-in call is denied" and "these are
+ * recommendations" in the session-start guidance. Adding a mode without
+ * updating both would have left assist telling the model its calls would be
+ * denied while allowing every one of them, and the next mode would have to
+ * find all the sites again.
+ */
+export function refusalsEnabled() {
+  return mode() === MODE_ENFORCE;
+}
 
 /**
  * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
@@ -64,6 +96,7 @@ export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
+  if (raw === MODE_ASSIST) return MODE_ASSIST;
   return MODE_ENFORCE;
 }
 
@@ -730,7 +763,10 @@ export function advise(context) {
  */
 export function enforce(reason, deniedBefore) {
   const current = mode();
-  if (current === MODE_OFF) allow();
+  // assist allows SILENTLY, like off and unlike advise: an advisory still
+  // spends context on every matched call, which is the cost assist exists to
+  // avoid while keeping the graph running.
+  if (current === MODE_OFF || current === MODE_ASSIST) allow();
   if (current === MODE_ADVISE || deniedBefore) advise(reason);
   deny(reason);
 }

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -25,7 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
-  MODE_ADVISE,
+  refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
   withEscape,
@@ -682,7 +682,7 @@ export function policyText(
     ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
     : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
   const enforcement = routes.length
-    ? canDeny && mode() !== MODE_ADVISE
+    ? canDeny && refusalsEnabled()
       ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
       : '\n\nThese are recommendations; the built-in tools remain available.'
     : '';
@@ -1310,7 +1310,7 @@ async function runHook(clientName, event, invocation) {
       client.canDeny &&
       event === 'pre-tool' &&
       !repeat &&
-      mode() !== MODE_ADVISE &&
+      refusalsEnabled() &&
       // Codex code mode presents orchestration as one outer `functions.exec`.
       // Refuse only when it contains one shell call; a multi-operation envelope
       // can include unrelated safe work that must not be discarded wholesale.

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -25,6 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
+  MODE_ASSIST,
   refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
@@ -678,14 +679,28 @@ export function policyText(
         : registrationProven
           ? 'The host supplied a proven empty optimizer MCP inventory for this session.'
           : 'This hook received no positive evidence that optimizer MCP tools are registered in this session.';
-  const routing = routes.length
-    ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
-    : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
-  const enforcement = routes.length
-    ? canDeny && refusalsEnabled()
-      ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
-      : '\n\nThese are recommendations; the built-in tools remain available.'
-    : '';
+  // ASSIST SAYS NOTHING ABOUT ROUTING. The routing list plus its "these are
+  // recommendations" tail cost ~800 bytes of context in every session, and
+  // under assist they advise about a mechanism that is switched off -- which is
+  // precisely the per-session overhead assist exists to remove. Measured: 813
+  // bytes emitted under assist against 898 under enforce, where the advice is
+  // at least true.
+  //
+  // The graph guidance below is deliberately NOT suppressed: retrieval and
+  // harvest are what assist keeps, so telling the model how to record findings
+  // still earns its place.
+  const advertiseRouting = mode() !== MODE_ASSIST;
+  const routing = !advertiseRouting
+    ? ''
+    : routes.length
+      ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
+      : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
+  const enforcement =
+    advertiseRouting && routes.length
+      ? canDeny && refusalsEnabled()
+        ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
+        : '\n\nThese are recommendations; the built-in tools remain available.'
+      : '';
   const utilities = [
     tools.has('optimize_session')
       ? 'When the context window gets tight, call optimize_session.'

--- a/integrations/kilo/hooks/lib/policy.mjs
+++ b/integrations/kilo/hooks/lib/policy.mjs
@@ -53,7 +53,39 @@ import { noteHookOutput } from './observability.mjs';
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
 export const MODE_ADVISE = 'advise';
+/**
+ * Refusals off, everything else on.
+ *
+ * THE POSTURE THAT WAS MISSING. `off` is not "enforcement disabled" -- it exits
+ * the hook process (see adapter.mjs and stop-harvest.mjs), taking retrieval,
+ * injection and harvest with it. The experiment arms cannot express this either:
+ * they are cumulative, and every arm carrying retrieval also carries routing.
+ *
+ * So there was no way to run the knowledge graph without also refusing tool
+ * calls -- which is exactly the configuration a benchmark needed, since the
+ * enforcing default measured 1.687x vanilla Claude Code while `off` measured
+ * 0.904 with most of the product switched off.
+ *
+ * Quieter than `advise`: no refusal AND no routing advisory, because an
+ * advisory still spends context on every matched call.
+ */
+export const MODE_ASSIST = 'assist';
 export const MODE_OFF = 'off';
+
+/**
+ * Whether this posture may refuse a tool call.
+ *
+ * A PREDICATE RATHER THAN A THIRD `!==` COMPARISON. Two call sites in
+ * adapter.mjs previously excluded only `advise` -- one gating whether a refusal
+ * is emitted, one choosing between "a built-in call is denied" and "these are
+ * recommendations" in the session-start guidance. Adding a mode without
+ * updating both would have left assist telling the model its calls would be
+ * denied while allowing every one of them, and the next mode would have to
+ * find all the sites again.
+ */
+export function refusalsEnabled() {
+  return mode() === MODE_ENFORCE;
+}
 
 /**
  * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
@@ -64,6 +96,7 @@ export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
+  if (raw === MODE_ASSIST) return MODE_ASSIST;
   return MODE_ENFORCE;
 }
 
@@ -730,7 +763,10 @@ export function advise(context) {
  */
 export function enforce(reason, deniedBefore) {
   const current = mode();
-  if (current === MODE_OFF) allow();
+  // assist allows SILENTLY, like off and unlike advise: an advisory still
+  // spends context on every matched call, which is the cost assist exists to
+  // avoid while keeping the graph running.
+  if (current === MODE_OFF || current === MODE_ASSIST) allow();
   if (current === MODE_ADVISE || deniedBefore) advise(reason);
   deny(reason);
 }

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -25,7 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
-  MODE_ADVISE,
+  refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
   withEscape,
@@ -682,7 +682,7 @@ export function policyText(
     ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
     : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
   const enforcement = routes.length
-    ? canDeny && mode() !== MODE_ADVISE
+    ? canDeny && refusalsEnabled()
       ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
       : '\n\nThese are recommendations; the built-in tools remain available.'
     : '';
@@ -1310,7 +1310,7 @@ async function runHook(clientName, event, invocation) {
       client.canDeny &&
       event === 'pre-tool' &&
       !repeat &&
-      mode() !== MODE_ADVISE &&
+      refusalsEnabled() &&
       // Codex code mode presents orchestration as one outer `functions.exec`.
       // Refuse only when it contains one shell call; a multi-operation envelope
       // can include unrelated safe work that must not be discarded wholesale.

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -25,6 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
+  MODE_ASSIST,
   refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
@@ -678,14 +679,28 @@ export function policyText(
         : registrationProven
           ? 'The host supplied a proven empty optimizer MCP inventory for this session.'
           : 'This hook received no positive evidence that optimizer MCP tools are registered in this session.';
-  const routing = routes.length
-    ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
-    : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
-  const enforcement = routes.length
-    ? canDeny && refusalsEnabled()
-      ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
-      : '\n\nThese are recommendations; the built-in tools remain available.'
-    : '';
+  // ASSIST SAYS NOTHING ABOUT ROUTING. The routing list plus its "these are
+  // recommendations" tail cost ~800 bytes of context in every session, and
+  // under assist they advise about a mechanism that is switched off -- which is
+  // precisely the per-session overhead assist exists to remove. Measured: 813
+  // bytes emitted under assist against 898 under enforce, where the advice is
+  // at least true.
+  //
+  // The graph guidance below is deliberately NOT suppressed: retrieval and
+  // harvest are what assist keeps, so telling the model how to record findings
+  // still earns its place.
+  const advertiseRouting = mode() !== MODE_ASSIST;
+  const routing = !advertiseRouting
+    ? ''
+    : routes.length
+      ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
+      : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
+  const enforcement =
+    advertiseRouting && routes.length
+      ? canDeny && refusalsEnabled()
+        ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
+        : '\n\nThese are recommendations; the built-in tools remain available.'
+      : '';
   const utilities = [
     tools.has('optimize_session')
       ? 'When the context window gets tight, call optimize_session.'

--- a/integrations/opencode/hooks/lib/policy.mjs
+++ b/integrations/opencode/hooks/lib/policy.mjs
@@ -53,7 +53,39 @@ import { noteHookOutput } from './observability.mjs';
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
 export const MODE_ADVISE = 'advise';
+/**
+ * Refusals off, everything else on.
+ *
+ * THE POSTURE THAT WAS MISSING. `off` is not "enforcement disabled" -- it exits
+ * the hook process (see adapter.mjs and stop-harvest.mjs), taking retrieval,
+ * injection and harvest with it. The experiment arms cannot express this either:
+ * they are cumulative, and every arm carrying retrieval also carries routing.
+ *
+ * So there was no way to run the knowledge graph without also refusing tool
+ * calls -- which is exactly the configuration a benchmark needed, since the
+ * enforcing default measured 1.687x vanilla Claude Code while `off` measured
+ * 0.904 with most of the product switched off.
+ *
+ * Quieter than `advise`: no refusal AND no routing advisory, because an
+ * advisory still spends context on every matched call.
+ */
+export const MODE_ASSIST = 'assist';
 export const MODE_OFF = 'off';
+
+/**
+ * Whether this posture may refuse a tool call.
+ *
+ * A PREDICATE RATHER THAN A THIRD `!==` COMPARISON. Two call sites in
+ * adapter.mjs previously excluded only `advise` -- one gating whether a refusal
+ * is emitted, one choosing between "a built-in call is denied" and "these are
+ * recommendations" in the session-start guidance. Adding a mode without
+ * updating both would have left assist telling the model its calls would be
+ * denied while allowing every one of them, and the next mode would have to
+ * find all the sites again.
+ */
+export function refusalsEnabled() {
+  return mode() === MODE_ENFORCE;
+}
 
 /**
  * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
@@ -64,6 +96,7 @@ export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
+  if (raw === MODE_ASSIST) return MODE_ASSIST;
   return MODE_ENFORCE;
 }
 
@@ -730,7 +763,10 @@ export function advise(context) {
  */
 export function enforce(reason, deniedBefore) {
   const current = mode();
-  if (current === MODE_OFF) allow();
+  // assist allows SILENTLY, like off and unlike advise: an advisory still
+  // spends context on every matched call, which is the cost assist exists to
+  // avoid while keeping the graph running.
+  if (current === MODE_OFF || current === MODE_ASSIST) allow();
   if (current === MODE_ADVISE || deniedBefore) advise(reason);
   deny(reason);
 }

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -25,7 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
-  MODE_ADVISE,
+  refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
   withEscape,
@@ -682,7 +682,7 @@ export function policyText(
     ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
     : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
   const enforcement = routes.length
-    ? canDeny && mode() !== MODE_ADVISE
+    ? canDeny && refusalsEnabled()
       ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
       : '\n\nThese are recommendations; the built-in tools remain available.'
     : '';
@@ -1310,7 +1310,7 @@ async function runHook(clientName, event, invocation) {
       client.canDeny &&
       event === 'pre-tool' &&
       !repeat &&
-      mode() !== MODE_ADVISE &&
+      refusalsEnabled() &&
       // Codex code mode presents orchestration as one outer `functions.exec`.
       // Refuse only when it contains one shell call; a multi-operation envelope
       // can include unrelated safe work that must not be discarded wholesale.

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -25,6 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
+  MODE_ASSIST,
   refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
@@ -678,14 +679,28 @@ export function policyText(
         : registrationProven
           ? 'The host supplied a proven empty optimizer MCP inventory for this session.'
           : 'This hook received no positive evidence that optimizer MCP tools are registered in this session.';
-  const routing = routes.length
-    ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
-    : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
-  const enforcement = routes.length
-    ? canDeny && refusalsEnabled()
-      ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
-      : '\n\nThese are recommendations; the built-in tools remain available.'
-    : '';
+  // ASSIST SAYS NOTHING ABOUT ROUTING. The routing list plus its "these are
+  // recommendations" tail cost ~800 bytes of context in every session, and
+  // under assist they advise about a mechanism that is switched off -- which is
+  // precisely the per-session overhead assist exists to remove. Measured: 813
+  // bytes emitted under assist against 898 under enforce, where the advice is
+  // at least true.
+  //
+  // The graph guidance below is deliberately NOT suppressed: retrieval and
+  // harvest are what assist keeps, so telling the model how to record findings
+  // still earns its place.
+  const advertiseRouting = mode() !== MODE_ASSIST;
+  const routing = !advertiseRouting
+    ? ''
+    : routes.length
+      ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
+      : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
+  const enforcement =
+    advertiseRouting && routes.length
+      ? canDeny && refusalsEnabled()
+        ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
+        : '\n\nThese are recommendations; the built-in tools remain available.'
+      : '';
   const utilities = [
     tools.has('optimize_session')
       ? 'When the context window gets tight, call optimize_session.'

--- a/integrations/qwen/hooks/lib/policy.mjs
+++ b/integrations/qwen/hooks/lib/policy.mjs
@@ -53,7 +53,39 @@ import { noteHookOutput } from './observability.mjs';
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
 export const MODE_ADVISE = 'advise';
+/**
+ * Refusals off, everything else on.
+ *
+ * THE POSTURE THAT WAS MISSING. `off` is not "enforcement disabled" -- it exits
+ * the hook process (see adapter.mjs and stop-harvest.mjs), taking retrieval,
+ * injection and harvest with it. The experiment arms cannot express this either:
+ * they are cumulative, and every arm carrying retrieval also carries routing.
+ *
+ * So there was no way to run the knowledge graph without also refusing tool
+ * calls -- which is exactly the configuration a benchmark needed, since the
+ * enforcing default measured 1.687x vanilla Claude Code while `off` measured
+ * 0.904 with most of the product switched off.
+ *
+ * Quieter than `advise`: no refusal AND no routing advisory, because an
+ * advisory still spends context on every matched call.
+ */
+export const MODE_ASSIST = 'assist';
 export const MODE_OFF = 'off';
+
+/**
+ * Whether this posture may refuse a tool call.
+ *
+ * A PREDICATE RATHER THAN A THIRD `!==` COMPARISON. Two call sites in
+ * adapter.mjs previously excluded only `advise` -- one gating whether a refusal
+ * is emitted, one choosing between "a built-in call is denied" and "these are
+ * recommendations" in the session-start guidance. Adding a mode without
+ * updating both would have left assist telling the model its calls would be
+ * denied while allowing every one of them, and the next mode would have to
+ * find all the sites again.
+ */
+export function refusalsEnabled() {
+  return mode() === MODE_ENFORCE;
+}
 
 /**
  * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
@@ -64,6 +96,7 @@ export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
+  if (raw === MODE_ASSIST) return MODE_ASSIST;
   return MODE_ENFORCE;
 }
 
@@ -730,7 +763,10 @@ export function advise(context) {
  */
 export function enforce(reason, deniedBefore) {
   const current = mode();
-  if (current === MODE_OFF) allow();
+  // assist allows SILENTLY, like off and unlike advise: an advisory still
+  // spends context on every matched call, which is the cost assist exists to
+  // avoid while keeping the graph running.
+  if (current === MODE_OFF || current === MODE_ASSIST) allow();
   if (current === MODE_ADVISE || deniedBefore) advise(reason);
   deny(reason);
 }

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -25,7 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
-  MODE_ADVISE,
+  refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
   withEscape,
@@ -682,7 +682,7 @@ export function policyText(
     ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
     : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
   const enforcement = routes.length
-    ? canDeny && mode() !== MODE_ADVISE
+    ? canDeny && refusalsEnabled()
       ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
       : '\n\nThese are recommendations; the built-in tools remain available.'
     : '';
@@ -1310,7 +1310,7 @@ async function runHook(clientName, event, invocation) {
       client.canDeny &&
       event === 'pre-tool' &&
       !repeat &&
-      mode() !== MODE_ADVISE &&
+      refusalsEnabled() &&
       // Codex code mode presents orchestration as one outer `functions.exec`.
       // Refuse only when it contains one shell call; a multi-operation envelope
       // can include unrelated safe work that must not be discarded wholesale.

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -25,6 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
+  MODE_ASSIST,
   refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
@@ -678,14 +679,28 @@ export function policyText(
         : registrationProven
           ? 'The host supplied a proven empty optimizer MCP inventory for this session.'
           : 'This hook received no positive evidence that optimizer MCP tools are registered in this session.';
-  const routing = routes.length
-    ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
-    : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
-  const enforcement = routes.length
-    ? canDeny && refusalsEnabled()
-      ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
-      : '\n\nThese are recommendations; the built-in tools remain available.'
-    : '';
+  // ASSIST SAYS NOTHING ABOUT ROUTING. The routing list plus its "these are
+  // recommendations" tail cost ~800 bytes of context in every session, and
+  // under assist they advise about a mechanism that is switched off -- which is
+  // precisely the per-session overhead assist exists to remove. Measured: 813
+  // bytes emitted under assist against 898 under enforce, where the advice is
+  // at least true.
+  //
+  // The graph guidance below is deliberately NOT suppressed: retrieval and
+  // harvest are what assist keeps, so telling the model how to record findings
+  // still earns its place.
+  const advertiseRouting = mode() !== MODE_ASSIST;
+  const routing = !advertiseRouting
+    ? ''
+    : routes.length
+      ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
+      : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
+  const enforcement =
+    advertiseRouting && routes.length
+      ? canDeny && refusalsEnabled()
+        ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
+        : '\n\nThese are recommendations; the built-in tools remain available.'
+      : '';
   const utilities = [
     tools.has('optimize_session')
       ? 'When the context window gets tight, call optimize_session.'

--- a/integrations/windsurf/hooks/lib/policy.mjs
+++ b/integrations/windsurf/hooks/lib/policy.mjs
@@ -53,7 +53,39 @@ import { noteHookOutput } from './observability.mjs';
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
 export const MODE_ADVISE = 'advise';
+/**
+ * Refusals off, everything else on.
+ *
+ * THE POSTURE THAT WAS MISSING. `off` is not "enforcement disabled" -- it exits
+ * the hook process (see adapter.mjs and stop-harvest.mjs), taking retrieval,
+ * injection and harvest with it. The experiment arms cannot express this either:
+ * they are cumulative, and every arm carrying retrieval also carries routing.
+ *
+ * So there was no way to run the knowledge graph without also refusing tool
+ * calls -- which is exactly the configuration a benchmark needed, since the
+ * enforcing default measured 1.687x vanilla Claude Code while `off` measured
+ * 0.904 with most of the product switched off.
+ *
+ * Quieter than `advise`: no refusal AND no routing advisory, because an
+ * advisory still spends context on every matched call.
+ */
+export const MODE_ASSIST = 'assist';
 export const MODE_OFF = 'off';
+
+/**
+ * Whether this posture may refuse a tool call.
+ *
+ * A PREDICATE RATHER THAN A THIRD `!==` COMPARISON. Two call sites in
+ * adapter.mjs previously excluded only `advise` -- one gating whether a refusal
+ * is emitted, one choosing between "a built-in call is denied" and "these are
+ * recommendations" in the session-start guidance. Adding a mode without
+ * updating both would have left assist telling the model its calls would be
+ * denied while allowing every one of them, and the next mode would have to
+ * find all the sites again.
+ */
+export function refusalsEnabled() {
+  return mode() === MODE_ENFORCE;
+}
 
 /**
  * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
@@ -64,6 +96,7 @@ export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
+  if (raw === MODE_ASSIST) return MODE_ASSIST;
   return MODE_ENFORCE;
 }
 
@@ -730,7 +763,10 @@ export function advise(context) {
  */
 export function enforce(reason, deniedBefore) {
   const current = mode();
-  if (current === MODE_OFF) allow();
+  // assist allows SILENTLY, like off and unlike advise: an advisory still
+  // spends context on every matched call, which is the cost assist exists to
+  // avoid while keeping the graph running.
+  if (current === MODE_OFF || current === MODE_ASSIST) allow();
   if (current === MODE_ADVISE || deniedBefore) advise(reason);
   deny(reason);
 }

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -25,7 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
-  MODE_ADVISE,
+  refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
   withEscape,
@@ -682,7 +682,7 @@ export function policyText(
     ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
     : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
   const enforcement = routes.length
-    ? canDeny && mode() !== MODE_ADVISE
+    ? canDeny && refusalsEnabled()
       ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
       : '\n\nThese are recommendations; the built-in tools remain available.'
     : '';
@@ -1310,7 +1310,7 @@ async function runHook(clientName, event, invocation) {
       client.canDeny &&
       event === 'pre-tool' &&
       !repeat &&
-      mode() !== MODE_ADVISE &&
+      refusalsEnabled() &&
       // Codex code mode presents orchestration as one outer `functions.exec`.
       // Refuse only when it contains one shell call; a multi-operation envelope
       // can include unrelated safe work that must not be discarded wholesale.

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -25,6 +25,7 @@ import {
   alreadyDenied,
   mode,
   MODE_OFF,
+  MODE_ASSIST,
   refusalsEnabled,
   largeFileBytes,
   readPayloadResult,
@@ -678,14 +679,28 @@ export function policyText(
         : registrationProven
           ? 'The host supplied a proven empty optimizer MCP inventory for this session.'
           : 'This hook received no positive evidence that optimizer MCP tools are registered in this session.';
-  const routing = routes.length
-    ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
-    : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
-  const enforcement = routes.length
-    ? canDeny && refusalsEnabled()
-      ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
-      : '\n\nThese are recommendations; the built-in tools remain available.'
-    : '';
+  // ASSIST SAYS NOTHING ABOUT ROUTING. The routing list plus its "these are
+  // recommendations" tail cost ~800 bytes of context in every session, and
+  // under assist they advise about a mechanism that is switched off -- which is
+  // precisely the per-session overhead assist exists to remove. Measured: 813
+  // bytes emitted under assist against 898 under enforce, where the advice is
+  // at least true.
+  //
+  // The graph guidance below is deliberately NOT suppressed: retrieval and
+  // harvest are what assist keeps, so telling the model how to record findings
+  // still earns its place.
+  const advertiseRouting = mode() !== MODE_ASSIST;
+  const routing = !advertiseRouting
+    ? ''
+    : routes.length
+      ? `\n\nPrefer only the registered replacements listed below; they cache, diff, or bound output:\n\n${routes.join('\n')}`
+      : "\n\nKeep the CLI's native tools available and bound their output. Do not redirect to or call an optimizer MCP tool unless its schema is visible in the current tool inventory.";
+  const enforcement =
+    advertiseRouting && routes.length
+      ? canDeny && refusalsEnabled()
+        ? '\n\nA built-in call is denied only when its exact replacement has positive registration evidence. A second attempt at the same target remains available.'
+        : '\n\nThese are recommendations; the built-in tools remain available.'
+      : '';
   const utilities = [
     tools.has('optimize_session')
       ? 'When the context window gets tight, call optimize_session.'

--- a/plugin/hooks/lib/policy.mjs
+++ b/plugin/hooks/lib/policy.mjs
@@ -53,7 +53,39 @@ import { noteHookOutput } from './observability.mjs';
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
 export const MODE_ADVISE = 'advise';
+/**
+ * Refusals off, everything else on.
+ *
+ * THE POSTURE THAT WAS MISSING. `off` is not "enforcement disabled" -- it exits
+ * the hook process (see adapter.mjs and stop-harvest.mjs), taking retrieval,
+ * injection and harvest with it. The experiment arms cannot express this either:
+ * they are cumulative, and every arm carrying retrieval also carries routing.
+ *
+ * So there was no way to run the knowledge graph without also refusing tool
+ * calls -- which is exactly the configuration a benchmark needed, since the
+ * enforcing default measured 1.687x vanilla Claude Code while `off` measured
+ * 0.904 with most of the product switched off.
+ *
+ * Quieter than `advise`: no refusal AND no routing advisory, because an
+ * advisory still spends context on every matched call.
+ */
+export const MODE_ASSIST = 'assist';
 export const MODE_OFF = 'off';
+
+/**
+ * Whether this posture may refuse a tool call.
+ *
+ * A PREDICATE RATHER THAN A THIRD `!==` COMPARISON. Two call sites in
+ * adapter.mjs previously excluded only `advise` -- one gating whether a refusal
+ * is emitted, one choosing between "a built-in call is denied" and "these are
+ * recommendations" in the session-start guidance. Adding a mode without
+ * updating both would have left assist telling the model its calls would be
+ * denied while allowing every one of them, and the next mode would have to
+ * find all the sites again.
+ */
+export function refusalsEnabled() {
+  return mode() === MODE_ENFORCE;
+}
 
 /**
  * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
@@ -64,6 +96,7 @@ export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
+  if (raw === MODE_ASSIST) return MODE_ASSIST;
   return MODE_ENFORCE;
 }
 
@@ -730,7 +763,10 @@ export function advise(context) {
  */
 export function enforce(reason, deniedBefore) {
   const current = mode();
-  if (current === MODE_OFF) allow();
+  // assist allows SILENTLY, like off and unlike advise: an advisory still
+  // spends context on every matched call, which is the cost assist exists to
+  // avoid while keeping the graph running.
+  if (current === MODE_OFF || current === MODE_ASSIST) allow();
   if (current === MODE_ADVISE || deniedBefore) advise(reason);
   deny(reason);
 }

--- a/tests/hooks/assist-mode.test.mjs
+++ b/tests/hooks/assist-mode.test.mjs
@@ -132,3 +132,31 @@ describe('assist keeps the parts off destroys', () => {
     expect(assist.stdout.trim().length).toBeGreaterThan(0);
   });
 });
+
+describe('assist does not advertise routing it will not perform', () => {
+  const startUnder = (modeValue) =>
+    runHook(SESSION_START, { hook_event_name: 'SessionStart', cwd: workspace }, modeValue)
+      .stdout;
+
+  test('the routing advisory is suppressed', () => {
+    // The routing list and its "these are recommendations" tail cost context in
+    // every session, and under assist they describe a mechanism that is off --
+    // which is the per-session overhead assist exists to remove.
+    const out = startUnder('assist');
+    expect(out).not.toContain('Prefer only the registered');
+    expect(out).not.toContain('These are recommendations');
+    expect(out).not.toContain('denied only when');
+  });
+
+  test('but the graph guidance survives, which is the point of assist', () => {
+    // Guards against over-correction: suppressing the whole payload would make
+    // assist indistinguishable from off.
+    expect(startUnder('assist')).toContain('Record what you work out');
+  });
+
+  test('enforce still advertises routing, so this is scoped to assist', () => {
+    const out = startUnder('enforce');
+    expect(out).toContain('Prefer only the registered');
+    expect(out).toContain('denied only when');
+  });
+});

--- a/tests/hooks/assist-mode.test.mjs
+++ b/tests/hooks/assist-mode.test.mjs
@@ -1,0 +1,134 @@
+/**
+ * `assist` is the posture the product was missing: refusals off, graph on.
+ *
+ * Before this there was no way to run the knowledge graph without routing.
+ * `TOKEN_OPTIMIZER_MODE=off` exits the hook process outright -- adapter.mjs runs
+ * `if (mode() === MODE_OFF) process.exit(0)` before any event handling, and
+ * stop-harvest.mjs returns early on the same check -- so it takes retrieval,
+ * injection and harvest with it. The experiment arms cannot express it either:
+ * they are strictly cumulative, and every arm carrying retrieval also carries
+ * routing.
+ *
+ * That mattered because a benchmark measured the enforcing default at 1.687x
+ * vanilla Claude Code while `off` measured 0.904 -- but `off` is the product
+ * almost entirely disabled, so 0.904 was never the number a sane default could
+ * ship on. `assist` is the configuration that question actually needs.
+ *
+ * The load-bearing test here is the last one: it distinguishes `assist` from
+ * `off` by what the SESSION-START hook still does, which is the half `off`
+ * silently destroys. A test that only checked "a read is allowed" would pass
+ * identically for both and prove nothing.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { mode, MODE_ASSIST, MODE_ENFORCE, MODE_OFF } from '../../hooks-core/policy.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROUTER = join(HERE, '..', '..', 'plugin', 'hooks', 'pretooluse-router.mjs');
+const SESSION_START = join(HERE, '..', '..', 'plugin', 'hooks', 'session-start.mjs');
+
+const ISOLATED_GRAPH = mkdtempSync(join(tmpdir(), 'assist-graph-'));
+
+let workspace;
+let big;
+
+beforeAll(() => {
+  workspace = mkdtempSync(join(tmpdir(), 'assist-mode-'));
+  big = join(workspace, 'big.ts');
+  writeFileSync(big, 'x'.repeat(80_000));
+});
+
+afterAll(() => rmSync(workspace, { recursive: true, force: true }));
+
+// A UNIQUE SESSION PER CALL. Loop breaking and re-read detection are keyed on
+// the session, so reusing one id let an earlier assist run mark the target and
+// the later enforce run was allowed through by loop breaking -- the control
+// test failed for state left by its neighbours rather than for the mode.
+let sessionSeq = 0;
+
+function runHook(script, payload, modeValue) {
+  return spawnSync(process.execPath, [script], {
+    input: JSON.stringify({ session_id: `assist-${++sessionSeq}`, ...payload }),
+    encoding: 'utf8',
+    timeout: 30_000,
+    env: {
+      ...process.env,
+      TOKEN_OPTIMIZER_MODE: modeValue,
+      TOKEN_OPTIMIZER_MCP_CAPABILITIES:
+        'smart_read,smart_write,smart_edit,smart_glob,smart_grep,wiki_write',
+      TOKEN_OPTIMIZER_WIKI_DIR: ISOLATED_GRAPH,
+      TOKEN_OPTIMIZER_SHARED_DIR: ISOLATED_GRAPH,
+    },
+  });
+}
+
+const decisionOf = (result) => {
+  if (!result.stdout.trim()) return 'allow';
+  const out = JSON.parse(result.stdout).hookSpecificOutput || {};
+  return out.permissionDecision || (out.additionalContext ? 'advise' : 'allow');
+};
+
+// A FUNCTION, NOT A CONSTANT. `big` is assigned in beforeAll, so a module-scope
+// object captured `file_path: undefined` -- the router could not stat it and
+// allowed every call. The assist tests then PASSED VACUOUSLY, because `allow` is
+// exactly what an undefined path produces, and only the enforce control caught
+// it by expecting a deny that could never happen.
+const bigRead = () => ({ tool_name: 'Read', tool_input: { file_path: big } });
+
+describe('mode resolution', () => {
+  const withMode = (value, fn) => {
+    const prev = process.env.TOKEN_OPTIMIZER_MODE;
+    process.env.TOKEN_OPTIMIZER_MODE = value;
+    try {
+      return fn();
+    } finally {
+      if (prev === undefined) delete process.env.TOKEN_OPTIMIZER_MODE;
+      else process.env.TOKEN_OPTIMIZER_MODE = prev;
+    }
+  };
+
+  test('assist is reachable by exact opt-in', () => {
+    expect(withMode('assist', mode)).toBe(MODE_ASSIST);
+    expect(withMode('ASSIST', mode)).toBe(MODE_ASSIST);
+  });
+
+  test('the other postures are unchanged', () => {
+    expect(withMode('enforce', mode)).toBe(MODE_ENFORCE);
+    expect(withMode('off', mode)).toBe(MODE_OFF);
+  });
+});
+
+describe('assist does not refuse', () => {
+  test('a large read is allowed', () => {
+    expect(decisionOf(runHook(ROUTER, bigRead(), 'assist'))).toBe('allow');
+  });
+
+  test('and it does not merely downgrade to an advisory', () => {
+    // `advise` already exists and costs context on every matched call. assist is
+    // quieter than that: no refusal AND no routing advisory.
+    const r = runHook(ROUTER, bigRead(), 'assist');
+    expect(r.stdout.trim()).toBe('');
+  });
+
+  test('enforce still refuses, so this is a new posture not a global disable', () => {
+    expect(decisionOf(runHook(ROUTER, bigRead(), 'enforce'))).toBe('deny');
+  });
+});
+
+describe('assist keeps the parts off destroys', () => {
+  test('session-start still runs under assist but not under off', () => {
+    const payload = { hook_event_name: 'SessionStart', cwd: workspace };
+
+    const assist = runHook(SESSION_START, payload, 'assist');
+    const off = runHook(SESSION_START, payload, 'off');
+
+    // `off` exits before any event handling, so it can never emit context.
+    expect(off.stdout.trim()).toBe('');
+    // assist must not: the graph, injection and harvest are the point of it.
+    expect(assist.stdout.trim().length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Part of #357 (M0).

Unblocks the default-mode work. Spec: `docs/superpowers/specs/2026-08-29-benchmark-harness-and-competitive-program-design.md` (M0).

## The gap

There was no way to keep the knowledge graph while turning refusals off.

- **`off` is not "enforcement disabled".** `hooks-core/adapter.mjs` runs `if (mode() === MODE_OFF) process.exit(0);` **before any event handling**, and `hooks-core/stop-harvest.mjs` returns early on the same check. It takes retrieval, injection and harvest with it.
- **The experiment arms cannot express it either.** They are strictly cumulative — `baseline` → `optimizer {routing:true}` → `retrieval {routing:true, retrieval:true}` → `full`. **Every arm carrying retrieval also carries routing.** There is no `{routing:false, retrieval:true}`.

That mattered concretely: a local benchmark measured the enforcing default at **1.687×** vanilla Claude Code while `off` measured **0.904** — but `off` is the product almost entirely disabled, so 0.904 was never a number a default could ship on. `assist` is the configuration that comparison actually needs.

## The posture

`assist` = refusals off, everything else on. It **allows silently** rather than advising, because `advise` still spends context on every matched call — which is the cost `assist` exists to avoid.

## `refusalsEnabled()` rather than a third comparison

Two sites in `adapter.mjs` excluded only `MODE_ADVISE`: one gating whether a refusal is emitted, one choosing between *"a built-in call is denied"* and *"these are recommendations"* in the session-start guidance. Adding a mode without updating both would have left `assist` **telling the model its calls would be denied while allowing every one of them** — and the next mode would have to find the sites again. A predicate makes that a single point of truth.

## The default is unchanged

`assist` ships as the default only once measured. That is a later milestone, deliberately — shipping an unmeasured default is the mistake this whole line of work exists to correct.

`MODE_OFF` also keeps its documented meaning as the complete escape hatch; re-pointing it would leave no full off switch.

## Tests

`tests/hooks/assist-mode.test.mjs`, 6 tests. The load-bearing one distinguishes `assist` from `off` by what **session-start** still does — the half `off` silently destroys. A test that only checked "a read is allowed" would pass identically for both and prove nothing.

Worth recording: the first version of this suite **passed vacuously**. `bigRead` was built at module scope while `big` is assigned in `beforeAll`, so `file_path` was `undefined`, the router could not stat it, and every call was allowed — which is exactly what the assist tests asserted. Only the `enforce` control caught it, by expecting a deny that could never happen. The payload is now built lazily, and that control test is why the suite is trustworthy.

Lint clean; **92 suites / 1594 tests passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
