### PR TITLE
feat(wiki): add a switch that makes the graph inert for measurement

### DIFF
--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,4 @@
+auth/
+results/
+*.sqlite
+thol/pkg/

--- a/hooks-core/wiki.mjs
+++ b/hooks-core/wiki.mjs
@@ -657,6 +657,11 @@ function append(dir, record) {
 export function putNode(dir, { kind, key, ...rest }) {
   if (!NODE_KINDS.includes(kind)) throw new Error(`unknown node kind: ${kind}`);
   const id = nodeId(kind, key);
+  // DEGRADES, NEVER THROWS. The id is still computed and returned, so callers
+  // that chain on it -- indexFile mints a file node then edges symbols to it --
+  // keep working and simply persist nothing. Returning undefined here would
+  // turn a measurement switch into a crash.
+  if (wikiDisabled()) return id;
   // `rest` is spread FIRST so it can never override the bookkeeping fields.
   // Spreading it after `id` let a caller passing a whole existing node back in
   // -- which curate.mjs does on every pin, retire and correct -- carry a stale
@@ -681,6 +686,9 @@ export function putNode(dir, { kind, key, ...rest }) {
 /** Records an edge. */
 export function putEdge(dir, from, edge, to) {
   if (!EDGE_KINDS.includes(edge)) throw new Error(`unknown edge kind: ${edge}`);
+  // The kind check stays ABOVE the gate: a disabled graph should not turn a
+  // programming error into silence, or the bug reappears when it is re-enabled.
+  if (wikiDisabled()) return;
   append(dir, { t: 'e', v: GRAPH_VERSION, from, edge, to, at: Date.now() });
 }
 
@@ -811,9 +819,38 @@ function readSnapshots(dir) {
  * never sees the payload. Parsing and then discarding would have cost the same
  * as keeping it, which is the whole reason this is a separate record type.
  */
+/**
+ * Whether the graph is switched off entirely.
+ *
+ * FOR MEASUREMENT, NOT FOR USERS. A benchmark arm needs to isolate what the
+ * graph costs when it can deliver nothing -- which is its situation in any
+ * single-shot harness, because every run gets a throwaway HOME so the store
+ * starts empty and a finding harvested at Stop cannot help the session that
+ * produced it. What is left is pure overhead, and measuring it needs an arm
+ * with the graph off and everything else identical.
+ *
+ * NOT the same as pointing TOKEN_OPTIMIZER_WIKI_DIR at an empty directory: that
+ * stops delivery but leaves harvest writing, so the arm would measure something
+ * other than what it claims.
+ *
+ * Only the affirmative spellings count, so an empty or `0` value cannot switch
+ * the product's main feature off by accident.
+ */
+export function wikiDisabled() {
+  const raw = String(process.env.TOKEN_OPTIMIZER_WIKI_DISABLED || '')
+    .trim()
+    .toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes';
+}
+
 export function load(dir, { snapshots = false } = {}) {
   const nodes = new Map();
   const edges = [];
+  // GATED AT THE STORAGE LAYER, not at the callers. This and the two writers
+  // below are the choke point every higher-level path funnels through; gating
+  // callers instead would mean finding all of them, and one missed site would
+  // leave a "disabled" arm quietly reading or writing.
+  if (wikiDisabled()) return { nodes, edges };
   const path = logPath(dir);
   if (!existsSync(path)) return { nodes, edges };
 

--- a/integrations/cline/hooks/token-optimizer/lib/wiki.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/wiki.mjs
@@ -659,6 +659,11 @@ function append(dir, record) {
 export function putNode(dir, { kind, key, ...rest }) {
   if (!NODE_KINDS.includes(kind)) throw new Error(`unknown node kind: ${kind}`);
   const id = nodeId(kind, key);
+  // DEGRADES, NEVER THROWS. The id is still computed and returned, so callers
+  // that chain on it -- indexFile mints a file node then edges symbols to it --
+  // keep working and simply persist nothing. Returning undefined here would
+  // turn a measurement switch into a crash.
+  if (wikiDisabled()) return id;
   // `rest` is spread FIRST so it can never override the bookkeeping fields.
   // Spreading it after `id` let a caller passing a whole existing node back in
   // -- which curate.mjs does on every pin, retire and correct -- carry a stale
@@ -683,6 +688,9 @@ export function putNode(dir, { kind, key, ...rest }) {
 /** Records an edge. */
 export function putEdge(dir, from, edge, to) {
   if (!EDGE_KINDS.includes(edge)) throw new Error(`unknown edge kind: ${edge}`);
+  // The kind check stays ABOVE the gate: a disabled graph should not turn a
+  // programming error into silence, or the bug reappears when it is re-enabled.
+  if (wikiDisabled()) return;
   append(dir, { t: 'e', v: GRAPH_VERSION, from, edge, to, at: Date.now() });
 }
 
@@ -813,9 +821,38 @@ function readSnapshots(dir) {
  * never sees the payload. Parsing and then discarding would have cost the same
  * as keeping it, which is the whole reason this is a separate record type.
  */
+/**
+ * Whether the graph is switched off entirely.
+ *
+ * FOR MEASUREMENT, NOT FOR USERS. A benchmark arm needs to isolate what the
+ * graph costs when it can deliver nothing -- which is its situation in any
+ * single-shot harness, because every run gets a throwaway HOME so the store
+ * starts empty and a finding harvested at Stop cannot help the session that
+ * produced it. What is left is pure overhead, and measuring it needs an arm
+ * with the graph off and everything else identical.
+ *
+ * NOT the same as pointing TOKEN_OPTIMIZER_WIKI_DIR at an empty directory: that
+ * stops delivery but leaves harvest writing, so the arm would measure something
+ * other than what it claims.
+ *
+ * Only the affirmative spellings count, so an empty or `0` value cannot switch
+ * the product's main feature off by accident.
+ */
+export function wikiDisabled() {
+  const raw = String(process.env.TOKEN_OPTIMIZER_WIKI_DISABLED || '')
+    .trim()
+    .toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes';
+}
+
 export function load(dir, { snapshots = false } = {}) {
   const nodes = new Map();
   const edges = [];
+  // GATED AT THE STORAGE LAYER, not at the callers. This and the two writers
+  // below are the choke point every higher-level path funnels through; gating
+  // callers instead would mean finding all of them, and one missed site would
+  // leave a "disabled" arm quietly reading or writing.
+  if (wikiDisabled()) return { nodes, edges };
   const path = logPath(dir);
   if (!existsSync(path)) return { nodes, edges };
 

--- a/integrations/codex/hooks/lib/wiki.mjs
+++ b/integrations/codex/hooks/lib/wiki.mjs
@@ -659,6 +659,11 @@ function append(dir, record) {
 export function putNode(dir, { kind, key, ...rest }) {
   if (!NODE_KINDS.includes(kind)) throw new Error(`unknown node kind: ${kind}`);
   const id = nodeId(kind, key);
+  // DEGRADES, NEVER THROWS. The id is still computed and returned, so callers
+  // that chain on it -- indexFile mints a file node then edges symbols to it --
+  // keep working and simply persist nothing. Returning undefined here would
+  // turn a measurement switch into a crash.
+  if (wikiDisabled()) return id;
   // `rest` is spread FIRST so it can never override the bookkeeping fields.
   // Spreading it after `id` let a caller passing a whole existing node back in
   // -- which curate.mjs does on every pin, retire and correct -- carry a stale
@@ -683,6 +688,9 @@ export function putNode(dir, { kind, key, ...rest }) {
 /** Records an edge. */
 export function putEdge(dir, from, edge, to) {
   if (!EDGE_KINDS.includes(edge)) throw new Error(`unknown edge kind: ${edge}`);
+  // The kind check stays ABOVE the gate: a disabled graph should not turn a
+  // programming error into silence, or the bug reappears when it is re-enabled.
+  if (wikiDisabled()) return;
   append(dir, { t: 'e', v: GRAPH_VERSION, from, edge, to, at: Date.now() });
 }
 
@@ -813,9 +821,38 @@ function readSnapshots(dir) {
  * never sees the payload. Parsing and then discarding would have cost the same
  * as keeping it, which is the whole reason this is a separate record type.
  */
+/**
+ * Whether the graph is switched off entirely.
+ *
+ * FOR MEASUREMENT, NOT FOR USERS. A benchmark arm needs to isolate what the
+ * graph costs when it can deliver nothing -- which is its situation in any
+ * single-shot harness, because every run gets a throwaway HOME so the store
+ * starts empty and a finding harvested at Stop cannot help the session that
+ * produced it. What is left is pure overhead, and measuring it needs an arm
+ * with the graph off and everything else identical.
+ *
+ * NOT the same as pointing TOKEN_OPTIMIZER_WIKI_DIR at an empty directory: that
+ * stops delivery but leaves harvest writing, so the arm would measure something
+ * other than what it claims.
+ *
+ * Only the affirmative spellings count, so an empty or `0` value cannot switch
+ * the product's main feature off by accident.
+ */
+export function wikiDisabled() {
+  const raw = String(process.env.TOKEN_OPTIMIZER_WIKI_DISABLED || '')
+    .trim()
+    .toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes';
+}
+
 export function load(dir, { snapshots = false } = {}) {
   const nodes = new Map();
   const edges = [];
+  // GATED AT THE STORAGE LAYER, not at the callers. This and the two writers
+  // below are the choke point every higher-level path funnels through; gating
+  // callers instead would mean finding all of them, and one missed site would
+  // leave a "disabled" arm quietly reading or writing.
+  if (wikiDisabled()) return { nodes, edges };
   const path = logPath(dir);
   if (!existsSync(path)) return { nodes, edges };
 

--- a/integrations/codex/plugin/hooks/lib/wiki.mjs
+++ b/integrations/codex/plugin/hooks/lib/wiki.mjs
@@ -659,6 +659,11 @@ function append(dir, record) {
 export function putNode(dir, { kind, key, ...rest }) {
   if (!NODE_KINDS.includes(kind)) throw new Error(`unknown node kind: ${kind}`);
   const id = nodeId(kind, key);
+  // DEGRADES, NEVER THROWS. The id is still computed and returned, so callers
+  // that chain on it -- indexFile mints a file node then edges symbols to it --
+  // keep working and simply persist nothing. Returning undefined here would
+  // turn a measurement switch into a crash.
+  if (wikiDisabled()) return id;
   // `rest` is spread FIRST so it can never override the bookkeeping fields.
   // Spreading it after `id` let a caller passing a whole existing node back in
   // -- which curate.mjs does on every pin, retire and correct -- carry a stale
@@ -683,6 +688,9 @@ export function putNode(dir, { kind, key, ...rest }) {
 /** Records an edge. */
 export function putEdge(dir, from, edge, to) {
   if (!EDGE_KINDS.includes(edge)) throw new Error(`unknown edge kind: ${edge}`);
+  // The kind check stays ABOVE the gate: a disabled graph should not turn a
+  // programming error into silence, or the bug reappears when it is re-enabled.
+  if (wikiDisabled()) return;
   append(dir, { t: 'e', v: GRAPH_VERSION, from, edge, to, at: Date.now() });
 }
 
@@ -813,9 +821,38 @@ function readSnapshots(dir) {
  * never sees the payload. Parsing and then discarding would have cost the same
  * as keeping it, which is the whole reason this is a separate record type.
  */
+/**
+ * Whether the graph is switched off entirely.
+ *
+ * FOR MEASUREMENT, NOT FOR USERS. A benchmark arm needs to isolate what the
+ * graph costs when it can deliver nothing -- which is its situation in any
+ * single-shot harness, because every run gets a throwaway HOME so the store
+ * starts empty and a finding harvested at Stop cannot help the session that
+ * produced it. What is left is pure overhead, and measuring it needs an arm
+ * with the graph off and everything else identical.
+ *
+ * NOT the same as pointing TOKEN_OPTIMIZER_WIKI_DIR at an empty directory: that
+ * stops delivery but leaves harvest writing, so the arm would measure something
+ * other than what it claims.
+ *
+ * Only the affirmative spellings count, so an empty or `0` value cannot switch
+ * the product's main feature off by accident.
+ */
+export function wikiDisabled() {
+  const raw = String(process.env.TOKEN_OPTIMIZER_WIKI_DISABLED || '')
+    .trim()
+    .toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes';
+}
+
 export function load(dir, { snapshots = false } = {}) {
   const nodes = new Map();
   const edges = [];
+  // GATED AT THE STORAGE LAYER, not at the callers. This and the two writers
+  // below are the choke point every higher-level path funnels through; gating
+  // callers instead would mean finding all of them, and one missed site would
+  // leave a "disabled" arm quietly reading or writing.
+  if (wikiDisabled()) return { nodes, edges };
   const path = logPath(dir);
   if (!existsSync(path)) return { nodes, edges };
 

--- a/integrations/copilot/.github/hooks/lib/wiki.mjs
+++ b/integrations/copilot/.github/hooks/lib/wiki.mjs
@@ -659,6 +659,11 @@ function append(dir, record) {
 export function putNode(dir, { kind, key, ...rest }) {
   if (!NODE_KINDS.includes(kind)) throw new Error(`unknown node kind: ${kind}`);
   const id = nodeId(kind, key);
+  // DEGRADES, NEVER THROWS. The id is still computed and returned, so callers
+  // that chain on it -- indexFile mints a file node then edges symbols to it --
+  // keep working and simply persist nothing. Returning undefined here would
+  // turn a measurement switch into a crash.
+  if (wikiDisabled()) return id;
   // `rest` is spread FIRST so it can never override the bookkeeping fields.
   // Spreading it after `id` let a caller passing a whole existing node back in
   // -- which curate.mjs does on every pin, retire and correct -- carry a stale
@@ -683,6 +688,9 @@ export function putNode(dir, { kind, key, ...rest }) {
 /** Records an edge. */
 export function putEdge(dir, from, edge, to) {
   if (!EDGE_KINDS.includes(edge)) throw new Error(`unknown edge kind: ${edge}`);
+  // The kind check stays ABOVE the gate: a disabled graph should not turn a
+  // programming error into silence, or the bug reappears when it is re-enabled.
+  if (wikiDisabled()) return;
   append(dir, { t: 'e', v: GRAPH_VERSION, from, edge, to, at: Date.now() });
 }
 
@@ -813,9 +821,38 @@ function readSnapshots(dir) {
  * never sees the payload. Parsing and then discarding would have cost the same
  * as keeping it, which is the whole reason this is a separate record type.
  */
+/**
+ * Whether the graph is switched off entirely.
+ *
+ * FOR MEASUREMENT, NOT FOR USERS. A benchmark arm needs to isolate what the
+ * graph costs when it can deliver nothing -- which is its situation in any
+ * single-shot harness, because every run gets a throwaway HOME so the store
+ * starts empty and a finding harvested at Stop cannot help the session that
+ * produced it. What is left is pure overhead, and measuring it needs an arm
+ * with the graph off and everything else identical.
+ *
+ * NOT the same as pointing TOKEN_OPTIMIZER_WIKI_DIR at an empty directory: that
+ * stops delivery but leaves harvest writing, so the arm would measure something
+ * other than what it claims.
+ *
+ * Only the affirmative spellings count, so an empty or `0` value cannot switch
+ * the product's main feature off by accident.
+ */
+export function wikiDisabled() {
+  const raw = String(process.env.TOKEN_OPTIMIZER_WIKI_DISABLED || '')
+    .trim()
+    .toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes';
+}
+
 export function load(dir, { snapshots = false } = {}) {
   const nodes = new Map();
   const edges = [];
+  // GATED AT THE STORAGE LAYER, not at the callers. This and the two writers
+  // below are the choke point every higher-level path funnels through; gating
+  // callers instead would mean finding all of them, and one missed site would
+  // leave a "disabled" arm quietly reading or writing.
+  if (wikiDisabled()) return { nodes, edges };
   const path = logPath(dir);
   if (!existsSync(path)) return { nodes, edges };
 

--- a/integrations/cursor/hooks/lib/wiki.mjs
+++ b/integrations/cursor/hooks/lib/wiki.mjs
@@ -659,6 +659,11 @@ function append(dir, record) {
 export function putNode(dir, { kind, key, ...rest }) {
   if (!NODE_KINDS.includes(kind)) throw new Error(`unknown node kind: ${kind}`);
   const id = nodeId(kind, key);
+  // DEGRADES, NEVER THROWS. The id is still computed and returned, so callers
+  // that chain on it -- indexFile mints a file node then edges symbols to it --
+  // keep working and simply persist nothing. Returning undefined here would
+  // turn a measurement switch into a crash.
+  if (wikiDisabled()) return id;
   // `rest` is spread FIRST so it can never override the bookkeeping fields.
   // Spreading it after `id` let a caller passing a whole existing node back in
   // -- which curate.mjs does on every pin, retire and correct -- carry a stale
@@ -683,6 +688,9 @@ export function putNode(dir, { kind, key, ...rest }) {
 /** Records an edge. */
 export function putEdge(dir, from, edge, to) {
   if (!EDGE_KINDS.includes(edge)) throw new Error(`unknown edge kind: ${edge}`);
+  // The kind check stays ABOVE the gate: a disabled graph should not turn a
+  // programming error into silence, or the bug reappears when it is re-enabled.
+  if (wikiDisabled()) return;
   append(dir, { t: 'e', v: GRAPH_VERSION, from, edge, to, at: Date.now() });
 }
 
@@ -813,9 +821,38 @@ function readSnapshots(dir) {
  * never sees the payload. Parsing and then discarding would have cost the same
  * as keeping it, which is the whole reason this is a separate record type.
  */
+/**
+ * Whether the graph is switched off entirely.
+ *
+ * FOR MEASUREMENT, NOT FOR USERS. A benchmark arm needs to isolate what the
+ * graph costs when it can deliver nothing -- which is its situation in any
+ * single-shot harness, because every run gets a throwaway HOME so the store
+ * starts empty and a finding harvested at Stop cannot help the session that
+ * produced it. What is left is pure overhead, and measuring it needs an arm
+ * with the graph off and everything else identical.
+ *
+ * NOT the same as pointing TOKEN_OPTIMIZER_WIKI_DIR at an empty directory: that
+ * stops delivery but leaves harvest writing, so the arm would measure something
+ * other than what it claims.
+ *
+ * Only the affirmative spellings count, so an empty or `0` value cannot switch
+ * the product's main feature off by accident.
+ */
+export function wikiDisabled() {
+  const raw = String(process.env.TOKEN_OPTIMIZER_WIKI_DISABLED || '')
+    .trim()
+    .toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes';
+}
+
 export function load(dir, { snapshots = false } = {}) {
   const nodes = new Map();
   const edges = [];
+  // GATED AT THE STORAGE LAYER, not at the callers. This and the two writers
+  // below are the choke point every higher-level path funnels through; gating
+  // callers instead would mean finding all of them, and one missed site would
+  // leave a "disabled" arm quietly reading or writing.
+  if (wikiDisabled()) return { nodes, edges };
   const path = logPath(dir);
   if (!existsSync(path)) return { nodes, edges };
 

--- a/integrations/gemini/hooks/lib/wiki.mjs
+++ b/integrations/gemini/hooks/lib/wiki.mjs
@@ -659,6 +659,11 @@ function append(dir, record) {
 export function putNode(dir, { kind, key, ...rest }) {
   if (!NODE_KINDS.includes(kind)) throw new Error(`unknown node kind: ${kind}`);
   const id = nodeId(kind, key);
+  // DEGRADES, NEVER THROWS. The id is still computed and returned, so callers
+  // that chain on it -- indexFile mints a file node then edges symbols to it --
+  // keep working and simply persist nothing. Returning undefined here would
+  // turn a measurement switch into a crash.
+  if (wikiDisabled()) return id;
   // `rest` is spread FIRST so it can never override the bookkeeping fields.
   // Spreading it after `id` let a caller passing a whole existing node back in
   // -- which curate.mjs does on every pin, retire and correct -- carry a stale
@@ -683,6 +688,9 @@ export function putNode(dir, { kind, key, ...rest }) {
 /** Records an edge. */
 export function putEdge(dir, from, edge, to) {
   if (!EDGE_KINDS.includes(edge)) throw new Error(`unknown edge kind: ${edge}`);
+  // The kind check stays ABOVE the gate: a disabled graph should not turn a
+  // programming error into silence, or the bug reappears when it is re-enabled.
+  if (wikiDisabled()) return;
   append(dir, { t: 'e', v: GRAPH_VERSION, from, edge, to, at: Date.now() });
 }
 
@@ -813,9 +821,38 @@ function readSnapshots(dir) {
  * never sees the payload. Parsing and then discarding would have cost the same
  * as keeping it, which is the whole reason this is a separate record type.
  */
+/**
+ * Whether the graph is switched off entirely.
+ *
+ * FOR MEASUREMENT, NOT FOR USERS. A benchmark arm needs to isolate what the
+ * graph costs when it can deliver nothing -- which is its situation in any
+ * single-shot harness, because every run gets a throwaway HOME so the store
+ * starts empty and a finding harvested at Stop cannot help the session that
+ * produced it. What is left is pure overhead, and measuring it needs an arm
+ * with the graph off and everything else identical.
+ *
+ * NOT the same as pointing TOKEN_OPTIMIZER_WIKI_DIR at an empty directory: that
+ * stops delivery but leaves harvest writing, so the arm would measure something
+ * other than what it claims.
+ *
+ * Only the affirmative spellings count, so an empty or `0` value cannot switch
+ * the product's main feature off by accident.
+ */
+export function wikiDisabled() {
+  const raw = String(process.env.TOKEN_OPTIMIZER_WIKI_DISABLED || '')
+    .trim()
+    .toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes';
+}
+
 export function load(dir, { snapshots = false } = {}) {
   const nodes = new Map();
   const edges = [];
+  // GATED AT THE STORAGE LAYER, not at the callers. This and the two writers
+  // below are the choke point every higher-level path funnels through; gating
+  // callers instead would mean finding all of them, and one missed site would
+  // leave a "disabled" arm quietly reading or writing.
+  if (wikiDisabled()) return { nodes, edges };
   const path = logPath(dir);
   if (!existsSync(path)) return { nodes, edges };
 

--- a/integrations/kilo/hooks/lib/wiki.mjs
+++ b/integrations/kilo/hooks/lib/wiki.mjs
@@ -659,6 +659,11 @@ function append(dir, record) {
 export function putNode(dir, { kind, key, ...rest }) {
   if (!NODE_KINDS.includes(kind)) throw new Error(`unknown node kind: ${kind}`);
   const id = nodeId(kind, key);
+  // DEGRADES, NEVER THROWS. The id is still computed and returned, so callers
+  // that chain on it -- indexFile mints a file node then edges symbols to it --
+  // keep working and simply persist nothing. Returning undefined here would
+  // turn a measurement switch into a crash.
+  if (wikiDisabled()) return id;
   // `rest` is spread FIRST so it can never override the bookkeeping fields.
   // Spreading it after `id` let a caller passing a whole existing node back in
   // -- which curate.mjs does on every pin, retire and correct -- carry a stale
@@ -683,6 +688,9 @@ export function putNode(dir, { kind, key, ...rest }) {
 /** Records an edge. */
 export function putEdge(dir, from, edge, to) {
   if (!EDGE_KINDS.includes(edge)) throw new Error(`unknown edge kind: ${edge}`);
+  // The kind check stays ABOVE the gate: a disabled graph should not turn a
+  // programming error into silence, or the bug reappears when it is re-enabled.
+  if (wikiDisabled()) return;
   append(dir, { t: 'e', v: GRAPH_VERSION, from, edge, to, at: Date.now() });
 }
 
@@ -813,9 +821,38 @@ function readSnapshots(dir) {
  * never sees the payload. Parsing and then discarding would have cost the same
  * as keeping it, which is the whole reason this is a separate record type.
  */
+/**
+ * Whether the graph is switched off entirely.
+ *
+ * FOR MEASUREMENT, NOT FOR USERS. A benchmark arm needs to isolate what the
+ * graph costs when it can deliver nothing -- which is its situation in any
+ * single-shot harness, because every run gets a throwaway HOME so the store
+ * starts empty and a finding harvested at Stop cannot help the session that
+ * produced it. What is left is pure overhead, and measuring it needs an arm
+ * with the graph off and everything else identical.
+ *
+ * NOT the same as pointing TOKEN_OPTIMIZER_WIKI_DIR at an empty directory: that
+ * stops delivery but leaves harvest writing, so the arm would measure something
+ * other than what it claims.
+ *
+ * Only the affirmative spellings count, so an empty or `0` value cannot switch
+ * the product's main feature off by accident.
+ */
+export function wikiDisabled() {
+  const raw = String(process.env.TOKEN_OPTIMIZER_WIKI_DISABLED || '')
+    .trim()
+    .toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes';
+}
+
 export function load(dir, { snapshots = false } = {}) {
   const nodes = new Map();
   const edges = [];
+  // GATED AT THE STORAGE LAYER, not at the callers. This and the two writers
+  // below are the choke point every higher-level path funnels through; gating
+  // callers instead would mean finding all of them, and one missed site would
+  // leave a "disabled" arm quietly reading or writing.
+  if (wikiDisabled()) return { nodes, edges };
   const path = logPath(dir);
   if (!existsSync(path)) return { nodes, edges };
 

--- a/integrations/opencode/hooks/lib/wiki.mjs
+++ b/integrations/opencode/hooks/lib/wiki.mjs
@@ -659,6 +659,11 @@ function append(dir, record) {
 export function putNode(dir, { kind, key, ...rest }) {
   if (!NODE_KINDS.includes(kind)) throw new Error(`unknown node kind: ${kind}`);
   const id = nodeId(kind, key);
+  // DEGRADES, NEVER THROWS. The id is still computed and returned, so callers
+  // that chain on it -- indexFile mints a file node then edges symbols to it --
+  // keep working and simply persist nothing. Returning undefined here would
+  // turn a measurement switch into a crash.
+  if (wikiDisabled()) return id;
   // `rest` is spread FIRST so it can never override the bookkeeping fields.
   // Spreading it after `id` let a caller passing a whole existing node back in
   // -- which curate.mjs does on every pin, retire and correct -- carry a stale
@@ -683,6 +688,9 @@ export function putNode(dir, { kind, key, ...rest }) {
 /** Records an edge. */
 export function putEdge(dir, from, edge, to) {
   if (!EDGE_KINDS.includes(edge)) throw new Error(`unknown edge kind: ${edge}`);
+  // The kind check stays ABOVE the gate: a disabled graph should not turn a
+  // programming error into silence, or the bug reappears when it is re-enabled.
+  if (wikiDisabled()) return;
   append(dir, { t: 'e', v: GRAPH_VERSION, from, edge, to, at: Date.now() });
 }
 
@@ -813,9 +821,38 @@ function readSnapshots(dir) {
  * never sees the payload. Parsing and then discarding would have cost the same
  * as keeping it, which is the whole reason this is a separate record type.
  */
+/**
+ * Whether the graph is switched off entirely.
+ *
+ * FOR MEASUREMENT, NOT FOR USERS. A benchmark arm needs to isolate what the
+ * graph costs when it can deliver nothing -- which is its situation in any
+ * single-shot harness, because every run gets a throwaway HOME so the store
+ * starts empty and a finding harvested at Stop cannot help the session that
+ * produced it. What is left is pure overhead, and measuring it needs an arm
+ * with the graph off and everything else identical.
+ *
+ * NOT the same as pointing TOKEN_OPTIMIZER_WIKI_DIR at an empty directory: that
+ * stops delivery but leaves harvest writing, so the arm would measure something
+ * other than what it claims.
+ *
+ * Only the affirmative spellings count, so an empty or `0` value cannot switch
+ * the product's main feature off by accident.
+ */
+export function wikiDisabled() {
+  const raw = String(process.env.TOKEN_OPTIMIZER_WIKI_DISABLED || '')
+    .trim()
+    .toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes';
+}
+
 export function load(dir, { snapshots = false } = {}) {
   const nodes = new Map();
   const edges = [];
+  // GATED AT THE STORAGE LAYER, not at the callers. This and the two writers
+  // below are the choke point every higher-level path funnels through; gating
+  // callers instead would mean finding all of them, and one missed site would
+  // leave a "disabled" arm quietly reading or writing.
+  if (wikiDisabled()) return { nodes, edges };
   const path = logPath(dir);
   if (!existsSync(path)) return { nodes, edges };
 

--- a/integrations/qwen/hooks/lib/wiki.mjs
+++ b/integrations/qwen/hooks/lib/wiki.mjs
@@ -659,6 +659,11 @@ function append(dir, record) {
 export function putNode(dir, { kind, key, ...rest }) {
   if (!NODE_KINDS.includes(kind)) throw new Error(`unknown node kind: ${kind}`);
   const id = nodeId(kind, key);
+  // DEGRADES, NEVER THROWS. The id is still computed and returned, so callers
+  // that chain on it -- indexFile mints a file node then edges symbols to it --
+  // keep working and simply persist nothing. Returning undefined here would
+  // turn a measurement switch into a crash.
+  if (wikiDisabled()) return id;
   // `rest` is spread FIRST so it can never override the bookkeeping fields.
   // Spreading it after `id` let a caller passing a whole existing node back in
   // -- which curate.mjs does on every pin, retire and correct -- carry a stale
@@ -683,6 +688,9 @@ export function putNode(dir, { kind, key, ...rest }) {
 /** Records an edge. */
 export function putEdge(dir, from, edge, to) {
   if (!EDGE_KINDS.includes(edge)) throw new Error(`unknown edge kind: ${edge}`);
+  // The kind check stays ABOVE the gate: a disabled graph should not turn a
+  // programming error into silence, or the bug reappears when it is re-enabled.
+  if (wikiDisabled()) return;
   append(dir, { t: 'e', v: GRAPH_VERSION, from, edge, to, at: Date.now() });
 }
 
@@ -813,9 +821,38 @@ function readSnapshots(dir) {
  * never sees the payload. Parsing and then discarding would have cost the same
  * as keeping it, which is the whole reason this is a separate record type.
  */
+/**
+ * Whether the graph is switched off entirely.
+ *
+ * FOR MEASUREMENT, NOT FOR USERS. A benchmark arm needs to isolate what the
+ * graph costs when it can deliver nothing -- which is its situation in any
+ * single-shot harness, because every run gets a throwaway HOME so the store
+ * starts empty and a finding harvested at Stop cannot help the session that
+ * produced it. What is left is pure overhead, and measuring it needs an arm
+ * with the graph off and everything else identical.
+ *
+ * NOT the same as pointing TOKEN_OPTIMIZER_WIKI_DIR at an empty directory: that
+ * stops delivery but leaves harvest writing, so the arm would measure something
+ * other than what it claims.
+ *
+ * Only the affirmative spellings count, so an empty or `0` value cannot switch
+ * the product's main feature off by accident.
+ */
+export function wikiDisabled() {
+  const raw = String(process.env.TOKEN_OPTIMIZER_WIKI_DISABLED || '')
+    .trim()
+    .toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes';
+}
+
 export function load(dir, { snapshots = false } = {}) {
   const nodes = new Map();
   const edges = [];
+  // GATED AT THE STORAGE LAYER, not at the callers. This and the two writers
+  // below are the choke point every higher-level path funnels through; gating
+  // callers instead would mean finding all of them, and one missed site would
+  // leave a "disabled" arm quietly reading or writing.
+  if (wikiDisabled()) return { nodes, edges };
   const path = logPath(dir);
   if (!existsSync(path)) return { nodes, edges };
 

--- a/integrations/windsurf/hooks/lib/wiki.mjs
+++ b/integrations/windsurf/hooks/lib/wiki.mjs
@@ -659,6 +659,11 @@ function append(dir, record) {
 export function putNode(dir, { kind, key, ...rest }) {
   if (!NODE_KINDS.includes(kind)) throw new Error(`unknown node kind: ${kind}`);
   const id = nodeId(kind, key);
+  // DEGRADES, NEVER THROWS. The id is still computed and returned, so callers
+  // that chain on it -- indexFile mints a file node then edges symbols to it --
+  // keep working and simply persist nothing. Returning undefined here would
+  // turn a measurement switch into a crash.
+  if (wikiDisabled()) return id;
   // `rest` is spread FIRST so it can never override the bookkeeping fields.
   // Spreading it after `id` let a caller passing a whole existing node back in
   // -- which curate.mjs does on every pin, retire and correct -- carry a stale
@@ -683,6 +688,9 @@ export function putNode(dir, { kind, key, ...rest }) {
 /** Records an edge. */
 export function putEdge(dir, from, edge, to) {
   if (!EDGE_KINDS.includes(edge)) throw new Error(`unknown edge kind: ${edge}`);
+  // The kind check stays ABOVE the gate: a disabled graph should not turn a
+  // programming error into silence, or the bug reappears when it is re-enabled.
+  if (wikiDisabled()) return;
   append(dir, { t: 'e', v: GRAPH_VERSION, from, edge, to, at: Date.now() });
 }
 
@@ -813,9 +821,38 @@ function readSnapshots(dir) {
  * never sees the payload. Parsing and then discarding would have cost the same
  * as keeping it, which is the whole reason this is a separate record type.
  */
+/**
+ * Whether the graph is switched off entirely.
+ *
+ * FOR MEASUREMENT, NOT FOR USERS. A benchmark arm needs to isolate what the
+ * graph costs when it can deliver nothing -- which is its situation in any
+ * single-shot harness, because every run gets a throwaway HOME so the store
+ * starts empty and a finding harvested at Stop cannot help the session that
+ * produced it. What is left is pure overhead, and measuring it needs an arm
+ * with the graph off and everything else identical.
+ *
+ * NOT the same as pointing TOKEN_OPTIMIZER_WIKI_DIR at an empty directory: that
+ * stops delivery but leaves harvest writing, so the arm would measure something
+ * other than what it claims.
+ *
+ * Only the affirmative spellings count, so an empty or `0` value cannot switch
+ * the product's main feature off by accident.
+ */
+export function wikiDisabled() {
+  const raw = String(process.env.TOKEN_OPTIMIZER_WIKI_DISABLED || '')
+    .trim()
+    .toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes';
+}
+
 export function load(dir, { snapshots = false } = {}) {
   const nodes = new Map();
   const edges = [];
+  // GATED AT THE STORAGE LAYER, not at the callers. This and the two writers
+  // below are the choke point every higher-level path funnels through; gating
+  // callers instead would mean finding all of them, and one missed site would
+  // leave a "disabled" arm quietly reading or writing.
+  if (wikiDisabled()) return { nodes, edges };
   const path = logPath(dir);
   if (!existsSync(path)) return { nodes, edges };
 

--- a/plugin/hooks/lib/wiki.mjs
+++ b/plugin/hooks/lib/wiki.mjs
@@ -659,6 +659,11 @@ function append(dir, record) {
 export function putNode(dir, { kind, key, ...rest }) {
   if (!NODE_KINDS.includes(kind)) throw new Error(`unknown node kind: ${kind}`);
   const id = nodeId(kind, key);
+  // DEGRADES, NEVER THROWS. The id is still computed and returned, so callers
+  // that chain on it -- indexFile mints a file node then edges symbols to it --
+  // keep working and simply persist nothing. Returning undefined here would
+  // turn a measurement switch into a crash.
+  if (wikiDisabled()) return id;
   // `rest` is spread FIRST so it can never override the bookkeeping fields.
   // Spreading it after `id` let a caller passing a whole existing node back in
   // -- which curate.mjs does on every pin, retire and correct -- carry a stale
@@ -683,6 +688,9 @@ export function putNode(dir, { kind, key, ...rest }) {
 /** Records an edge. */
 export function putEdge(dir, from, edge, to) {
   if (!EDGE_KINDS.includes(edge)) throw new Error(`unknown edge kind: ${edge}`);
+  // The kind check stays ABOVE the gate: a disabled graph should not turn a
+  // programming error into silence, or the bug reappears when it is re-enabled.
+  if (wikiDisabled()) return;
   append(dir, { t: 'e', v: GRAPH_VERSION, from, edge, to, at: Date.now() });
 }
 
@@ -813,9 +821,38 @@ function readSnapshots(dir) {
  * never sees the payload. Parsing and then discarding would have cost the same
  * as keeping it, which is the whole reason this is a separate record type.
  */
+/**
+ * Whether the graph is switched off entirely.
+ *
+ * FOR MEASUREMENT, NOT FOR USERS. A benchmark arm needs to isolate what the
+ * graph costs when it can deliver nothing -- which is its situation in any
+ * single-shot harness, because every run gets a throwaway HOME so the store
+ * starts empty and a finding harvested at Stop cannot help the session that
+ * produced it. What is left is pure overhead, and measuring it needs an arm
+ * with the graph off and everything else identical.
+ *
+ * NOT the same as pointing TOKEN_OPTIMIZER_WIKI_DIR at an empty directory: that
+ * stops delivery but leaves harvest writing, so the arm would measure something
+ * other than what it claims.
+ *
+ * Only the affirmative spellings count, so an empty or `0` value cannot switch
+ * the product's main feature off by accident.
+ */
+export function wikiDisabled() {
+  const raw = String(process.env.TOKEN_OPTIMIZER_WIKI_DISABLED || '')
+    .trim()
+    .toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes';
+}
+
 export function load(dir, { snapshots = false } = {}) {
   const nodes = new Map();
   const edges = [];
+  // GATED AT THE STORAGE LAYER, not at the callers. This and the two writers
+  // below are the choke point every higher-level path funnels through; gating
+  // callers instead would mean finding all of them, and one missed site would
+  // leave a "disabled" arm quietly reading or writing.
+  if (wikiDisabled()) return { nodes, edges };
   const path = logPath(dir);
   if (!existsSync(path)) return { nodes, edges };
 

--- a/tests/hooks/wiki-disabled.test.mjs
+++ b/tests/hooks/wiki-disabled.test.mjs
@@ -1,0 +1,106 @@
+/**
+ * `TOKEN_OPTIMIZER_WIKI_DISABLED=1` makes the graph inert without breaking it.
+ *
+ * WHY THIS EXISTS. A benchmark arm needs to isolate what the knowledge graph
+ * costs when it can deliver nothing. Every THOL run gets a throwaway HOME, so
+ * the graph starts empty on every run and its retrieval value is structurally
+ * zero there -- what remains is pure overhead: SessionStart injection walking an
+ * empty store, and Stop harvest writing findings nothing will read. Measuring
+ * that needs an arm with the graph off and everything else identical.
+ *
+ * The obvious shortcut is wrong and is deliberately not used: pointing
+ * TOKEN_OPTIMIZER_WIKI_DIR at an empty directory stops delivery but leaves
+ * harvest WRITING, so the arm would measure something other than what it
+ * claims.
+ *
+ * The gate sits at the storage layer -- `load`, `putNode`, `putEdge` -- because
+ * that is the one choke point every higher-level path funnels through. Gating
+ * the callers instead would mean finding all of them, and missing one would
+ * leave the arm quietly writing.
+ *
+ * DEGRADES, NEVER THROWS. `putNode` still returns a well-formed id so callers
+ * that chain on it keep working; they simply persist nothing.
+ */
+
+import { mkdtempSync, rmSync, existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { load, putNode, putEdge, wikiDisabled } from '../../hooks-core/wiki.mjs';
+
+let dir;
+
+const withDisabled = (value, fn) => {
+  const had = Object.hasOwn(process.env, 'TOKEN_OPTIMIZER_WIKI_DISABLED');
+  const prev = process.env.TOKEN_OPTIMIZER_WIKI_DISABLED;
+  if (value === undefined) delete process.env.TOKEN_OPTIMIZER_WIKI_DISABLED;
+  else process.env.TOKEN_OPTIMIZER_WIKI_DISABLED = value;
+  try {
+    return fn();
+  } finally {
+    if (had) process.env.TOKEN_OPTIMIZER_WIKI_DISABLED = prev;
+    else delete process.env.TOKEN_OPTIMIZER_WIKI_DISABLED;
+  }
+};
+
+const fileNode = (key) => ({ kind: 'file', key, hash: 'abc123', bytes: 10 });
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'wiki-disabled-'));
+});
+
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe('the switch itself', () => {
+  test('is off unless explicitly set', () => {
+    expect(withDisabled(undefined, wikiDisabled)).toBe(false);
+    expect(withDisabled('', wikiDisabled)).toBe(false);
+    expect(withDisabled('0', wikiDisabled)).toBe(false);
+    expect(withDisabled('false', wikiDisabled)).toBe(false);
+  });
+
+  test('is on for the values a person would actually type', () => {
+    expect(withDisabled('1', wikiDisabled)).toBe(true);
+    expect(withDisabled('true', wikiDisabled)).toBe(true);
+    expect(withDisabled('TRUE', wikiDisabled)).toBe(true);
+  });
+});
+
+describe('enabled -- the control, so the tests below cannot pass vacuously', () => {
+  test('a node is written and read back', () => {
+    withDisabled(undefined, () => {
+      const id = putNode(dir, fileNode('/tmp/a.ts'));
+      expect(typeof id).toBe('string');
+      expect(load(dir).nodes.size).toBe(1);
+    });
+  });
+});
+
+describe('disabled', () => {
+  test('writes nothing to disk', () => {
+    withDisabled('1', () => {
+      putNode(dir, fileNode('/tmp/a.ts'));
+      putEdge(dir, 'from-id', 'related', 'to-id');
+    });
+    // Not merely "no graph loads" -- nothing was persisted at all, which is what
+    // makes this an overhead measurement rather than a delivery one.
+    expect(existsSync(dir) ? readdirSync(dir) : []).toEqual([]);
+  });
+
+  test('still returns a usable id, so callers that chain on it do not break', () => {
+    const id = withDisabled('1', () => putNode(dir, fileNode('/tmp/a.ts')));
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  test('reads as empty even when a populated graph is sitting there', () => {
+    // The graph is written with the switch OFF, then read with it ON. This is
+    // the case that separates a real gate from one that only works because
+    // nothing was ever stored.
+    withDisabled(undefined, () => putNode(dir, fileNode('/tmp/a.ts')));
+    expect(withDisabled(undefined, () => load(dir).nodes.size)).toBe(1);
+
+    const loaded = withDisabled('1', () => load(dir));
+    expect(loaded.nodes.size).toBe(0);
+    expect(loaded.edges).toEqual([]);
+  });
+});


### PR DESCRIPTION
Part of #357 (M3 prerequisite).

Prerequisite for the `nograph` benchmark arm in M3 (spec: #353). Independent of #352 and #354.

## Why

A benchmark arm needs to isolate what the knowledge graph **costs when it can deliver nothing** — which is its situation in any single-shot harness. Every THOL run gets a throwaway `HOME`, so the store starts empty and a finding harvested at `Stop` cannot help the session that produced it. What remains is pure overhead: SessionStart injection walking an empty store, harvest writing findings nothing will read.

Measuring that needs an arm with the graph off and **everything else identical**.

## The shortcut this deliberately does not take

Pointing `TOKEN_OPTIMIZER_WIKI_DIR` at an empty directory stops *delivery* but leaves *harvest writing*. An arm built that way would measure something other than what its manifest claims — which is worse than not measuring, because the number looks real.

## Design

**Gated at the storage layer** — `load`, `putNode`, `putEdge`. That is the choke point every higher-level path funnels through. Gating callers instead would mean finding all of them, and one missed site leaves a "disabled" arm quietly reading or writing.

**Degrades, never throws.** `putNode` still computes and returns a well-formed id when disabled, so callers that chain on it keep working and simply persist nothing — `indexFile` mints a file node and then edges symbols to it, so returning `undefined` would turn a measurement switch into a crash.

**`putEdge` keeps its kind check above the gate**, so a disabled graph cannot turn a programming error into silence and hide it until the graph is re-enabled.

**Only affirmative spellings count** (`1`, `true`, `yes`), so an empty or `0` value cannot switch the product's main feature off by accident.

## Tests

`tests/hooks/wiki-disabled.test.mjs`, 6 tests. Two are load-bearing:

- a **control** that writes and reads back with the switch off, so the disabled assertions cannot pass vacuously
- a case that **populates a graph with the switch off, then reads it with the switch on** — which separates a real gate from one that only appears to work because nothing was ever stored

Lint clean; **209 suites / 2749 tests passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
