### PR TITLE
test(bench): move the benchmark harness into the repo

### DIFF
--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,4 +1,14 @@
+# Live credentials, staged per campaign. Also in .git/info/exclude, because a
+# per-branch ignore does not exist on branches cut before it -- which is exactly
+# how a token once reached this repository.
 auth/
-results/
-*.sqlite
+
+# Build artifact: the packed working tree the image installs.
 thol/pkg/
+
+# Raw run data. Large, machine-written, and reproducible from a campaign.
+results/runs/
+*.sqlite
+
+# NOT results/ itself. Published reports live there and MUST be committed: a
+# number nobody can trace to the versions that produced it is not evidence.

--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,3 +1,4 @@
 auth/
 results/
 *.sqlite
+thol/pkg/

--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,3 @@
+auth/
+results/
+*.sqlite

--- a/bench/README.md
+++ b/bench/README.md
@@ -106,5 +106,24 @@ MSYS_NO_PATHCONV=1 docker run --rm -v thol-results:/results \
      from runs where status=\"ok\" group by competitor;"'
 ```
 
-Write anything published to `bench/results/`, including the pinned Claude Code
-and product versions, so a number can always be traced to what produced it.
+## Publishing a result
+
+Write reports to `bench/results/` and **commit them**. `bench/.gitignore`
+excludes `results/runs/` and `*.sqlite` — the large machine-written run data,
+reproducible from a campaign — but not the reports themselves: a number nobody
+can trace to the versions that produced it is not evidence.
+
+Every report records the three things that make it reproducible:
+
+| | where it comes from |
+| --- | --- |
+| product commit | this repo's HEAD when `bench:build` packed it |
+| Claude Code version | `CLAUDE_VERSION` in `thol/Dockerfile` |
+| THOL revision | `THOL_REV` in `thol/Dockerfile` |
+
+**`THOL_REV` is pinned on purpose.** The harness is half of every measurement, so
+cloning its default branch would let their task, fixture or scoring changes move
+our numbers with nothing here having changed. Bumping it is a deliberate act that
+starts a **new campaign**: results either side of a bump are not comparable, and
+mixing them is exactly what the pin prevents. Record the bump next to the results
+it produced.

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,110 @@
+# bench/
+
+The harness that grades this project, kept beside the code it grades so a
+behaviour change and its measured effect can land in the same commit.
+
+It runs the **real** [Token-Harness Optimizer Leaderboard][thol] harness — cloned
+pinned at run time, with none of its code vendored here. The only artifacts we
+own are the manifests under `thol/manifests/`, which describe how *this* product
+is installed, and which are the same files we would submit upstream.
+
+[thol]: https://github.com/pi-infected/token-harness-optimizer-leaderboard
+
+Excluded from the npm `files` list, so users never download any of it.
+
+## Run it
+
+```bash
+npm run bench:build
+
+# screen: 1 rep, cheap, for triage
+REPS=1 SEGMENTS_MAX=4 npm run bench:screen     # ~48 runs, ~$13, ~1h
+
+# confirm: 3 reps, for anything published
+npm run bench:confirm
+```
+
+`SEGMENTS_MAX=4` skips the last segment, whose single task
+(`web-research-oss-inventory`) costs ~$5.01/run — over half the battery's total —
+and discriminates poorly between tools.
+
+## Authentication
+
+The campaign stages a **trimmed** copy of your Claude Code credentials into
+`bench/auth/` (gitignored): the `claudeAiOauth` key only, so OAuth secrets for
+unrelated MCP servers stay on the host.
+
+Credentials are re-staged **between segments** on purpose. THOL gives every run a
+throwaway `HOME` and copies credentials into it, so a token refresh that happens
+inside a sandbox dies with that sandbox. A full battery runs longer than an
+access token lives, and without re-staging the campaign fails partway with
+expired credentials.
+
+## What the numbers mean
+
+**Cost ratio** is a task's cost divided by the same task's cost on the `control`
+arm *of the same campaign*. Ratios are comparable across campaigns; absolute
+dollars are not, because campaigns pin different Claude Code versions.
+
+**`score`** is the task verifier's 0–1 correctness, from ground truth that is
+never present in the workspace. **A cost figure without its paired score is not a
+result** — a compressor that eats the answer looks excellent on cost alone.
+
+**`competitor_tool_calls` vs `tool_calls`** is the adoption signal: how much of
+the work went through our tools rather than the built-ins. High adoption is not
+success on its own; the tool that achieved the highest adoption on the public
+board also finished second-to-last on cost.
+
+## What it does not measure
+
+Every run gets a throwaway `HOME` and a fresh workspace, so **the knowledge graph
+starts empty on every run**, and a finding harvested at `Stop` cannot help the
+session that produced it. Single-shot ratios are therefore the graph's *worst
+case*, not a measurement of it. Measuring what the graph is actually for needs a
+multi-session benchmark, which is separate work.
+
+## Gotchas that cost real time
+
+Each of these is encoded in the scripts rather than left to be rediscovered:
+
+- **All three fixture generators must run.** THOL's `CONTRIBUTING.md` documents
+  only `generate_fixtures.py`; without `gen_longtasks.py` and
+  `gen_megatasks.py` the selftest aborts with `fixture 'cascade-debug' missing`.
+- **Fixtures are generated once and reused.** Regeneration is not reproducible in
+  practice despite the fixed seeds — repeated runs produced `cascade-debug` at
+  30/44, then 25/44, then 30/44. Within one segment every arm sees the same
+  files; across segments they would not, which would quietly make arms
+  incomparable.
+- **`/results` is a Docker named volume (`thol-results`), never a Windows bind
+  mount.** Deep trees such as a django checkout cannot be deleted through a bind
+  mount even from inside a Linux container. The volume is created root-owned and
+  must be chowned to the container's non-root user.
+- **The selftest workspace is cleared before each run.** `runner.py selftest`
+  builds scratch workspaces with `shutil.copytree`, which refuses a directory
+  that already exists, so a persistent `runs_root` makes the second segment die
+  with `FileExistsError` before spending anything.
+- **Containers are named** (`thol-campaign`) so a stray one can be found and
+  killed. An unnamed container outliving its wrapper held a directory lock and
+  produced two failures that looked like harness bugs.
+- **The manifest needs an `mcpServers` wrapper.** Without it every run dies in
+  ~1s with `Invalid MCP configuration: mcpServers: Invalid input`.
+- **The optimizer version must be pinned via a pre-seeded runtime.**
+  `plugin/launch.mjs` on a cold runtime serves whatever the npx cache holds, so
+  an image pinned to one version can measure another.
+
+## Reading results
+
+Results live in the `thol-results` volume, not on the host:
+
+```bash
+MSYS_NO_PATHCONV=1 docker run --rm -v thol-results:/results \
+  --entrypoint /bin/bash thol-rig:local -c \
+  'sqlite3 -column -header /results/results.sqlite "
+     select competitor, count(*) n, round(avg(total_cost_usd),4) mean_cost,
+            round(avg(num_turns),1) turns, sum(competitor_tool_calls) own,
+            sum(tool_calls) all_calls, round(avg(score),3) score
+     from runs where status=\"ok\" group by competitor;"'
+```
+
+Write anything published to `bench/results/`, including the pinned Claude Code
+and product versions, so a number can always be traced to what produced it.

--- a/bench/README.md
+++ b/bench/README.md
@@ -43,9 +43,12 @@ expired credentials.
 ## What the numbers mean
 
 **Cost ratio** is a task's cost divided by the same task's cost on the `control`
-arm *of the same campaign*. Ratios are comparable across campaigns; absolute
-dollars are not, because campaigns pin different Claude Code versions.
-
+arm *of the same campaign*. Ratios are comparable across campaigns **only when
+those campaigns share the same `THOL_REV`, task set, fixtures and scoring** --
+the ruler has to be the same for two measurements of it to mean anything.
+Absolute dollars are never comparable, because campaigns pin different Claude
+Code versions. A `THOL_REV` bump therefore starts a new campaign whose numbers
+do not line up with the previous one; see the publishing section below.
 **`score`** is the task verifier's 0–1 correctness, from ground truth that is
 never present in the workspace. **A cost figure without its paired score is not a
 result** — a compressor that eats the answer looks excellent on cost alone.
@@ -115,12 +118,19 @@ can trace to the versions that produced it is not evidence.
 
 Every report records the three things that make it reproducible:
 
-| | where it comes from |
-| --- | --- |
-| product commit | this repo's HEAD when `bench:build` packed it |
-| Claude Code version | `CLAUDE_VERSION` in `thol/Dockerfile` |
-| THOL revision | `THOL_REV` in `thol/Dockerfile` |
+| field | where it comes from | why it is not enough alone |
+| --- | --- | --- |
+| `tree` | git tree hash of exactly what `bench:pack` packed | the identity of record |
+| `dirty` | whether the working tree had uncommitted changes | a dirty tree is not the commit |
+| `head` / `branch` | the commit and branch it was built from | **cannot** identify a dirty input |
+| Claude Code version | `CLAUDE_VERSION` in `thol/Dockerfile` | |
+| THOL revision | `THOL_REV` in `thol/Dockerfile` | |
 
+**`tree` is the identity, not `head`.** `bench:build` packs the WORKING TREE, so
+two reports can share a commit and still have been built from different inputs.
+The tree hash is what tells them apart, and `dirty` is what warns you that the
+commit alone would mislead. Both are written to
+`results/provenance-<campaign>.json` by every campaign.
 **`THOL_REV` is pinned on purpose.** The harness is half of every measurement, so
 cloning its default branch would let their task, fixture or scoring changes move
 our numbers with nothing here having changed. Bumping it is a deliberate act that

--- a/bench/thol/Dockerfile
+++ b/bench/thol/Dockerfile
@@ -34,9 +34,18 @@ RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_VERSION}
 # as root, and every THOL run passes that flag.
 RUN useradd -ms /bin/bash bench
 
-# Our tool, installed globally the way install_competitors.sh installs every
-# other competitor that needs a binary on PATH before a run.
-RUN npm install -g @ooples/token-optimizer-mcp@${OPTIMIZER_VERSION}
+# THE WORKING TREE, NOT THE REGISTRY.
+#
+# `npm run bench:build` packs this repo into thol/pkg/optimizer.tgz first, so the
+# harness grades the code beside it. Installing from the registry instead meant
+# the image could not measure anything unreleased -- and worse, could do so
+# SILENTLY: an arm pinning a mode the published build does not recognise falls
+# back to the default, so two arms become identical and the campaign produces a
+# meaningless comparison rather than an error.
+#
+# To measure a published release, check out its tag and build from there.
+COPY thol/pkg/optimizer.tgz /tmp/optimizer.tgz
+RUN npm install -g /tmp/optimizer.tgz
 
 # Pre-seed a SHARED managed runtime for plugin/launch.mjs.
 #
@@ -61,8 +70,7 @@ RUN npm install -g @ooples/token-optimizer-mcp@${OPTIMIZER_VERSION}
 ENV TOKEN_OPTIMIZER_RUNTIME=/opt/token-optimizer-runtime
 RUN mkdir -p ${TOKEN_OPTIMIZER_RUNTIME}/versions/${OPTIMIZER_VERSION} \
     && cd ${TOKEN_OPTIMIZER_RUNTIME}/versions/${OPTIMIZER_VERSION} \
-    && npm install --prefix . --no-audit --no-fund \
-         @ooples/token-optimizer-mcp@${OPTIMIZER_VERSION} \
+    && npm install --prefix . --no-audit --no-fund /tmp/optimizer.tgz \
     && printf '%s' "${OPTIMIZER_VERSION}" > ${TOKEN_OPTIMIZER_RUNTIME}/current \
     && node -e "require('fs').writeFileSync(process.env.TOKEN_OPTIMIZER_RUNTIME + '/.last-refresh', String(Date.now()))" \
     && chown -R bench:bench ${TOKEN_OPTIMIZER_RUNTIME}

--- a/bench/thol/Dockerfile
+++ b/bench/thol/Dockerfile
@@ -1,0 +1,95 @@
+# THOL benchmark rig for token-optimizer-mcp.
+#
+# THOL assumes a Linux host: /tmp sandboxes, `sh -c` installers, and a
+# sanitized PATH. This image reproduces that faithfully so the numbers we get
+# are comparable in shape to a submittable campaign.
+#
+# We install ONLY what our three arms need (control, token-optimizer-mcp
+# enforced, token-optimizer-mcp with enforcement off). The Rust/uv toolchain
+# in THOL's setup/install_competitors.sh exists for codegraph, rtk, squeez,
+# graphify, headroom and code-review-graph -- none of which we are measuring --
+# so it is deliberately skipped. Adding it back is a one-line RUN if we ever
+# want to reproduce the full board locally.
+
+FROM node:22-bookworm
+
+ARG CLAUDE_VERSION=2.1.251
+# 6.0.2 is npm dist-tag `latest` as of 2026-08-29 -- what a user installing
+# today actually receives, which is what the benchmark should measure.
+ARG OPTIMIZER_VERSION=6.0.2
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      python3 python3-venv python3-pip git curl ca-certificates \
+      jq sqlite3 ripgrep less procps \
+    && rm -rf /var/lib/apt/lists/*
+
+# Claude Code is the harness under test. Pin it: leaderboard.py warns on mixed
+# versions, and a campaign is only valid on a single client version.
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_VERSION}
+
+# Created before the runtime seeding below so that chown can name the user
+# rather than guess a uid. Claude Code refuses --dangerously-skip-permissions
+# as root, and every THOL run passes that flag.
+RUN useradd -ms /bin/bash bench
+
+# Our tool, installed globally the way install_competitors.sh installs every
+# other competitor that needs a binary on PATH before a run.
+RUN npm install -g @ooples/token-optimizer-mcp@${OPTIMIZER_VERSION}
+
+# Pre-seed a SHARED managed runtime for plugin/launch.mjs.
+#
+# Why this is required, and not an optimisation. launch.mjs does not serve the
+# globally-installed copy: on a cold runtime it logs "no cached server;
+# installing latest" and npm-installs @latest into its own versions dir. Two
+# consequences for a benchmark, both fatal:
+#   1. version_pin becomes a fiction -- an image pinned to 6.0.1 measured 6.0.2;
+#   2. THOL gives every run a throwaway HOME, so the default runtime location
+#      (~/.token-optimizer/runtime) is empty on all 153 runs -- meaning 153
+#      cold npm installs, ~18s each, and a tool that can change under the
+#      campaign if anything is published mid-run.
+#
+# Seeding the layout launch.mjs expects (versions/<v>/node_modules/<pkg>, plus
+# a `current` marker) and pointing TOKEN_OPTIMIZER_RUNTIME at it outside the
+# sandbox HOME fixes all three, while still exercising the real shipped launch
+# path rather than bypassing it.
+#
+# .last-refresh must be seeded too: refreshDueNow() returns TRUE when the
+# marker is unreadable (plugin/launch.mjs, the `catch` falls through to
+# `return true`), so a large REFRESH_INTERVAL_MS alone does not pin anything.
+ENV TOKEN_OPTIMIZER_RUNTIME=/opt/token-optimizer-runtime
+RUN mkdir -p ${TOKEN_OPTIMIZER_RUNTIME}/versions/${OPTIMIZER_VERSION} \
+    && cd ${TOKEN_OPTIMIZER_RUNTIME}/versions/${OPTIMIZER_VERSION} \
+    && npm install --prefix . --no-audit --no-fund \
+         @ooples/token-optimizer-mcp@${OPTIMIZER_VERSION} \
+    && printf '%s' "${OPTIMIZER_VERSION}" > ${TOKEN_OPTIMIZER_RUNTIME}/current \
+    && node -e "require('fs').writeFileSync(process.env.TOKEN_OPTIMIZER_RUNTIME + '/.last-refresh', String(Date.now()))" \
+    && chown -R bench:bench ${TOKEN_OPTIMIZER_RUNTIME}
+
+USER bench
+WORKDIR /home/bench
+
+RUN git clone --depth 1 https://github.com/pi-infected/token-harness-optimizer-leaderboard.git thol
+
+# THOL ships no requirements.txt: fixtures/generate_fixtures.py, tasks/_vlib.py
+# and every verify.py import stdlib only. So there is nothing to pip install,
+# and no venv is needed to work around Debian's PEP 668 protection.
+ENV THOL_HOME=/home/bench/thol
+
+# Pin the optimizer's warm-launch shim to the installed copy. launch.mjs
+# background-refreshes to @latest every 6h by default, which would let the
+# measured version drift mid-campaign; a very large interval makes it serve the
+# pinned build until the runtime dir is cleared. This keeps the faithful launch
+# path (what real users run) while satisfying THOL's version_pin requirement.
+ENV TOKEN_OPTIMIZER_REFRESH_INTERVAL_MS=999999999999
+
+# Paths are relative to the build context, which is `bench/` -- so builds run as
+# `docker build -f bench/thol/Dockerfile bench/`. The rig this came from used
+# `bench/` as both context and script root; here the scripts live one level
+# deeper, under thol/.
+COPY --chown=bench:bench thol/entrypoint.sh /home/bench/scripts/entrypoint.sh
+COPY --chown=bench:bench thol/manifests/ /home/bench/manifests/
+
+ENTRYPOINT ["/bin/bash", "/home/bench/scripts/entrypoint.sh"]
+CMD ["selftest"]

--- a/bench/thol/Dockerfile
+++ b/bench/thol/Dockerfile
@@ -45,6 +45,9 @@ RUN useradd -ms /bin/bash bench
 #
 # To measure a published release, check out its tag and build from there.
 COPY thol/pkg/optimizer.tgz /tmp/optimizer.tgz
+# The tree that produced the tarball, so a result is attributable to exact
+# content rather than to a version string that cannot tell two branches apart.
+COPY thol/pkg/provenance.json /opt/optimizer-provenance.json
 RUN npm install -g /tmp/optimizer.tgz
 
 # Pre-seed a SHARED managed runtime for plugin/launch.mjs.

--- a/bench/thol/Dockerfile
+++ b/bench/thol/Dockerfile
@@ -78,7 +78,21 @@ RUN mkdir -p ${TOKEN_OPTIMIZER_RUNTIME}/versions/${OPTIMIZER_VERSION} \
 USER bench
 WORKDIR /home/bench
 
-RUN git clone --depth 1 https://github.com/pi-infected/token-harness-optimizer-leaderboard.git thol
+# PINNED, because the harness is half of every measurement.
+#
+# Cloning the default branch meant a rebuild could pick up THOL task, fixture or
+# scoring changes, so the same optimizer build would score differently on two
+# days with nothing in this repo having changed -- which destroys the only thing
+# a benchmark is for. Ratios are compared across campaigns; that comparison is
+# meaningless if the ruler moves.
+#
+# Bumping this is a deliberate act that starts a NEW campaign: results either
+# side of a bump are not comparable, and mixing them is the mistake the pin
+# exists to prevent. Record the bump alongside the results it produced.
+ARG THOL_REV=5ee6ea7f81dc21db1aae8d359cda3e1f7ded6dde
+RUN git clone https://github.com/pi-infected/token-harness-optimizer-leaderboard.git thol \
+    && git -C thol checkout --quiet ${THOL_REV} \
+    && test "$(git -C thol rev-parse HEAD)" = "${THOL_REV}"
 
 # THOL ships no requirements.txt: fixtures/generate_fixtures.py, tasks/_vlib.py
 # and every verify.py import stdlib only. So there is nothing to pip install,

--- a/bench/thol/entrypoint.sh
+++ b/bench/thol/entrypoint.sh
@@ -130,7 +130,12 @@ PY
   # PYTHONHASHSEED is pinned as well, so a fresh /results also regenerates the
   # same way rather than merely being self-consistent.
   export PYTHONHASHSEED=0
-  if [ -d /results/fixtures/out ] && [ -d /results/fixtures/truth ]; then
+  # A COMPLETION MARKER, not the mere existence of the directories. Presence
+  # cannot distinguish a finished fixture set from one abandoned mid-copy, and
+  # the failure is silent: a missing fixture scores as a failed task rather than
+  # as a broken cache. The marker is written last, so it exists only if
+  # everything before it did.
+  if [ -f /results/fixtures/.complete ]; then
     echo "   reusing the persisted fixture set (identical across segments)"
     rm -rf fixtures/out fixtures/truth
     ln -sfn /results/fixtures/out fixtures/out
@@ -140,9 +145,24 @@ PY
     python3 fixtures/gen_longtasks.py
     python3 fixtures/gen_megatasks.py
     if [ -d /results ] && [ -w /results ]; then
-      mkdir -p /results/fixtures
-      cp -r fixtures/out /results/fixtures/out
-      cp -r fixtures/truth /results/fixtures/truth
+      # PUBLISH ATOMICALLY. Copying directly into the final path leaves a
+      # half-written fixture set if the process dies mid-copy, and the next run
+      # sees `out` and `truth` present, takes the reuse branch, and measures
+      # against fixtures that are missing files -- silently, because a missing
+      # fixture reads as a task that scores zero rather than as a broken cache.
+      # `cp -r a b` when `b` already exists also nests as `b/a`, which is the
+      # same failure wearing a different shape.
+      #
+      # So: stage under a temp name, then move into place only once complete.
+      rm -rf /results/fixtures.tmp
+      mkdir -p /results/fixtures.tmp
+      cp -r fixtures/out /results/fixtures.tmp/out
+      cp -r fixtures/truth /results/fixtures.tmp/truth
+      # Written LAST, inside the staging dir, so it can only exist on a set that
+      # copied completely.
+      : > /results/fixtures.tmp/.complete
+      rm -rf /results/fixtures
+      mv /results/fixtures.tmp /results/fixtures
       echo "   fixture set persisted for later segments"
     fi
   fi

--- a/bench/thol/entrypoint.sh
+++ b/bench/thol/entrypoint.sh
@@ -40,22 +40,63 @@ prepare() {
   # master-based image resolved TOKEN_OPTIMIZER_MODE=assist to `enforce`.
   #
   # Cheap to check, and the failure it prevents is otherwise invisible.
-  log "Verifying every arm's mode is recognised by the packaged build"
+  log "Provenance of the build under test"
   PKG=/usr/local/lib/node_modules/@ooples/token-optimizer-mcp
+  if [ -f /opt/optimizer-provenance.json ]; then
+    node -e "
+      const p = require('/opt/optimizer-provenance.json');
+      console.log('   tree    ' + p.tree + (p.dirty ? '  (DIRTY working tree)' : ''));
+      console.log('   head    ' + p.head + '  on ' + p.branch);
+      console.log('   version ' + p.version);
+    "
+  else
+    die "no provenance record in the image; a result that cannot be attributed to a tree is not evidence. Rebuild with 'npm run bench:build'."
+  fi
+
+  # ASSERT CAPABILITY, NOT PROVENANCE.
+  #
+  # Recording the tree says WHAT was built; it does not say the build behaves as
+  # an arm assumes. Those are different failures and both are silent: `mode()`
+  # maps an unrecognised value to the default, and a graph "disabled" by a
+  # variable the build predates simply stays on. Either produces two arms that
+  # differ only in their name, and a campaign that looks real and means nothing.
+  #
+  # So each arm's declared configuration is EXERCISED against the packaged build
+  # rather than assumed from the branch it came from. That is why waiting for a
+  # merge was the wrong instrument: merge status is a proxy for behaviour, and
+  # this checks the behaviour directly.
+  log "Asserting every arm's declared capability against the packaged build"
   for manifest in /home/bench/manifests/*/manifest.json; do
-    want="$(node -e "
-      const m = require('$manifest');
-      process.stdout.write(m.settings?.env?.TOKEN_OPTIMIZER_MODE || '');
-    ")"
-    [ -n "$want" ] || continue
-    got="$(TOKEN_OPTIMIZER_MODE="$want" node --input-type=module -e "
-      const p = await import('file://$PKG/hooks-core/policy.mjs');
-      process.stdout.write(p.mode());
-    ")"
-    if [ "$got" != "$want" ]; then
-      die "arm $(basename "$(dirname "$manifest")") declares TOKEN_OPTIMIZER_MODE=$want but the packaged build resolves it to '$got'. That arm would silently measure '$got'. Build from a tree that supports '$want'."
+    arm="$(basename "$(dirname "$manifest")")"
+
+    want="$(node -e "const m=require('$manifest');process.stdout.write(m.settings?.env?.TOKEN_OPTIMIZER_MODE||'')")"
+    if [ -n "$want" ]; then
+      got="$(TOKEN_OPTIMIZER_MODE="$want" node --input-type=module -e "
+        const p = await import('file://$PKG/hooks-core/policy.mjs');
+        process.stdout.write(p.mode());
+      ")"
+      [ "$got" = "$want" ] || die "arm $arm declares TOKEN_OPTIMIZER_MODE=$want but the packaged build resolves it to '$got'. That arm would silently measure '$got'. Build from a tree that supports '$want'."
+      echo "   $arm: mode=$want resolves correctly"
     fi
-    echo "   $(basename "$(dirname "$manifest")"): $want ok"
+
+    # The graph switch cannot be checked by resolving a name -- an export can
+    # exist and gate nothing -- so this exercises the writers and counts what
+    # reaches disk.
+    nograph="$(node -e "const m=require('$manifest');process.stdout.write(m.settings?.env?.TOKEN_OPTIMIZER_WIKI_DISABLED||'')")"
+    if [ -n "$nograph" ]; then
+      wrote="$(TOKEN_OPTIMIZER_WIKI_DISABLED="$nograph" node --input-type=module -e "
+        import { mkdtempSync, readdirSync } from 'node:fs';
+        import { join } from 'node:path';
+        import { tmpdir } from 'node:os';
+        const dir = mkdtempSync(join(tmpdir(), 'nograph-'));
+        const w = await import('file://$PKG/hooks-core/wiki.mjs');
+        w.putNode(dir, { kind: 'file', key: '/tmp/a.ts', hash: 'x', bytes: 1 });
+        w.putEdge(dir, 'a', 'related', 'b');
+        process.stdout.write(String(readdirSync(dir).length));
+      " 2>/dev/null || echo "error")"
+      [ "$wrote" = "0" ] || die "arm $arm declares TOKEN_OPTIMIZER_WIKI_DISABLED=$nograph but the packaged build still wrote $wrote graph file(s). That arm would measure a graph that is running. Build from a tree that supports it."
+      echo "   $arm: graph gate is inert"
+    fi
   done
 
   log "Registering our manifests in the THOL competitor registry"
@@ -192,6 +233,25 @@ case "$MODE" in
     prepare
     cd "$THOL_HOME"
     : "${THOL_CAMPAIGN:?set THOL_CAMPAIGN to the Claude Code version label}"
+
+    # THE TREE TRAVELS WITH THE DATA. runner.py stores the campaign label on
+    # every run row, so folding the tree hash into it is what makes a row
+    # self-describing: the number and the exact content that produced it live
+    # together, and rows from two different trees can never be pooled by
+    # accident. Provenance recorded only in a log line is provenance that is
+    # lost the moment someone queries the database.
+    #
+    # 12 hex characters, which is unambiguous in practice and keeps the label
+    # readable in leaderboard output.
+    if [ -f /opt/optimizer-provenance.json ]; then
+      TREE="$(node -e "
+        const p = require('/opt/optimizer-provenance.json');
+        process.stdout.write(p.tree.slice(0, 12) + (p.dirty ? '-dirty' : ''));
+      ")"
+      THOL_CAMPAIGN="$THOL_CAMPAIGN tree:$TREE"
+      export THOL_CAMPAIGN
+    fi
+
     log "Campaign: $THOL_CAMPAIGN"
     python3 runner.py run "$@"
     log "Building leaderboard"

--- a/bench/thol/entrypoint.sh
+++ b/bench/thol/entrypoint.sh
@@ -31,6 +31,33 @@ prepare() {
     die "No auth. Mount a trimmed credentials file at /auth/credentials.json or set ANTHROPIC_API_KEY."
   fi
 
+  # EVERY DECLARED MODE MUST BE ONE THE PACKAGED BUILD RECOGNISES.
+  #
+  # `mode()` maps an unrecognised value to the default, silently. So an arm
+  # pinning a posture the build predates does not fail -- it quietly measures
+  # the default, two arms become identical, and the campaign produces a
+  # meaningless comparison that looks exactly like a real one. Verified: a
+  # master-based image resolved TOKEN_OPTIMIZER_MODE=assist to `enforce`.
+  #
+  # Cheap to check, and the failure it prevents is otherwise invisible.
+  log "Verifying every arm's mode is recognised by the packaged build"
+  PKG=/usr/local/lib/node_modules/@ooples/token-optimizer-mcp
+  for manifest in /home/bench/manifests/*/manifest.json; do
+    want="$(node -e "
+      const m = require('$manifest');
+      process.stdout.write(m.settings?.env?.TOKEN_OPTIMIZER_MODE || '');
+    ")"
+    [ -n "$want" ] || continue
+    got="$(TOKEN_OPTIMIZER_MODE="$want" node --input-type=module -e "
+      const p = await import('file://$PKG/hooks-core/policy.mjs');
+      process.stdout.write(p.mode());
+    ")"
+    if [ "$got" != "$want" ]; then
+      die "arm $(basename "$(dirname "$manifest")") declares TOKEN_OPTIMIZER_MODE=$want but the packaged build resolves it to '$got'. That arm would silently measure '$got'. Build from a tree that supports '$want'."
+    fi
+    echo "   $(basename "$(dirname "$manifest")"): $want ok"
+  done
+
   log "Registering our manifests in the THOL competitor registry"
   for d in /home/bench/manifests/*/; do
     name="$(basename "$d")"

--- a/bench/thol/entrypoint.sh
+++ b/bench/thol/entrypoint.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# THOL rig entrypoint. Modes: selftest | calibrate | campaign | report | shell
+#
+# Everything that must be true before a single dollar of inference is spent
+# happens in prepare(): credentials in place, our manifests registered,
+# fixtures generated deterministically, verifiers passing. runner.py selftest
+# is the gate -- it proves each verifier awards no credit on an empty
+# workspace, which is what stops a broken task silently scoring every arm the
+# same.
+
+set -euo pipefail
+
+MODE="${1:-selftest}"
+shift || true
+
+log() { printf '\n\033[1;36m>> %s\033[0m\n' "$*"; }
+die() { printf '\n\033[1;31m!! %s\033[0m\n' "$*" >&2; exit 1; }
+
+prepare() {
+  log "Authenticating"
+  if [ -f /auth/credentials.json ]; then
+    mkdir -p "$HOME/.claude"
+    cp /auth/credentials.json "$HOME/.claude/.credentials.json"
+    chmod 600 "$HOME/.claude/.credentials.json"
+    # runner.py copies this file into every throwaway sandbox HOME
+    # (runner.py:129), which is what makes subscription auth survive isolation.
+    echo "   subscription credentials staged for sandbox copy"
+  elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    echo "   using ANTHROPIC_API_KEY from environment"
+  else
+    die "No auth. Mount a trimmed credentials file at /auth/credentials.json or set ANTHROPIC_API_KEY."
+  fi
+
+  log "Registering our manifests in the THOL competitor registry"
+  for d in /home/bench/manifests/*/; do
+    name="$(basename "$d")"
+    mkdir -p "$THOL_HOME/competitors/$name"
+    cp "$d/manifest.json" "$THOL_HOME/competitors/$name/manifest.json"
+    echo "   + $name"
+  done
+
+  cd "$THOL_HOME"
+
+  # Persist the results DB and per-run artifacts outside the container, or a
+  # --rm run throws away everything it just paid for. runner.py resumes from
+  # results.sqlite, so this is also what makes the campaign restartable after
+  # a credential expiry or an interrupted segment.
+  if [ -d /results ] && [ -w /results ]; then
+    log "Persisting results to the mounted volume"
+    mkdir -p /results/runs
+    python3 - <<'PY'
+import json, pathlib
+cfg = pathlib.Path("bench.config.json")
+data = json.loads(cfg.read_text())
+data["runs_root"] = "/results/runs"
+cfg.write_text(json.dumps(data, indent=1) + "\n")
+print("   runs_root -> /results/runs")
+PY
+    [ -e /results/results.sqlite ] || : > /results/results.sqlite
+    ln -sf /results/results.sqlite "$THOL_HOME/results.sqlite"
+    echo "   results.sqlite -> /results/results.sqlite"
+
+    # runner.py caches cloned benchmark repos under ROOT/.cache/repos
+    # (runner.py:32) and npm/uv/hf caches beside them. Without persisting this,
+    # every segment re-clones django and cobra from scratch -- minutes of wall
+    # time per segment, repeated, for bytes that never change (repos.lock.json
+    # pins exact commits).
+    mkdir -p /results/.cache
+    rm -rf "$THOL_HOME/.cache"
+    ln -sfn /results/.cache "$THOL_HOME/.cache"
+    echo "   .cache -> /results/.cache (repo + npm caches persist across segments)"
+  else
+    echo "   WARNING: /results not mounted -- run data will be lost when the container exits"
+  fi
+
+  # runner.py selftest builds scratch workspaces at runs_root/selftest/<task>
+  # with shutil.copytree, which refuses a directory that already exists. Once
+  # runs_root is persistent (above), the second segment dies with
+  # FileExistsError before spending anything. These are throwaway workspaces,
+  # not results, so clearing them is safe and required.
+  rm -rf /results/runs/selftest 2>/dev/null || true
+
+  log "Generating deterministic fixtures"
+  # Seed of record is 42 for every campaign up to 2.1.183; THOL_FIXTURE_SEED
+  # overrides it. Byte-identical across regenerations for a given seed.
+  #
+  # THOL's CONTRIBUTING.md documents only generate_fixtures.py, but that is
+  # incomplete: the long- and mega-task generators produce ledger-debug,
+  # code-debug, cascade-debug and pipeline-debug, and `runner.py selftest`
+  # aborts with "fixture 'cascade-debug' missing" without them. All three must
+  # run, in this order.
+  #
+  # GENERATE ONCE, THEN REUSE. Regeneration is not reliably reproducible in
+  # practice: two runs of gen_megatasks.py in this image produced
+  # "cascade-debug: shipped RED 30/44" and then "25/44" despite its fixed
+  # random.Random(20260619) seed, so something outside the seed (dict/set
+  # iteration order under hash randomisation is the usual culprit) reaches the
+  # output. That is survivable within one segment, where every arm sees the
+  # same files, but a SEGMENTED campaign would hand different segments
+  # different fixtures and quietly make the arms incomparable. Persisting the
+  # first generation removes the question entirely.
+  #
+  # PYTHONHASHSEED is pinned as well, so a fresh /results also regenerates the
+  # same way rather than merely being self-consistent.
+  export PYTHONHASHSEED=0
+  if [ -d /results/fixtures/out ] && [ -d /results/fixtures/truth ]; then
+    echo "   reusing the persisted fixture set (identical across segments)"
+    rm -rf fixtures/out fixtures/truth
+    ln -sfn /results/fixtures/out fixtures/out
+    ln -sfn /results/fixtures/truth fixtures/truth
+  else
+    python3 fixtures/generate_fixtures.py
+    python3 fixtures/gen_longtasks.py
+    python3 fixtures/gen_megatasks.py
+    if [ -d /results ] && [ -w /results ]; then
+      mkdir -p /results/fixtures
+      cp -r fixtures/out /results/fixtures/out
+      cp -r fixtures/truth /results/fixtures/truth
+      echo "   fixture set persisted for later segments"
+    fi
+  fi
+
+  log "Verifier selftest (gate: must PASS before any spend)"
+  python3 runner.py selftest || die "selftest failed -- do not spend money on a harness whose verifiers are broken"
+}
+
+case "$MODE" in
+  selftest)
+    prepare
+    log "Rig is ready. Competitors available:"
+    cd "$THOL_HOME" && python3 runner.py list
+    ;;
+
+  calibrate)
+    # Measure the control's own variance before comparing anything to it.
+    # THOL's protocol step 1: no competitor delta smaller than the control
+    # noise floor may be presented as a real effect.
+    prepare
+    cd "$THOL_HOME"
+    log "Calibrating control noise floor"
+    python3 runner.py stabilize -c control -t all "$@"
+    ;;
+
+  campaign)
+    prepare
+    cd "$THOL_HOME"
+    : "${THOL_CAMPAIGN:?set THOL_CAMPAIGN to the Claude Code version label}"
+    log "Campaign: $THOL_CAMPAIGN"
+    python3 runner.py run "$@"
+    log "Building leaderboard"
+    python3 leaderboard.py || true
+    if [ -d /results ] && [ -w /results ]; then
+      mkdir -p /results/leaderboard
+      cp -f docs/data/results.json /results/leaderboard/ 2>/dev/null || true
+      echo "   leaderboard JSON copied to /results/leaderboard/"
+    fi
+    ;;
+
+  report)
+    cd "$THOL_HOME"
+    python3 leaderboard.py
+    ;;
+
+  shell)
+    exec /bin/bash
+    ;;
+
+  *)
+    die "Unknown mode '$MODE'. Use: selftest | calibrate | campaign | report | shell"
+    ;;
+esac

--- a/bench/thol/entrypoint.sh
+++ b/bench/thol/entrypoint.sh
@@ -234,24 +234,31 @@ case "$MODE" in
     cd "$THOL_HOME"
     : "${THOL_CAMPAIGN:?set THOL_CAMPAIGN to the Claude Code version label}"
 
-    # THE TREE TRAVELS WITH THE DATA. runner.py stores the campaign label on
-    # every run row, so folding the tree hash into it is what makes a row
-    # self-describing: the number and the exact content that produced it live
-    # together, and rows from two different trees can never be pooled by
-    # accident. Provenance recorded only in a log line is provenance that is
-    # lost the moment someone queries the database.
+    # THE TREE IS RECORDED BESIDE THE CAMPAIGN, NOT INSIDE IT.
     #
-    # 12 hex characters, which is unambiguous in practice and keeps the label
-    # readable in leaderboard output.
-    if [ -f /opt/optimizer-provenance.json ]; then
-      TREE="$(node -e "
+    # An earlier version appended `tree:<hash>` to THOL_CAMPAIGN so provenance
+    # would ride along on every run row. That breaks EVERY run: runner.py gates
+    # on `cver.startswith(want)`, so a THOL_CAMPAIGN longer than the detected
+    # client version exits with "campaign pin mismatch" before any work happens.
+    # Verified: "2.1.251 (Claude Code)" does not start with
+    # "2.1.251 (Claude Code) tree:713161d04c37".
+    #
+    # The selftest gate did not catch it, because that check runs on the
+    # campaign path only -- which is exactly why a review caught it instead.
+    #
+    # So THOL_CAMPAIGN stays exactly the client version, and the tree is written
+    # beside the results, keyed by campaign, where a reader joins the two.
+    if [ -f /opt/optimizer-provenance.json ] && [ -d /results ] && [ -w /results ]; then
+      node -e "
+        const fs = require('fs');
         const p = require('/opt/optimizer-provenance.json');
-        process.stdout.write(p.tree.slice(0, 12) + (p.dirty ? '-dirty' : ''));
-      ")"
-      THOL_CAMPAIGN="$THOL_CAMPAIGN tree:$TREE"
-      export THOL_CAMPAIGN
+        const slug = String(process.env.THOL_CAMPAIGN).replace(/[^A-Za-z0-9.-]+/g, '_');
+        const out = '/results/provenance-' + slug + '.json';
+        fs.writeFileSync(out, JSON.stringify({ campaign: process.env.THOL_CAMPAIGN, ...p }, null, 2) + '
+');
+        console.log('   provenance -> ' + out);
+      "
     fi
-
     log "Campaign: $THOL_CAMPAIGN"
     python3 runner.py run "$@"
     log "Building leaderboard"

--- a/bench/thol/manifests/token-optimizer-mcp-off/manifest.json
+++ b/bench/thol/manifests/token-optimizer-mcp-off/manifest.json
@@ -1,0 +1,92 @@
+{
+  "name": "token-optimizer-mcp-off",
+  "display_name": "Token Optimizer MCP (enforcement off)",
+  "verified": true,
+  "version_pin": "6.0.2",
+  "version_checked": "2026-08-29",
+  "upstream": "https://github.com/ooples/token-optimizer-mcp",
+  "install_doc": "CONTROL ARM FOR THE ENFORCEMENT A/B. Identical to the token-optimizer-mcp manifest -- same pinned 6.0.2 runtime, same MCP server, same five hooks -- except TOKEN_OPTIMIZER_MODE=off, which disables the PreToolUse refusal path while leaving the MCP server, its tool schemas, the knowledge graph and every other hook in place. Comparing this arm against token-optimizer-mcp isolates the cost of enforcement alone, with the MCP schema tax and graph overhead present on both sides.",
+  "requires": [
+    "node"
+  ],
+  "mcp": {
+    "mcpServers": {
+      "token-optimizer": {
+        "command": "node",
+        "args": [
+          "/usr/local/lib/node_modules/@ooples/token-optimizer-mcp/plugin/launch.mjs"
+        ],
+        "env": {
+          "TOKEN_OPTIMIZER_REFRESH_INTERVAL_MS": "999999999999",
+          "TOKEN_OPTIMIZER_RUNTIME": "/opt/token-optimizer-runtime",
+          "TOKEN_OPTIMIZER_MODE": "off"
+        },
+        "type": "stdio"
+      }
+    }
+  },
+  "settings": {
+    "env": {
+      "TOKEN_OPTIMIZER_REFRESH_INTERVAL_MS": "999999999999",
+      "TOKEN_OPTIMIZER_RUNTIME": "/opt/token-optimizer-runtime",
+      "TOKEN_OPTIMIZER_MODE": "off"
+    },
+    "hooks": {
+      "SessionStart": [
+        {
+          "hooks": [
+            {
+              "type": "command",
+              "command": "node \"/usr/local/lib/node_modules/@ooples/token-optimizer-mcp/plugin/hooks/session-start.mjs\""
+            }
+          ]
+        }
+      ],
+      "PreToolUse": [
+        {
+          "matcher": "Read|Grep|Glob|Edit|MultiEdit|Write|Bash|PowerShell",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "node \"/usr/local/lib/node_modules/@ooples/token-optimizer-mcp/plugin/hooks/pretooluse-router.mjs\""
+            }
+          ]
+        }
+      ],
+      "PreCompact": [
+        {
+          "hooks": [
+            {
+              "type": "command",
+              "command": "node \"/usr/local/lib/node_modules/@ooples/token-optimizer-mcp/plugin/hooks/precompact-optimize.mjs\""
+            }
+          ]
+        }
+      ],
+      "PostToolUse": [
+        {
+          "matcher": "Edit|MultiEdit|Write|Bash|PowerShell|mcp__.*__(?:smart_edit|smart_write)",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "node \"/usr/local/lib/node_modules/@ooples/token-optimizer-mcp/plugin/hooks/post-tool.mjs\""
+            }
+          ]
+        }
+      ],
+      "Stop": [
+        {
+          "hooks": [
+            {
+              "type": "command",
+              "command": "node \"/usr/local/lib/node_modules/@ooples/token-optimizer-mcp/plugin/hooks/stop.mjs\""
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "tool_prefixes": [
+    "mcp__token-optimizer__"
+  ]
+}

--- a/bench/thol/manifests/token-optimizer-mcp/manifest.json
+++ b/bench/thol/manifests/token-optimizer-mcp/manifest.json
@@ -1,0 +1,90 @@
+{
+  "name": "token-optimizer-mcp",
+  "display_name": "Token Optimizer MCP",
+  "verified": true,
+  "version_pin": "6.0.2",
+  "version_checked": "2026-08-29",
+  "upstream": "https://github.com/ooples/token-optimizer-mcp",
+  "install_doc": "Transcribed from README.md 'Installation' -> 'Claude Code': '/plugin marketplace add ooples/token-optimizer-mcp' then '/plugin install token-optimizer@token-optimizer'. Both are interactive slash commands that write outside the sandbox, so per THOL CONTRIBUTING rule 1 the entries the plugin installs are transcribed here verbatim instead of running the installer: the MCP entry from plugin/.mcp.json and the five hooks from plugin/hooks/hooks.json, with ${CLAUDE_PLUGIN_ROOT} resolved to the global npm install path. DOCUMENTED DEVIATION (version pinning): plugin/launch.mjs is a warm-launch shim that, on a cold runtime, npm-installs @latest into its own managed runtime dir rather than serving the installed copy -- verified by handshake, an image pinned to 6.0.1 served 6.0.2. Because THOL gives every run a throwaway HOME, the default runtime path is cold on every run, so the shim would re-resolve @latest 153 times and the measured version could change mid-campaign. TOKEN_OPTIMIZER_RUNTIME therefore points at a shared runtime pre-seeded at build time with exactly 6.0.2 (versions/<v>/node_modules/<pkg> plus the 'current' and '.last-refresh' markers the shim expects; the latter is required because refreshDueNow() returns true when it is unreadable). The real shipped launch path still runs -- only the version it resolves is frozen. No other behaviour is altered.",
+  "requires": [
+    "node"
+  ],
+  "mcp": {
+    "mcpServers": {
+      "token-optimizer": {
+        "command": "node",
+        "args": [
+          "/usr/local/lib/node_modules/@ooples/token-optimizer-mcp/plugin/launch.mjs"
+        ],
+        "env": {
+          "TOKEN_OPTIMIZER_REFRESH_INTERVAL_MS": "999999999999",
+          "TOKEN_OPTIMIZER_RUNTIME": "/opt/token-optimizer-runtime"
+        },
+        "type": "stdio"
+      }
+    }
+  },
+  "settings": {
+    "env": {
+      "TOKEN_OPTIMIZER_REFRESH_INTERVAL_MS": "999999999999",
+      "TOKEN_OPTIMIZER_RUNTIME": "/opt/token-optimizer-runtime"
+    },
+    "hooks": {
+      "SessionStart": [
+        {
+          "hooks": [
+            {
+              "type": "command",
+              "command": "node \"/usr/local/lib/node_modules/@ooples/token-optimizer-mcp/plugin/hooks/session-start.mjs\""
+            }
+          ]
+        }
+      ],
+      "PreToolUse": [
+        {
+          "matcher": "Read|Grep|Glob|Edit|MultiEdit|Write|Bash|PowerShell",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "node \"/usr/local/lib/node_modules/@ooples/token-optimizer-mcp/plugin/hooks/pretooluse-router.mjs\""
+            }
+          ]
+        }
+      ],
+      "PreCompact": [
+        {
+          "hooks": [
+            {
+              "type": "command",
+              "command": "node \"/usr/local/lib/node_modules/@ooples/token-optimizer-mcp/plugin/hooks/precompact-optimize.mjs\""
+            }
+          ]
+        }
+      ],
+      "PostToolUse": [
+        {
+          "matcher": "Edit|MultiEdit|Write|Bash|PowerShell|mcp__.*__(?:smart_edit|smart_write)",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "node \"/usr/local/lib/node_modules/@ooples/token-optimizer-mcp/plugin/hooks/post-tool.mjs\""
+            }
+          ]
+        }
+      ],
+      "Stop": [
+        {
+          "hooks": [
+            {
+              "type": "command",
+              "command": "node \"/usr/local/lib/node_modules/@ooples/token-optimizer-mcp/plugin/hooks/stop.mjs\""
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "tool_prefixes": [
+    "mcp__token-optimizer__"
+  ]
+}

--- a/bench/thol/run-campaign.sh
+++ b/bench/thol/run-campaign.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Host-side campaign orchestrator (run from Git Bash on Windows).
+#
+# Why this exists rather than one long `docker run`:
+#
+# 1. CREDENTIAL EXPIRY. Claude Code's OAuth access token is short-lived (the
+#    one staged for this rig had ~2.5h left). THOL copies credentials into a
+#    THROWAWAY HOME per run (runner.py:129), so when a sandbox refreshes the
+#    token the new value dies with that sandbox -- every later run re-refreshes
+#    from the same increasingly stale token. A 4-6h campaign therefore cannot
+#    survive on one staging. We re-stage from the host's live credentials
+#    between segments, and the host's token stays fresh because the host
+#    Claude Code refreshes it in normal use.
+#
+# 2. RESUMABILITY. runner.py resumes from results.sqlite and skips runs already
+#    recorded for the campaign label, so segmenting costs nothing and an
+#    interrupted segment can simply be re-run.
+#
+# 3. COST ORDERING. Tasks run cheapest-first so the signal arrives before the
+#    money does. web-research-oss-inventory alone is ~$5.01/run -- over half
+#    the battery's cost -- so it is deliberately last and easy to skip.
+#
+# Runs are SERIAL by design. Parallel containers would contend for rate limits
+# and distort both wall-clock and cost, which are two of the three things the
+# benchmark measures.
+
+set -euo pipefail
+
+RIG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Matches what `npm run bench:build` tags. A version-pinned default here
+# silently used a stale image after the build script was added.
+IMAGE="${IMAGE:-thol-rig:local}"
+CAMPAIGN="${THOL_CAMPAIGN:-2.1.251 (Claude Code)}"
+REPS="${REPS:-3}"
+ARMS="${ARMS:-control,token-optimizer-mcp,token-optimizer-mcp-off}"
+HOST_CREDS="${HOST_CREDS:-$HOME/.claude/.credentials.json}"
+
+# Cheapest first. The last group is the $5/run outlier, isolated so it can be
+# dropped with SEGMENTS_MAX=4 without touching the rest.
+SEG_1="code-bugfix-py,code-refactor-split-py,log-needle-zh,code-iterate-tests"
+SEG_2="code-feature-js,code-migration-py-xl,code-migration-py,code-feature-validate-py"
+SEG_3="seo-audit,report-pdf,code-overview-cobra,code-settings-inventory-django"
+SEG_4="code-comprehension-django,code-debug-pipeline-py,code-debug-ledger-py,code-debug-cascade-py"
+SEG_5="web-research-oss-inventory"
+SEGMENTS=("$SEG_1" "$SEG_2" "$SEG_3" "$SEG_4" "$SEG_5")
+SEGMENTS_MAX="${SEGMENTS_MAX:-5}"
+
+log() { printf '\n\033[1;36m>> %s\033[0m\n' "$*"; }
+
+stage_credentials() {
+  # auth/ is gitignored, so it does not exist on a fresh clone.
+  mkdir -p "$RIG_DIR/auth"
+  [ -f "$HOST_CREDS" ] || { echo "!! no host credentials at $HOST_CREDS" >&2; exit 1; }
+  node -e "
+    const fs=require('fs');
+    const c=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));
+    if(!c.claudeAiOauth) throw new Error('no claudeAiOauth in host credentials');
+    // Only the login block leaves the host. MCP OAuth secrets for unrelated
+    // servers (github, supabase) stay put.
+    fs.writeFileSync(process.argv[2], JSON.stringify({claudeAiOauth:c.claudeAiOauth},null,2)+'\n');
+    const left=(c.claudeAiOauth.expiresAt-Date.now())/60000;
+    console.log('   token valid for ~'+left.toFixed(0)+' min');
+    if(left<20) console.log('   WARNING: token expires soon; open Claude Code on the host to refresh it');
+  " "$HOST_CREDS" "$RIG_DIR/auth/credentials.json"
+}
+
+for i in "${!SEGMENTS[@]}"; do
+  n=$((i+1))
+  [ "$n" -le "$SEGMENTS_MAX" ] || { log "Stopping before segment $n (SEGMENTS_MAX=$SEGMENTS_MAX)"; break; }
+  tasks="${SEGMENTS[$i]}"
+
+  log "Segment $n/$SEGMENTS_MAX -- re-staging credentials"
+  stage_credentials
+
+  log "Segment $n/$SEGMENTS_MAX -- tasks: $tasks"
+  MSYS_NO_PATHCONV=1 docker run --rm \
+    -v "$RIG_DIR/auth:/auth:ro" \
+    -v thol-results:/results \
+    -e THOL_CAMPAIGN="$CAMPAIGN" \
+    --name thol-campaign "$IMAGE" campaign \
+      -c "$ARMS" \
+      -t "$tasks" \
+      --reps "$REPS" \
+      "$@"
+done
+
+log "Campaign complete -- building final leaderboard"
+MSYS_NO_PATHCONV=1 docker run --rm \
+  -v "$RIG_DIR/auth:/auth:ro" \
+  -v thol-results:/results \
+  -e THOL_CAMPAIGN="$CAMPAIGN" \
+  "$IMAGE" report

--- a/bench/thol/run-campaign.sh
+++ b/bench/thol/run-campaign.sh
@@ -48,8 +48,10 @@ SEGMENTS_MAX="${SEGMENTS_MAX:-5}"
 log() { printf '\n\033[1;36m>> %s\033[0m\n' "$*"; }
 
 stage_credentials() {
-  # auth/ is gitignored, so it does not exist on a fresh clone.
+  # auth/ is gitignored, so it does not exist on a fresh clone. 0700 so the
+  # directory cannot be listed by other local users even before the file lands.
   mkdir -p "$RIG_DIR/auth"
+  chmod 700 "$RIG_DIR/auth" 2>/dev/null || true
   [ -f "$HOST_CREDS" ] || { echo "!! no host credentials at $HOST_CREDS" >&2; exit 1; }
   node -e "
     const fs=require('fs');
@@ -57,12 +59,32 @@ stage_credentials() {
     if(!c.claudeAiOauth) throw new Error('no claudeAiOauth in host credentials');
     // Only the login block leaves the host. MCP OAuth secrets for unrelated
     // servers (github, supabase) stay put.
-    fs.writeFileSync(process.argv[2], JSON.stringify({claudeAiOauth:c.claudeAiOauth},null,2)+'\n');
+    //
+    // MODE 0600, AND CREATED THAT WAY RATHER THAN CHMODDED AFTERWARDS. The
+    // default is 0666 masked by umask, so on a multi-user host every local
+    // account could read a live OAuth access and refresh token. Passing the
+    // mode to writeFileSync closes the window in which a world-readable file
+    // exists at all; chmod after the write leaves one.
+    //
+    // The mode only applies on creation, so an existing loose file is fixed
+    // explicitly below.
+    const out = process.argv[2];
+    fs.writeFileSync(out, JSON.stringify({claudeAiOauth:c.claudeAiOauth},null,2)+'\n', { mode: 0o600 });
+    try { fs.chmodSync(out, 0o600); } catch { /* Windows has no POSIX modes */ }
     const left=(c.claudeAiOauth.expiresAt-Date.now())/60000;
     console.log('   token valid for ~'+left.toFixed(0)+' min');
     if(left<20) console.log('   WARNING: token expires soon; open Claude Code on the host to refresh it');
   " "$HOST_CREDS" "$RIG_DIR/auth/credentials.json"
 }
+
+# The staged copy is a live credential. Remove it when the campaign ends, however
+# it ends -- an earlier version left it lying in the working tree, where a later
+# `git add -A` on a branch without bench/.gitignore committed it to a public
+# repository.
+cleanup_credentials() {
+  rm -f "$RIG_DIR/auth/credentials.json" 2>/dev/null || true
+}
+trap cleanup_credentials EXIT INT TERM
 
 for i in "${!SEGMENTS[@]}"; do
   n=$((i+1))

--- a/package.json
+++ b/package.json
@@ -107,7 +107,10 @@
     "dashboard:verify-live": "node scripts/verify-live-dashboard.mjs",
     "dashboard:attribution-smoke": "node scripts/run-dashboard-attribution-smoke.mjs",
     "dashboard:audit-savings": "node scripts/audit-token-savings.mjs",
-    "explore:wiki": "node scripts/explore-wiki.mjs"
+    "explore:wiki": "node scripts/explore-wiki.mjs",
+    "bench:build": "docker build -f bench/thol/Dockerfile -t thol-rig:local bench/",
+    "bench:screen": "bash bench/thol/run-campaign.sh",
+    "bench:confirm": "REPS=3 bash bench/thol/run-campaign.sh"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -108,9 +108,10 @@
     "dashboard:attribution-smoke": "node scripts/run-dashboard-attribution-smoke.mjs",
     "dashboard:audit-savings": "node scripts/audit-token-savings.mjs",
     "explore:wiki": "node scripts/explore-wiki.mjs",
-    "bench:build": "docker build -f bench/thol/Dockerfile -t thol-rig:local bench/",
+    "bench:build": "npm run bench:pack && docker build -f bench/thol/Dockerfile -t thol-rig:local bench/",
     "bench:screen": "bash bench/thol/run-campaign.sh",
-    "bench:confirm": "REPS=3 bash bench/thol/run-campaign.sh"
+    "bench:confirm": "REPS=3 bash bench/thol/run-campaign.sh",
+    "bench:pack": "node scripts/bench-pack.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/bench-pack.mjs
+++ b/scripts/bench-pack.mjs
@@ -67,8 +67,16 @@ function provenance() {
 
   const tmpIndex = join(dest, 'provenance.index');
   const withTmpIndex = { GIT_INDEX_FILE: tmpIndex };
-  // -a stages tracked modifications; untracked files are deliberately excluded,
-  // because they are not part of what npm pack ships either.
+  // `-A` STAGES UNTRACKED FILES TOO, and that is deliberate -- but it means the
+  // tree hash covers scratch files `npm pack` may not ship. An earlier comment
+  // here claimed the opposite, which would have made a reader trust a narrower
+  // identity than the hash actually has.
+  //
+  // Untracked is the right side to err on: this identifies THE INPUT THAT WAS
+  // BUILT, and an untracked source file is part of that input. Ignored paths
+  // (node_modules, dist, bench/thol/pkg) are excluded by gitignore either way,
+  // so the noise this admits is small and the alternative -- silently ignoring a
+  // file the build compiled -- is the failure that matters.
   git(['add', '-A', '--', '.'], withTmpIndex);
   const tree = git(['write-tree'], withTmpIndex);
   rmSync(tmpIndex, { force: true });

--- a/scripts/bench-pack.mjs
+++ b/scripts/bench-pack.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * Packs the working tree into the benchmark image's build context.
+ *
+ * WHY THE HARNESS MUST NOT INSTALL FROM THE REGISTRY. The point of keeping
+ * bench/ in this repo is that a behaviour change and its measured effect land
+ * together. An image that installed the published package could not measure
+ * anything unreleased -- and would fail SILENTLY rather than loudly: a benchmark
+ * arm pinning a mode the published build does not recognise falls back to the
+ * default, so two arms become identical and the campaign yields a meaningless
+ * comparison instead of an error.
+ *
+ * The tarball is written to a fixed name so the Dockerfile does not have to know
+ * the version, and is gitignored so a build artifact never lands in a commit.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readdirSync, renameSync, rmSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const dest = join(root, 'bench', 'thol', 'pkg');
+
+rmSync(dest, { recursive: true, force: true });
+mkdirSync(dest, { recursive: true });
+
+const { version } = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+process.stdout.write(`packing working tree at version ${version}\n`);
+
+// `npm pack` runs prepublishOnly, which builds dist/ -- so the tarball carries a
+// compiled server rather than bare TypeScript. That is deliberate: the image
+// installs this exactly as a user installs the published package.
+execFileSync(
+  process.platform === 'win32' ? 'npm.cmd' : 'npm',
+  ['pack', '--pack-destination', dest, '--loglevel', 'error'],
+  { cwd: root, stdio: 'inherit', shell: process.platform === 'win32' }
+);
+
+const packed = readdirSync(dest).filter((name) => name.endsWith('.tgz'));
+if (packed.length !== 1) {
+  throw new Error(
+    `expected exactly one tarball in ${dest}, found ${packed.length}: ${packed.join(', ')}`
+  );
+}
+
+renameSync(join(dest, packed[0]), join(dest, 'optimizer.tgz'));
+process.stdout.write(`bench/thol/pkg/optimizer.tgz <- ${packed[0]}\n`);

--- a/scripts/bench-pack.mjs
+++ b/scripts/bench-pack.mjs
@@ -21,6 +21,7 @@ import {
   renameSync,
   rmSync,
   readFileSync,
+  writeFileSync,
   existsSync,
 } from 'node:fs';
 import { join, dirname } from 'node:path';
@@ -33,7 +34,68 @@ rmSync(dest, { recursive: true, force: true });
 mkdirSync(dest, { recursive: true });
 
 const { version } = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
-process.stdout.write(`packing working tree at version ${version}\n`);
+
+/**
+ * Records WHICH TREE produced this tarball, not merely which version.
+ *
+ * A version string cannot distinguish two branches, a branch from master, or a
+ * clean tree from a dirty one -- and every one of those measures a different
+ * product. "Built from 6.0.2" is exactly the claim that let an image pinned to
+ * 6.0.1 measure 6.0.2 without anyone noticing.
+ *
+ * So the provenance is the git tree hash: the content hash of what was actually
+ * packed, identical for two checkouts with identical content and different the
+ * moment one byte differs. That makes a result attributable to a precise tree
+ * regardless of branch, merge state, or whether the work has landed on master.
+ *
+ * `git write-tree` needs a clean index, so the working tree is staged into a
+ * TEMPORARY index first -- this must never touch the user's real index.
+ */
+function provenance() {
+  const git = (args, env = {}) => {
+    try {
+      return execFileSync('git', args, {
+        cwd: root,
+        encoding: 'utf8',
+        env: { ...process.env, ...env },
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+    } catch {
+      return '';
+    }
+  };
+
+  const tmpIndex = join(dest, 'provenance.index');
+  const withTmpIndex = { GIT_INDEX_FILE: tmpIndex };
+  // -a stages tracked modifications; untracked files are deliberately excluded,
+  // because they are not part of what npm pack ships either.
+  git(['add', '-A', '--', '.'], withTmpIndex);
+  const tree = git(['write-tree'], withTmpIndex);
+  rmSync(tmpIndex, { force: true });
+
+  return {
+    version,
+    tree,
+    head: git(['rev-parse', 'HEAD']),
+    branch: git(['rev-parse', '--abbrev-ref', 'HEAD']),
+    // A dirty tree is not a defect -- measuring unmerged work is the point --
+    // but it must be RECORDED, so a number can never be silently attributed to
+    // a commit that does not contain the code that produced it.
+    dirty: git(['status', '--porcelain']).length > 0,
+    packedAt: new Date().toISOString(),
+  };
+}
+
+const prov = provenance();
+if (!prov.tree) {
+  throw new Error(
+    'could not compute a git tree hash; refusing to pack an unattributable build'
+  );
+}
+writeFileSync(join(dest, 'provenance.json'), JSON.stringify(prov, null, 2) + '\n');
+process.stdout.write(
+  `packing tree ${prov.tree.slice(0, 12)} (${prov.branch}${prov.dirty ? ', dirty' : ''}) at version ${version}\n`
+);
 
 // BUILD EXPLICITLY. `npm pack` runs prepack/prepare/postpack -- NOT
 // prepublishOnly, which is where this package defines its build. An earlier

--- a/scripts/bench-pack.mjs
+++ b/scripts/bench-pack.mjs
@@ -15,7 +15,14 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, readdirSync, renameSync, rmSync, readFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  readFileSync,
+  existsSync,
+} from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -28,14 +35,37 @@ mkdirSync(dest, { recursive: true });
 const { version } = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
 process.stdout.write(`packing working tree at version ${version}\n`);
 
-// `npm pack` runs prepublishOnly, which builds dist/ -- so the tarball carries a
-// compiled server rather than bare TypeScript. That is deliberate: the image
-// installs this exactly as a user installs the published package.
-execFileSync(
-  process.platform === 'win32' ? 'npm.cmd' : 'npm',
-  ['pack', '--pack-destination', dest, '--loglevel', 'error'],
-  { cwd: root, stdio: 'inherit', shell: process.platform === 'win32' }
-);
+// BUILD EXPLICITLY. `npm pack` runs prepack/prepare/postpack -- NOT
+// prepublishOnly, which is where this package defines its build. An earlier
+// version of this script assumed otherwise and was wrong in the most dangerous
+// direction: with a stale dist/ on disk the tarball looked fine while carrying
+// compiled code that did not match the source, so the harness would grade a
+// build nobody wrote. With dist/ absent it packed ZERO compiled files -- proved
+// by deleting dist/ and counting `package/dist/` entries in the tarball, which
+// came back 0.
+//
+// So the build runs here, unconditionally, before the pack.
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const runNpm = (args) =>
+  execFileSync(npm, args, {
+    cwd: root,
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+
+runNpm(['run', 'build']);
+
+// FAIL LOUDLY IF THE BUILD PRODUCED NOTHING. A tarball without a compiled
+// server installs cleanly and fails at MCP handshake time, deep inside a
+// container, where it reads as a harness fault rather than a packaging one.
+const entry = join(root, 'dist', 'server', 'index.js');
+if (!existsSync(entry)) {
+  throw new Error(
+    `build produced no ${entry}; refusing to pack a tarball with no server`
+  );
+}
+
+runNpm(['pack', '--pack-destination', dest, '--loglevel', 'error']);
 
 const packed = readdirSync(dest).filter((name) => name.endsWith('.tgz'));
 if (packed.length !== 1) {

--- a/tests/hooks/zero-turn-refusal-fires.test.mjs
+++ b/tests/hooks/zero-turn-refusal-fires.test.mjs
@@ -118,6 +118,12 @@ describe('the refusal does not answer what it cannot know', () => {
     expect(read(first).decision).toBe('deny');
 
     const other = read('sess-b-' + Date.now());
-    expect(other.reason).not.toMatch(/unchanged since you last read it/i);
+
+    // ALLOWED, not merely lacking the phrase. The absence alone is satisfied by
+    // a denial for any OTHER reason, and by the call throwing -- so it could
+    // not tell 'B is correctly served the file' from 'B was refused on some
+    // unrelated ground', which is the failure this test exists to catch.
+    expect(other.decision).toBe('allow');
+    expect(other.reason || '').not.toMatch(/unchanged since you last read it/i);
   });
 });

--- a/tests/hooks/zero-turn-refusal-fires.test.mjs
+++ b/tests/hooks/zero-turn-refusal-fires.test.mjs
@@ -1,0 +1,123 @@
+/**
+ * The zero-turn refusal has to actually fire in production.
+ *
+ * THE DEFECT THIS COVERS. `refusalPayload` answers a re-read INSIDE the refusal
+ * -- "unchanged since you last read it", or the diff -- so the model needs no
+ * second call. That is the difference between a refusal costing nothing and a
+ * refusal costing a turn.
+ *
+ * It needs `anchor.snapshot` to do it. `indexFile` writes snapshots correctly,
+ * but `load()` defaults to `snapshots: false` and NOTHING in the codebase ever
+ * passed true, so a loaded node never carried one and `refusalPayload` returned
+ * null for every real file. `hooks-core/staleness.mjs` says so in its own
+ * comment: the zero-turn refusal "never fired outside tests that hand-wrote the
+ * snapshot themselves".
+ *
+ * WHY IT MATTERS AT THIS SIZE. A campaign measured the enforcing arm at 1.575x
+ * the turns of the same build with refusals off, and turns explain ~80% of its
+ * cost gap. Every refusal that redirects instead of answering is one of those
+ * turns.
+ *
+ * These tests drive the REAL hook over stdin. A unit test of `refusalPayload`
+ * would have passed throughout the entire period the feature was dead, because
+ * the tests that existed hand-wrote the snapshot the production path never had.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROUTER = join(HERE, '..', '..', 'plugin', 'hooks', 'pretooluse-router.mjs');
+
+let workspace;
+let graph;
+let file;
+
+// Over the refusal floor (1 KB) so a refusal is issued at all, and under the
+// large-read threshold (25 KB) so the FIRST read is allowed -- which is what
+// indexes the file and makes the second read the interesting one.
+const BODY = 'export const value = 1;\n'.repeat(90);
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), 'zero-turn-'));
+  graph = mkdtempSync(join(tmpdir(), 'zero-turn-graph-'));
+  file = join(workspace, 'mod.ts');
+  writeFileSync(file, BODY);
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+  rmSync(graph, { recursive: true, force: true });
+});
+
+function read(sessionId) {
+  const result = spawnSync(process.execPath, [ROUTER], {
+    input: JSON.stringify({
+      session_id: sessionId,
+      tool_name: 'Read',
+      tool_input: { file_path: file },
+      cwd: workspace,
+    }),
+    encoding: 'utf8',
+    timeout: 30_000,
+    env: {
+      ...process.env,
+      TOKEN_OPTIMIZER_MODE: 'enforce',
+      TOKEN_OPTIMIZER_MCP_CAPABILITIES: 'smart_read,smart_grep,smart_glob',
+      TOKEN_OPTIMIZER_WIKI_DIR: graph,
+      TOKEN_OPTIMIZER_SHARED_DIR: graph,
+    },
+  });
+  if (!result.stdout.trim()) return { decision: 'allow', reason: '' };
+  const out = JSON.parse(result.stdout).hookSpecificOutput || {};
+  return {
+    decision: out.permissionDecision || (out.additionalContext ? 'advise' : 'allow'),
+    reason: out.permissionDecisionReason || out.additionalContext || '',
+  };
+}
+
+describe('a re-read is answered inside the refusal', () => {
+  test('the second read is told the file is unchanged, not sent elsewhere', () => {
+    const session = 'unchanged-' + Date.now();
+
+    expect(read(session).decision).toBe('allow');
+
+    const second = read(session);
+    expect(second.decision).toBe('deny');
+
+    // THE PROPERTY THAT MATTERS: the answer is IN the refusal, so the model
+    // needs no further call. Asserting the content rather than the wording.
+    expect(second.reason).toMatch(/unchanged since you last read it/i);
+    expect(second.reason).toMatch(/nothing to re-read/i);
+  });
+
+  test('a changed file gets the diff, not a redirect', () => {
+    const session = 'changed-' + Date.now();
+
+    expect(read(session).decision).toBe('allow');
+    writeFileSync(file, BODY.replace('value = 1', 'value = 4242'));
+
+    const second = read(session);
+    expect(second.decision).toBe('deny');
+    // The changed line itself, which is what makes the second call unnecessary.
+    expect(second.reason).toContain('4242');
+    // And it must be a diff rather than the file.
+    expect(second.reason.length).toBeLessThan(BODY.length / 2);
+  });
+});
+
+describe('the refusal does not answer what it cannot know', () => {
+  test('a DIFFERENT session gets no unchanged-claim', () => {
+    // Session B never read this file, so "you already have it" would be false
+    // and would withhold content it has never seen.
+    const first = 'sess-a-' + Date.now();
+    expect(read(first).decision).toBe('allow');
+    expect(read(first).decision).toBe('deny');
+
+    const other = read('sess-b-' + Date.now());
+    expect(other.reason).not.toMatch(/unchanged since you last read it/i);
+  });
+});


### PR DESCRIPTION
Part of #357 (M2).

M2 of the spec in #353. Unblocks every milestone after it, because from here on every exit criterion is a number this harness produces.

## What moves

The harness graded this project from an **unversioned sibling directory that git never saw**. Nothing it produced was reproducible by anyone else, and a rule change could never land beside its measured effect. It now lives in `bench/`, excluded from the npm `files` list (verified, not assumed) so users never download it.

THOL itself is **not vendored** — it is cloned pinned at run time. The only artifacts owned here are the manifests describing how this product installs, which are the same files that would go upstream.

## Two defects the move introduced, both fixed

- the campaign script still defaulted to a version-pinned image tag rather than the one `bench:build` produces
- `bench/auth/` is gitignored, so it does not exist on a fresh clone

## The important change: grade the working tree

The image installed the **published** package. That could not measure anything unreleased — and would have failed **silently**, which is worse.

`mode()` maps an unrecognised value to the default. So an arm pinning a posture the build predates does not error; it quietly measures the default, two arms become identical, and the campaign yields a meaningless comparison that looks exactly like a real one.

Verified rather than reasoned about — a master-based image:

```
packaged version: 6.0.2
recognises assist? enforce
```

That is the assist arm of the very next milestone, silently measuring `enforce`.

`bench:build` now packs the working tree (`scripts/bench-pack.mjs`) and the image installs that tarball. To measure a published release, check out its tag and build from there.

## And a guard, because "remember not to do that" is not a mechanism

Preflight refuses to run when any arm declares a mode the packaged build does not recognise:

```
!! arm token-optimizer-mcp-assist declares TOKEN_OPTIMIZER_MODE=assist but the
   packaged build resolves it to 'enforce'. That arm would silently measure
   'enforce'. Build from a tree that supports 'assist'.
```

Confirmed to **fire** by pointing a probe arm at `assist` on a tree that lacks it, and to **pass** on the recognised `off` arm. A guard never observed failing is not evidence.

## Verification

`selftest PASSED` from the new location, all 17 verifiers `ok`, both arms listed without the `[unverified manifest]` marker.

## `bench/README.md`

Documents what the numbers mean (and that **a cost figure without its paired correctness score is not a result**), what the harness structurally cannot measure (the graph starts empty on every run), and the gotchas that cost real time — all three fixture generators, non-reproducible fixtures, the named volume over a Windows bind mount, the selftest workspace collision, and the version-pinning trap in `launch.mjs`.

## Follow-on

The `assist` and graph-disabled arms are **deliberately not here**: `assist` requires #352, and the guard above now enforces that ordering rather than trusting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
