### PR TITLE
feat(read): diff against what this session wrote, not against what a hook saw

### DIFF
--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -70,6 +70,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
@@ -866,6 +867,22 @@ function observeAndInject(payload, state, episode, features) {
           hash: contentHash(path, source),
         });
         indexFile(dir, path, source);
+
+        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
+        // because it answers a different question. `indexFile` records what a
+        // hook OBSERVED -- reads included, across sessions -- which is unusable
+        // as a diff base: it would tell a session that never saw a file that
+        // nothing had changed. This record is written only on a mutation and
+        // carries the authoring session, so `smart_read` can ask "did I write
+        // this?" rather than "has anyone seen this?".
+        //
+        // Free here: the source is already in hand for the graph write.
+        recordAuthoredContent(
+          projectRootFor(path, payload.cwd),
+          payload.session_id,
+          path,
+          source
+        );
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }

--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -764,7 +764,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state, episode, features) {
+function observeAndInject(payload, state, episode, features, authored = false) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
   const registerRoot = (root) => {
@@ -868,21 +868,31 @@ function observeAndInject(payload, state, episode, features) {
         });
         indexFile(dir, path, source);
 
-        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
-        // because it answers a different question. `indexFile` records what a
-        // hook OBSERVED -- reads included, across sessions -- which is unusable
-        // as a diff base: it would tell a session that never saw a file that
-        // nothing had changed. This record is written only on a mutation and
-        // carries the authoring session, so `smart_read` can ask "did I write
-        // this?" rather than "has anyone seen this?".
+        // WHAT THIS SESSION WROTE -- and ONLY what it wrote.
         //
-        // Free here: the source is already in hand for the graph write.
-        recordAuthoredContent(
-          projectRootFor(path, payload.cwd),
-          payload.session_id,
-          path,
-          source
-        );
+        // GATED ON A SUCCESSFUL MUTATION, because this loop is not one. It
+        // iterates `touchedFiles`, which covers every tool that NAMES a file,
+        // reads included, and its own comment above calls that "evidence about
+        // what was touched". Recording an authored base from a read would
+        // recreate the exact defect this store exists to avoid: a later
+        // smart_read in the same session would be told "no changes" about
+        // content the model never received.
+        //
+        // A failed write is excluded for the same reason -- the bytes on disk
+        // are not what we tried to write, so they are not a truthful base.
+        // `mutationSucceeded` is the existing conservative classifier, already
+        // used to gate edit counting, so this cannot disagree with the rest of
+        // the accounting about what a successful mutation is.
+        //
+        // Free when it does apply: the source is already in hand for the graph.
+        if (authored) {
+          recordAuthoredContent(
+            projectRootFor(path, payload.cwd),
+            payload.session_id,
+            path,
+            source
+          );
+        }
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }
@@ -1391,7 +1401,20 @@ async function runHook(clientName, event, invocation) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state, episode, features);
+    // Computed HERE because clientName, event and raw are in scope here and
+    // not inside observeAndInject -- a first attempt referenced them there and
+    // would have thrown at runtime on the one path that matters.
+    const authoredWrite =
+      event === 'post-tool' &&
+      new Set(['Edit', 'MultiEdit', 'Write']).has(String(payload.tool_name || '')) &&
+      mutationSucceeded(clientName, raw);
+    graphContext = observeAndInject(
+      payload,
+      state,
+      episode,
+      features,
+      authoredWrite
+    );
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -433,6 +433,18 @@ function codexStringLiteral(literal) {
   return decoded;
 }
 
+/**
+ * Cline's write tools, under the names the rest of the pipeline matches on.
+ *
+ * Cline calls them `write_to_file` and `replace_in_file`; authoredWrite tests
+ * membership of {Edit, MultiEdit, Write}, so without the rename the
+ * integration reads the right field and still never records an authored write.
+ */
+const CLINE_TOOL_NAMES = {
+  write_to_file: 'Write',
+  replace_in_file: 'Edit',
+};
+
 /** Convert client-specific lifecycle envelopes into the common tool shape. */
 function codexStringBindings(source) {
   const values = new Map();
@@ -517,17 +529,28 @@ export function normalizeClientPayload(clientName, event, raw) {
   if (clientName === 'cline') {
     const body = event === 'post-tool' ? raw.postToolUse : raw.preToolUse;
     if (!body) return raw;
+    // `toolName` IS THE FIELD CLINE SENDS. Reading only `body.tool` left
+    // `tool_name` null, and the handler exits on a null tool name -- so every
+    // Cline call fell out before authoredWrite or recordAuthoredContent could
+    // run, and the whole integration was a silent no-op. `body.tool` is kept as
+    // a fallback rather than replaced, because a payload carrying it costs
+    // nothing to accept.
+    const rawTool = body.toolName ?? body.tool;
     return {
       ...raw,
       session_id: raw.taskId ?? raw.task_id,
       cwd: raw.workspaceRoots?.[0] ?? raw.workspacePath,
       model: raw.model?.slug,
-      tool: body.tool,
+      // MAPPED TO THE CANONICAL NAMES the rest of the pipeline matches on.
+      // authoredWrite tests membership of {Edit, MultiEdit, Write}, so Cline's
+      // own spellings would still have missed even once the field was read.
+      tool: CLINE_TOOL_NAMES[rawTool] ?? rawTool,
       parameters: body.parameters,
     };
   }
 
   if (clientName === 'windsurf') {
+    // (see CLINE_TOOL_NAMES above for why the cline branch renames its tools)
     const info = raw.tool_info || {};
     const action = String(raw.agent_action_name || '');
     const tool = action.includes('read_code')

--- a/hooks-core/authored.mjs
+++ b/hooks-core/authored.mjs
@@ -73,30 +73,39 @@ export function recordAuthoredContent(projectRoot, sessionId, filePath, content)
   try {
     if (!projectRoot || !sessionId || !filePath) return;
     if (typeof content !== 'string') return;
+    // A CHEAP LOWER BOUND FIRST. The serialized record is never smaller than
+    // its content, so this rejects the obvious cases without paying to
+    // stringify them. It is not the real check.
+    //
     // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
     // so 100k CJK characters measured 100,000 against a 262,144 cap while
-    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
-    // so the check is on the encoded size of the field that dominates it.
+    // writing 300,000 bytes -- 15% over.
     if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);
     mkdirSync(dir, { recursive: true });
 
+    const record = JSON.stringify({
+      v: 1,
+      sessionId,
+      path: canonicalPath(filePath),
+      hash: hash(content),
+      content,
+      at: Date.now(),
+    });
+
+    // THE AUTHORITATIVE CHECK, ON WHAT IS ACTUALLY WRITTEN. Measuring the
+    // content alone does not bound the record, because JSON escapes: a control
+    // character costs one byte in `content` and six in the record. 262,144 NUL
+    // characters therefore passed the check above and persisted about 1.5 MiB
+    // -- six times the configured cap -- and the field the cap exists to bound
+    // is the file on disk, not the string that went into it.
+    if (Buffer.byteLength(record, 'utf8') > limit()) return;
+
     const target = recordPath(projectRoot, filePath);
     const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
-    writeFileSync(
-      tmp,
-      JSON.stringify({
-        v: 1,
-        sessionId,
-        path: canonicalPath(filePath),
-        hash: hash(content),
-        content,
-        at: Date.now(),
-      }),
-      { mode: 0o600 }
-    );
+    writeFileSync(tmp, record, { mode: 0o600 });
     renameSync(tmp, target);
   } catch {
     /* the write landed; the record is an optimization */

--- a/hooks-core/authored.mjs
+++ b/hooks-core/authored.mjs
@@ -1,0 +1,136 @@
+/**
+ * What THIS session wrote, so a later read can diff against it.
+ *
+ * THE QUESTION THIS ANSWERS, AND THE ONE IT DOES NOT. A diff base is only sound
+ * if the caller already holds the bytes it is being diffed against. That is a
+ * statement about AUTHORSHIP or DELIVERY, never about observation.
+ *
+ * The knowledge graph cannot supply it, and the distinction is not academic:
+ * `indexFile` runs on every file either hook OBSERVES -- reads included, across
+ * sessions -- so a graph snapshot means "some hook last saw these bytes". Using
+ * that as a base would hand a fresh session `// No changes` for a file it has
+ * never seen, withholding content while reporting success. That is strictly
+ * worse than resending the file, which is the behaviour being improved on.
+ *
+ * So this store is written ONLY by a write, and every record carries the
+ * session that made it.
+ *
+ * DEGRADATION IS ONE-DIRECTIONAL, BY CONSTRUCTION. Every uncertain state --
+ * missing record, unreadable record, different session, absent session id,
+ * content whose hash no longer matches disk, a file that has since been deleted
+ * -- resolves to `null`, meaning "no base", meaning the caller resends the file.
+ * The store can never make a read worse than it is today; at worst it does
+ * nothing. Nothing here may throw, because these run inside hooks and a hook
+ * that breaks a tool call is worse than one that saves nothing.
+ */
+
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+/**
+ * Largest authored file kept.
+ *
+ * Matched to the graph's own snapshot cap for the same reason it has one: a
+ * store that keeps every write becomes a second copy of the repository. Past
+ * the cap a read simply gets no base and resends, which is today's behaviour.
+ */
+const limit = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_AUTHORED_LIMIT);
+  return Number.isFinite(raw) && raw > 0 ? raw : 262_144;
+};
+
+const storeDir = (projectRoot) =>
+  join(projectRoot, '.token-optimizer', 'authored');
+
+/** One file per authored path, named by a digest so no path escapes the store. */
+const recordPath = (projectRoot, filePath) =>
+  join(
+    storeDir(projectRoot),
+    createHash('sha256').update(canonicalPath(filePath)).digest('hex').slice(0, 32) +
+      '.json'
+  );
+
+const hash = (text) =>
+  createHash('sha256').update(text, 'utf8').digest('hex').slice(0, 32);
+
+/**
+ * Records that `sessionId` wrote `content` to `filePath`.
+ *
+ * Written atomically: a torn record read back as valid JSON with the wrong
+ * bytes would be a WRONG diff base, which is the one outcome this store must
+ * never produce. A temp file plus rename means a reader sees the old record or
+ * the new one, never half of either.
+ */
+export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return;
+    if (typeof content !== 'string' || content.length > limit()) return;
+    if (!isFsSafePath(filePath)) return;
+
+    const dir = storeDir(projectRoot);
+    mkdirSync(dir, { recursive: true });
+
+    const target = recordPath(projectRoot, filePath);
+    const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+    writeFileSync(
+      tmp,
+      JSON.stringify({
+        v: 1,
+        sessionId,
+        path: canonicalPath(filePath),
+        hash: hash(content),
+        content,
+        at: Date.now(),
+      }),
+      { mode: 0o600 }
+    );
+    renameSync(tmp, target);
+  } catch {
+    /* the write landed; the record is an optimization */
+  }
+}
+
+/**
+ * The bytes `sessionId` wrote to `filePath`, or null.
+ *
+ * Null on every uncertainty. The hash check against disk is what makes a stale
+ * record safe rather than merely unlikely: if anything changed the file after
+ * we wrote it -- another process, another tool, a `git checkout` -- the recorded
+ * bytes are no longer a truthful "before", and a diff against them would
+ * describe a change that never happened.
+ */
+export function authoredContentFor(projectRoot, sessionId, filePath) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return null;
+    if (!isFsSafePath(filePath)) return null;
+
+    const raw = readFileSync(recordPath(projectRoot, filePath), 'utf8');
+    const record = JSON.parse(raw);
+
+    // THE SESSION GATE, which is the whole point. A record from another session
+    // describes bytes this caller never received.
+    if (record?.v !== 1 || record.sessionId !== sessionId) return null;
+    if (typeof record.content !== 'string') return null;
+    if (record.path !== canonicalPath(filePath)) return null;
+
+    // Cheap rejection before reading the file: a size change is a content
+    // change, and this runs on a tool-call path.
+    const size = statSync(filePath).size;
+    if (size !== Buffer.byteLength(record.content, 'utf8')) return null;
+
+    const onDisk = readFileSync(filePath, 'utf8');
+    if (hash(onDisk) !== record.hash) return null;
+
+    return record.content;
+  } catch {
+    return null;
+  }
+}

--- a/hooks-core/authored.mjs
+++ b/hooks-core/authored.mjs
@@ -72,7 +72,12 @@ const hash = (text) =>
 export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
   try {
     if (!projectRoot || !sessionId || !filePath) return;
-    if (typeof content !== 'string' || content.length > limit()) return;
+    if (typeof content !== 'string') return;
+    // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
+    // so 100k CJK characters measured 100,000 against a 262,144 cap while
+    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
+    // so the check is on the encoded size of the field that dominates it.
+    if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -72,6 +72,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
@@ -868,6 +869,22 @@ function observeAndInject(payload, state, episode, features) {
           hash: contentHash(path, source),
         });
         indexFile(dir, path, source);
+
+        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
+        // because it answers a different question. `indexFile` records what a
+        // hook OBSERVED -- reads included, across sessions -- which is unusable
+        // as a diff base: it would tell a session that never saw a file that
+        // nothing had changed. This record is written only on a mutation and
+        // carries the authoring session, so `smart_read` can ask "did I write
+        // this?" rather than "has anyone seen this?".
+        //
+        // Free here: the source is already in hand for the graph write.
+        recordAuthoredContent(
+          projectRootFor(path, payload.cwd),
+          payload.session_id,
+          path,
+          source
+        );
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -766,7 +766,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state, episode, features) {
+function observeAndInject(payload, state, episode, features, authored = false) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
   const registerRoot = (root) => {
@@ -870,21 +870,31 @@ function observeAndInject(payload, state, episode, features) {
         });
         indexFile(dir, path, source);
 
-        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
-        // because it answers a different question. `indexFile` records what a
-        // hook OBSERVED -- reads included, across sessions -- which is unusable
-        // as a diff base: it would tell a session that never saw a file that
-        // nothing had changed. This record is written only on a mutation and
-        // carries the authoring session, so `smart_read` can ask "did I write
-        // this?" rather than "has anyone seen this?".
+        // WHAT THIS SESSION WROTE -- and ONLY what it wrote.
         //
-        // Free here: the source is already in hand for the graph write.
-        recordAuthoredContent(
-          projectRootFor(path, payload.cwd),
-          payload.session_id,
-          path,
-          source
-        );
+        // GATED ON A SUCCESSFUL MUTATION, because this loop is not one. It
+        // iterates `touchedFiles`, which covers every tool that NAMES a file,
+        // reads included, and its own comment above calls that "evidence about
+        // what was touched". Recording an authored base from a read would
+        // recreate the exact defect this store exists to avoid: a later
+        // smart_read in the same session would be told "no changes" about
+        // content the model never received.
+        //
+        // A failed write is excluded for the same reason -- the bytes on disk
+        // are not what we tried to write, so they are not a truthful base.
+        // `mutationSucceeded` is the existing conservative classifier, already
+        // used to gate edit counting, so this cannot disagree with the rest of
+        // the accounting about what a successful mutation is.
+        //
+        // Free when it does apply: the source is already in hand for the graph.
+        if (authored) {
+          recordAuthoredContent(
+            projectRootFor(path, payload.cwd),
+            payload.session_id,
+            path,
+            source
+          );
+        }
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }
@@ -1393,7 +1403,20 @@ async function runHook(clientName, event, invocation) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state, episode, features);
+    // Computed HERE because clientName, event and raw are in scope here and
+    // not inside observeAndInject -- a first attempt referenced them there and
+    // would have thrown at runtime on the one path that matters.
+    const authoredWrite =
+      event === 'post-tool' &&
+      new Set(['Edit', 'MultiEdit', 'Write']).has(String(payload.tool_name || '')) &&
+      mutationSucceeded(clientName, raw);
+    graphContext = observeAndInject(
+      payload,
+      state,
+      episode,
+      features,
+      authoredWrite
+    );
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -435,6 +435,18 @@ function codexStringLiteral(literal) {
   return decoded;
 }
 
+/**
+ * Cline's write tools, under the names the rest of the pipeline matches on.
+ *
+ * Cline calls them `write_to_file` and `replace_in_file`; authoredWrite tests
+ * membership of {Edit, MultiEdit, Write}, so without the rename the
+ * integration reads the right field and still never records an authored write.
+ */
+const CLINE_TOOL_NAMES = {
+  write_to_file: 'Write',
+  replace_in_file: 'Edit',
+};
+
 /** Convert client-specific lifecycle envelopes into the common tool shape. */
 function codexStringBindings(source) {
   const values = new Map();
@@ -519,17 +531,28 @@ export function normalizeClientPayload(clientName, event, raw) {
   if (clientName === 'cline') {
     const body = event === 'post-tool' ? raw.postToolUse : raw.preToolUse;
     if (!body) return raw;
+    // `toolName` IS THE FIELD CLINE SENDS. Reading only `body.tool` left
+    // `tool_name` null, and the handler exits on a null tool name -- so every
+    // Cline call fell out before authoredWrite or recordAuthoredContent could
+    // run, and the whole integration was a silent no-op. `body.tool` is kept as
+    // a fallback rather than replaced, because a payload carrying it costs
+    // nothing to accept.
+    const rawTool = body.toolName ?? body.tool;
     return {
       ...raw,
       session_id: raw.taskId ?? raw.task_id,
       cwd: raw.workspaceRoots?.[0] ?? raw.workspacePath,
       model: raw.model?.slug,
-      tool: body.tool,
+      // MAPPED TO THE CANONICAL NAMES the rest of the pipeline matches on.
+      // authoredWrite tests membership of {Edit, MultiEdit, Write}, so Cline's
+      // own spellings would still have missed even once the field was read.
+      tool: CLINE_TOOL_NAMES[rawTool] ?? rawTool,
       parameters: body.parameters,
     };
   }
 
   if (clientName === 'windsurf') {
+    // (see CLINE_TOOL_NAMES above for why the cline branch renames its tools)
     const info = raw.tool_info || {};
     const action = String(raw.agent_action_name || '');
     const tool = action.includes('read_code')

--- a/integrations/cline/hooks/token-optimizer/lib/authored.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/authored.mjs
@@ -75,30 +75,39 @@ export function recordAuthoredContent(projectRoot, sessionId, filePath, content)
   try {
     if (!projectRoot || !sessionId || !filePath) return;
     if (typeof content !== 'string') return;
+    // A CHEAP LOWER BOUND FIRST. The serialized record is never smaller than
+    // its content, so this rejects the obvious cases without paying to
+    // stringify them. It is not the real check.
+    //
     // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
     // so 100k CJK characters measured 100,000 against a 262,144 cap while
-    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
-    // so the check is on the encoded size of the field that dominates it.
+    // writing 300,000 bytes -- 15% over.
     if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);
     mkdirSync(dir, { recursive: true });
 
+    const record = JSON.stringify({
+      v: 1,
+      sessionId,
+      path: canonicalPath(filePath),
+      hash: hash(content),
+      content,
+      at: Date.now(),
+    });
+
+    // THE AUTHORITATIVE CHECK, ON WHAT IS ACTUALLY WRITTEN. Measuring the
+    // content alone does not bound the record, because JSON escapes: a control
+    // character costs one byte in `content` and six in the record. 262,144 NUL
+    // characters therefore passed the check above and persisted about 1.5 MiB
+    // -- six times the configured cap -- and the field the cap exists to bound
+    // is the file on disk, not the string that went into it.
+    if (Buffer.byteLength(record, 'utf8') > limit()) return;
+
     const target = recordPath(projectRoot, filePath);
     const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
-    writeFileSync(
-      tmp,
-      JSON.stringify({
-        v: 1,
-        sessionId,
-        path: canonicalPath(filePath),
-        hash: hash(content),
-        content,
-        at: Date.now(),
-      }),
-      { mode: 0o600 }
-    );
+    writeFileSync(tmp, record, { mode: 0o600 });
     renameSync(tmp, target);
   } catch {
     /* the write landed; the record is an optimization */

--- a/integrations/cline/hooks/token-optimizer/lib/authored.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/authored.mjs
@@ -74,7 +74,12 @@ const hash = (text) =>
 export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
   try {
     if (!projectRoot || !sessionId || !filePath) return;
-    if (typeof content !== 'string' || content.length > limit()) return;
+    if (typeof content !== 'string') return;
+    // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
+    // so 100k CJK characters measured 100,000 against a 262,144 cap while
+    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
+    // so the check is on the encoded size of the field that dominates it.
+    if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);

--- a/integrations/cline/hooks/token-optimizer/lib/authored.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/authored.mjs
@@ -1,0 +1,138 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/authored.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * What THIS session wrote, so a later read can diff against it.
+ *
+ * THE QUESTION THIS ANSWERS, AND THE ONE IT DOES NOT. A diff base is only sound
+ * if the caller already holds the bytes it is being diffed against. That is a
+ * statement about AUTHORSHIP or DELIVERY, never about observation.
+ *
+ * The knowledge graph cannot supply it, and the distinction is not academic:
+ * `indexFile` runs on every file either hook OBSERVES -- reads included, across
+ * sessions -- so a graph snapshot means "some hook last saw these bytes". Using
+ * that as a base would hand a fresh session `// No changes` for a file it has
+ * never seen, withholding content while reporting success. That is strictly
+ * worse than resending the file, which is the behaviour being improved on.
+ *
+ * So this store is written ONLY by a write, and every record carries the
+ * session that made it.
+ *
+ * DEGRADATION IS ONE-DIRECTIONAL, BY CONSTRUCTION. Every uncertain state --
+ * missing record, unreadable record, different session, absent session id,
+ * content whose hash no longer matches disk, a file that has since been deleted
+ * -- resolves to `null`, meaning "no base", meaning the caller resends the file.
+ * The store can never make a read worse than it is today; at worst it does
+ * nothing. Nothing here may throw, because these run inside hooks and a hook
+ * that breaks a tool call is worse than one that saves nothing.
+ */
+
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+/**
+ * Largest authored file kept.
+ *
+ * Matched to the graph's own snapshot cap for the same reason it has one: a
+ * store that keeps every write becomes a second copy of the repository. Past
+ * the cap a read simply gets no base and resends, which is today's behaviour.
+ */
+const limit = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_AUTHORED_LIMIT);
+  return Number.isFinite(raw) && raw > 0 ? raw : 262_144;
+};
+
+const storeDir = (projectRoot) =>
+  join(projectRoot, '.token-optimizer', 'authored');
+
+/** One file per authored path, named by a digest so no path escapes the store. */
+const recordPath = (projectRoot, filePath) =>
+  join(
+    storeDir(projectRoot),
+    createHash('sha256').update(canonicalPath(filePath)).digest('hex').slice(0, 32) +
+      '.json'
+  );
+
+const hash = (text) =>
+  createHash('sha256').update(text, 'utf8').digest('hex').slice(0, 32);
+
+/**
+ * Records that `sessionId` wrote `content` to `filePath`.
+ *
+ * Written atomically: a torn record read back as valid JSON with the wrong
+ * bytes would be a WRONG diff base, which is the one outcome this store must
+ * never produce. A temp file plus rename means a reader sees the old record or
+ * the new one, never half of either.
+ */
+export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return;
+    if (typeof content !== 'string' || content.length > limit()) return;
+    if (!isFsSafePath(filePath)) return;
+
+    const dir = storeDir(projectRoot);
+    mkdirSync(dir, { recursive: true });
+
+    const target = recordPath(projectRoot, filePath);
+    const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+    writeFileSync(
+      tmp,
+      JSON.stringify({
+        v: 1,
+        sessionId,
+        path: canonicalPath(filePath),
+        hash: hash(content),
+        content,
+        at: Date.now(),
+      }),
+      { mode: 0o600 }
+    );
+    renameSync(tmp, target);
+  } catch {
+    /* the write landed; the record is an optimization */
+  }
+}
+
+/**
+ * The bytes `sessionId` wrote to `filePath`, or null.
+ *
+ * Null on every uncertainty. The hash check against disk is what makes a stale
+ * record safe rather than merely unlikely: if anything changed the file after
+ * we wrote it -- another process, another tool, a `git checkout` -- the recorded
+ * bytes are no longer a truthful "before", and a diff against them would
+ * describe a change that never happened.
+ */
+export function authoredContentFor(projectRoot, sessionId, filePath) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return null;
+    if (!isFsSafePath(filePath)) return null;
+
+    const raw = readFileSync(recordPath(projectRoot, filePath), 'utf8');
+    const record = JSON.parse(raw);
+
+    // THE SESSION GATE, which is the whole point. A record from another session
+    // describes bytes this caller never received.
+    if (record?.v !== 1 || record.sessionId !== sessionId) return null;
+    if (typeof record.content !== 'string') return null;
+    if (record.path !== canonicalPath(filePath)) return null;
+
+    // Cheap rejection before reading the file: a size change is a content
+    // change, and this runs on a tool-call path.
+    const size = statSync(filePath).size;
+    if (size !== Buffer.byteLength(record.content, 'utf8')) return null;
+
+    const onDisk = readFileSync(filePath, 'utf8');
+    if (hash(onDisk) !== record.hash) return null;
+
+    return record.content;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -72,6 +72,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
@@ -868,6 +869,22 @@ function observeAndInject(payload, state, episode, features) {
           hash: contentHash(path, source),
         });
         indexFile(dir, path, source);
+
+        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
+        // because it answers a different question. `indexFile` records what a
+        // hook OBSERVED -- reads included, across sessions -- which is unusable
+        // as a diff base: it would tell a session that never saw a file that
+        // nothing had changed. This record is written only on a mutation and
+        // carries the authoring session, so `smart_read` can ask "did I write
+        // this?" rather than "has anyone seen this?".
+        //
+        // Free here: the source is already in hand for the graph write.
+        recordAuthoredContent(
+          projectRootFor(path, payload.cwd),
+          payload.session_id,
+          path,
+          source
+        );
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -766,7 +766,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state, episode, features) {
+function observeAndInject(payload, state, episode, features, authored = false) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
   const registerRoot = (root) => {
@@ -870,21 +870,31 @@ function observeAndInject(payload, state, episode, features) {
         });
         indexFile(dir, path, source);
 
-        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
-        // because it answers a different question. `indexFile` records what a
-        // hook OBSERVED -- reads included, across sessions -- which is unusable
-        // as a diff base: it would tell a session that never saw a file that
-        // nothing had changed. This record is written only on a mutation and
-        // carries the authoring session, so `smart_read` can ask "did I write
-        // this?" rather than "has anyone seen this?".
+        // WHAT THIS SESSION WROTE -- and ONLY what it wrote.
         //
-        // Free here: the source is already in hand for the graph write.
-        recordAuthoredContent(
-          projectRootFor(path, payload.cwd),
-          payload.session_id,
-          path,
-          source
-        );
+        // GATED ON A SUCCESSFUL MUTATION, because this loop is not one. It
+        // iterates `touchedFiles`, which covers every tool that NAMES a file,
+        // reads included, and its own comment above calls that "evidence about
+        // what was touched". Recording an authored base from a read would
+        // recreate the exact defect this store exists to avoid: a later
+        // smart_read in the same session would be told "no changes" about
+        // content the model never received.
+        //
+        // A failed write is excluded for the same reason -- the bytes on disk
+        // are not what we tried to write, so they are not a truthful base.
+        // `mutationSucceeded` is the existing conservative classifier, already
+        // used to gate edit counting, so this cannot disagree with the rest of
+        // the accounting about what a successful mutation is.
+        //
+        // Free when it does apply: the source is already in hand for the graph.
+        if (authored) {
+          recordAuthoredContent(
+            projectRootFor(path, payload.cwd),
+            payload.session_id,
+            path,
+            source
+          );
+        }
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }
@@ -1393,7 +1403,20 @@ async function runHook(clientName, event, invocation) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state, episode, features);
+    // Computed HERE because clientName, event and raw are in scope here and
+    // not inside observeAndInject -- a first attempt referenced them there and
+    // would have thrown at runtime on the one path that matters.
+    const authoredWrite =
+      event === 'post-tool' &&
+      new Set(['Edit', 'MultiEdit', 'Write']).has(String(payload.tool_name || '')) &&
+      mutationSucceeded(clientName, raw);
+    graphContext = observeAndInject(
+      payload,
+      state,
+      episode,
+      features,
+      authoredWrite
+    );
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -435,6 +435,18 @@ function codexStringLiteral(literal) {
   return decoded;
 }
 
+/**
+ * Cline's write tools, under the names the rest of the pipeline matches on.
+ *
+ * Cline calls them `write_to_file` and `replace_in_file`; authoredWrite tests
+ * membership of {Edit, MultiEdit, Write}, so without the rename the
+ * integration reads the right field and still never records an authored write.
+ */
+const CLINE_TOOL_NAMES = {
+  write_to_file: 'Write',
+  replace_in_file: 'Edit',
+};
+
 /** Convert client-specific lifecycle envelopes into the common tool shape. */
 function codexStringBindings(source) {
   const values = new Map();
@@ -519,17 +531,28 @@ export function normalizeClientPayload(clientName, event, raw) {
   if (clientName === 'cline') {
     const body = event === 'post-tool' ? raw.postToolUse : raw.preToolUse;
     if (!body) return raw;
+    // `toolName` IS THE FIELD CLINE SENDS. Reading only `body.tool` left
+    // `tool_name` null, and the handler exits on a null tool name -- so every
+    // Cline call fell out before authoredWrite or recordAuthoredContent could
+    // run, and the whole integration was a silent no-op. `body.tool` is kept as
+    // a fallback rather than replaced, because a payload carrying it costs
+    // nothing to accept.
+    const rawTool = body.toolName ?? body.tool;
     return {
       ...raw,
       session_id: raw.taskId ?? raw.task_id,
       cwd: raw.workspaceRoots?.[0] ?? raw.workspacePath,
       model: raw.model?.slug,
-      tool: body.tool,
+      // MAPPED TO THE CANONICAL NAMES the rest of the pipeline matches on.
+      // authoredWrite tests membership of {Edit, MultiEdit, Write}, so Cline's
+      // own spellings would still have missed even once the field was read.
+      tool: CLINE_TOOL_NAMES[rawTool] ?? rawTool,
       parameters: body.parameters,
     };
   }
 
   if (clientName === 'windsurf') {
+    // (see CLINE_TOOL_NAMES above for why the cline branch renames its tools)
     const info = raw.tool_info || {};
     const action = String(raw.agent_action_name || '');
     const tool = action.includes('read_code')

--- a/integrations/codex/hooks/lib/authored.mjs
+++ b/integrations/codex/hooks/lib/authored.mjs
@@ -75,30 +75,39 @@ export function recordAuthoredContent(projectRoot, sessionId, filePath, content)
   try {
     if (!projectRoot || !sessionId || !filePath) return;
     if (typeof content !== 'string') return;
+    // A CHEAP LOWER BOUND FIRST. The serialized record is never smaller than
+    // its content, so this rejects the obvious cases without paying to
+    // stringify them. It is not the real check.
+    //
     // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
     // so 100k CJK characters measured 100,000 against a 262,144 cap while
-    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
-    // so the check is on the encoded size of the field that dominates it.
+    // writing 300,000 bytes -- 15% over.
     if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);
     mkdirSync(dir, { recursive: true });
 
+    const record = JSON.stringify({
+      v: 1,
+      sessionId,
+      path: canonicalPath(filePath),
+      hash: hash(content),
+      content,
+      at: Date.now(),
+    });
+
+    // THE AUTHORITATIVE CHECK, ON WHAT IS ACTUALLY WRITTEN. Measuring the
+    // content alone does not bound the record, because JSON escapes: a control
+    // character costs one byte in `content` and six in the record. 262,144 NUL
+    // characters therefore passed the check above and persisted about 1.5 MiB
+    // -- six times the configured cap -- and the field the cap exists to bound
+    // is the file on disk, not the string that went into it.
+    if (Buffer.byteLength(record, 'utf8') > limit()) return;
+
     const target = recordPath(projectRoot, filePath);
     const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
-    writeFileSync(
-      tmp,
-      JSON.stringify({
-        v: 1,
-        sessionId,
-        path: canonicalPath(filePath),
-        hash: hash(content),
-        content,
-        at: Date.now(),
-      }),
-      { mode: 0o600 }
-    );
+    writeFileSync(tmp, record, { mode: 0o600 });
     renameSync(tmp, target);
   } catch {
     /* the write landed; the record is an optimization */

--- a/integrations/codex/hooks/lib/authored.mjs
+++ b/integrations/codex/hooks/lib/authored.mjs
@@ -74,7 +74,12 @@ const hash = (text) =>
 export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
   try {
     if (!projectRoot || !sessionId || !filePath) return;
-    if (typeof content !== 'string' || content.length > limit()) return;
+    if (typeof content !== 'string') return;
+    // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
+    // so 100k CJK characters measured 100,000 against a 262,144 cap while
+    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
+    // so the check is on the encoded size of the field that dominates it.
+    if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);

--- a/integrations/codex/hooks/lib/authored.mjs
+++ b/integrations/codex/hooks/lib/authored.mjs
@@ -1,0 +1,138 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/authored.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * What THIS session wrote, so a later read can diff against it.
+ *
+ * THE QUESTION THIS ANSWERS, AND THE ONE IT DOES NOT. A diff base is only sound
+ * if the caller already holds the bytes it is being diffed against. That is a
+ * statement about AUTHORSHIP or DELIVERY, never about observation.
+ *
+ * The knowledge graph cannot supply it, and the distinction is not academic:
+ * `indexFile` runs on every file either hook OBSERVES -- reads included, across
+ * sessions -- so a graph snapshot means "some hook last saw these bytes". Using
+ * that as a base would hand a fresh session `// No changes` for a file it has
+ * never seen, withholding content while reporting success. That is strictly
+ * worse than resending the file, which is the behaviour being improved on.
+ *
+ * So this store is written ONLY by a write, and every record carries the
+ * session that made it.
+ *
+ * DEGRADATION IS ONE-DIRECTIONAL, BY CONSTRUCTION. Every uncertain state --
+ * missing record, unreadable record, different session, absent session id,
+ * content whose hash no longer matches disk, a file that has since been deleted
+ * -- resolves to `null`, meaning "no base", meaning the caller resends the file.
+ * The store can never make a read worse than it is today; at worst it does
+ * nothing. Nothing here may throw, because these run inside hooks and a hook
+ * that breaks a tool call is worse than one that saves nothing.
+ */
+
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+/**
+ * Largest authored file kept.
+ *
+ * Matched to the graph's own snapshot cap for the same reason it has one: a
+ * store that keeps every write becomes a second copy of the repository. Past
+ * the cap a read simply gets no base and resends, which is today's behaviour.
+ */
+const limit = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_AUTHORED_LIMIT);
+  return Number.isFinite(raw) && raw > 0 ? raw : 262_144;
+};
+
+const storeDir = (projectRoot) =>
+  join(projectRoot, '.token-optimizer', 'authored');
+
+/** One file per authored path, named by a digest so no path escapes the store. */
+const recordPath = (projectRoot, filePath) =>
+  join(
+    storeDir(projectRoot),
+    createHash('sha256').update(canonicalPath(filePath)).digest('hex').slice(0, 32) +
+      '.json'
+  );
+
+const hash = (text) =>
+  createHash('sha256').update(text, 'utf8').digest('hex').slice(0, 32);
+
+/**
+ * Records that `sessionId` wrote `content` to `filePath`.
+ *
+ * Written atomically: a torn record read back as valid JSON with the wrong
+ * bytes would be a WRONG diff base, which is the one outcome this store must
+ * never produce. A temp file plus rename means a reader sees the old record or
+ * the new one, never half of either.
+ */
+export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return;
+    if (typeof content !== 'string' || content.length > limit()) return;
+    if (!isFsSafePath(filePath)) return;
+
+    const dir = storeDir(projectRoot);
+    mkdirSync(dir, { recursive: true });
+
+    const target = recordPath(projectRoot, filePath);
+    const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+    writeFileSync(
+      tmp,
+      JSON.stringify({
+        v: 1,
+        sessionId,
+        path: canonicalPath(filePath),
+        hash: hash(content),
+        content,
+        at: Date.now(),
+      }),
+      { mode: 0o600 }
+    );
+    renameSync(tmp, target);
+  } catch {
+    /* the write landed; the record is an optimization */
+  }
+}
+
+/**
+ * The bytes `sessionId` wrote to `filePath`, or null.
+ *
+ * Null on every uncertainty. The hash check against disk is what makes a stale
+ * record safe rather than merely unlikely: if anything changed the file after
+ * we wrote it -- another process, another tool, a `git checkout` -- the recorded
+ * bytes are no longer a truthful "before", and a diff against them would
+ * describe a change that never happened.
+ */
+export function authoredContentFor(projectRoot, sessionId, filePath) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return null;
+    if (!isFsSafePath(filePath)) return null;
+
+    const raw = readFileSync(recordPath(projectRoot, filePath), 'utf8');
+    const record = JSON.parse(raw);
+
+    // THE SESSION GATE, which is the whole point. A record from another session
+    // describes bytes this caller never received.
+    if (record?.v !== 1 || record.sessionId !== sessionId) return null;
+    if (typeof record.content !== 'string') return null;
+    if (record.path !== canonicalPath(filePath)) return null;
+
+    // Cheap rejection before reading the file: a size change is a content
+    // change, and this runs on a tool-call path.
+    const size = statSync(filePath).size;
+    if (size !== Buffer.byteLength(record.content, 'utf8')) return null;
+
+    const onDisk = readFileSync(filePath, 'utf8');
+    if (hash(onDisk) !== record.hash) return null;
+
+    return record.content;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -72,6 +72,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
@@ -868,6 +869,22 @@ function observeAndInject(payload, state, episode, features) {
           hash: contentHash(path, source),
         });
         indexFile(dir, path, source);
+
+        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
+        // because it answers a different question. `indexFile` records what a
+        // hook OBSERVED -- reads included, across sessions -- which is unusable
+        // as a diff base: it would tell a session that never saw a file that
+        // nothing had changed. This record is written only on a mutation and
+        // carries the authoring session, so `smart_read` can ask "did I write
+        // this?" rather than "has anyone seen this?".
+        //
+        // Free here: the source is already in hand for the graph write.
+        recordAuthoredContent(
+          projectRootFor(path, payload.cwd),
+          payload.session_id,
+          path,
+          source
+        );
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -766,7 +766,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state, episode, features) {
+function observeAndInject(payload, state, episode, features, authored = false) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
   const registerRoot = (root) => {
@@ -870,21 +870,31 @@ function observeAndInject(payload, state, episode, features) {
         });
         indexFile(dir, path, source);
 
-        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
-        // because it answers a different question. `indexFile` records what a
-        // hook OBSERVED -- reads included, across sessions -- which is unusable
-        // as a diff base: it would tell a session that never saw a file that
-        // nothing had changed. This record is written only on a mutation and
-        // carries the authoring session, so `smart_read` can ask "did I write
-        // this?" rather than "has anyone seen this?".
+        // WHAT THIS SESSION WROTE -- and ONLY what it wrote.
         //
-        // Free here: the source is already in hand for the graph write.
-        recordAuthoredContent(
-          projectRootFor(path, payload.cwd),
-          payload.session_id,
-          path,
-          source
-        );
+        // GATED ON A SUCCESSFUL MUTATION, because this loop is not one. It
+        // iterates `touchedFiles`, which covers every tool that NAMES a file,
+        // reads included, and its own comment above calls that "evidence about
+        // what was touched". Recording an authored base from a read would
+        // recreate the exact defect this store exists to avoid: a later
+        // smart_read in the same session would be told "no changes" about
+        // content the model never received.
+        //
+        // A failed write is excluded for the same reason -- the bytes on disk
+        // are not what we tried to write, so they are not a truthful base.
+        // `mutationSucceeded` is the existing conservative classifier, already
+        // used to gate edit counting, so this cannot disagree with the rest of
+        // the accounting about what a successful mutation is.
+        //
+        // Free when it does apply: the source is already in hand for the graph.
+        if (authored) {
+          recordAuthoredContent(
+            projectRootFor(path, payload.cwd),
+            payload.session_id,
+            path,
+            source
+          );
+        }
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }
@@ -1393,7 +1403,20 @@ async function runHook(clientName, event, invocation) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state, episode, features);
+    // Computed HERE because clientName, event and raw are in scope here and
+    // not inside observeAndInject -- a first attempt referenced them there and
+    // would have thrown at runtime on the one path that matters.
+    const authoredWrite =
+      event === 'post-tool' &&
+      new Set(['Edit', 'MultiEdit', 'Write']).has(String(payload.tool_name || '')) &&
+      mutationSucceeded(clientName, raw);
+    graphContext = observeAndInject(
+      payload,
+      state,
+      episode,
+      features,
+      authoredWrite
+    );
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -435,6 +435,18 @@ function codexStringLiteral(literal) {
   return decoded;
 }
 
+/**
+ * Cline's write tools, under the names the rest of the pipeline matches on.
+ *
+ * Cline calls them `write_to_file` and `replace_in_file`; authoredWrite tests
+ * membership of {Edit, MultiEdit, Write}, so without the rename the
+ * integration reads the right field and still never records an authored write.
+ */
+const CLINE_TOOL_NAMES = {
+  write_to_file: 'Write',
+  replace_in_file: 'Edit',
+};
+
 /** Convert client-specific lifecycle envelopes into the common tool shape. */
 function codexStringBindings(source) {
   const values = new Map();
@@ -519,17 +531,28 @@ export function normalizeClientPayload(clientName, event, raw) {
   if (clientName === 'cline') {
     const body = event === 'post-tool' ? raw.postToolUse : raw.preToolUse;
     if (!body) return raw;
+    // `toolName` IS THE FIELD CLINE SENDS. Reading only `body.tool` left
+    // `tool_name` null, and the handler exits on a null tool name -- so every
+    // Cline call fell out before authoredWrite or recordAuthoredContent could
+    // run, and the whole integration was a silent no-op. `body.tool` is kept as
+    // a fallback rather than replaced, because a payload carrying it costs
+    // nothing to accept.
+    const rawTool = body.toolName ?? body.tool;
     return {
       ...raw,
       session_id: raw.taskId ?? raw.task_id,
       cwd: raw.workspaceRoots?.[0] ?? raw.workspacePath,
       model: raw.model?.slug,
-      tool: body.tool,
+      // MAPPED TO THE CANONICAL NAMES the rest of the pipeline matches on.
+      // authoredWrite tests membership of {Edit, MultiEdit, Write}, so Cline's
+      // own spellings would still have missed even once the field was read.
+      tool: CLINE_TOOL_NAMES[rawTool] ?? rawTool,
       parameters: body.parameters,
     };
   }
 
   if (clientName === 'windsurf') {
+    // (see CLINE_TOOL_NAMES above for why the cline branch renames its tools)
     const info = raw.tool_info || {};
     const action = String(raw.agent_action_name || '');
     const tool = action.includes('read_code')

--- a/integrations/codex/plugin/hooks/lib/authored.mjs
+++ b/integrations/codex/plugin/hooks/lib/authored.mjs
@@ -75,30 +75,39 @@ export function recordAuthoredContent(projectRoot, sessionId, filePath, content)
   try {
     if (!projectRoot || !sessionId || !filePath) return;
     if (typeof content !== 'string') return;
+    // A CHEAP LOWER BOUND FIRST. The serialized record is never smaller than
+    // its content, so this rejects the obvious cases without paying to
+    // stringify them. It is not the real check.
+    //
     // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
     // so 100k CJK characters measured 100,000 against a 262,144 cap while
-    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
-    // so the check is on the encoded size of the field that dominates it.
+    // writing 300,000 bytes -- 15% over.
     if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);
     mkdirSync(dir, { recursive: true });
 
+    const record = JSON.stringify({
+      v: 1,
+      sessionId,
+      path: canonicalPath(filePath),
+      hash: hash(content),
+      content,
+      at: Date.now(),
+    });
+
+    // THE AUTHORITATIVE CHECK, ON WHAT IS ACTUALLY WRITTEN. Measuring the
+    // content alone does not bound the record, because JSON escapes: a control
+    // character costs one byte in `content` and six in the record. 262,144 NUL
+    // characters therefore passed the check above and persisted about 1.5 MiB
+    // -- six times the configured cap -- and the field the cap exists to bound
+    // is the file on disk, not the string that went into it.
+    if (Buffer.byteLength(record, 'utf8') > limit()) return;
+
     const target = recordPath(projectRoot, filePath);
     const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
-    writeFileSync(
-      tmp,
-      JSON.stringify({
-        v: 1,
-        sessionId,
-        path: canonicalPath(filePath),
-        hash: hash(content),
-        content,
-        at: Date.now(),
-      }),
-      { mode: 0o600 }
-    );
+    writeFileSync(tmp, record, { mode: 0o600 });
     renameSync(tmp, target);
   } catch {
     /* the write landed; the record is an optimization */

--- a/integrations/codex/plugin/hooks/lib/authored.mjs
+++ b/integrations/codex/plugin/hooks/lib/authored.mjs
@@ -74,7 +74,12 @@ const hash = (text) =>
 export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
   try {
     if (!projectRoot || !sessionId || !filePath) return;
-    if (typeof content !== 'string' || content.length > limit()) return;
+    if (typeof content !== 'string') return;
+    // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
+    // so 100k CJK characters measured 100,000 against a 262,144 cap while
+    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
+    // so the check is on the encoded size of the field that dominates it.
+    if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);

--- a/integrations/codex/plugin/hooks/lib/authored.mjs
+++ b/integrations/codex/plugin/hooks/lib/authored.mjs
@@ -1,0 +1,138 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/authored.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * What THIS session wrote, so a later read can diff against it.
+ *
+ * THE QUESTION THIS ANSWERS, AND THE ONE IT DOES NOT. A diff base is only sound
+ * if the caller already holds the bytes it is being diffed against. That is a
+ * statement about AUTHORSHIP or DELIVERY, never about observation.
+ *
+ * The knowledge graph cannot supply it, and the distinction is not academic:
+ * `indexFile` runs on every file either hook OBSERVES -- reads included, across
+ * sessions -- so a graph snapshot means "some hook last saw these bytes". Using
+ * that as a base would hand a fresh session `// No changes` for a file it has
+ * never seen, withholding content while reporting success. That is strictly
+ * worse than resending the file, which is the behaviour being improved on.
+ *
+ * So this store is written ONLY by a write, and every record carries the
+ * session that made it.
+ *
+ * DEGRADATION IS ONE-DIRECTIONAL, BY CONSTRUCTION. Every uncertain state --
+ * missing record, unreadable record, different session, absent session id,
+ * content whose hash no longer matches disk, a file that has since been deleted
+ * -- resolves to `null`, meaning "no base", meaning the caller resends the file.
+ * The store can never make a read worse than it is today; at worst it does
+ * nothing. Nothing here may throw, because these run inside hooks and a hook
+ * that breaks a tool call is worse than one that saves nothing.
+ */
+
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+/**
+ * Largest authored file kept.
+ *
+ * Matched to the graph's own snapshot cap for the same reason it has one: a
+ * store that keeps every write becomes a second copy of the repository. Past
+ * the cap a read simply gets no base and resends, which is today's behaviour.
+ */
+const limit = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_AUTHORED_LIMIT);
+  return Number.isFinite(raw) && raw > 0 ? raw : 262_144;
+};
+
+const storeDir = (projectRoot) =>
+  join(projectRoot, '.token-optimizer', 'authored');
+
+/** One file per authored path, named by a digest so no path escapes the store. */
+const recordPath = (projectRoot, filePath) =>
+  join(
+    storeDir(projectRoot),
+    createHash('sha256').update(canonicalPath(filePath)).digest('hex').slice(0, 32) +
+      '.json'
+  );
+
+const hash = (text) =>
+  createHash('sha256').update(text, 'utf8').digest('hex').slice(0, 32);
+
+/**
+ * Records that `sessionId` wrote `content` to `filePath`.
+ *
+ * Written atomically: a torn record read back as valid JSON with the wrong
+ * bytes would be a WRONG diff base, which is the one outcome this store must
+ * never produce. A temp file plus rename means a reader sees the old record or
+ * the new one, never half of either.
+ */
+export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return;
+    if (typeof content !== 'string' || content.length > limit()) return;
+    if (!isFsSafePath(filePath)) return;
+
+    const dir = storeDir(projectRoot);
+    mkdirSync(dir, { recursive: true });
+
+    const target = recordPath(projectRoot, filePath);
+    const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+    writeFileSync(
+      tmp,
+      JSON.stringify({
+        v: 1,
+        sessionId,
+        path: canonicalPath(filePath),
+        hash: hash(content),
+        content,
+        at: Date.now(),
+      }),
+      { mode: 0o600 }
+    );
+    renameSync(tmp, target);
+  } catch {
+    /* the write landed; the record is an optimization */
+  }
+}
+
+/**
+ * The bytes `sessionId` wrote to `filePath`, or null.
+ *
+ * Null on every uncertainty. The hash check against disk is what makes a stale
+ * record safe rather than merely unlikely: if anything changed the file after
+ * we wrote it -- another process, another tool, a `git checkout` -- the recorded
+ * bytes are no longer a truthful "before", and a diff against them would
+ * describe a change that never happened.
+ */
+export function authoredContentFor(projectRoot, sessionId, filePath) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return null;
+    if (!isFsSafePath(filePath)) return null;
+
+    const raw = readFileSync(recordPath(projectRoot, filePath), 'utf8');
+    const record = JSON.parse(raw);
+
+    // THE SESSION GATE, which is the whole point. A record from another session
+    // describes bytes this caller never received.
+    if (record?.v !== 1 || record.sessionId !== sessionId) return null;
+    if (typeof record.content !== 'string') return null;
+    if (record.path !== canonicalPath(filePath)) return null;
+
+    // Cheap rejection before reading the file: a size change is a content
+    // change, and this runs on a tool-call path.
+    const size = statSync(filePath).size;
+    if (size !== Buffer.byteLength(record.content, 'utf8')) return null;
+
+    const onDisk = readFileSync(filePath, 'utf8');
+    if (hash(onDisk) !== record.hash) return null;
+
+    return record.content;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -72,6 +72,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
@@ -868,6 +869,22 @@ function observeAndInject(payload, state, episode, features) {
           hash: contentHash(path, source),
         });
         indexFile(dir, path, source);
+
+        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
+        // because it answers a different question. `indexFile` records what a
+        // hook OBSERVED -- reads included, across sessions -- which is unusable
+        // as a diff base: it would tell a session that never saw a file that
+        // nothing had changed. This record is written only on a mutation and
+        // carries the authoring session, so `smart_read` can ask "did I write
+        // this?" rather than "has anyone seen this?".
+        //
+        // Free here: the source is already in hand for the graph write.
+        recordAuthoredContent(
+          projectRootFor(path, payload.cwd),
+          payload.session_id,
+          path,
+          source
+        );
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -766,7 +766,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state, episode, features) {
+function observeAndInject(payload, state, episode, features, authored = false) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
   const registerRoot = (root) => {
@@ -870,21 +870,31 @@ function observeAndInject(payload, state, episode, features) {
         });
         indexFile(dir, path, source);
 
-        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
-        // because it answers a different question. `indexFile` records what a
-        // hook OBSERVED -- reads included, across sessions -- which is unusable
-        // as a diff base: it would tell a session that never saw a file that
-        // nothing had changed. This record is written only on a mutation and
-        // carries the authoring session, so `smart_read` can ask "did I write
-        // this?" rather than "has anyone seen this?".
+        // WHAT THIS SESSION WROTE -- and ONLY what it wrote.
         //
-        // Free here: the source is already in hand for the graph write.
-        recordAuthoredContent(
-          projectRootFor(path, payload.cwd),
-          payload.session_id,
-          path,
-          source
-        );
+        // GATED ON A SUCCESSFUL MUTATION, because this loop is not one. It
+        // iterates `touchedFiles`, which covers every tool that NAMES a file,
+        // reads included, and its own comment above calls that "evidence about
+        // what was touched". Recording an authored base from a read would
+        // recreate the exact defect this store exists to avoid: a later
+        // smart_read in the same session would be told "no changes" about
+        // content the model never received.
+        //
+        // A failed write is excluded for the same reason -- the bytes on disk
+        // are not what we tried to write, so they are not a truthful base.
+        // `mutationSucceeded` is the existing conservative classifier, already
+        // used to gate edit counting, so this cannot disagree with the rest of
+        // the accounting about what a successful mutation is.
+        //
+        // Free when it does apply: the source is already in hand for the graph.
+        if (authored) {
+          recordAuthoredContent(
+            projectRootFor(path, payload.cwd),
+            payload.session_id,
+            path,
+            source
+          );
+        }
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }
@@ -1393,7 +1403,20 @@ async function runHook(clientName, event, invocation) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state, episode, features);
+    // Computed HERE because clientName, event and raw are in scope here and
+    // not inside observeAndInject -- a first attempt referenced them there and
+    // would have thrown at runtime on the one path that matters.
+    const authoredWrite =
+      event === 'post-tool' &&
+      new Set(['Edit', 'MultiEdit', 'Write']).has(String(payload.tool_name || '')) &&
+      mutationSucceeded(clientName, raw);
+    graphContext = observeAndInject(
+      payload,
+      state,
+      episode,
+      features,
+      authoredWrite
+    );
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -435,6 +435,18 @@ function codexStringLiteral(literal) {
   return decoded;
 }
 
+/**
+ * Cline's write tools, under the names the rest of the pipeline matches on.
+ *
+ * Cline calls them `write_to_file` and `replace_in_file`; authoredWrite tests
+ * membership of {Edit, MultiEdit, Write}, so without the rename the
+ * integration reads the right field and still never records an authored write.
+ */
+const CLINE_TOOL_NAMES = {
+  write_to_file: 'Write',
+  replace_in_file: 'Edit',
+};
+
 /** Convert client-specific lifecycle envelopes into the common tool shape. */
 function codexStringBindings(source) {
   const values = new Map();
@@ -519,17 +531,28 @@ export function normalizeClientPayload(clientName, event, raw) {
   if (clientName === 'cline') {
     const body = event === 'post-tool' ? raw.postToolUse : raw.preToolUse;
     if (!body) return raw;
+    // `toolName` IS THE FIELD CLINE SENDS. Reading only `body.tool` left
+    // `tool_name` null, and the handler exits on a null tool name -- so every
+    // Cline call fell out before authoredWrite or recordAuthoredContent could
+    // run, and the whole integration was a silent no-op. `body.tool` is kept as
+    // a fallback rather than replaced, because a payload carrying it costs
+    // nothing to accept.
+    const rawTool = body.toolName ?? body.tool;
     return {
       ...raw,
       session_id: raw.taskId ?? raw.task_id,
       cwd: raw.workspaceRoots?.[0] ?? raw.workspacePath,
       model: raw.model?.slug,
-      tool: body.tool,
+      // MAPPED TO THE CANONICAL NAMES the rest of the pipeline matches on.
+      // authoredWrite tests membership of {Edit, MultiEdit, Write}, so Cline's
+      // own spellings would still have missed even once the field was read.
+      tool: CLINE_TOOL_NAMES[rawTool] ?? rawTool,
       parameters: body.parameters,
     };
   }
 
   if (clientName === 'windsurf') {
+    // (see CLINE_TOOL_NAMES above for why the cline branch renames its tools)
     const info = raw.tool_info || {};
     const action = String(raw.agent_action_name || '');
     const tool = action.includes('read_code')

--- a/integrations/copilot/.github/hooks/lib/authored.mjs
+++ b/integrations/copilot/.github/hooks/lib/authored.mjs
@@ -75,30 +75,39 @@ export function recordAuthoredContent(projectRoot, sessionId, filePath, content)
   try {
     if (!projectRoot || !sessionId || !filePath) return;
     if (typeof content !== 'string') return;
+    // A CHEAP LOWER BOUND FIRST. The serialized record is never smaller than
+    // its content, so this rejects the obvious cases without paying to
+    // stringify them. It is not the real check.
+    //
     // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
     // so 100k CJK characters measured 100,000 against a 262,144 cap while
-    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
-    // so the check is on the encoded size of the field that dominates it.
+    // writing 300,000 bytes -- 15% over.
     if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);
     mkdirSync(dir, { recursive: true });
 
+    const record = JSON.stringify({
+      v: 1,
+      sessionId,
+      path: canonicalPath(filePath),
+      hash: hash(content),
+      content,
+      at: Date.now(),
+    });
+
+    // THE AUTHORITATIVE CHECK, ON WHAT IS ACTUALLY WRITTEN. Measuring the
+    // content alone does not bound the record, because JSON escapes: a control
+    // character costs one byte in `content` and six in the record. 262,144 NUL
+    // characters therefore passed the check above and persisted about 1.5 MiB
+    // -- six times the configured cap -- and the field the cap exists to bound
+    // is the file on disk, not the string that went into it.
+    if (Buffer.byteLength(record, 'utf8') > limit()) return;
+
     const target = recordPath(projectRoot, filePath);
     const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
-    writeFileSync(
-      tmp,
-      JSON.stringify({
-        v: 1,
-        sessionId,
-        path: canonicalPath(filePath),
-        hash: hash(content),
-        content,
-        at: Date.now(),
-      }),
-      { mode: 0o600 }
-    );
+    writeFileSync(tmp, record, { mode: 0o600 });
     renameSync(tmp, target);
   } catch {
     /* the write landed; the record is an optimization */

--- a/integrations/copilot/.github/hooks/lib/authored.mjs
+++ b/integrations/copilot/.github/hooks/lib/authored.mjs
@@ -74,7 +74,12 @@ const hash = (text) =>
 export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
   try {
     if (!projectRoot || !sessionId || !filePath) return;
-    if (typeof content !== 'string' || content.length > limit()) return;
+    if (typeof content !== 'string') return;
+    // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
+    // so 100k CJK characters measured 100,000 against a 262,144 cap while
+    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
+    // so the check is on the encoded size of the field that dominates it.
+    if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);

--- a/integrations/copilot/.github/hooks/lib/authored.mjs
+++ b/integrations/copilot/.github/hooks/lib/authored.mjs
@@ -1,0 +1,138 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/authored.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * What THIS session wrote, so a later read can diff against it.
+ *
+ * THE QUESTION THIS ANSWERS, AND THE ONE IT DOES NOT. A diff base is only sound
+ * if the caller already holds the bytes it is being diffed against. That is a
+ * statement about AUTHORSHIP or DELIVERY, never about observation.
+ *
+ * The knowledge graph cannot supply it, and the distinction is not academic:
+ * `indexFile` runs on every file either hook OBSERVES -- reads included, across
+ * sessions -- so a graph snapshot means "some hook last saw these bytes". Using
+ * that as a base would hand a fresh session `// No changes` for a file it has
+ * never seen, withholding content while reporting success. That is strictly
+ * worse than resending the file, which is the behaviour being improved on.
+ *
+ * So this store is written ONLY by a write, and every record carries the
+ * session that made it.
+ *
+ * DEGRADATION IS ONE-DIRECTIONAL, BY CONSTRUCTION. Every uncertain state --
+ * missing record, unreadable record, different session, absent session id,
+ * content whose hash no longer matches disk, a file that has since been deleted
+ * -- resolves to `null`, meaning "no base", meaning the caller resends the file.
+ * The store can never make a read worse than it is today; at worst it does
+ * nothing. Nothing here may throw, because these run inside hooks and a hook
+ * that breaks a tool call is worse than one that saves nothing.
+ */
+
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+/**
+ * Largest authored file kept.
+ *
+ * Matched to the graph's own snapshot cap for the same reason it has one: a
+ * store that keeps every write becomes a second copy of the repository. Past
+ * the cap a read simply gets no base and resends, which is today's behaviour.
+ */
+const limit = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_AUTHORED_LIMIT);
+  return Number.isFinite(raw) && raw > 0 ? raw : 262_144;
+};
+
+const storeDir = (projectRoot) =>
+  join(projectRoot, '.token-optimizer', 'authored');
+
+/** One file per authored path, named by a digest so no path escapes the store. */
+const recordPath = (projectRoot, filePath) =>
+  join(
+    storeDir(projectRoot),
+    createHash('sha256').update(canonicalPath(filePath)).digest('hex').slice(0, 32) +
+      '.json'
+  );
+
+const hash = (text) =>
+  createHash('sha256').update(text, 'utf8').digest('hex').slice(0, 32);
+
+/**
+ * Records that `sessionId` wrote `content` to `filePath`.
+ *
+ * Written atomically: a torn record read back as valid JSON with the wrong
+ * bytes would be a WRONG diff base, which is the one outcome this store must
+ * never produce. A temp file plus rename means a reader sees the old record or
+ * the new one, never half of either.
+ */
+export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return;
+    if (typeof content !== 'string' || content.length > limit()) return;
+    if (!isFsSafePath(filePath)) return;
+
+    const dir = storeDir(projectRoot);
+    mkdirSync(dir, { recursive: true });
+
+    const target = recordPath(projectRoot, filePath);
+    const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+    writeFileSync(
+      tmp,
+      JSON.stringify({
+        v: 1,
+        sessionId,
+        path: canonicalPath(filePath),
+        hash: hash(content),
+        content,
+        at: Date.now(),
+      }),
+      { mode: 0o600 }
+    );
+    renameSync(tmp, target);
+  } catch {
+    /* the write landed; the record is an optimization */
+  }
+}
+
+/**
+ * The bytes `sessionId` wrote to `filePath`, or null.
+ *
+ * Null on every uncertainty. The hash check against disk is what makes a stale
+ * record safe rather than merely unlikely: if anything changed the file after
+ * we wrote it -- another process, another tool, a `git checkout` -- the recorded
+ * bytes are no longer a truthful "before", and a diff against them would
+ * describe a change that never happened.
+ */
+export function authoredContentFor(projectRoot, sessionId, filePath) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return null;
+    if (!isFsSafePath(filePath)) return null;
+
+    const raw = readFileSync(recordPath(projectRoot, filePath), 'utf8');
+    const record = JSON.parse(raw);
+
+    // THE SESSION GATE, which is the whole point. A record from another session
+    // describes bytes this caller never received.
+    if (record?.v !== 1 || record.sessionId !== sessionId) return null;
+    if (typeof record.content !== 'string') return null;
+    if (record.path !== canonicalPath(filePath)) return null;
+
+    // Cheap rejection before reading the file: a size change is a content
+    // change, and this runs on a tool-call path.
+    const size = statSync(filePath).size;
+    if (size !== Buffer.byteLength(record.content, 'utf8')) return null;
+
+    const onDisk = readFileSync(filePath, 'utf8');
+    if (hash(onDisk) !== record.hash) return null;
+
+    return record.content;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -72,6 +72,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
@@ -868,6 +869,22 @@ function observeAndInject(payload, state, episode, features) {
           hash: contentHash(path, source),
         });
         indexFile(dir, path, source);
+
+        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
+        // because it answers a different question. `indexFile` records what a
+        // hook OBSERVED -- reads included, across sessions -- which is unusable
+        // as a diff base: it would tell a session that never saw a file that
+        // nothing had changed. This record is written only on a mutation and
+        // carries the authoring session, so `smart_read` can ask "did I write
+        // this?" rather than "has anyone seen this?".
+        //
+        // Free here: the source is already in hand for the graph write.
+        recordAuthoredContent(
+          projectRootFor(path, payload.cwd),
+          payload.session_id,
+          path,
+          source
+        );
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -766,7 +766,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state, episode, features) {
+function observeAndInject(payload, state, episode, features, authored = false) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
   const registerRoot = (root) => {
@@ -870,21 +870,31 @@ function observeAndInject(payload, state, episode, features) {
         });
         indexFile(dir, path, source);
 
-        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
-        // because it answers a different question. `indexFile` records what a
-        // hook OBSERVED -- reads included, across sessions -- which is unusable
-        // as a diff base: it would tell a session that never saw a file that
-        // nothing had changed. This record is written only on a mutation and
-        // carries the authoring session, so `smart_read` can ask "did I write
-        // this?" rather than "has anyone seen this?".
+        // WHAT THIS SESSION WROTE -- and ONLY what it wrote.
         //
-        // Free here: the source is already in hand for the graph write.
-        recordAuthoredContent(
-          projectRootFor(path, payload.cwd),
-          payload.session_id,
-          path,
-          source
-        );
+        // GATED ON A SUCCESSFUL MUTATION, because this loop is not one. It
+        // iterates `touchedFiles`, which covers every tool that NAMES a file,
+        // reads included, and its own comment above calls that "evidence about
+        // what was touched". Recording an authored base from a read would
+        // recreate the exact defect this store exists to avoid: a later
+        // smart_read in the same session would be told "no changes" about
+        // content the model never received.
+        //
+        // A failed write is excluded for the same reason -- the bytes on disk
+        // are not what we tried to write, so they are not a truthful base.
+        // `mutationSucceeded` is the existing conservative classifier, already
+        // used to gate edit counting, so this cannot disagree with the rest of
+        // the accounting about what a successful mutation is.
+        //
+        // Free when it does apply: the source is already in hand for the graph.
+        if (authored) {
+          recordAuthoredContent(
+            projectRootFor(path, payload.cwd),
+            payload.session_id,
+            path,
+            source
+          );
+        }
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }
@@ -1393,7 +1403,20 @@ async function runHook(clientName, event, invocation) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state, episode, features);
+    // Computed HERE because clientName, event and raw are in scope here and
+    // not inside observeAndInject -- a first attempt referenced them there and
+    // would have thrown at runtime on the one path that matters.
+    const authoredWrite =
+      event === 'post-tool' &&
+      new Set(['Edit', 'MultiEdit', 'Write']).has(String(payload.tool_name || '')) &&
+      mutationSucceeded(clientName, raw);
+    graphContext = observeAndInject(
+      payload,
+      state,
+      episode,
+      features,
+      authoredWrite
+    );
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -435,6 +435,18 @@ function codexStringLiteral(literal) {
   return decoded;
 }
 
+/**
+ * Cline's write tools, under the names the rest of the pipeline matches on.
+ *
+ * Cline calls them `write_to_file` and `replace_in_file`; authoredWrite tests
+ * membership of {Edit, MultiEdit, Write}, so without the rename the
+ * integration reads the right field and still never records an authored write.
+ */
+const CLINE_TOOL_NAMES = {
+  write_to_file: 'Write',
+  replace_in_file: 'Edit',
+};
+
 /** Convert client-specific lifecycle envelopes into the common tool shape. */
 function codexStringBindings(source) {
   const values = new Map();
@@ -519,17 +531,28 @@ export function normalizeClientPayload(clientName, event, raw) {
   if (clientName === 'cline') {
     const body = event === 'post-tool' ? raw.postToolUse : raw.preToolUse;
     if (!body) return raw;
+    // `toolName` IS THE FIELD CLINE SENDS. Reading only `body.tool` left
+    // `tool_name` null, and the handler exits on a null tool name -- so every
+    // Cline call fell out before authoredWrite or recordAuthoredContent could
+    // run, and the whole integration was a silent no-op. `body.tool` is kept as
+    // a fallback rather than replaced, because a payload carrying it costs
+    // nothing to accept.
+    const rawTool = body.toolName ?? body.tool;
     return {
       ...raw,
       session_id: raw.taskId ?? raw.task_id,
       cwd: raw.workspaceRoots?.[0] ?? raw.workspacePath,
       model: raw.model?.slug,
-      tool: body.tool,
+      // MAPPED TO THE CANONICAL NAMES the rest of the pipeline matches on.
+      // authoredWrite tests membership of {Edit, MultiEdit, Write}, so Cline's
+      // own spellings would still have missed even once the field was read.
+      tool: CLINE_TOOL_NAMES[rawTool] ?? rawTool,
       parameters: body.parameters,
     };
   }
 
   if (clientName === 'windsurf') {
+    // (see CLINE_TOOL_NAMES above for why the cline branch renames its tools)
     const info = raw.tool_info || {};
     const action = String(raw.agent_action_name || '');
     const tool = action.includes('read_code')

--- a/integrations/cursor/hooks/lib/authored.mjs
+++ b/integrations/cursor/hooks/lib/authored.mjs
@@ -75,30 +75,39 @@ export function recordAuthoredContent(projectRoot, sessionId, filePath, content)
   try {
     if (!projectRoot || !sessionId || !filePath) return;
     if (typeof content !== 'string') return;
+    // A CHEAP LOWER BOUND FIRST. The serialized record is never smaller than
+    // its content, so this rejects the obvious cases without paying to
+    // stringify them. It is not the real check.
+    //
     // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
     // so 100k CJK characters measured 100,000 against a 262,144 cap while
-    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
-    // so the check is on the encoded size of the field that dominates it.
+    // writing 300,000 bytes -- 15% over.
     if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);
     mkdirSync(dir, { recursive: true });
 
+    const record = JSON.stringify({
+      v: 1,
+      sessionId,
+      path: canonicalPath(filePath),
+      hash: hash(content),
+      content,
+      at: Date.now(),
+    });
+
+    // THE AUTHORITATIVE CHECK, ON WHAT IS ACTUALLY WRITTEN. Measuring the
+    // content alone does not bound the record, because JSON escapes: a control
+    // character costs one byte in `content` and six in the record. 262,144 NUL
+    // characters therefore passed the check above and persisted about 1.5 MiB
+    // -- six times the configured cap -- and the field the cap exists to bound
+    // is the file on disk, not the string that went into it.
+    if (Buffer.byteLength(record, 'utf8') > limit()) return;
+
     const target = recordPath(projectRoot, filePath);
     const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
-    writeFileSync(
-      tmp,
-      JSON.stringify({
-        v: 1,
-        sessionId,
-        path: canonicalPath(filePath),
-        hash: hash(content),
-        content,
-        at: Date.now(),
-      }),
-      { mode: 0o600 }
-    );
+    writeFileSync(tmp, record, { mode: 0o600 });
     renameSync(tmp, target);
   } catch {
     /* the write landed; the record is an optimization */

--- a/integrations/cursor/hooks/lib/authored.mjs
+++ b/integrations/cursor/hooks/lib/authored.mjs
@@ -74,7 +74,12 @@ const hash = (text) =>
 export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
   try {
     if (!projectRoot || !sessionId || !filePath) return;
-    if (typeof content !== 'string' || content.length > limit()) return;
+    if (typeof content !== 'string') return;
+    // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
+    // so 100k CJK characters measured 100,000 against a 262,144 cap while
+    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
+    // so the check is on the encoded size of the field that dominates it.
+    if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);

--- a/integrations/cursor/hooks/lib/authored.mjs
+++ b/integrations/cursor/hooks/lib/authored.mjs
@@ -1,0 +1,138 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/authored.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * What THIS session wrote, so a later read can diff against it.
+ *
+ * THE QUESTION THIS ANSWERS, AND THE ONE IT DOES NOT. A diff base is only sound
+ * if the caller already holds the bytes it is being diffed against. That is a
+ * statement about AUTHORSHIP or DELIVERY, never about observation.
+ *
+ * The knowledge graph cannot supply it, and the distinction is not academic:
+ * `indexFile` runs on every file either hook OBSERVES -- reads included, across
+ * sessions -- so a graph snapshot means "some hook last saw these bytes". Using
+ * that as a base would hand a fresh session `// No changes` for a file it has
+ * never seen, withholding content while reporting success. That is strictly
+ * worse than resending the file, which is the behaviour being improved on.
+ *
+ * So this store is written ONLY by a write, and every record carries the
+ * session that made it.
+ *
+ * DEGRADATION IS ONE-DIRECTIONAL, BY CONSTRUCTION. Every uncertain state --
+ * missing record, unreadable record, different session, absent session id,
+ * content whose hash no longer matches disk, a file that has since been deleted
+ * -- resolves to `null`, meaning "no base", meaning the caller resends the file.
+ * The store can never make a read worse than it is today; at worst it does
+ * nothing. Nothing here may throw, because these run inside hooks and a hook
+ * that breaks a tool call is worse than one that saves nothing.
+ */
+
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+/**
+ * Largest authored file kept.
+ *
+ * Matched to the graph's own snapshot cap for the same reason it has one: a
+ * store that keeps every write becomes a second copy of the repository. Past
+ * the cap a read simply gets no base and resends, which is today's behaviour.
+ */
+const limit = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_AUTHORED_LIMIT);
+  return Number.isFinite(raw) && raw > 0 ? raw : 262_144;
+};
+
+const storeDir = (projectRoot) =>
+  join(projectRoot, '.token-optimizer', 'authored');
+
+/** One file per authored path, named by a digest so no path escapes the store. */
+const recordPath = (projectRoot, filePath) =>
+  join(
+    storeDir(projectRoot),
+    createHash('sha256').update(canonicalPath(filePath)).digest('hex').slice(0, 32) +
+      '.json'
+  );
+
+const hash = (text) =>
+  createHash('sha256').update(text, 'utf8').digest('hex').slice(0, 32);
+
+/**
+ * Records that `sessionId` wrote `content` to `filePath`.
+ *
+ * Written atomically: a torn record read back as valid JSON with the wrong
+ * bytes would be a WRONG diff base, which is the one outcome this store must
+ * never produce. A temp file plus rename means a reader sees the old record or
+ * the new one, never half of either.
+ */
+export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return;
+    if (typeof content !== 'string' || content.length > limit()) return;
+    if (!isFsSafePath(filePath)) return;
+
+    const dir = storeDir(projectRoot);
+    mkdirSync(dir, { recursive: true });
+
+    const target = recordPath(projectRoot, filePath);
+    const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+    writeFileSync(
+      tmp,
+      JSON.stringify({
+        v: 1,
+        sessionId,
+        path: canonicalPath(filePath),
+        hash: hash(content),
+        content,
+        at: Date.now(),
+      }),
+      { mode: 0o600 }
+    );
+    renameSync(tmp, target);
+  } catch {
+    /* the write landed; the record is an optimization */
+  }
+}
+
+/**
+ * The bytes `sessionId` wrote to `filePath`, or null.
+ *
+ * Null on every uncertainty. The hash check against disk is what makes a stale
+ * record safe rather than merely unlikely: if anything changed the file after
+ * we wrote it -- another process, another tool, a `git checkout` -- the recorded
+ * bytes are no longer a truthful "before", and a diff against them would
+ * describe a change that never happened.
+ */
+export function authoredContentFor(projectRoot, sessionId, filePath) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return null;
+    if (!isFsSafePath(filePath)) return null;
+
+    const raw = readFileSync(recordPath(projectRoot, filePath), 'utf8');
+    const record = JSON.parse(raw);
+
+    // THE SESSION GATE, which is the whole point. A record from another session
+    // describes bytes this caller never received.
+    if (record?.v !== 1 || record.sessionId !== sessionId) return null;
+    if (typeof record.content !== 'string') return null;
+    if (record.path !== canonicalPath(filePath)) return null;
+
+    // Cheap rejection before reading the file: a size change is a content
+    // change, and this runs on a tool-call path.
+    const size = statSync(filePath).size;
+    if (size !== Buffer.byteLength(record.content, 'utf8')) return null;
+
+    const onDisk = readFileSync(filePath, 'utf8');
+    if (hash(onDisk) !== record.hash) return null;
+
+    return record.content;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -72,6 +72,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
@@ -868,6 +869,22 @@ function observeAndInject(payload, state, episode, features) {
           hash: contentHash(path, source),
         });
         indexFile(dir, path, source);
+
+        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
+        // because it answers a different question. `indexFile` records what a
+        // hook OBSERVED -- reads included, across sessions -- which is unusable
+        // as a diff base: it would tell a session that never saw a file that
+        // nothing had changed. This record is written only on a mutation and
+        // carries the authoring session, so `smart_read` can ask "did I write
+        // this?" rather than "has anyone seen this?".
+        //
+        // Free here: the source is already in hand for the graph write.
+        recordAuthoredContent(
+          projectRootFor(path, payload.cwd),
+          payload.session_id,
+          path,
+          source
+        );
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -766,7 +766,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state, episode, features) {
+function observeAndInject(payload, state, episode, features, authored = false) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
   const registerRoot = (root) => {
@@ -870,21 +870,31 @@ function observeAndInject(payload, state, episode, features) {
         });
         indexFile(dir, path, source);
 
-        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
-        // because it answers a different question. `indexFile` records what a
-        // hook OBSERVED -- reads included, across sessions -- which is unusable
-        // as a diff base: it would tell a session that never saw a file that
-        // nothing had changed. This record is written only on a mutation and
-        // carries the authoring session, so `smart_read` can ask "did I write
-        // this?" rather than "has anyone seen this?".
+        // WHAT THIS SESSION WROTE -- and ONLY what it wrote.
         //
-        // Free here: the source is already in hand for the graph write.
-        recordAuthoredContent(
-          projectRootFor(path, payload.cwd),
-          payload.session_id,
-          path,
-          source
-        );
+        // GATED ON A SUCCESSFUL MUTATION, because this loop is not one. It
+        // iterates `touchedFiles`, which covers every tool that NAMES a file,
+        // reads included, and its own comment above calls that "evidence about
+        // what was touched". Recording an authored base from a read would
+        // recreate the exact defect this store exists to avoid: a later
+        // smart_read in the same session would be told "no changes" about
+        // content the model never received.
+        //
+        // A failed write is excluded for the same reason -- the bytes on disk
+        // are not what we tried to write, so they are not a truthful base.
+        // `mutationSucceeded` is the existing conservative classifier, already
+        // used to gate edit counting, so this cannot disagree with the rest of
+        // the accounting about what a successful mutation is.
+        //
+        // Free when it does apply: the source is already in hand for the graph.
+        if (authored) {
+          recordAuthoredContent(
+            projectRootFor(path, payload.cwd),
+            payload.session_id,
+            path,
+            source
+          );
+        }
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }
@@ -1393,7 +1403,20 @@ async function runHook(clientName, event, invocation) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state, episode, features);
+    // Computed HERE because clientName, event and raw are in scope here and
+    // not inside observeAndInject -- a first attempt referenced them there and
+    // would have thrown at runtime on the one path that matters.
+    const authoredWrite =
+      event === 'post-tool' &&
+      new Set(['Edit', 'MultiEdit', 'Write']).has(String(payload.tool_name || '')) &&
+      mutationSucceeded(clientName, raw);
+    graphContext = observeAndInject(
+      payload,
+      state,
+      episode,
+      features,
+      authoredWrite
+    );
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -435,6 +435,18 @@ function codexStringLiteral(literal) {
   return decoded;
 }
 
+/**
+ * Cline's write tools, under the names the rest of the pipeline matches on.
+ *
+ * Cline calls them `write_to_file` and `replace_in_file`; authoredWrite tests
+ * membership of {Edit, MultiEdit, Write}, so without the rename the
+ * integration reads the right field and still never records an authored write.
+ */
+const CLINE_TOOL_NAMES = {
+  write_to_file: 'Write',
+  replace_in_file: 'Edit',
+};
+
 /** Convert client-specific lifecycle envelopes into the common tool shape. */
 function codexStringBindings(source) {
   const values = new Map();
@@ -519,17 +531,28 @@ export function normalizeClientPayload(clientName, event, raw) {
   if (clientName === 'cline') {
     const body = event === 'post-tool' ? raw.postToolUse : raw.preToolUse;
     if (!body) return raw;
+    // `toolName` IS THE FIELD CLINE SENDS. Reading only `body.tool` left
+    // `tool_name` null, and the handler exits on a null tool name -- so every
+    // Cline call fell out before authoredWrite or recordAuthoredContent could
+    // run, and the whole integration was a silent no-op. `body.tool` is kept as
+    // a fallback rather than replaced, because a payload carrying it costs
+    // nothing to accept.
+    const rawTool = body.toolName ?? body.tool;
     return {
       ...raw,
       session_id: raw.taskId ?? raw.task_id,
       cwd: raw.workspaceRoots?.[0] ?? raw.workspacePath,
       model: raw.model?.slug,
-      tool: body.tool,
+      // MAPPED TO THE CANONICAL NAMES the rest of the pipeline matches on.
+      // authoredWrite tests membership of {Edit, MultiEdit, Write}, so Cline's
+      // own spellings would still have missed even once the field was read.
+      tool: CLINE_TOOL_NAMES[rawTool] ?? rawTool,
       parameters: body.parameters,
     };
   }
 
   if (clientName === 'windsurf') {
+    // (see CLINE_TOOL_NAMES above for why the cline branch renames its tools)
     const info = raw.tool_info || {};
     const action = String(raw.agent_action_name || '');
     const tool = action.includes('read_code')

--- a/integrations/gemini/hooks/lib/authored.mjs
+++ b/integrations/gemini/hooks/lib/authored.mjs
@@ -75,30 +75,39 @@ export function recordAuthoredContent(projectRoot, sessionId, filePath, content)
   try {
     if (!projectRoot || !sessionId || !filePath) return;
     if (typeof content !== 'string') return;
+    // A CHEAP LOWER BOUND FIRST. The serialized record is never smaller than
+    // its content, so this rejects the obvious cases without paying to
+    // stringify them. It is not the real check.
+    //
     // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
     // so 100k CJK characters measured 100,000 against a 262,144 cap while
-    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
-    // so the check is on the encoded size of the field that dominates it.
+    // writing 300,000 bytes -- 15% over.
     if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);
     mkdirSync(dir, { recursive: true });
 
+    const record = JSON.stringify({
+      v: 1,
+      sessionId,
+      path: canonicalPath(filePath),
+      hash: hash(content),
+      content,
+      at: Date.now(),
+    });
+
+    // THE AUTHORITATIVE CHECK, ON WHAT IS ACTUALLY WRITTEN. Measuring the
+    // content alone does not bound the record, because JSON escapes: a control
+    // character costs one byte in `content` and six in the record. 262,144 NUL
+    // characters therefore passed the check above and persisted about 1.5 MiB
+    // -- six times the configured cap -- and the field the cap exists to bound
+    // is the file on disk, not the string that went into it.
+    if (Buffer.byteLength(record, 'utf8') > limit()) return;
+
     const target = recordPath(projectRoot, filePath);
     const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
-    writeFileSync(
-      tmp,
-      JSON.stringify({
-        v: 1,
-        sessionId,
-        path: canonicalPath(filePath),
-        hash: hash(content),
-        content,
-        at: Date.now(),
-      }),
-      { mode: 0o600 }
-    );
+    writeFileSync(tmp, record, { mode: 0o600 });
     renameSync(tmp, target);
   } catch {
     /* the write landed; the record is an optimization */

--- a/integrations/gemini/hooks/lib/authored.mjs
+++ b/integrations/gemini/hooks/lib/authored.mjs
@@ -74,7 +74,12 @@ const hash = (text) =>
 export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
   try {
     if (!projectRoot || !sessionId || !filePath) return;
-    if (typeof content !== 'string' || content.length > limit()) return;
+    if (typeof content !== 'string') return;
+    // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
+    // so 100k CJK characters measured 100,000 against a 262,144 cap while
+    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
+    // so the check is on the encoded size of the field that dominates it.
+    if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);

--- a/integrations/gemini/hooks/lib/authored.mjs
+++ b/integrations/gemini/hooks/lib/authored.mjs
@@ -1,0 +1,138 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/authored.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * What THIS session wrote, so a later read can diff against it.
+ *
+ * THE QUESTION THIS ANSWERS, AND THE ONE IT DOES NOT. A diff base is only sound
+ * if the caller already holds the bytes it is being diffed against. That is a
+ * statement about AUTHORSHIP or DELIVERY, never about observation.
+ *
+ * The knowledge graph cannot supply it, and the distinction is not academic:
+ * `indexFile` runs on every file either hook OBSERVES -- reads included, across
+ * sessions -- so a graph snapshot means "some hook last saw these bytes". Using
+ * that as a base would hand a fresh session `// No changes` for a file it has
+ * never seen, withholding content while reporting success. That is strictly
+ * worse than resending the file, which is the behaviour being improved on.
+ *
+ * So this store is written ONLY by a write, and every record carries the
+ * session that made it.
+ *
+ * DEGRADATION IS ONE-DIRECTIONAL, BY CONSTRUCTION. Every uncertain state --
+ * missing record, unreadable record, different session, absent session id,
+ * content whose hash no longer matches disk, a file that has since been deleted
+ * -- resolves to `null`, meaning "no base", meaning the caller resends the file.
+ * The store can never make a read worse than it is today; at worst it does
+ * nothing. Nothing here may throw, because these run inside hooks and a hook
+ * that breaks a tool call is worse than one that saves nothing.
+ */
+
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+/**
+ * Largest authored file kept.
+ *
+ * Matched to the graph's own snapshot cap for the same reason it has one: a
+ * store that keeps every write becomes a second copy of the repository. Past
+ * the cap a read simply gets no base and resends, which is today's behaviour.
+ */
+const limit = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_AUTHORED_LIMIT);
+  return Number.isFinite(raw) && raw > 0 ? raw : 262_144;
+};
+
+const storeDir = (projectRoot) =>
+  join(projectRoot, '.token-optimizer', 'authored');
+
+/** One file per authored path, named by a digest so no path escapes the store. */
+const recordPath = (projectRoot, filePath) =>
+  join(
+    storeDir(projectRoot),
+    createHash('sha256').update(canonicalPath(filePath)).digest('hex').slice(0, 32) +
+      '.json'
+  );
+
+const hash = (text) =>
+  createHash('sha256').update(text, 'utf8').digest('hex').slice(0, 32);
+
+/**
+ * Records that `sessionId` wrote `content` to `filePath`.
+ *
+ * Written atomically: a torn record read back as valid JSON with the wrong
+ * bytes would be a WRONG diff base, which is the one outcome this store must
+ * never produce. A temp file plus rename means a reader sees the old record or
+ * the new one, never half of either.
+ */
+export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return;
+    if (typeof content !== 'string' || content.length > limit()) return;
+    if (!isFsSafePath(filePath)) return;
+
+    const dir = storeDir(projectRoot);
+    mkdirSync(dir, { recursive: true });
+
+    const target = recordPath(projectRoot, filePath);
+    const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+    writeFileSync(
+      tmp,
+      JSON.stringify({
+        v: 1,
+        sessionId,
+        path: canonicalPath(filePath),
+        hash: hash(content),
+        content,
+        at: Date.now(),
+      }),
+      { mode: 0o600 }
+    );
+    renameSync(tmp, target);
+  } catch {
+    /* the write landed; the record is an optimization */
+  }
+}
+
+/**
+ * The bytes `sessionId` wrote to `filePath`, or null.
+ *
+ * Null on every uncertainty. The hash check against disk is what makes a stale
+ * record safe rather than merely unlikely: if anything changed the file after
+ * we wrote it -- another process, another tool, a `git checkout` -- the recorded
+ * bytes are no longer a truthful "before", and a diff against them would
+ * describe a change that never happened.
+ */
+export function authoredContentFor(projectRoot, sessionId, filePath) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return null;
+    if (!isFsSafePath(filePath)) return null;
+
+    const raw = readFileSync(recordPath(projectRoot, filePath), 'utf8');
+    const record = JSON.parse(raw);
+
+    // THE SESSION GATE, which is the whole point. A record from another session
+    // describes bytes this caller never received.
+    if (record?.v !== 1 || record.sessionId !== sessionId) return null;
+    if (typeof record.content !== 'string') return null;
+    if (record.path !== canonicalPath(filePath)) return null;
+
+    // Cheap rejection before reading the file: a size change is a content
+    // change, and this runs on a tool-call path.
+    const size = statSync(filePath).size;
+    if (size !== Buffer.byteLength(record.content, 'utf8')) return null;
+
+    const onDisk = readFileSync(filePath, 'utf8');
+    if (hash(onDisk) !== record.hash) return null;
+
+    return record.content;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -72,6 +72,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
@@ -868,6 +869,22 @@ function observeAndInject(payload, state, episode, features) {
           hash: contentHash(path, source),
         });
         indexFile(dir, path, source);
+
+        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
+        // because it answers a different question. `indexFile` records what a
+        // hook OBSERVED -- reads included, across sessions -- which is unusable
+        // as a diff base: it would tell a session that never saw a file that
+        // nothing had changed. This record is written only on a mutation and
+        // carries the authoring session, so `smart_read` can ask "did I write
+        // this?" rather than "has anyone seen this?".
+        //
+        // Free here: the source is already in hand for the graph write.
+        recordAuthoredContent(
+          projectRootFor(path, payload.cwd),
+          payload.session_id,
+          path,
+          source
+        );
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -766,7 +766,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state, episode, features) {
+function observeAndInject(payload, state, episode, features, authored = false) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
   const registerRoot = (root) => {
@@ -870,21 +870,31 @@ function observeAndInject(payload, state, episode, features) {
         });
         indexFile(dir, path, source);
 
-        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
-        // because it answers a different question. `indexFile` records what a
-        // hook OBSERVED -- reads included, across sessions -- which is unusable
-        // as a diff base: it would tell a session that never saw a file that
-        // nothing had changed. This record is written only on a mutation and
-        // carries the authoring session, so `smart_read` can ask "did I write
-        // this?" rather than "has anyone seen this?".
+        // WHAT THIS SESSION WROTE -- and ONLY what it wrote.
         //
-        // Free here: the source is already in hand for the graph write.
-        recordAuthoredContent(
-          projectRootFor(path, payload.cwd),
-          payload.session_id,
-          path,
-          source
-        );
+        // GATED ON A SUCCESSFUL MUTATION, because this loop is not one. It
+        // iterates `touchedFiles`, which covers every tool that NAMES a file,
+        // reads included, and its own comment above calls that "evidence about
+        // what was touched". Recording an authored base from a read would
+        // recreate the exact defect this store exists to avoid: a later
+        // smart_read in the same session would be told "no changes" about
+        // content the model never received.
+        //
+        // A failed write is excluded for the same reason -- the bytes on disk
+        // are not what we tried to write, so they are not a truthful base.
+        // `mutationSucceeded` is the existing conservative classifier, already
+        // used to gate edit counting, so this cannot disagree with the rest of
+        // the accounting about what a successful mutation is.
+        //
+        // Free when it does apply: the source is already in hand for the graph.
+        if (authored) {
+          recordAuthoredContent(
+            projectRootFor(path, payload.cwd),
+            payload.session_id,
+            path,
+            source
+          );
+        }
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }
@@ -1393,7 +1403,20 @@ async function runHook(clientName, event, invocation) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state, episode, features);
+    // Computed HERE because clientName, event and raw are in scope here and
+    // not inside observeAndInject -- a first attempt referenced them there and
+    // would have thrown at runtime on the one path that matters.
+    const authoredWrite =
+      event === 'post-tool' &&
+      new Set(['Edit', 'MultiEdit', 'Write']).has(String(payload.tool_name || '')) &&
+      mutationSucceeded(clientName, raw);
+    graphContext = observeAndInject(
+      payload,
+      state,
+      episode,
+      features,
+      authoredWrite
+    );
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -435,6 +435,18 @@ function codexStringLiteral(literal) {
   return decoded;
 }
 
+/**
+ * Cline's write tools, under the names the rest of the pipeline matches on.
+ *
+ * Cline calls them `write_to_file` and `replace_in_file`; authoredWrite tests
+ * membership of {Edit, MultiEdit, Write}, so without the rename the
+ * integration reads the right field and still never records an authored write.
+ */
+const CLINE_TOOL_NAMES = {
+  write_to_file: 'Write',
+  replace_in_file: 'Edit',
+};
+
 /** Convert client-specific lifecycle envelopes into the common tool shape. */
 function codexStringBindings(source) {
   const values = new Map();
@@ -519,17 +531,28 @@ export function normalizeClientPayload(clientName, event, raw) {
   if (clientName === 'cline') {
     const body = event === 'post-tool' ? raw.postToolUse : raw.preToolUse;
     if (!body) return raw;
+    // `toolName` IS THE FIELD CLINE SENDS. Reading only `body.tool` left
+    // `tool_name` null, and the handler exits on a null tool name -- so every
+    // Cline call fell out before authoredWrite or recordAuthoredContent could
+    // run, and the whole integration was a silent no-op. `body.tool` is kept as
+    // a fallback rather than replaced, because a payload carrying it costs
+    // nothing to accept.
+    const rawTool = body.toolName ?? body.tool;
     return {
       ...raw,
       session_id: raw.taskId ?? raw.task_id,
       cwd: raw.workspaceRoots?.[0] ?? raw.workspacePath,
       model: raw.model?.slug,
-      tool: body.tool,
+      // MAPPED TO THE CANONICAL NAMES the rest of the pipeline matches on.
+      // authoredWrite tests membership of {Edit, MultiEdit, Write}, so Cline's
+      // own spellings would still have missed even once the field was read.
+      tool: CLINE_TOOL_NAMES[rawTool] ?? rawTool,
       parameters: body.parameters,
     };
   }
 
   if (clientName === 'windsurf') {
+    // (see CLINE_TOOL_NAMES above for why the cline branch renames its tools)
     const info = raw.tool_info || {};
     const action = String(raw.agent_action_name || '');
     const tool = action.includes('read_code')

--- a/integrations/kilo/hooks/lib/authored.mjs
+++ b/integrations/kilo/hooks/lib/authored.mjs
@@ -75,30 +75,39 @@ export function recordAuthoredContent(projectRoot, sessionId, filePath, content)
   try {
     if (!projectRoot || !sessionId || !filePath) return;
     if (typeof content !== 'string') return;
+    // A CHEAP LOWER BOUND FIRST. The serialized record is never smaller than
+    // its content, so this rejects the obvious cases without paying to
+    // stringify them. It is not the real check.
+    //
     // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
     // so 100k CJK characters measured 100,000 against a 262,144 cap while
-    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
-    // so the check is on the encoded size of the field that dominates it.
+    // writing 300,000 bytes -- 15% over.
     if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);
     mkdirSync(dir, { recursive: true });
 
+    const record = JSON.stringify({
+      v: 1,
+      sessionId,
+      path: canonicalPath(filePath),
+      hash: hash(content),
+      content,
+      at: Date.now(),
+    });
+
+    // THE AUTHORITATIVE CHECK, ON WHAT IS ACTUALLY WRITTEN. Measuring the
+    // content alone does not bound the record, because JSON escapes: a control
+    // character costs one byte in `content` and six in the record. 262,144 NUL
+    // characters therefore passed the check above and persisted about 1.5 MiB
+    // -- six times the configured cap -- and the field the cap exists to bound
+    // is the file on disk, not the string that went into it.
+    if (Buffer.byteLength(record, 'utf8') > limit()) return;
+
     const target = recordPath(projectRoot, filePath);
     const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
-    writeFileSync(
-      tmp,
-      JSON.stringify({
-        v: 1,
-        sessionId,
-        path: canonicalPath(filePath),
-        hash: hash(content),
-        content,
-        at: Date.now(),
-      }),
-      { mode: 0o600 }
-    );
+    writeFileSync(tmp, record, { mode: 0o600 });
     renameSync(tmp, target);
   } catch {
     /* the write landed; the record is an optimization */

--- a/integrations/kilo/hooks/lib/authored.mjs
+++ b/integrations/kilo/hooks/lib/authored.mjs
@@ -74,7 +74,12 @@ const hash = (text) =>
 export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
   try {
     if (!projectRoot || !sessionId || !filePath) return;
-    if (typeof content !== 'string' || content.length > limit()) return;
+    if (typeof content !== 'string') return;
+    // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
+    // so 100k CJK characters measured 100,000 against a 262,144 cap while
+    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
+    // so the check is on the encoded size of the field that dominates it.
+    if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);

--- a/integrations/kilo/hooks/lib/authored.mjs
+++ b/integrations/kilo/hooks/lib/authored.mjs
@@ -1,0 +1,138 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/authored.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * What THIS session wrote, so a later read can diff against it.
+ *
+ * THE QUESTION THIS ANSWERS, AND THE ONE IT DOES NOT. A diff base is only sound
+ * if the caller already holds the bytes it is being diffed against. That is a
+ * statement about AUTHORSHIP or DELIVERY, never about observation.
+ *
+ * The knowledge graph cannot supply it, and the distinction is not academic:
+ * `indexFile` runs on every file either hook OBSERVES -- reads included, across
+ * sessions -- so a graph snapshot means "some hook last saw these bytes". Using
+ * that as a base would hand a fresh session `// No changes` for a file it has
+ * never seen, withholding content while reporting success. That is strictly
+ * worse than resending the file, which is the behaviour being improved on.
+ *
+ * So this store is written ONLY by a write, and every record carries the
+ * session that made it.
+ *
+ * DEGRADATION IS ONE-DIRECTIONAL, BY CONSTRUCTION. Every uncertain state --
+ * missing record, unreadable record, different session, absent session id,
+ * content whose hash no longer matches disk, a file that has since been deleted
+ * -- resolves to `null`, meaning "no base", meaning the caller resends the file.
+ * The store can never make a read worse than it is today; at worst it does
+ * nothing. Nothing here may throw, because these run inside hooks and a hook
+ * that breaks a tool call is worse than one that saves nothing.
+ */
+
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+/**
+ * Largest authored file kept.
+ *
+ * Matched to the graph's own snapshot cap for the same reason it has one: a
+ * store that keeps every write becomes a second copy of the repository. Past
+ * the cap a read simply gets no base and resends, which is today's behaviour.
+ */
+const limit = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_AUTHORED_LIMIT);
+  return Number.isFinite(raw) && raw > 0 ? raw : 262_144;
+};
+
+const storeDir = (projectRoot) =>
+  join(projectRoot, '.token-optimizer', 'authored');
+
+/** One file per authored path, named by a digest so no path escapes the store. */
+const recordPath = (projectRoot, filePath) =>
+  join(
+    storeDir(projectRoot),
+    createHash('sha256').update(canonicalPath(filePath)).digest('hex').slice(0, 32) +
+      '.json'
+  );
+
+const hash = (text) =>
+  createHash('sha256').update(text, 'utf8').digest('hex').slice(0, 32);
+
+/**
+ * Records that `sessionId` wrote `content` to `filePath`.
+ *
+ * Written atomically: a torn record read back as valid JSON with the wrong
+ * bytes would be a WRONG diff base, which is the one outcome this store must
+ * never produce. A temp file plus rename means a reader sees the old record or
+ * the new one, never half of either.
+ */
+export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return;
+    if (typeof content !== 'string' || content.length > limit()) return;
+    if (!isFsSafePath(filePath)) return;
+
+    const dir = storeDir(projectRoot);
+    mkdirSync(dir, { recursive: true });
+
+    const target = recordPath(projectRoot, filePath);
+    const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+    writeFileSync(
+      tmp,
+      JSON.stringify({
+        v: 1,
+        sessionId,
+        path: canonicalPath(filePath),
+        hash: hash(content),
+        content,
+        at: Date.now(),
+      }),
+      { mode: 0o600 }
+    );
+    renameSync(tmp, target);
+  } catch {
+    /* the write landed; the record is an optimization */
+  }
+}
+
+/**
+ * The bytes `sessionId` wrote to `filePath`, or null.
+ *
+ * Null on every uncertainty. The hash check against disk is what makes a stale
+ * record safe rather than merely unlikely: if anything changed the file after
+ * we wrote it -- another process, another tool, a `git checkout` -- the recorded
+ * bytes are no longer a truthful "before", and a diff against them would
+ * describe a change that never happened.
+ */
+export function authoredContentFor(projectRoot, sessionId, filePath) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return null;
+    if (!isFsSafePath(filePath)) return null;
+
+    const raw = readFileSync(recordPath(projectRoot, filePath), 'utf8');
+    const record = JSON.parse(raw);
+
+    // THE SESSION GATE, which is the whole point. A record from another session
+    // describes bytes this caller never received.
+    if (record?.v !== 1 || record.sessionId !== sessionId) return null;
+    if (typeof record.content !== 'string') return null;
+    if (record.path !== canonicalPath(filePath)) return null;
+
+    // Cheap rejection before reading the file: a size change is a content
+    // change, and this runs on a tool-call path.
+    const size = statSync(filePath).size;
+    if (size !== Buffer.byteLength(record.content, 'utf8')) return null;
+
+    const onDisk = readFileSync(filePath, 'utf8');
+    if (hash(onDisk) !== record.hash) return null;
+
+    return record.content;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -72,6 +72,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
@@ -868,6 +869,22 @@ function observeAndInject(payload, state, episode, features) {
           hash: contentHash(path, source),
         });
         indexFile(dir, path, source);
+
+        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
+        // because it answers a different question. `indexFile` records what a
+        // hook OBSERVED -- reads included, across sessions -- which is unusable
+        // as a diff base: it would tell a session that never saw a file that
+        // nothing had changed. This record is written only on a mutation and
+        // carries the authoring session, so `smart_read` can ask "did I write
+        // this?" rather than "has anyone seen this?".
+        //
+        // Free here: the source is already in hand for the graph write.
+        recordAuthoredContent(
+          projectRootFor(path, payload.cwd),
+          payload.session_id,
+          path,
+          source
+        );
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -766,7 +766,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state, episode, features) {
+function observeAndInject(payload, state, episode, features, authored = false) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
   const registerRoot = (root) => {
@@ -870,21 +870,31 @@ function observeAndInject(payload, state, episode, features) {
         });
         indexFile(dir, path, source);
 
-        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
-        // because it answers a different question. `indexFile` records what a
-        // hook OBSERVED -- reads included, across sessions -- which is unusable
-        // as a diff base: it would tell a session that never saw a file that
-        // nothing had changed. This record is written only on a mutation and
-        // carries the authoring session, so `smart_read` can ask "did I write
-        // this?" rather than "has anyone seen this?".
+        // WHAT THIS SESSION WROTE -- and ONLY what it wrote.
         //
-        // Free here: the source is already in hand for the graph write.
-        recordAuthoredContent(
-          projectRootFor(path, payload.cwd),
-          payload.session_id,
-          path,
-          source
-        );
+        // GATED ON A SUCCESSFUL MUTATION, because this loop is not one. It
+        // iterates `touchedFiles`, which covers every tool that NAMES a file,
+        // reads included, and its own comment above calls that "evidence about
+        // what was touched". Recording an authored base from a read would
+        // recreate the exact defect this store exists to avoid: a later
+        // smart_read in the same session would be told "no changes" about
+        // content the model never received.
+        //
+        // A failed write is excluded for the same reason -- the bytes on disk
+        // are not what we tried to write, so they are not a truthful base.
+        // `mutationSucceeded` is the existing conservative classifier, already
+        // used to gate edit counting, so this cannot disagree with the rest of
+        // the accounting about what a successful mutation is.
+        //
+        // Free when it does apply: the source is already in hand for the graph.
+        if (authored) {
+          recordAuthoredContent(
+            projectRootFor(path, payload.cwd),
+            payload.session_id,
+            path,
+            source
+          );
+        }
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }
@@ -1393,7 +1403,20 @@ async function runHook(clientName, event, invocation) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state, episode, features);
+    // Computed HERE because clientName, event and raw are in scope here and
+    // not inside observeAndInject -- a first attempt referenced them there and
+    // would have thrown at runtime on the one path that matters.
+    const authoredWrite =
+      event === 'post-tool' &&
+      new Set(['Edit', 'MultiEdit', 'Write']).has(String(payload.tool_name || '')) &&
+      mutationSucceeded(clientName, raw);
+    graphContext = observeAndInject(
+      payload,
+      state,
+      episode,
+      features,
+      authoredWrite
+    );
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -435,6 +435,18 @@ function codexStringLiteral(literal) {
   return decoded;
 }
 
+/**
+ * Cline's write tools, under the names the rest of the pipeline matches on.
+ *
+ * Cline calls them `write_to_file` and `replace_in_file`; authoredWrite tests
+ * membership of {Edit, MultiEdit, Write}, so without the rename the
+ * integration reads the right field and still never records an authored write.
+ */
+const CLINE_TOOL_NAMES = {
+  write_to_file: 'Write',
+  replace_in_file: 'Edit',
+};
+
 /** Convert client-specific lifecycle envelopes into the common tool shape. */
 function codexStringBindings(source) {
   const values = new Map();
@@ -519,17 +531,28 @@ export function normalizeClientPayload(clientName, event, raw) {
   if (clientName === 'cline') {
     const body = event === 'post-tool' ? raw.postToolUse : raw.preToolUse;
     if (!body) return raw;
+    // `toolName` IS THE FIELD CLINE SENDS. Reading only `body.tool` left
+    // `tool_name` null, and the handler exits on a null tool name -- so every
+    // Cline call fell out before authoredWrite or recordAuthoredContent could
+    // run, and the whole integration was a silent no-op. `body.tool` is kept as
+    // a fallback rather than replaced, because a payload carrying it costs
+    // nothing to accept.
+    const rawTool = body.toolName ?? body.tool;
     return {
       ...raw,
       session_id: raw.taskId ?? raw.task_id,
       cwd: raw.workspaceRoots?.[0] ?? raw.workspacePath,
       model: raw.model?.slug,
-      tool: body.tool,
+      // MAPPED TO THE CANONICAL NAMES the rest of the pipeline matches on.
+      // authoredWrite tests membership of {Edit, MultiEdit, Write}, so Cline's
+      // own spellings would still have missed even once the field was read.
+      tool: CLINE_TOOL_NAMES[rawTool] ?? rawTool,
       parameters: body.parameters,
     };
   }
 
   if (clientName === 'windsurf') {
+    // (see CLINE_TOOL_NAMES above for why the cline branch renames its tools)
     const info = raw.tool_info || {};
     const action = String(raw.agent_action_name || '');
     const tool = action.includes('read_code')

--- a/integrations/opencode/hooks/lib/authored.mjs
+++ b/integrations/opencode/hooks/lib/authored.mjs
@@ -75,30 +75,39 @@ export function recordAuthoredContent(projectRoot, sessionId, filePath, content)
   try {
     if (!projectRoot || !sessionId || !filePath) return;
     if (typeof content !== 'string') return;
+    // A CHEAP LOWER BOUND FIRST. The serialized record is never smaller than
+    // its content, so this rejects the obvious cases without paying to
+    // stringify them. It is not the real check.
+    //
     // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
     // so 100k CJK characters measured 100,000 against a 262,144 cap while
-    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
-    // so the check is on the encoded size of the field that dominates it.
+    // writing 300,000 bytes -- 15% over.
     if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);
     mkdirSync(dir, { recursive: true });
 
+    const record = JSON.stringify({
+      v: 1,
+      sessionId,
+      path: canonicalPath(filePath),
+      hash: hash(content),
+      content,
+      at: Date.now(),
+    });
+
+    // THE AUTHORITATIVE CHECK, ON WHAT IS ACTUALLY WRITTEN. Measuring the
+    // content alone does not bound the record, because JSON escapes: a control
+    // character costs one byte in `content` and six in the record. 262,144 NUL
+    // characters therefore passed the check above and persisted about 1.5 MiB
+    // -- six times the configured cap -- and the field the cap exists to bound
+    // is the file on disk, not the string that went into it.
+    if (Buffer.byteLength(record, 'utf8') > limit()) return;
+
     const target = recordPath(projectRoot, filePath);
     const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
-    writeFileSync(
-      tmp,
-      JSON.stringify({
-        v: 1,
-        sessionId,
-        path: canonicalPath(filePath),
-        hash: hash(content),
-        content,
-        at: Date.now(),
-      }),
-      { mode: 0o600 }
-    );
+    writeFileSync(tmp, record, { mode: 0o600 });
     renameSync(tmp, target);
   } catch {
     /* the write landed; the record is an optimization */

--- a/integrations/opencode/hooks/lib/authored.mjs
+++ b/integrations/opencode/hooks/lib/authored.mjs
@@ -74,7 +74,12 @@ const hash = (text) =>
 export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
   try {
     if (!projectRoot || !sessionId || !filePath) return;
-    if (typeof content !== 'string' || content.length > limit()) return;
+    if (typeof content !== 'string') return;
+    // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
+    // so 100k CJK characters measured 100,000 against a 262,144 cap while
+    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
+    // so the check is on the encoded size of the field that dominates it.
+    if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);

--- a/integrations/opencode/hooks/lib/authored.mjs
+++ b/integrations/opencode/hooks/lib/authored.mjs
@@ -1,0 +1,138 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/authored.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * What THIS session wrote, so a later read can diff against it.
+ *
+ * THE QUESTION THIS ANSWERS, AND THE ONE IT DOES NOT. A diff base is only sound
+ * if the caller already holds the bytes it is being diffed against. That is a
+ * statement about AUTHORSHIP or DELIVERY, never about observation.
+ *
+ * The knowledge graph cannot supply it, and the distinction is not academic:
+ * `indexFile` runs on every file either hook OBSERVES -- reads included, across
+ * sessions -- so a graph snapshot means "some hook last saw these bytes". Using
+ * that as a base would hand a fresh session `// No changes` for a file it has
+ * never seen, withholding content while reporting success. That is strictly
+ * worse than resending the file, which is the behaviour being improved on.
+ *
+ * So this store is written ONLY by a write, and every record carries the
+ * session that made it.
+ *
+ * DEGRADATION IS ONE-DIRECTIONAL, BY CONSTRUCTION. Every uncertain state --
+ * missing record, unreadable record, different session, absent session id,
+ * content whose hash no longer matches disk, a file that has since been deleted
+ * -- resolves to `null`, meaning "no base", meaning the caller resends the file.
+ * The store can never make a read worse than it is today; at worst it does
+ * nothing. Nothing here may throw, because these run inside hooks and a hook
+ * that breaks a tool call is worse than one that saves nothing.
+ */
+
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+/**
+ * Largest authored file kept.
+ *
+ * Matched to the graph's own snapshot cap for the same reason it has one: a
+ * store that keeps every write becomes a second copy of the repository. Past
+ * the cap a read simply gets no base and resends, which is today's behaviour.
+ */
+const limit = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_AUTHORED_LIMIT);
+  return Number.isFinite(raw) && raw > 0 ? raw : 262_144;
+};
+
+const storeDir = (projectRoot) =>
+  join(projectRoot, '.token-optimizer', 'authored');
+
+/** One file per authored path, named by a digest so no path escapes the store. */
+const recordPath = (projectRoot, filePath) =>
+  join(
+    storeDir(projectRoot),
+    createHash('sha256').update(canonicalPath(filePath)).digest('hex').slice(0, 32) +
+      '.json'
+  );
+
+const hash = (text) =>
+  createHash('sha256').update(text, 'utf8').digest('hex').slice(0, 32);
+
+/**
+ * Records that `sessionId` wrote `content` to `filePath`.
+ *
+ * Written atomically: a torn record read back as valid JSON with the wrong
+ * bytes would be a WRONG diff base, which is the one outcome this store must
+ * never produce. A temp file plus rename means a reader sees the old record or
+ * the new one, never half of either.
+ */
+export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return;
+    if (typeof content !== 'string' || content.length > limit()) return;
+    if (!isFsSafePath(filePath)) return;
+
+    const dir = storeDir(projectRoot);
+    mkdirSync(dir, { recursive: true });
+
+    const target = recordPath(projectRoot, filePath);
+    const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+    writeFileSync(
+      tmp,
+      JSON.stringify({
+        v: 1,
+        sessionId,
+        path: canonicalPath(filePath),
+        hash: hash(content),
+        content,
+        at: Date.now(),
+      }),
+      { mode: 0o600 }
+    );
+    renameSync(tmp, target);
+  } catch {
+    /* the write landed; the record is an optimization */
+  }
+}
+
+/**
+ * The bytes `sessionId` wrote to `filePath`, or null.
+ *
+ * Null on every uncertainty. The hash check against disk is what makes a stale
+ * record safe rather than merely unlikely: if anything changed the file after
+ * we wrote it -- another process, another tool, a `git checkout` -- the recorded
+ * bytes are no longer a truthful "before", and a diff against them would
+ * describe a change that never happened.
+ */
+export function authoredContentFor(projectRoot, sessionId, filePath) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return null;
+    if (!isFsSafePath(filePath)) return null;
+
+    const raw = readFileSync(recordPath(projectRoot, filePath), 'utf8');
+    const record = JSON.parse(raw);
+
+    // THE SESSION GATE, which is the whole point. A record from another session
+    // describes bytes this caller never received.
+    if (record?.v !== 1 || record.sessionId !== sessionId) return null;
+    if (typeof record.content !== 'string') return null;
+    if (record.path !== canonicalPath(filePath)) return null;
+
+    // Cheap rejection before reading the file: a size change is a content
+    // change, and this runs on a tool-call path.
+    const size = statSync(filePath).size;
+    if (size !== Buffer.byteLength(record.content, 'utf8')) return null;
+
+    const onDisk = readFileSync(filePath, 'utf8');
+    if (hash(onDisk) !== record.hash) return null;
+
+    return record.content;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -72,6 +72,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
@@ -868,6 +869,22 @@ function observeAndInject(payload, state, episode, features) {
           hash: contentHash(path, source),
         });
         indexFile(dir, path, source);
+
+        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
+        // because it answers a different question. `indexFile` records what a
+        // hook OBSERVED -- reads included, across sessions -- which is unusable
+        // as a diff base: it would tell a session that never saw a file that
+        // nothing had changed. This record is written only on a mutation and
+        // carries the authoring session, so `smart_read` can ask "did I write
+        // this?" rather than "has anyone seen this?".
+        //
+        // Free here: the source is already in hand for the graph write.
+        recordAuthoredContent(
+          projectRootFor(path, payload.cwd),
+          payload.session_id,
+          path,
+          source
+        );
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -766,7 +766,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state, episode, features) {
+function observeAndInject(payload, state, episode, features, authored = false) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
   const registerRoot = (root) => {
@@ -870,21 +870,31 @@ function observeAndInject(payload, state, episode, features) {
         });
         indexFile(dir, path, source);
 
-        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
-        // because it answers a different question. `indexFile` records what a
-        // hook OBSERVED -- reads included, across sessions -- which is unusable
-        // as a diff base: it would tell a session that never saw a file that
-        // nothing had changed. This record is written only on a mutation and
-        // carries the authoring session, so `smart_read` can ask "did I write
-        // this?" rather than "has anyone seen this?".
+        // WHAT THIS SESSION WROTE -- and ONLY what it wrote.
         //
-        // Free here: the source is already in hand for the graph write.
-        recordAuthoredContent(
-          projectRootFor(path, payload.cwd),
-          payload.session_id,
-          path,
-          source
-        );
+        // GATED ON A SUCCESSFUL MUTATION, because this loop is not one. It
+        // iterates `touchedFiles`, which covers every tool that NAMES a file,
+        // reads included, and its own comment above calls that "evidence about
+        // what was touched". Recording an authored base from a read would
+        // recreate the exact defect this store exists to avoid: a later
+        // smart_read in the same session would be told "no changes" about
+        // content the model never received.
+        //
+        // A failed write is excluded for the same reason -- the bytes on disk
+        // are not what we tried to write, so they are not a truthful base.
+        // `mutationSucceeded` is the existing conservative classifier, already
+        // used to gate edit counting, so this cannot disagree with the rest of
+        // the accounting about what a successful mutation is.
+        //
+        // Free when it does apply: the source is already in hand for the graph.
+        if (authored) {
+          recordAuthoredContent(
+            projectRootFor(path, payload.cwd),
+            payload.session_id,
+            path,
+            source
+          );
+        }
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }
@@ -1393,7 +1403,20 @@ async function runHook(clientName, event, invocation) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state, episode, features);
+    // Computed HERE because clientName, event and raw are in scope here and
+    // not inside observeAndInject -- a first attempt referenced them there and
+    // would have thrown at runtime on the one path that matters.
+    const authoredWrite =
+      event === 'post-tool' &&
+      new Set(['Edit', 'MultiEdit', 'Write']).has(String(payload.tool_name || '')) &&
+      mutationSucceeded(clientName, raw);
+    graphContext = observeAndInject(
+      payload,
+      state,
+      episode,
+      features,
+      authoredWrite
+    );
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -435,6 +435,18 @@ function codexStringLiteral(literal) {
   return decoded;
 }
 
+/**
+ * Cline's write tools, under the names the rest of the pipeline matches on.
+ *
+ * Cline calls them `write_to_file` and `replace_in_file`; authoredWrite tests
+ * membership of {Edit, MultiEdit, Write}, so without the rename the
+ * integration reads the right field and still never records an authored write.
+ */
+const CLINE_TOOL_NAMES = {
+  write_to_file: 'Write',
+  replace_in_file: 'Edit',
+};
+
 /** Convert client-specific lifecycle envelopes into the common tool shape. */
 function codexStringBindings(source) {
   const values = new Map();
@@ -519,17 +531,28 @@ export function normalizeClientPayload(clientName, event, raw) {
   if (clientName === 'cline') {
     const body = event === 'post-tool' ? raw.postToolUse : raw.preToolUse;
     if (!body) return raw;
+    // `toolName` IS THE FIELD CLINE SENDS. Reading only `body.tool` left
+    // `tool_name` null, and the handler exits on a null tool name -- so every
+    // Cline call fell out before authoredWrite or recordAuthoredContent could
+    // run, and the whole integration was a silent no-op. `body.tool` is kept as
+    // a fallback rather than replaced, because a payload carrying it costs
+    // nothing to accept.
+    const rawTool = body.toolName ?? body.tool;
     return {
       ...raw,
       session_id: raw.taskId ?? raw.task_id,
       cwd: raw.workspaceRoots?.[0] ?? raw.workspacePath,
       model: raw.model?.slug,
-      tool: body.tool,
+      // MAPPED TO THE CANONICAL NAMES the rest of the pipeline matches on.
+      // authoredWrite tests membership of {Edit, MultiEdit, Write}, so Cline's
+      // own spellings would still have missed even once the field was read.
+      tool: CLINE_TOOL_NAMES[rawTool] ?? rawTool,
       parameters: body.parameters,
     };
   }
 
   if (clientName === 'windsurf') {
+    // (see CLINE_TOOL_NAMES above for why the cline branch renames its tools)
     const info = raw.tool_info || {};
     const action = String(raw.agent_action_name || '');
     const tool = action.includes('read_code')

--- a/integrations/qwen/hooks/lib/authored.mjs
+++ b/integrations/qwen/hooks/lib/authored.mjs
@@ -75,30 +75,39 @@ export function recordAuthoredContent(projectRoot, sessionId, filePath, content)
   try {
     if (!projectRoot || !sessionId || !filePath) return;
     if (typeof content !== 'string') return;
+    // A CHEAP LOWER BOUND FIRST. The serialized record is never smaller than
+    // its content, so this rejects the obvious cases without paying to
+    // stringify them. It is not the real check.
+    //
     // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
     // so 100k CJK characters measured 100,000 against a 262,144 cap while
-    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
-    // so the check is on the encoded size of the field that dominates it.
+    // writing 300,000 bytes -- 15% over.
     if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);
     mkdirSync(dir, { recursive: true });
 
+    const record = JSON.stringify({
+      v: 1,
+      sessionId,
+      path: canonicalPath(filePath),
+      hash: hash(content),
+      content,
+      at: Date.now(),
+    });
+
+    // THE AUTHORITATIVE CHECK, ON WHAT IS ACTUALLY WRITTEN. Measuring the
+    // content alone does not bound the record, because JSON escapes: a control
+    // character costs one byte in `content` and six in the record. 262,144 NUL
+    // characters therefore passed the check above and persisted about 1.5 MiB
+    // -- six times the configured cap -- and the field the cap exists to bound
+    // is the file on disk, not the string that went into it.
+    if (Buffer.byteLength(record, 'utf8') > limit()) return;
+
     const target = recordPath(projectRoot, filePath);
     const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
-    writeFileSync(
-      tmp,
-      JSON.stringify({
-        v: 1,
-        sessionId,
-        path: canonicalPath(filePath),
-        hash: hash(content),
-        content,
-        at: Date.now(),
-      }),
-      { mode: 0o600 }
-    );
+    writeFileSync(tmp, record, { mode: 0o600 });
     renameSync(tmp, target);
   } catch {
     /* the write landed; the record is an optimization */

--- a/integrations/qwen/hooks/lib/authored.mjs
+++ b/integrations/qwen/hooks/lib/authored.mjs
@@ -74,7 +74,12 @@ const hash = (text) =>
 export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
   try {
     if (!projectRoot || !sessionId || !filePath) return;
-    if (typeof content !== 'string' || content.length > limit()) return;
+    if (typeof content !== 'string') return;
+    // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
+    // so 100k CJK characters measured 100,000 against a 262,144 cap while
+    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
+    // so the check is on the encoded size of the field that dominates it.
+    if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);

--- a/integrations/qwen/hooks/lib/authored.mjs
+++ b/integrations/qwen/hooks/lib/authored.mjs
@@ -1,0 +1,138 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/authored.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * What THIS session wrote, so a later read can diff against it.
+ *
+ * THE QUESTION THIS ANSWERS, AND THE ONE IT DOES NOT. A diff base is only sound
+ * if the caller already holds the bytes it is being diffed against. That is a
+ * statement about AUTHORSHIP or DELIVERY, never about observation.
+ *
+ * The knowledge graph cannot supply it, and the distinction is not academic:
+ * `indexFile` runs on every file either hook OBSERVES -- reads included, across
+ * sessions -- so a graph snapshot means "some hook last saw these bytes". Using
+ * that as a base would hand a fresh session `// No changes` for a file it has
+ * never seen, withholding content while reporting success. That is strictly
+ * worse than resending the file, which is the behaviour being improved on.
+ *
+ * So this store is written ONLY by a write, and every record carries the
+ * session that made it.
+ *
+ * DEGRADATION IS ONE-DIRECTIONAL, BY CONSTRUCTION. Every uncertain state --
+ * missing record, unreadable record, different session, absent session id,
+ * content whose hash no longer matches disk, a file that has since been deleted
+ * -- resolves to `null`, meaning "no base", meaning the caller resends the file.
+ * The store can never make a read worse than it is today; at worst it does
+ * nothing. Nothing here may throw, because these run inside hooks and a hook
+ * that breaks a tool call is worse than one that saves nothing.
+ */
+
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+/**
+ * Largest authored file kept.
+ *
+ * Matched to the graph's own snapshot cap for the same reason it has one: a
+ * store that keeps every write becomes a second copy of the repository. Past
+ * the cap a read simply gets no base and resends, which is today's behaviour.
+ */
+const limit = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_AUTHORED_LIMIT);
+  return Number.isFinite(raw) && raw > 0 ? raw : 262_144;
+};
+
+const storeDir = (projectRoot) =>
+  join(projectRoot, '.token-optimizer', 'authored');
+
+/** One file per authored path, named by a digest so no path escapes the store. */
+const recordPath = (projectRoot, filePath) =>
+  join(
+    storeDir(projectRoot),
+    createHash('sha256').update(canonicalPath(filePath)).digest('hex').slice(0, 32) +
+      '.json'
+  );
+
+const hash = (text) =>
+  createHash('sha256').update(text, 'utf8').digest('hex').slice(0, 32);
+
+/**
+ * Records that `sessionId` wrote `content` to `filePath`.
+ *
+ * Written atomically: a torn record read back as valid JSON with the wrong
+ * bytes would be a WRONG diff base, which is the one outcome this store must
+ * never produce. A temp file plus rename means a reader sees the old record or
+ * the new one, never half of either.
+ */
+export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return;
+    if (typeof content !== 'string' || content.length > limit()) return;
+    if (!isFsSafePath(filePath)) return;
+
+    const dir = storeDir(projectRoot);
+    mkdirSync(dir, { recursive: true });
+
+    const target = recordPath(projectRoot, filePath);
+    const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+    writeFileSync(
+      tmp,
+      JSON.stringify({
+        v: 1,
+        sessionId,
+        path: canonicalPath(filePath),
+        hash: hash(content),
+        content,
+        at: Date.now(),
+      }),
+      { mode: 0o600 }
+    );
+    renameSync(tmp, target);
+  } catch {
+    /* the write landed; the record is an optimization */
+  }
+}
+
+/**
+ * The bytes `sessionId` wrote to `filePath`, or null.
+ *
+ * Null on every uncertainty. The hash check against disk is what makes a stale
+ * record safe rather than merely unlikely: if anything changed the file after
+ * we wrote it -- another process, another tool, a `git checkout` -- the recorded
+ * bytes are no longer a truthful "before", and a diff against them would
+ * describe a change that never happened.
+ */
+export function authoredContentFor(projectRoot, sessionId, filePath) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return null;
+    if (!isFsSafePath(filePath)) return null;
+
+    const raw = readFileSync(recordPath(projectRoot, filePath), 'utf8');
+    const record = JSON.parse(raw);
+
+    // THE SESSION GATE, which is the whole point. A record from another session
+    // describes bytes this caller never received.
+    if (record?.v !== 1 || record.sessionId !== sessionId) return null;
+    if (typeof record.content !== 'string') return null;
+    if (record.path !== canonicalPath(filePath)) return null;
+
+    // Cheap rejection before reading the file: a size change is a content
+    // change, and this runs on a tool-call path.
+    const size = statSync(filePath).size;
+    if (size !== Buffer.byteLength(record.content, 'utf8')) return null;
+
+    const onDisk = readFileSync(filePath, 'utf8');
+    if (hash(onDisk) !== record.hash) return null;
+
+    return record.content;
+  } catch {
+    return null;
+  }
+}

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -72,6 +72,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
@@ -868,6 +869,22 @@ function observeAndInject(payload, state, episode, features) {
           hash: contentHash(path, source),
         });
         indexFile(dir, path, source);
+
+        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
+        // because it answers a different question. `indexFile` records what a
+        // hook OBSERVED -- reads included, across sessions -- which is unusable
+        // as a diff base: it would tell a session that never saw a file that
+        // nothing had changed. This record is written only on a mutation and
+        // carries the authoring session, so `smart_read` can ask "did I write
+        // this?" rather than "has anyone seen this?".
+        //
+        // Free here: the source is already in hand for the graph write.
+        recordAuthoredContent(
+          projectRootFor(path, payload.cwd),
+          payload.session_id,
+          path,
+          source
+        );
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -766,7 +766,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state, episode, features) {
+function observeAndInject(payload, state, episode, features, authored = false) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
   const registerRoot = (root) => {
@@ -870,21 +870,31 @@ function observeAndInject(payload, state, episode, features) {
         });
         indexFile(dir, path, source);
 
-        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
-        // because it answers a different question. `indexFile` records what a
-        // hook OBSERVED -- reads included, across sessions -- which is unusable
-        // as a diff base: it would tell a session that never saw a file that
-        // nothing had changed. This record is written only on a mutation and
-        // carries the authoring session, so `smart_read` can ask "did I write
-        // this?" rather than "has anyone seen this?".
+        // WHAT THIS SESSION WROTE -- and ONLY what it wrote.
         //
-        // Free here: the source is already in hand for the graph write.
-        recordAuthoredContent(
-          projectRootFor(path, payload.cwd),
-          payload.session_id,
-          path,
-          source
-        );
+        // GATED ON A SUCCESSFUL MUTATION, because this loop is not one. It
+        // iterates `touchedFiles`, which covers every tool that NAMES a file,
+        // reads included, and its own comment above calls that "evidence about
+        // what was touched". Recording an authored base from a read would
+        // recreate the exact defect this store exists to avoid: a later
+        // smart_read in the same session would be told "no changes" about
+        // content the model never received.
+        //
+        // A failed write is excluded for the same reason -- the bytes on disk
+        // are not what we tried to write, so they are not a truthful base.
+        // `mutationSucceeded` is the existing conservative classifier, already
+        // used to gate edit counting, so this cannot disagree with the rest of
+        // the accounting about what a successful mutation is.
+        //
+        // Free when it does apply: the source is already in hand for the graph.
+        if (authored) {
+          recordAuthoredContent(
+            projectRootFor(path, payload.cwd),
+            payload.session_id,
+            path,
+            source
+          );
+        }
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }
@@ -1393,7 +1403,20 @@ async function runHook(clientName, event, invocation) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state, episode, features);
+    // Computed HERE because clientName, event and raw are in scope here and
+    // not inside observeAndInject -- a first attempt referenced them there and
+    // would have thrown at runtime on the one path that matters.
+    const authoredWrite =
+      event === 'post-tool' &&
+      new Set(['Edit', 'MultiEdit', 'Write']).has(String(payload.tool_name || '')) &&
+      mutationSucceeded(clientName, raw);
+    graphContext = observeAndInject(
+      payload,
+      state,
+      episode,
+      features,
+      authoredWrite
+    );
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -435,6 +435,18 @@ function codexStringLiteral(literal) {
   return decoded;
 }
 
+/**
+ * Cline's write tools, under the names the rest of the pipeline matches on.
+ *
+ * Cline calls them `write_to_file` and `replace_in_file`; authoredWrite tests
+ * membership of {Edit, MultiEdit, Write}, so without the rename the
+ * integration reads the right field and still never records an authored write.
+ */
+const CLINE_TOOL_NAMES = {
+  write_to_file: 'Write',
+  replace_in_file: 'Edit',
+};
+
 /** Convert client-specific lifecycle envelopes into the common tool shape. */
 function codexStringBindings(source) {
   const values = new Map();
@@ -519,17 +531,28 @@ export function normalizeClientPayload(clientName, event, raw) {
   if (clientName === 'cline') {
     const body = event === 'post-tool' ? raw.postToolUse : raw.preToolUse;
     if (!body) return raw;
+    // `toolName` IS THE FIELD CLINE SENDS. Reading only `body.tool` left
+    // `tool_name` null, and the handler exits on a null tool name -- so every
+    // Cline call fell out before authoredWrite or recordAuthoredContent could
+    // run, and the whole integration was a silent no-op. `body.tool` is kept as
+    // a fallback rather than replaced, because a payload carrying it costs
+    // nothing to accept.
+    const rawTool = body.toolName ?? body.tool;
     return {
       ...raw,
       session_id: raw.taskId ?? raw.task_id,
       cwd: raw.workspaceRoots?.[0] ?? raw.workspacePath,
       model: raw.model?.slug,
-      tool: body.tool,
+      // MAPPED TO THE CANONICAL NAMES the rest of the pipeline matches on.
+      // authoredWrite tests membership of {Edit, MultiEdit, Write}, so Cline's
+      // own spellings would still have missed even once the field was read.
+      tool: CLINE_TOOL_NAMES[rawTool] ?? rawTool,
       parameters: body.parameters,
     };
   }
 
   if (clientName === 'windsurf') {
+    // (see CLINE_TOOL_NAMES above for why the cline branch renames its tools)
     const info = raw.tool_info || {};
     const action = String(raw.agent_action_name || '');
     const tool = action.includes('read_code')

--- a/integrations/windsurf/hooks/lib/authored.mjs
+++ b/integrations/windsurf/hooks/lib/authored.mjs
@@ -75,30 +75,39 @@ export function recordAuthoredContent(projectRoot, sessionId, filePath, content)
   try {
     if (!projectRoot || !sessionId || !filePath) return;
     if (typeof content !== 'string') return;
+    // A CHEAP LOWER BOUND FIRST. The serialized record is never smaller than
+    // its content, so this rejects the obvious cases without paying to
+    // stringify them. It is not the real check.
+    //
     // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
     // so 100k CJK characters measured 100,000 against a 262,144 cap while
-    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
-    // so the check is on the encoded size of the field that dominates it.
+    // writing 300,000 bytes -- 15% over.
     if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);
     mkdirSync(dir, { recursive: true });
 
+    const record = JSON.stringify({
+      v: 1,
+      sessionId,
+      path: canonicalPath(filePath),
+      hash: hash(content),
+      content,
+      at: Date.now(),
+    });
+
+    // THE AUTHORITATIVE CHECK, ON WHAT IS ACTUALLY WRITTEN. Measuring the
+    // content alone does not bound the record, because JSON escapes: a control
+    // character costs one byte in `content` and six in the record. 262,144 NUL
+    // characters therefore passed the check above and persisted about 1.5 MiB
+    // -- six times the configured cap -- and the field the cap exists to bound
+    // is the file on disk, not the string that went into it.
+    if (Buffer.byteLength(record, 'utf8') > limit()) return;
+
     const target = recordPath(projectRoot, filePath);
     const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
-    writeFileSync(
-      tmp,
-      JSON.stringify({
-        v: 1,
-        sessionId,
-        path: canonicalPath(filePath),
-        hash: hash(content),
-        content,
-        at: Date.now(),
-      }),
-      { mode: 0o600 }
-    );
+    writeFileSync(tmp, record, { mode: 0o600 });
     renameSync(tmp, target);
   } catch {
     /* the write landed; the record is an optimization */

--- a/integrations/windsurf/hooks/lib/authored.mjs
+++ b/integrations/windsurf/hooks/lib/authored.mjs
@@ -74,7 +74,12 @@ const hash = (text) =>
 export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
   try {
     if (!projectRoot || !sessionId || !filePath) return;
-    if (typeof content !== 'string' || content.length > limit()) return;
+    if (typeof content !== 'string') return;
+    // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
+    // so 100k CJK characters measured 100,000 against a 262,144 cap while
+    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
+    // so the check is on the encoded size of the field that dominates it.
+    if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);

--- a/integrations/windsurf/hooks/lib/authored.mjs
+++ b/integrations/windsurf/hooks/lib/authored.mjs
@@ -1,0 +1,138 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/authored.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * What THIS session wrote, so a later read can diff against it.
+ *
+ * THE QUESTION THIS ANSWERS, AND THE ONE IT DOES NOT. A diff base is only sound
+ * if the caller already holds the bytes it is being diffed against. That is a
+ * statement about AUTHORSHIP or DELIVERY, never about observation.
+ *
+ * The knowledge graph cannot supply it, and the distinction is not academic:
+ * `indexFile` runs on every file either hook OBSERVES -- reads included, across
+ * sessions -- so a graph snapshot means "some hook last saw these bytes". Using
+ * that as a base would hand a fresh session `// No changes` for a file it has
+ * never seen, withholding content while reporting success. That is strictly
+ * worse than resending the file, which is the behaviour being improved on.
+ *
+ * So this store is written ONLY by a write, and every record carries the
+ * session that made it.
+ *
+ * DEGRADATION IS ONE-DIRECTIONAL, BY CONSTRUCTION. Every uncertain state --
+ * missing record, unreadable record, different session, absent session id,
+ * content whose hash no longer matches disk, a file that has since been deleted
+ * -- resolves to `null`, meaning "no base", meaning the caller resends the file.
+ * The store can never make a read worse than it is today; at worst it does
+ * nothing. Nothing here may throw, because these run inside hooks and a hook
+ * that breaks a tool call is worse than one that saves nothing.
+ */
+
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+/**
+ * Largest authored file kept.
+ *
+ * Matched to the graph's own snapshot cap for the same reason it has one: a
+ * store that keeps every write becomes a second copy of the repository. Past
+ * the cap a read simply gets no base and resends, which is today's behaviour.
+ */
+const limit = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_AUTHORED_LIMIT);
+  return Number.isFinite(raw) && raw > 0 ? raw : 262_144;
+};
+
+const storeDir = (projectRoot) =>
+  join(projectRoot, '.token-optimizer', 'authored');
+
+/** One file per authored path, named by a digest so no path escapes the store. */
+const recordPath = (projectRoot, filePath) =>
+  join(
+    storeDir(projectRoot),
+    createHash('sha256').update(canonicalPath(filePath)).digest('hex').slice(0, 32) +
+      '.json'
+  );
+
+const hash = (text) =>
+  createHash('sha256').update(text, 'utf8').digest('hex').slice(0, 32);
+
+/**
+ * Records that `sessionId` wrote `content` to `filePath`.
+ *
+ * Written atomically: a torn record read back as valid JSON with the wrong
+ * bytes would be a WRONG diff base, which is the one outcome this store must
+ * never produce. A temp file plus rename means a reader sees the old record or
+ * the new one, never half of either.
+ */
+export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return;
+    if (typeof content !== 'string' || content.length > limit()) return;
+    if (!isFsSafePath(filePath)) return;
+
+    const dir = storeDir(projectRoot);
+    mkdirSync(dir, { recursive: true });
+
+    const target = recordPath(projectRoot, filePath);
+    const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+    writeFileSync(
+      tmp,
+      JSON.stringify({
+        v: 1,
+        sessionId,
+        path: canonicalPath(filePath),
+        hash: hash(content),
+        content,
+        at: Date.now(),
+      }),
+      { mode: 0o600 }
+    );
+    renameSync(tmp, target);
+  } catch {
+    /* the write landed; the record is an optimization */
+  }
+}
+
+/**
+ * The bytes `sessionId` wrote to `filePath`, or null.
+ *
+ * Null on every uncertainty. The hash check against disk is what makes a stale
+ * record safe rather than merely unlikely: if anything changed the file after
+ * we wrote it -- another process, another tool, a `git checkout` -- the recorded
+ * bytes are no longer a truthful "before", and a diff against them would
+ * describe a change that never happened.
+ */
+export function authoredContentFor(projectRoot, sessionId, filePath) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return null;
+    if (!isFsSafePath(filePath)) return null;
+
+    const raw = readFileSync(recordPath(projectRoot, filePath), 'utf8');
+    const record = JSON.parse(raw);
+
+    // THE SESSION GATE, which is the whole point. A record from another session
+    // describes bytes this caller never received.
+    if (record?.v !== 1 || record.sessionId !== sessionId) return null;
+    if (typeof record.content !== 'string') return null;
+    if (record.path !== canonicalPath(filePath)) return null;
+
+    // Cheap rejection before reading the file: a size change is a content
+    // change, and this runs on a tool-call path.
+    const size = statSync(filePath).size;
+    if (size !== Buffer.byteLength(record.content, 'utf8')) return null;
+
+    const onDisk = readFileSync(filePath, 'utf8');
+    if (hash(onDisk) !== record.hash) return null;
+
+    return record.content;
+  } catch {
+    return null;
+  }
+}

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -72,6 +72,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
@@ -868,6 +869,22 @@ function observeAndInject(payload, state, episode, features) {
           hash: contentHash(path, source),
         });
         indexFile(dir, path, source);
+
+        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
+        // because it answers a different question. `indexFile` records what a
+        // hook OBSERVED -- reads included, across sessions -- which is unusable
+        // as a diff base: it would tell a session that never saw a file that
+        // nothing had changed. This record is written only on a mutation and
+        // carries the authoring session, so `smart_read` can ask "did I write
+        // this?" rather than "has anyone seen this?".
+        //
+        // Free here: the source is already in hand for the graph write.
+        recordAuthoredContent(
+          projectRootFor(path, payload.cwd),
+          payload.session_id,
+          path,
+          source
+        );
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -766,7 +766,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state, episode, features) {
+function observeAndInject(payload, state, episode, features, authored = false) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
   const registerRoot = (root) => {
@@ -870,21 +870,31 @@ function observeAndInject(payload, state, episode, features) {
         });
         indexFile(dir, path, source);
 
-        // WHAT THIS SESSION WROTE, kept separate from the graph snapshot above
-        // because it answers a different question. `indexFile` records what a
-        // hook OBSERVED -- reads included, across sessions -- which is unusable
-        // as a diff base: it would tell a session that never saw a file that
-        // nothing had changed. This record is written only on a mutation and
-        // carries the authoring session, so `smart_read` can ask "did I write
-        // this?" rather than "has anyone seen this?".
+        // WHAT THIS SESSION WROTE -- and ONLY what it wrote.
         //
-        // Free here: the source is already in hand for the graph write.
-        recordAuthoredContent(
-          projectRootFor(path, payload.cwd),
-          payload.session_id,
-          path,
-          source
-        );
+        // GATED ON A SUCCESSFUL MUTATION, because this loop is not one. It
+        // iterates `touchedFiles`, which covers every tool that NAMES a file,
+        // reads included, and its own comment above calls that "evidence about
+        // what was touched". Recording an authored base from a read would
+        // recreate the exact defect this store exists to avoid: a later
+        // smart_read in the same session would be told "no changes" about
+        // content the model never received.
+        //
+        // A failed write is excluded for the same reason -- the bytes on disk
+        // are not what we tried to write, so they are not a truthful base.
+        // `mutationSucceeded` is the existing conservative classifier, already
+        // used to gate edit counting, so this cannot disagree with the rest of
+        // the accounting about what a successful mutation is.
+        //
+        // Free when it does apply: the source is already in hand for the graph.
+        if (authored) {
+          recordAuthoredContent(
+            projectRootFor(path, payload.cwd),
+            payload.session_id,
+            path,
+            source
+          );
+        }
       } catch {
         // Graph bookkeeping must never break the user's tool call.
       }
@@ -1393,7 +1403,20 @@ async function runHook(clientName, event, invocation) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state, episode, features);
+    // Computed HERE because clientName, event and raw are in scope here and
+    // not inside observeAndInject -- a first attempt referenced them there and
+    // would have thrown at runtime on the one path that matters.
+    const authoredWrite =
+      event === 'post-tool' &&
+      new Set(['Edit', 'MultiEdit', 'Write']).has(String(payload.tool_name || '')) &&
+      mutationSucceeded(clientName, raw);
+    graphContext = observeAndInject(
+      payload,
+      state,
+      episode,
+      features,
+      authoredWrite
+    );
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -435,6 +435,18 @@ function codexStringLiteral(literal) {
   return decoded;
 }
 
+/**
+ * Cline's write tools, under the names the rest of the pipeline matches on.
+ *
+ * Cline calls them `write_to_file` and `replace_in_file`; authoredWrite tests
+ * membership of {Edit, MultiEdit, Write}, so without the rename the
+ * integration reads the right field and still never records an authored write.
+ */
+const CLINE_TOOL_NAMES = {
+  write_to_file: 'Write',
+  replace_in_file: 'Edit',
+};
+
 /** Convert client-specific lifecycle envelopes into the common tool shape. */
 function codexStringBindings(source) {
   const values = new Map();
@@ -519,17 +531,28 @@ export function normalizeClientPayload(clientName, event, raw) {
   if (clientName === 'cline') {
     const body = event === 'post-tool' ? raw.postToolUse : raw.preToolUse;
     if (!body) return raw;
+    // `toolName` IS THE FIELD CLINE SENDS. Reading only `body.tool` left
+    // `tool_name` null, and the handler exits on a null tool name -- so every
+    // Cline call fell out before authoredWrite or recordAuthoredContent could
+    // run, and the whole integration was a silent no-op. `body.tool` is kept as
+    // a fallback rather than replaced, because a payload carrying it costs
+    // nothing to accept.
+    const rawTool = body.toolName ?? body.tool;
     return {
       ...raw,
       session_id: raw.taskId ?? raw.task_id,
       cwd: raw.workspaceRoots?.[0] ?? raw.workspacePath,
       model: raw.model?.slug,
-      tool: body.tool,
+      // MAPPED TO THE CANONICAL NAMES the rest of the pipeline matches on.
+      // authoredWrite tests membership of {Edit, MultiEdit, Write}, so Cline's
+      // own spellings would still have missed even once the field was read.
+      tool: CLINE_TOOL_NAMES[rawTool] ?? rawTool,
       parameters: body.parameters,
     };
   }
 
   if (clientName === 'windsurf') {
+    // (see CLINE_TOOL_NAMES above for why the cline branch renames its tools)
     const info = raw.tool_info || {};
     const action = String(raw.agent_action_name || '');
     const tool = action.includes('read_code')

--- a/plugin/hooks/lib/authored.mjs
+++ b/plugin/hooks/lib/authored.mjs
@@ -75,30 +75,39 @@ export function recordAuthoredContent(projectRoot, sessionId, filePath, content)
   try {
     if (!projectRoot || !sessionId || !filePath) return;
     if (typeof content !== 'string') return;
+    // A CHEAP LOWER BOUND FIRST. The serialized record is never smaller than
+    // its content, so this rejects the obvious cases without paying to
+    // stringify them. It is not the real check.
+    //
     // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
     // so 100k CJK characters measured 100,000 against a 262,144 cap while
-    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
-    // so the check is on the encoded size of the field that dominates it.
+    // writing 300,000 bytes -- 15% over.
     if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);
     mkdirSync(dir, { recursive: true });
 
+    const record = JSON.stringify({
+      v: 1,
+      sessionId,
+      path: canonicalPath(filePath),
+      hash: hash(content),
+      content,
+      at: Date.now(),
+    });
+
+    // THE AUTHORITATIVE CHECK, ON WHAT IS ACTUALLY WRITTEN. Measuring the
+    // content alone does not bound the record, because JSON escapes: a control
+    // character costs one byte in `content` and six in the record. 262,144 NUL
+    // characters therefore passed the check above and persisted about 1.5 MiB
+    // -- six times the configured cap -- and the field the cap exists to bound
+    // is the file on disk, not the string that went into it.
+    if (Buffer.byteLength(record, 'utf8') > limit()) return;
+
     const target = recordPath(projectRoot, filePath);
     const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
-    writeFileSync(
-      tmp,
-      JSON.stringify({
-        v: 1,
-        sessionId,
-        path: canonicalPath(filePath),
-        hash: hash(content),
-        content,
-        at: Date.now(),
-      }),
-      { mode: 0o600 }
-    );
+    writeFileSync(tmp, record, { mode: 0o600 });
     renameSync(tmp, target);
   } catch {
     /* the write landed; the record is an optimization */

--- a/plugin/hooks/lib/authored.mjs
+++ b/plugin/hooks/lib/authored.mjs
@@ -74,7 +74,12 @@ const hash = (text) =>
 export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
   try {
     if (!projectRoot || !sessionId || !filePath) return;
-    if (typeof content !== 'string' || content.length > limit()) return;
+    if (typeof content !== 'string') return;
+    // BYTES AS PERSISTED, not UTF-16 code units. `content.length` counts units,
+    // so 100k CJK characters measured 100,000 against a 262,144 cap while
+    // writing 300,000 bytes -- 15% over. The record is what has to stay bounded,
+    // so the check is on the encoded size of the field that dominates it.
+    if (Buffer.byteLength(content, 'utf8') > limit()) return;
     if (!isFsSafePath(filePath)) return;
 
     const dir = storeDir(projectRoot);

--- a/plugin/hooks/lib/authored.mjs
+++ b/plugin/hooks/lib/authored.mjs
@@ -1,0 +1,138 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/authored.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * What THIS session wrote, so a later read can diff against it.
+ *
+ * THE QUESTION THIS ANSWERS, AND THE ONE IT DOES NOT. A diff base is only sound
+ * if the caller already holds the bytes it is being diffed against. That is a
+ * statement about AUTHORSHIP or DELIVERY, never about observation.
+ *
+ * The knowledge graph cannot supply it, and the distinction is not academic:
+ * `indexFile` runs on every file either hook OBSERVES -- reads included, across
+ * sessions -- so a graph snapshot means "some hook last saw these bytes". Using
+ * that as a base would hand a fresh session `// No changes` for a file it has
+ * never seen, withholding content while reporting success. That is strictly
+ * worse than resending the file, which is the behaviour being improved on.
+ *
+ * So this store is written ONLY by a write, and every record carries the
+ * session that made it.
+ *
+ * DEGRADATION IS ONE-DIRECTIONAL, BY CONSTRUCTION. Every uncertain state --
+ * missing record, unreadable record, different session, absent session id,
+ * content whose hash no longer matches disk, a file that has since been deleted
+ * -- resolves to `null`, meaning "no base", meaning the caller resends the file.
+ * The store can never make a read worse than it is today; at worst it does
+ * nothing. Nothing here may throw, because these run inside hooks and a hook
+ * that breaks a tool call is worse than one that saves nothing.
+ */
+
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+/**
+ * Largest authored file kept.
+ *
+ * Matched to the graph's own snapshot cap for the same reason it has one: a
+ * store that keeps every write becomes a second copy of the repository. Past
+ * the cap a read simply gets no base and resends, which is today's behaviour.
+ */
+const limit = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_AUTHORED_LIMIT);
+  return Number.isFinite(raw) && raw > 0 ? raw : 262_144;
+};
+
+const storeDir = (projectRoot) =>
+  join(projectRoot, '.token-optimizer', 'authored');
+
+/** One file per authored path, named by a digest so no path escapes the store. */
+const recordPath = (projectRoot, filePath) =>
+  join(
+    storeDir(projectRoot),
+    createHash('sha256').update(canonicalPath(filePath)).digest('hex').slice(0, 32) +
+      '.json'
+  );
+
+const hash = (text) =>
+  createHash('sha256').update(text, 'utf8').digest('hex').slice(0, 32);
+
+/**
+ * Records that `sessionId` wrote `content` to `filePath`.
+ *
+ * Written atomically: a torn record read back as valid JSON with the wrong
+ * bytes would be a WRONG diff base, which is the one outcome this store must
+ * never produce. A temp file plus rename means a reader sees the old record or
+ * the new one, never half of either.
+ */
+export function recordAuthoredContent(projectRoot, sessionId, filePath, content) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return;
+    if (typeof content !== 'string' || content.length > limit()) return;
+    if (!isFsSafePath(filePath)) return;
+
+    const dir = storeDir(projectRoot);
+    mkdirSync(dir, { recursive: true });
+
+    const target = recordPath(projectRoot, filePath);
+    const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+    writeFileSync(
+      tmp,
+      JSON.stringify({
+        v: 1,
+        sessionId,
+        path: canonicalPath(filePath),
+        hash: hash(content),
+        content,
+        at: Date.now(),
+      }),
+      { mode: 0o600 }
+    );
+    renameSync(tmp, target);
+  } catch {
+    /* the write landed; the record is an optimization */
+  }
+}
+
+/**
+ * The bytes `sessionId` wrote to `filePath`, or null.
+ *
+ * Null on every uncertainty. The hash check against disk is what makes a stale
+ * record safe rather than merely unlikely: if anything changed the file after
+ * we wrote it -- another process, another tool, a `git checkout` -- the recorded
+ * bytes are no longer a truthful "before", and a diff against them would
+ * describe a change that never happened.
+ */
+export function authoredContentFor(projectRoot, sessionId, filePath) {
+  try {
+    if (!projectRoot || !sessionId || !filePath) return null;
+    if (!isFsSafePath(filePath)) return null;
+
+    const raw = readFileSync(recordPath(projectRoot, filePath), 'utf8');
+    const record = JSON.parse(raw);
+
+    // THE SESSION GATE, which is the whole point. A record from another session
+    // describes bytes this caller never received.
+    if (record?.v !== 1 || record.sessionId !== sessionId) return null;
+    if (typeof record.content !== 'string') return null;
+    if (record.path !== canonicalPath(filePath)) return null;
+
+    // Cheap rejection before reading the file: a size change is a content
+    // change, and this runs on a tool-call path.
+    const size = statSync(filePath).size;
+    if (size !== Buffer.byteLength(record.content, 'utf8')) return null;
+
+    const onDisk = readFileSync(filePath, 'utf8');
+    if (hash(onDisk) !== record.hash) return null;
+
+    return record.content;
+  } catch {
+    return null;
+  }
+}

--- a/src/tools/file-operations/authored-base.ts
+++ b/src/tools/file-operations/authored-base.ts
@@ -1,0 +1,99 @@
+/**
+ * The bytes this session wrote to a file, for use as a diff base.
+ *
+ * THE BRIDGE THIS CROSSES. The hook knows the client's real `session_id` and
+ * the file's content; the MCP server knows neither. They share a filesystem and
+ * a project, so the hook records what it wrote and the server reads it back --
+ * the same shape the legacy PowerShell path used, rather than a new invention.
+ *
+ * WHY A SESSION SCOPE IS NOT OPTIONAL. A diff base is only sound if the caller
+ * already holds the bytes being diffed against. The knowledge-graph snapshot
+ * cannot supply that: `indexFile` runs on every file either hook observes,
+ * READS INCLUDED and across sessions, so it answers "what did some hook last
+ * see". Using it would hand a fresh session `// No changes` for a file it has
+ * never seen -- withholding content while reporting success, which is worse
+ * than the full resend this replaces.
+ *
+ * EVERY UNCERTAINTY RESOLVES TO NULL, and null means "resend the file", which
+ * is today's behaviour. So this can add a saving and can never subtract one.
+ * Nothing here throws: a diff-base lookup must not be able to fail a read.
+ */
+
+import { createRequire } from 'module';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const require = createRequire(import.meta.url);
+const here = dirname(fileURLToPath(import.meta.url));
+
+interface AuthoredModule {
+  authoredContentFor(
+    projectRoot: string,
+    sessionId: string,
+    filePath: string
+  ): string | null;
+}
+
+interface WikiModule {
+  projectRootFor(filePath: string, fallback: string): string;
+}
+
+let modules: { authored: AuthoredModule; wiki: WikiModule } | null = null;
+let loadFailed = false;
+
+/**
+ * Loads the hook-core modules, once.
+ *
+ * Loaded lazily and defensively for the same reason the wiki routes are: these
+ * are plain ESM the clients execute with no build step, and a missing runtime
+ * must degrade to "no base" rather than break every read. `createRequire` keeps
+ * this synchronous, because the read path cannot await a dynamic import without
+ * changing its own signature.
+ */
+function load(): { authored: AuthoredModule; wiki: WikiModule } | null {
+  if (modules) return modules;
+  if (loadFailed) return null;
+  try {
+    const root = join(here, '..', '..', '..', 'hooks-core');
+    modules = {
+      authored: require(join(root, 'authored.mjs')) as AuthoredModule,
+      wiki: require(join(root, 'wiki.mjs')) as WikiModule,
+    };
+    return modules;
+  } catch {
+    loadFailed = true;
+    return null;
+  }
+}
+
+/**
+ * The session this server belongs to, or null.
+ *
+ * TOKEN_OPTIMIZER_SESSION_ID is set by the client for both the hooks and the
+ * MCP server when the plugin can supply it. When it is absent there is no way
+ * to prove the caller authored anything, so there is no base -- deliberately,
+ * because guessing here is exactly the cross-session leak this design exists to
+ * avoid. Absent identity degrades to the current full-resend behaviour.
+ */
+function sessionId(): string | null {
+  const raw = (process.env.TOKEN_OPTIMIZER_SESSION_ID || '').trim();
+  return raw || null;
+}
+
+/** The content this session wrote to `filePath`, or null. */
+export function authoredBase(filePath: string): string | null {
+  try {
+    const session = sessionId();
+    if (!session) return null;
+
+    const loaded = load();
+    if (!loaded) return null;
+
+    const root = loaded.wiki.projectRootFor(filePath, process.cwd());
+    if (!root) return null;
+
+    return loaded.authored.authoredContentFor(root, session, filePath);
+  } catch {
+    return null;
+  }
+}

--- a/src/tools/file-operations/smart-read.ts
+++ b/src/tools/file-operations/smart-read.ts
@@ -168,10 +168,15 @@ export class SmartReadTool {
     // Ordered session-scoped first: it is the one with a provenance argument.
     // Both are only ever a BASE, never the answer, so a stale entry costs a
     // diff rather than a wrong result.
-    const cachedData =
-      ownCached ??
-      authoredBase(filePath) ??
-      (enableCache ? cacheGet(this.cache, lastWrittenKey(filePath)) : null);
+    // BOTH fallbacks are gated on enableCache. `enableCache: false` is a
+    // caller saying 'give me the file, not a diff against something you
+    // remember'; serving `// No changes` off a persisted authored record would
+    // ignore that opt-out just as surely as serving it off the cache.
+    const cachedData = enableCache
+      ? (ownCached ??
+        authoredBase(filePath) ??
+        cacheGet(this.cache, lastWrittenKey(filePath)))
+      : null;
 
     // Deliberately NOT `cachedData !== null`. This means "my own cache entry
     // hit", which is what the metrics below report and what gates the re-seed

--- a/src/tools/file-operations/smart-read.ts
+++ b/src/tools/file-operations/smart-read.ts
@@ -18,6 +18,7 @@ import { MetricsCollector } from '../../core/metrics.js';
 import { generateDiff, hasMeaningfulChanges } from '../shared/diff-utils.js';
 import { hashFile, generateCacheKey } from '../shared/hash-utils.js';
 import { cacheGet, cacheSet } from '../../utils/cache-helper.js';
+import { authoredBase } from './authored-base.js';
 import {
   chunkBySyntax,
   truncateContent,
@@ -140,8 +141,26 @@ export class SmartReadTool {
     });
 
     // Check cache
-    const cachedData = enableCache ? cacheGet(this.cache, cacheKey) : null;
-    const fromCache = cachedData !== null;
+    const ownCached = enableCache ? cacheGet(this.cache, cacheKey) : null;
+
+    // FALL BACK TO WHAT THIS SESSION WROTE. Without this, the first read of a
+    // file resends it in full even when the session wrote it moments earlier
+    // through the built-in Write -- the hook recorded those bytes, but nothing
+    // consulted the record.
+    //
+    // Session-scoped, and that is the whole safety argument. The record carries
+    // the session that authored it, so a caller that did not write the file
+    // gets nothing and resends -- which is today's behaviour, so this can never
+    // make a read worse. The knowledge-graph snapshot could NOT be used here
+    // for exactly that reason: `indexFile` runs on reads too, so it would have
+    // told a session that never saw a file that nothing had changed.
+    const cachedData = ownCached ?? authoredBase(filePath);
+
+    // Deliberately NOT `cachedData !== null`. This means "my own cache entry
+    // hit", which is what the metrics below report and what gates the re-seed
+    // further down -- so a read served off the fallback still populates its own
+    // key, and the next read needs no fallback.
+    const fromCache = ownCached !== null;
 
     // Read file content
     const rawContent = readFileSync(filePath, encoding);

--- a/tests/hooks/authored-content.test.mjs
+++ b/tests/hooks/authored-content.test.mjs
@@ -111,3 +111,27 @@ describe('bounded, so the store cannot mirror the repository', () => {
     expect(authoredContentFor(dir, 's-1', file())).toBeNull();
   });
 });
+
+describe('the cap counts persisted bytes, not UTF-16 units', () => {
+  test('multibyte content over the byte cap is rejected', () => {
+    // 100k CJK characters measure 100,000 by `content.length` -- under a
+    // 262,144 cap -- while persisting 300,000 UTF-8 bytes. Counting units let
+    // a record 15% over the limit through.
+    const multibyte = '日'.repeat(100_000);
+    expect(multibyte.length).toBeLessThan(262_144);
+    expect(Buffer.byteLength(multibyte, 'utf8')).toBeGreaterThan(262_144);
+
+    writeFileSync(file(), multibyte);
+    recordAuthoredContent(dir, 's-1', file(), multibyte);
+    expect(authoredContentFor(dir, 's-1', file())).toBeNull();
+  });
+
+  test('multibyte content under the byte cap is still recorded', () => {
+    // Guards against over-correction: the byte check must not reject content
+    // that genuinely fits.
+    const ok = '日'.repeat(1000);
+    writeFileSync(file(), ok);
+    recordAuthoredContent(dir, 's-1', file(), ok);
+    expect(authoredContentFor(dir, 's-1', file())).toBe(ok);
+  });
+});

--- a/tests/hooks/authored-content.test.mjs
+++ b/tests/hooks/authored-content.test.mjs
@@ -1,0 +1,113 @@
+/**
+ * The authored-content store: "THIS session wrote these bytes".
+ *
+ * WHY IT IS NOT THE WIKI SNAPSHOT. `indexFile` runs on every file either hook
+ * OBSERVES, reads included, so a graph snapshot answers "what did some hook last
+ * see" -- across sessions. Using it as a diff base would hand a fresh session
+ * `// No changes` for a file it has never seen, which is worse than resending
+ * the file: it withholds content while reporting success.
+ *
+ * This store answers a different question. A record is written only by a WRITE,
+ * and carries the session that made it, so a reader can ask "did I write this?"
+ * rather than "has anyone seen this?".
+ *
+ * DEGRADATION IS ONE-DIRECTIONAL BY CONSTRUCTION. No record, unreadable record,
+ * different session, or content whose hash no longer matches all mean *no base*
+ * -- and no base means the caller resends the file, which is exactly today's
+ * behaviour. The store can therefore never make a read worse than it is now.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  recordAuthoredContent,
+  authoredContentFor,
+} from '../../hooks-core/authored.mjs';
+
+let dir;
+const CONTENT = 'export const a = 1;\n'.repeat(20);
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'authored-'));
+});
+
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+const file = () => join(dir, 'src.ts');
+
+describe('a session reads back what it wrote', () => {
+  test('returns the content it recorded', () => {
+    writeFileSync(file(), CONTENT);
+    recordAuthoredContent(dir, 's-1', file(), CONTENT);
+    expect(authoredContentFor(dir, 's-1', file())).toBe(CONTENT);
+  });
+});
+
+describe('cross-session isolation -- the failure that disqualified the snapshot', () => {
+  test('a DIFFERENT session gets no base', () => {
+    writeFileSync(file(), CONTENT);
+    recordAuthoredContent(dir, 'session-a', file(), CONTENT);
+
+    // Session B has never seen this file. Handing it a base would make
+    // smart_read answer "no changes" and deliver nothing.
+    expect(authoredContentFor(dir, 'session-b', file())).toBeNull();
+  });
+
+  test('an absent session id gets no base', () => {
+    writeFileSync(file(), CONTENT);
+    recordAuthoredContent(dir, 'session-a', file(), CONTENT);
+    expect(authoredContentFor(dir, null, file())).toBeNull();
+    expect(authoredContentFor(dir, '', file())).toBeNull();
+  });
+});
+
+describe('the record must still describe the file on disk', () => {
+  test('content changed since the write means no base', () => {
+    // Another process edited the file after we wrote it. The recorded bytes are
+    // no longer a truthful "before", so the read must not diff against them.
+    writeFileSync(file(), CONTENT);
+    recordAuthoredContent(dir, 's-1', file(), CONTENT);
+    writeFileSync(file(), CONTENT + '// appended\n');
+    expect(authoredContentFor(dir, 's-1', file())).toBeNull();
+  });
+
+  test('a deleted file means no base rather than a throw', () => {
+    writeFileSync(file(), CONTENT);
+    recordAuthoredContent(dir, 's-1', file(), CONTENT);
+    rmSync(file());
+    expect(authoredContentFor(dir, 's-1', file())).toBeNull();
+  });
+});
+
+describe('it never throws, because a hook must not break a tool call', () => {
+  test('an unwritable store is a miss, not an error', () => {
+    expect(() =>
+      recordAuthoredContent('\0bad', 's-1', file(), CONTENT)
+    ).not.toThrow();
+    expect(authoredContentFor('\0bad', 's-1', file())).toBeNull();
+  });
+
+  test('reading a store that was never written is a miss', () => {
+    expect(authoredContentFor(dir, 's-1', file())).toBeNull();
+  });
+
+  test('a corrupt record is a miss, not a crash', () => {
+    writeFileSync(file(), CONTENT);
+    recordAuthoredContent(dir, 's-1', file(), CONTENT);
+    const store = join(dir, '.token-optimizer', 'authored');
+    for (const name of readdirSync(store)) {
+      writeFileSync(join(store, name), '{not json');
+    }
+    expect(authoredContentFor(dir, 's-1', file())).toBeNull();
+  });
+});
+
+describe('bounded, so the store cannot mirror the repository', () => {
+  test('content past the cap is not recorded', () => {
+    const huge = 'x'.repeat(400_000);
+    writeFileSync(file(), huge);
+    recordAuthoredContent(dir, 's-1', file(), huge);
+    expect(authoredContentFor(dir, 's-1', file())).toBeNull();
+  });
+});

--- a/tests/hooks/authored-content.test.mjs
+++ b/tests/hooks/authored-content.test.mjs
@@ -126,6 +126,20 @@ describe('the cap counts persisted bytes, not UTF-16 units', () => {
     expect(authoredContentFor(dir, 's-1', file())).toBeNull();
   });
 
+  test('control characters are counted as the record encodes them', () => {
+    // JSON escapes: a NUL costs ONE byte in `content` and SIX in the record.
+    // 200,000 NULs measure 200,000 bytes as content -- comfortably under the
+    // 262,144 cap -- and serialize to about 1.2 MiB, roughly five times it.
+    // Bounding the content instead of the record let that through.
+    const nuls = '\u0000'.repeat(200_000);
+    expect(Buffer.byteLength(nuls, 'utf8')).toBeLessThan(262_144);
+    expect(JSON.stringify({ content: nuls }).length).toBeGreaterThan(262_144);
+
+    writeFileSync(file(), nuls);
+    recordAuthoredContent(dir, 's-1', file(), nuls);
+    expect(authoredContentFor(dir, 's-1', file())).toBeNull();
+  });
+
   test('multibyte content under the byte cap is still recorded', () => {
     // Guards against over-correction: the byte check must not reject content
     // that genuinely fits.

--- a/tests/hooks/cline-payload-reaches-the-pipeline.test.mjs
+++ b/tests/hooks/cline-payload-reaches-the-pipeline.test.mjs
@@ -1,0 +1,96 @@
+/**
+ * Cline's payload has to arrive with a tool name the pipeline recognises.
+ *
+ * TWO SEPARATE MISTAKES STACKED, and either one alone made the integration a
+ * silent no-op:
+ *
+ *   1. Cline sends the tool as `toolName`; the adapter read `body.tool`. So
+ *      `tool_name` came out null, and the handler exits on a null tool name --
+ *      before authoredWrite or recordAuthoredContent could run.
+ *   2. Cline's write tools are `write_to_file` and `replace_in_file`, while
+ *      `authoredWrite` tests membership of {Edit, MultiEdit, Write}. Reading
+ *      the right field would still not have matched.
+ *
+ * Neither failure raises anything. The hook runs, finds no tool, allows
+ * everything, and records nothing -- which looks exactly like a client with
+ * nothing to optimise.
+ */
+import { describe, it, expect, beforeAll } from '@jest/globals';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+const CORE = (name) =>
+  pathToFileURL(join(process.cwd(), 'hooks-core', name)).href;
+
+let normalizeClientPayload;
+let normalizePayload;
+
+beforeAll(async () => {
+  // THE REAL COMPOSITION, as the router runs it:
+  //   normalizePayload(normalizeClientPayload(client, event, raw))
+  // Testing either half alone would miss the seam this bug lived in.
+  ({ normalizeClientPayload } = await import(CORE('adapter.mjs')));
+  ({ normalizePayload } = await import(CORE('decide.mjs')));
+});
+
+const throughPipeline = (raw, event) =>
+  normalizePayload(normalizeClientPayload('cline', event, raw));
+
+/** A Cline pre-tool payload, in the shape Cline actually sends. */
+const clinePayload = (toolName, parameters = {}) => ({
+  taskId: 'task-1',
+  workspaceRoots: ['/repo'],
+  model: { slug: 'claude' },
+  preToolUse: { toolName, parameters },
+});
+
+describe('a cline payload reaches the pipeline', () => {
+  it('reads the tool from toolName, which is the field cline sends', () => {
+    const payload = throughPipeline(
+      clinePayload('read_file', { path: '/repo/src/a.ts' }),
+      'pre-tool'
+    );
+
+    // Canonicalised to 'Read' by normalizePayload, which is the point: the
+    // name arrives and is recognised. The exact value, not merely something
+    // truthy -- a null here is the silent no-op the handler exits on.
+    expect(payload.tool_name).toBe('Read');
+  });
+
+  it.each([
+    ['write_to_file', 'Write'],
+    ['replace_in_file', 'Edit'],
+  ])('maps %s to %s, which is what authoredWrite matches', (cline, canonical) => {
+    const payload = throughPipeline(
+      {
+        taskId: 'task-1',
+        workspaceRoots: ['/repo'],
+        postToolUse: {
+          toolName: cline,
+          parameters: { path: '/repo/src/a.ts', content: 'export const a = 1;' },
+        },
+      },
+      'post-tool'
+    );
+
+    expect(payload.tool_name).toBe(canonical);
+    // The whole point of the rename: this set is what gates recording an
+    // authored write, and cline's own spellings are not in it.
+    expect(new Set(['Edit', 'MultiEdit', 'Write']).has(payload.tool_name)).toBe(
+      true
+    );
+  });
+
+  it('still accepts a payload that carries the older tool field', () => {
+    // Kept as a fallback rather than replaced: a payload carrying it costs
+    // nothing to accept, and dropping support would be a regression for any
+    // client or fixture still sending it.
+    const raw = {
+      taskId: 'task-2',
+      workspaceRoots: ['/repo'],
+      preToolUse: { tool: 'read_file', parameters: {} },
+    };
+
+    expect(throughPipeline(raw, 'pre-tool').tool_name).toBe('Read');
+  });
+});

--- a/tests/unit/file-operations/read-prefers-the-session-base.test.ts
+++ b/tests/unit/file-operations/read-prefers-the-session-base.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Which diff base wins when a read has two to choose from.
+ *
+ * TWO MECHANISMS FOR THE SAME PROBLEM LANDED INDEPENDENTLY, and merging them
+ * was a decision that nothing tested:
+ *
+ *   - `authoredBase(path)` is SESSION-SCOPED. The hook knows the client's real
+ *     session id and the bytes it wrote, so this covers a write made through
+ *     ANY path, including the built-in Write. A caller that did not author the
+ *     file gets nothing.
+ *   - `lastWrittenKey(path)` is PATH-SCOPED and covers only this product's own
+ *     smart_write / smart_edit.
+ *
+ * `smart_read` now consults them in that order. Neither subsumes the other, so
+ * the ordering is the claim, and this file is the only thing that states it.
+ * Without these tests the chain could be reordered, or either link dropped,
+ * with the whole suite still green.
+ *
+ * Assertions are POSITIVE -- an exact content string, an exact flag -- because
+ * an absence check here would pass just as well if the call threw and returned
+ * an error object.
+ */
+
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { pathToFileURL } from 'url';
+import { CacheEngine } from '../../../src/core/cache-engine.js';
+import { TokenCounter } from '../../../src/core/token-counter.js';
+import { MetricsCollector } from '../../../src/core/metrics.js';
+import { SmartReadTool } from '../../../src/tools/file-operations/smart-read.js';
+import { SmartWriteTool } from '../../../src/tools/file-operations/smart-write.js';
+
+let workspace: string;
+let cache: CacheEngine;
+let tokenCounter: TokenCounter;
+let metrics: MetricsCollector;
+let priorSession: string | undefined;
+
+const AUTHORED = Array.from(
+  { length: 100 },
+  (_, i) => `export const authored${i} = ${i};`
+).join('\n');
+
+const VIA_TOOL = Array.from(
+  { length: 100 },
+  (_, i) => `export const viaTool${i} = ${i};`
+).join('\n');
+
+// autoFormat would rewrite the bytes, so "nothing changed" could be false for a
+// reason unrelated to which base was chosen.
+const EXACT = { autoFormat: false } as const;
+
+const SESSION = 'session-base-test';
+
+beforeEach(() => {
+  // A .git marker so projectRootFor resolves the workspace as the project that
+  // owns the file -- the authored store is written per project.
+  workspace = mkdtempSync(join(tmpdir(), 'session-base-'));
+  mkdirSync(join(workspace, '.git'), { recursive: true });
+  cache = new CacheEngine();
+  tokenCounter = new TokenCounter();
+  metrics = new MetricsCollector();
+  priorSession = process.env.TOKEN_OPTIMIZER_SESSION_ID;
+});
+
+afterEach(() => {
+  if (priorSession === undefined) delete process.env.TOKEN_OPTIMIZER_SESSION_ID;
+  else process.env.TOKEN_OPTIMIZER_SESSION_ID = priorSession;
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+/** Records content as the hook does, for the session the server will claim. */
+async function recordAuthored(file: string, content: string): Promise<void> {
+  const authored = (await import(
+    pathToFileURL(join(process.cwd(), 'hooks-core', 'authored.mjs')).href
+  )) as {
+    recordAuthoredContent(
+      root: string,
+      session: string,
+      file: string,
+      content: string
+    ): unknown;
+  };
+  authored.recordAuthoredContent(workspace, SESSION, file, content);
+}
+
+describe('smart_read picks its diff base', () => {
+  // THE PREFERENCE ITSELF IS NOT ASSERTED HERE, AND THAT IS A GAP, NOT AN
+  // OVERSIGHT. `authored-base.ts` loads hooks-core through `createRequire`,
+  // which jest rejects for an ESM `.mjs` with "Must use import to load ES
+  // Module". Production is fine -- Node 22 supports require(esm) -- but under
+  // jest `load()` catches, returns null, and `authoredBase()` is inert. Verified
+  // directly: outside jest, recordAuthoredContent + authoredContentFor round
+  // trip the content and projectRootFor resolves a temp workspace correctly, so
+  // the store and the fixture are both right; only the loader is blocked.
+  //
+  // The consequence is worth stating plainly: the session-scoped base has NO
+  // integration coverage at this level and cannot have any without either
+  // changing how authored-base.ts loads or spawning a real server process. The
+  // two tests below cover the rest of the chain, and a test asserting the
+  // preference belongs in the stdio integration suite, where the server runs in
+  // a real Node process.
+
+  test('still uses the tool write when this session authored nothing', async () => {
+    // The other link in the chain. Dropping it would silently undo #351 for
+    // every client that cannot supply a session id.
+    delete process.env.TOKEN_OPTIMIZER_SESSION_ID;
+
+    const file = join(workspace, 'tool-only.ts');
+    const reader = new SmartReadTool(cache, tokenCounter, metrics);
+    const writer = new SmartWriteTool(cache, tokenCounter, metrics);
+
+    await writer.write(file, VIA_TOOL, EXACT);
+
+    const result = await reader.read(file);
+
+    expect(result.metadata.isDiff).toBe(true);
+    expect(result.content).toBe('// No changes');
+  });
+
+  test('gives a different session no base at all, and resends the file', async () => {
+    // The safety property the session scope exists for. A caller that did not
+    // author the file must get the file, not somebody else's diff.
+    const file = join(workspace, 'foreign.ts');
+    const reader = new SmartReadTool(cache, tokenCounter, metrics);
+
+    writeFileSync(file, AUTHORED);
+    await recordAuthored(file, AUTHORED);
+    process.env.TOKEN_OPTIMIZER_SESSION_ID = 'a-different-session';
+
+    const result = await reader.read(file);
+
+    expect(result.metadata.isDiff).toBe(false);
+    expect(result.content).toContain('authored0');
+  });
+});

--- a/tests/unit/file-operations/read-prefers-the-session-base.test.ts
+++ b/tests/unit/file-operations/read-prefers-the-session-base.test.ts
@@ -119,6 +119,22 @@ describe('smart_read picks its diff base', () => {
     expect(result.content).toBe('// No changes');
   });
 
+  test('honours enableCache: false by resending, not diffing', async () => {
+    // The opt-out has to cover BOTH fallbacks. A caller asking for the file is
+    // not asking for a diff against something the process remembers, whichever
+    // store that memory lives in.
+    const file = join(workspace, 'opted-out.ts');
+    const reader = new SmartReadTool(cache, tokenCounter, metrics);
+    const writer = new SmartWriteTool(cache, tokenCounter, metrics);
+
+    await writer.write(file, VIA_TOOL, EXACT);
+
+    const result = await reader.read(file, { enableCache: false });
+
+    expect(result.metadata.isDiff).toBe(false);
+    expect(result.content).toContain('viaTool0');
+  });
+
   test('gives a different session no base at all, and resends the file', async () => {
     // The safety property the session scope exists for. A caller that did not
     // author the file must get the file, not somebody else's diff.


### PR DESCRIPTION
Closes #350

Closes the built-in `Write` path left open by #351 — issue #350 item 3, which I had previously and wrongly called blocked.

## The correction

I marked this blocked on "the hook and the MCP server share no session identity". The gap is real; the verdict was not. The hook **already receives** the client's `session_id`, both processes run from the same plugin root against the same project, and a legacy path in this same repo had already solved the identical problem by writing a file both sides read. The obstacle was the work.

I also rejected the graph-snapshot approach as unsafe — that part stands — but then generalised it into rejecting the whole goal, while `hooks-core/decide.mjs` was already reading `tool_input.content` on a `Write`. The authored bytes were in the hook's hands the entire time.

## Why not the graph snapshot

A diff base is sound only if the caller **already holds** the bytes being diffed against — a statement about authorship, never observation.

`indexFile` runs on every file either hook *observes*, **reads included, across sessions**. So a snapshot answers "what did some hook last see". Using it would hand a fresh session `// No changes` for a file it has never seen: withholding content while reporting success, strictly worse than the resend it replaces. **That approach is closed for good.**

| | graph snapshot | authored-content store |
|---|---|---|
| written on | any observation, incl. reads | `Write`/`Edit` only |
| answers | "what did some hook last see" | "what did **this session** write" |
| cross-session | leaks | keyed by session; mismatch → no base |
| failure mode | silently withholds content | falls back to the full file |

## Safety by construction

Every uncertainty resolves to **no base**, and no base means the caller resends — today's behaviour. So this can add a saving and cannot subtract one:

- no record, corrupt record, or unreadable store
- **different session**, or no session id at all
- size or hash mismatch against disk (another process, another tool, a `git checkout`)
- deleted file

Records are written **atomically** (temp + rename), because a torn record read back as valid JSON with the wrong bytes would be a *wrong* diff base — the one outcome this must never produce. Bounded at 256 KB, matching the graph's own snapshot cap, so the store cannot become a second copy of the repository.

Nothing on either path throws: a hook must not break a tool call, and a diff-base lookup must not fail a read.

## What the reachability guard caught

`tests/hooks/reachability.test.mjs` failed with `authored.mjs: authoredContentFor` — the store and the hook write existed while **nothing read them**. That is the same "stop at the obstacle" pattern in miniature, caught by a guard rather than by me. Wiring `smart_read` is what makes this a feature instead of dead code.

## Tests

`tests/hooks/authored-content.test.mjs`, 9 tests. The load-bearing one is **cross-session isolation** — session A writes, session B gets `null` — since that is precisely the failure that disqualified the snapshot. Also covered: absent session id, content changed since the write, deleted file, corrupt record, unwritable store, and the size cap.

`tsc --noEmit` clean, eslint clean, **209 suites / 2752 tests passing**.

## Follow-on

`TOKEN_OPTIMIZER_SESSION_ID` must reach both the hooks and the MCP server for the fallback to engage; absent it, `authoredBase` returns null and behaviour is exactly as today. Wiring that through the launcher is the next change, and it pairs with the tree-recording work for the benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
