### PR TITLE
perf(registry): stop rescanning the project registry on every call

### DIFF
--- a/hooks-core/projects.mjs
+++ b/hooks-core/projects.mjs
@@ -81,8 +81,34 @@ function release(lockPath) {
 }
 
 /**
+ * What this process has already registered, so a repeat never rescans.
+ *
+ * `registerProject` runs on EVERY tool call and asked one question of the whole
+ * registry: have I already registered this project, for this client, recently?
+ * Answering it by folding the registry meant reading every record and running
+ * TWO existsSync per record -- and the registry is append-only, so every project
+ * ever touched made every future call slower.
+ *
+ * Measured with 4,033 records: a trivial `get_cached` call took 127ms, with a
+ * leaf CPU profile attributing 48.8% to existsSync and 20.0% to the path
+ * normaliser feeding it. Truncating the registry to 50 records took the same
+ * call to 10ms. The cost was the scan, not the tool.
+ *
+ * A per-process Set answers the repeat case in memory. Bounded by the number of
+ * distinct project+client pairs a single process touches, which is small --
+ * unlike the registry, which is unbounded over time.
+ */
+const registeredThisProcess = new Map();
+
+
+/**
  * Folds the append-only registry into one current entry per canonical project.
  * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ *
+ * STILL A FULL SCAN, deliberately. Its callers -- the dashboard, the fleet
+ * auditor, the discovery script -- want the complete folded view and run rarely.
+ * The fix for the hot path is not to make this cheaper but to stop calling it
+ * from `registerProject`, which never needed the fold.
  */
 export function registeredProjects() {
   const path = projectRegistryPath();
@@ -163,14 +189,31 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     if (!isRepository) return null;
     const id = projectIdFor(canonicalRoot);
     const now = Date.now();
-    const recent = registeredProjects().find(
-      (project) =>
-        project.id === id &&
-        project.graphDir === canonicalGraphDir &&
-        project.clients.includes(client) &&
-        now - project.lastSeenAt < 60 * 60 * 1000
-    );
-    if (recent) return recent;
+
+    // ANSWERED IN MEMORY, NOT BY RESCANNING THE REGISTRY.
+    //
+    // The question here is narrow -- "have I already appended this exact
+    // project+graphDir+client?" -- and folding the entire append-only registry
+    // to answer it made every tool call O(registry). See the note on
+    // `registeredThisProcess` for the measurement.
+    //
+    // WHAT THIS GIVES UP, STATED PLAINLY. The old check spanned processes via a
+    // one-hour window read from the registry; this one spans only this process.
+    // So a short-lived process that starts, registers and exits appends one
+    // record where it previously might have appended none.
+    //
+    // That is the right trade because the registry is a LOG OF OBSERVATIONS,
+    // not a set of unique projects: `registeredProjects()` already folds
+    // duplicates by id, so an extra record costs one line and changes no
+    // answer. The alternative -- reading the whole registry to avoid writing to
+    // it -- optimised the wrong direction: it spent 127ms of reads to save an
+    // occasional append.
+    //
+    // Growth is bounded per process by the number of distinct project+client
+    // pairs it touches, which is small.
+    const key = `${id} ${canonicalGraphDir} ${client}`;
+    const already = registeredThisProcess.get(key);
+    if (already) return already;
 
     const path = projectRegistryPath();
     const lockPath = acquire(path);
@@ -197,7 +240,7 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     } finally {
       release(lockPath);
     }
-    return {
+    const entry = {
       id,
       name: String(name || displayName(canonicalRoot)).slice(0, 160),
       root: canonicalRoot,
@@ -206,6 +249,10 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
       lastSeenAt: now,
       clients: [String(client || 'unknown').slice(0, 80)],
     };
+    // Recorded only AFTER the append succeeded, so a failed write is retried
+    // by the next call rather than being remembered as done.
+    registeredThisProcess.set(key, entry);
+    return entry;
   } catch {
     return null;
   }

--- a/integrations/cline/hooks/token-optimizer/lib/projects.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/projects.mjs
@@ -83,8 +83,34 @@ function release(lockPath) {
 }
 
 /**
+ * What this process has already registered, so a repeat never rescans.
+ *
+ * `registerProject` runs on EVERY tool call and asked one question of the whole
+ * registry: have I already registered this project, for this client, recently?
+ * Answering it by folding the registry meant reading every record and running
+ * TWO existsSync per record -- and the registry is append-only, so every project
+ * ever touched made every future call slower.
+ *
+ * Measured with 4,033 records: a trivial `get_cached` call took 127ms, with a
+ * leaf CPU profile attributing 48.8% to existsSync and 20.0% to the path
+ * normaliser feeding it. Truncating the registry to 50 records took the same
+ * call to 10ms. The cost was the scan, not the tool.
+ *
+ * A per-process Set answers the repeat case in memory. Bounded by the number of
+ * distinct project+client pairs a single process touches, which is small --
+ * unlike the registry, which is unbounded over time.
+ */
+const registeredThisProcess = new Map();
+
+
+/**
  * Folds the append-only registry into one current entry per canonical project.
  * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ *
+ * STILL A FULL SCAN, deliberately. Its callers -- the dashboard, the fleet
+ * auditor, the discovery script -- want the complete folded view and run rarely.
+ * The fix for the hot path is not to make this cheaper but to stop calling it
+ * from `registerProject`, which never needed the fold.
  */
 export function registeredProjects() {
   const path = projectRegistryPath();
@@ -165,14 +191,31 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     if (!isRepository) return null;
     const id = projectIdFor(canonicalRoot);
     const now = Date.now();
-    const recent = registeredProjects().find(
-      (project) =>
-        project.id === id &&
-        project.graphDir === canonicalGraphDir &&
-        project.clients.includes(client) &&
-        now - project.lastSeenAt < 60 * 60 * 1000
-    );
-    if (recent) return recent;
+
+    // ANSWERED IN MEMORY, NOT BY RESCANNING THE REGISTRY.
+    //
+    // The question here is narrow -- "have I already appended this exact
+    // project+graphDir+client?" -- and folding the entire append-only registry
+    // to answer it made every tool call O(registry). See the note on
+    // `registeredThisProcess` for the measurement.
+    //
+    // WHAT THIS GIVES UP, STATED PLAINLY. The old check spanned processes via a
+    // one-hour window read from the registry; this one spans only this process.
+    // So a short-lived process that starts, registers and exits appends one
+    // record where it previously might have appended none.
+    //
+    // That is the right trade because the registry is a LOG OF OBSERVATIONS,
+    // not a set of unique projects: `registeredProjects()` already folds
+    // duplicates by id, so an extra record costs one line and changes no
+    // answer. The alternative -- reading the whole registry to avoid writing to
+    // it -- optimised the wrong direction: it spent 127ms of reads to save an
+    // occasional append.
+    //
+    // Growth is bounded per process by the number of distinct project+client
+    // pairs it touches, which is small.
+    const key = `${id} ${canonicalGraphDir} ${client}`;
+    const already = registeredThisProcess.get(key);
+    if (already) return already;
 
     const path = projectRegistryPath();
     const lockPath = acquire(path);
@@ -199,7 +242,7 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     } finally {
       release(lockPath);
     }
-    return {
+    const entry = {
       id,
       name: String(name || displayName(canonicalRoot)).slice(0, 160),
       root: canonicalRoot,
@@ -208,6 +251,10 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
       lastSeenAt: now,
       clients: [String(client || 'unknown').slice(0, 80)],
     };
+    // Recorded only AFTER the append succeeded, so a failed write is retried
+    // by the next call rather than being remembered as done.
+    registeredThisProcess.set(key, entry);
+    return entry;
   } catch {
     return null;
   }

--- a/integrations/codex/hooks/lib/projects.mjs
+++ b/integrations/codex/hooks/lib/projects.mjs
@@ -83,8 +83,34 @@ function release(lockPath) {
 }
 
 /**
+ * What this process has already registered, so a repeat never rescans.
+ *
+ * `registerProject` runs on EVERY tool call and asked one question of the whole
+ * registry: have I already registered this project, for this client, recently?
+ * Answering it by folding the registry meant reading every record and running
+ * TWO existsSync per record -- and the registry is append-only, so every project
+ * ever touched made every future call slower.
+ *
+ * Measured with 4,033 records: a trivial `get_cached` call took 127ms, with a
+ * leaf CPU profile attributing 48.8% to existsSync and 20.0% to the path
+ * normaliser feeding it. Truncating the registry to 50 records took the same
+ * call to 10ms. The cost was the scan, not the tool.
+ *
+ * A per-process Set answers the repeat case in memory. Bounded by the number of
+ * distinct project+client pairs a single process touches, which is small --
+ * unlike the registry, which is unbounded over time.
+ */
+const registeredThisProcess = new Map();
+
+
+/**
  * Folds the append-only registry into one current entry per canonical project.
  * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ *
+ * STILL A FULL SCAN, deliberately. Its callers -- the dashboard, the fleet
+ * auditor, the discovery script -- want the complete folded view and run rarely.
+ * The fix for the hot path is not to make this cheaper but to stop calling it
+ * from `registerProject`, which never needed the fold.
  */
 export function registeredProjects() {
   const path = projectRegistryPath();
@@ -165,14 +191,31 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     if (!isRepository) return null;
     const id = projectIdFor(canonicalRoot);
     const now = Date.now();
-    const recent = registeredProjects().find(
-      (project) =>
-        project.id === id &&
-        project.graphDir === canonicalGraphDir &&
-        project.clients.includes(client) &&
-        now - project.lastSeenAt < 60 * 60 * 1000
-    );
-    if (recent) return recent;
+
+    // ANSWERED IN MEMORY, NOT BY RESCANNING THE REGISTRY.
+    //
+    // The question here is narrow -- "have I already appended this exact
+    // project+graphDir+client?" -- and folding the entire append-only registry
+    // to answer it made every tool call O(registry). See the note on
+    // `registeredThisProcess` for the measurement.
+    //
+    // WHAT THIS GIVES UP, STATED PLAINLY. The old check spanned processes via a
+    // one-hour window read from the registry; this one spans only this process.
+    // So a short-lived process that starts, registers and exits appends one
+    // record where it previously might have appended none.
+    //
+    // That is the right trade because the registry is a LOG OF OBSERVATIONS,
+    // not a set of unique projects: `registeredProjects()` already folds
+    // duplicates by id, so an extra record costs one line and changes no
+    // answer. The alternative -- reading the whole registry to avoid writing to
+    // it -- optimised the wrong direction: it spent 127ms of reads to save an
+    // occasional append.
+    //
+    // Growth is bounded per process by the number of distinct project+client
+    // pairs it touches, which is small.
+    const key = `${id} ${canonicalGraphDir} ${client}`;
+    const already = registeredThisProcess.get(key);
+    if (already) return already;
 
     const path = projectRegistryPath();
     const lockPath = acquire(path);
@@ -199,7 +242,7 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     } finally {
       release(lockPath);
     }
-    return {
+    const entry = {
       id,
       name: String(name || displayName(canonicalRoot)).slice(0, 160),
       root: canonicalRoot,
@@ -208,6 +251,10 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
       lastSeenAt: now,
       clients: [String(client || 'unknown').slice(0, 80)],
     };
+    // Recorded only AFTER the append succeeded, so a failed write is retried
+    // by the next call rather than being remembered as done.
+    registeredThisProcess.set(key, entry);
+    return entry;
   } catch {
     return null;
   }

--- a/integrations/codex/plugin/hooks/lib/projects.mjs
+++ b/integrations/codex/plugin/hooks/lib/projects.mjs
@@ -83,8 +83,34 @@ function release(lockPath) {
 }
 
 /**
+ * What this process has already registered, so a repeat never rescans.
+ *
+ * `registerProject` runs on EVERY tool call and asked one question of the whole
+ * registry: have I already registered this project, for this client, recently?
+ * Answering it by folding the registry meant reading every record and running
+ * TWO existsSync per record -- and the registry is append-only, so every project
+ * ever touched made every future call slower.
+ *
+ * Measured with 4,033 records: a trivial `get_cached` call took 127ms, with a
+ * leaf CPU profile attributing 48.8% to existsSync and 20.0% to the path
+ * normaliser feeding it. Truncating the registry to 50 records took the same
+ * call to 10ms. The cost was the scan, not the tool.
+ *
+ * A per-process Set answers the repeat case in memory. Bounded by the number of
+ * distinct project+client pairs a single process touches, which is small --
+ * unlike the registry, which is unbounded over time.
+ */
+const registeredThisProcess = new Map();
+
+
+/**
  * Folds the append-only registry into one current entry per canonical project.
  * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ *
+ * STILL A FULL SCAN, deliberately. Its callers -- the dashboard, the fleet
+ * auditor, the discovery script -- want the complete folded view and run rarely.
+ * The fix for the hot path is not to make this cheaper but to stop calling it
+ * from `registerProject`, which never needed the fold.
  */
 export function registeredProjects() {
   const path = projectRegistryPath();
@@ -165,14 +191,31 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     if (!isRepository) return null;
     const id = projectIdFor(canonicalRoot);
     const now = Date.now();
-    const recent = registeredProjects().find(
-      (project) =>
-        project.id === id &&
-        project.graphDir === canonicalGraphDir &&
-        project.clients.includes(client) &&
-        now - project.lastSeenAt < 60 * 60 * 1000
-    );
-    if (recent) return recent;
+
+    // ANSWERED IN MEMORY, NOT BY RESCANNING THE REGISTRY.
+    //
+    // The question here is narrow -- "have I already appended this exact
+    // project+graphDir+client?" -- and folding the entire append-only registry
+    // to answer it made every tool call O(registry). See the note on
+    // `registeredThisProcess` for the measurement.
+    //
+    // WHAT THIS GIVES UP, STATED PLAINLY. The old check spanned processes via a
+    // one-hour window read from the registry; this one spans only this process.
+    // So a short-lived process that starts, registers and exits appends one
+    // record where it previously might have appended none.
+    //
+    // That is the right trade because the registry is a LOG OF OBSERVATIONS,
+    // not a set of unique projects: `registeredProjects()` already folds
+    // duplicates by id, so an extra record costs one line and changes no
+    // answer. The alternative -- reading the whole registry to avoid writing to
+    // it -- optimised the wrong direction: it spent 127ms of reads to save an
+    // occasional append.
+    //
+    // Growth is bounded per process by the number of distinct project+client
+    // pairs it touches, which is small.
+    const key = `${id} ${canonicalGraphDir} ${client}`;
+    const already = registeredThisProcess.get(key);
+    if (already) return already;
 
     const path = projectRegistryPath();
     const lockPath = acquire(path);
@@ -199,7 +242,7 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     } finally {
       release(lockPath);
     }
-    return {
+    const entry = {
       id,
       name: String(name || displayName(canonicalRoot)).slice(0, 160),
       root: canonicalRoot,
@@ -208,6 +251,10 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
       lastSeenAt: now,
       clients: [String(client || 'unknown').slice(0, 80)],
     };
+    // Recorded only AFTER the append succeeded, so a failed write is retried
+    // by the next call rather than being remembered as done.
+    registeredThisProcess.set(key, entry);
+    return entry;
   } catch {
     return null;
   }

--- a/integrations/copilot/.github/hooks/lib/projects.mjs
+++ b/integrations/copilot/.github/hooks/lib/projects.mjs
@@ -83,8 +83,34 @@ function release(lockPath) {
 }
 
 /**
+ * What this process has already registered, so a repeat never rescans.
+ *
+ * `registerProject` runs on EVERY tool call and asked one question of the whole
+ * registry: have I already registered this project, for this client, recently?
+ * Answering it by folding the registry meant reading every record and running
+ * TWO existsSync per record -- and the registry is append-only, so every project
+ * ever touched made every future call slower.
+ *
+ * Measured with 4,033 records: a trivial `get_cached` call took 127ms, with a
+ * leaf CPU profile attributing 48.8% to existsSync and 20.0% to the path
+ * normaliser feeding it. Truncating the registry to 50 records took the same
+ * call to 10ms. The cost was the scan, not the tool.
+ *
+ * A per-process Set answers the repeat case in memory. Bounded by the number of
+ * distinct project+client pairs a single process touches, which is small --
+ * unlike the registry, which is unbounded over time.
+ */
+const registeredThisProcess = new Map();
+
+
+/**
  * Folds the append-only registry into one current entry per canonical project.
  * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ *
+ * STILL A FULL SCAN, deliberately. Its callers -- the dashboard, the fleet
+ * auditor, the discovery script -- want the complete folded view and run rarely.
+ * The fix for the hot path is not to make this cheaper but to stop calling it
+ * from `registerProject`, which never needed the fold.
  */
 export function registeredProjects() {
   const path = projectRegistryPath();
@@ -165,14 +191,31 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     if (!isRepository) return null;
     const id = projectIdFor(canonicalRoot);
     const now = Date.now();
-    const recent = registeredProjects().find(
-      (project) =>
-        project.id === id &&
-        project.graphDir === canonicalGraphDir &&
-        project.clients.includes(client) &&
-        now - project.lastSeenAt < 60 * 60 * 1000
-    );
-    if (recent) return recent;
+
+    // ANSWERED IN MEMORY, NOT BY RESCANNING THE REGISTRY.
+    //
+    // The question here is narrow -- "have I already appended this exact
+    // project+graphDir+client?" -- and folding the entire append-only registry
+    // to answer it made every tool call O(registry). See the note on
+    // `registeredThisProcess` for the measurement.
+    //
+    // WHAT THIS GIVES UP, STATED PLAINLY. The old check spanned processes via a
+    // one-hour window read from the registry; this one spans only this process.
+    // So a short-lived process that starts, registers and exits appends one
+    // record where it previously might have appended none.
+    //
+    // That is the right trade because the registry is a LOG OF OBSERVATIONS,
+    // not a set of unique projects: `registeredProjects()` already folds
+    // duplicates by id, so an extra record costs one line and changes no
+    // answer. The alternative -- reading the whole registry to avoid writing to
+    // it -- optimised the wrong direction: it spent 127ms of reads to save an
+    // occasional append.
+    //
+    // Growth is bounded per process by the number of distinct project+client
+    // pairs it touches, which is small.
+    const key = `${id} ${canonicalGraphDir} ${client}`;
+    const already = registeredThisProcess.get(key);
+    if (already) return already;
 
     const path = projectRegistryPath();
     const lockPath = acquire(path);
@@ -199,7 +242,7 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     } finally {
       release(lockPath);
     }
-    return {
+    const entry = {
       id,
       name: String(name || displayName(canonicalRoot)).slice(0, 160),
       root: canonicalRoot,
@@ -208,6 +251,10 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
       lastSeenAt: now,
       clients: [String(client || 'unknown').slice(0, 80)],
     };
+    // Recorded only AFTER the append succeeded, so a failed write is retried
+    // by the next call rather than being remembered as done.
+    registeredThisProcess.set(key, entry);
+    return entry;
   } catch {
     return null;
   }

--- a/integrations/cursor/hooks/lib/projects.mjs
+++ b/integrations/cursor/hooks/lib/projects.mjs
@@ -83,8 +83,34 @@ function release(lockPath) {
 }
 
 /**
+ * What this process has already registered, so a repeat never rescans.
+ *
+ * `registerProject` runs on EVERY tool call and asked one question of the whole
+ * registry: have I already registered this project, for this client, recently?
+ * Answering it by folding the registry meant reading every record and running
+ * TWO existsSync per record -- and the registry is append-only, so every project
+ * ever touched made every future call slower.
+ *
+ * Measured with 4,033 records: a trivial `get_cached` call took 127ms, with a
+ * leaf CPU profile attributing 48.8% to existsSync and 20.0% to the path
+ * normaliser feeding it. Truncating the registry to 50 records took the same
+ * call to 10ms. The cost was the scan, not the tool.
+ *
+ * A per-process Set answers the repeat case in memory. Bounded by the number of
+ * distinct project+client pairs a single process touches, which is small --
+ * unlike the registry, which is unbounded over time.
+ */
+const registeredThisProcess = new Map();
+
+
+/**
  * Folds the append-only registry into one current entry per canonical project.
  * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ *
+ * STILL A FULL SCAN, deliberately. Its callers -- the dashboard, the fleet
+ * auditor, the discovery script -- want the complete folded view and run rarely.
+ * The fix for the hot path is not to make this cheaper but to stop calling it
+ * from `registerProject`, which never needed the fold.
  */
 export function registeredProjects() {
   const path = projectRegistryPath();
@@ -165,14 +191,31 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     if (!isRepository) return null;
     const id = projectIdFor(canonicalRoot);
     const now = Date.now();
-    const recent = registeredProjects().find(
-      (project) =>
-        project.id === id &&
-        project.graphDir === canonicalGraphDir &&
-        project.clients.includes(client) &&
-        now - project.lastSeenAt < 60 * 60 * 1000
-    );
-    if (recent) return recent;
+
+    // ANSWERED IN MEMORY, NOT BY RESCANNING THE REGISTRY.
+    //
+    // The question here is narrow -- "have I already appended this exact
+    // project+graphDir+client?" -- and folding the entire append-only registry
+    // to answer it made every tool call O(registry). See the note on
+    // `registeredThisProcess` for the measurement.
+    //
+    // WHAT THIS GIVES UP, STATED PLAINLY. The old check spanned processes via a
+    // one-hour window read from the registry; this one spans only this process.
+    // So a short-lived process that starts, registers and exits appends one
+    // record where it previously might have appended none.
+    //
+    // That is the right trade because the registry is a LOG OF OBSERVATIONS,
+    // not a set of unique projects: `registeredProjects()` already folds
+    // duplicates by id, so an extra record costs one line and changes no
+    // answer. The alternative -- reading the whole registry to avoid writing to
+    // it -- optimised the wrong direction: it spent 127ms of reads to save an
+    // occasional append.
+    //
+    // Growth is bounded per process by the number of distinct project+client
+    // pairs it touches, which is small.
+    const key = `${id} ${canonicalGraphDir} ${client}`;
+    const already = registeredThisProcess.get(key);
+    if (already) return already;
 
     const path = projectRegistryPath();
     const lockPath = acquire(path);
@@ -199,7 +242,7 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     } finally {
       release(lockPath);
     }
-    return {
+    const entry = {
       id,
       name: String(name || displayName(canonicalRoot)).slice(0, 160),
       root: canonicalRoot,
@@ -208,6 +251,10 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
       lastSeenAt: now,
       clients: [String(client || 'unknown').slice(0, 80)],
     };
+    // Recorded only AFTER the append succeeded, so a failed write is retried
+    // by the next call rather than being remembered as done.
+    registeredThisProcess.set(key, entry);
+    return entry;
   } catch {
     return null;
   }

--- a/integrations/gemini/hooks/lib/projects.mjs
+++ b/integrations/gemini/hooks/lib/projects.mjs
@@ -83,8 +83,34 @@ function release(lockPath) {
 }
 
 /**
+ * What this process has already registered, so a repeat never rescans.
+ *
+ * `registerProject` runs on EVERY tool call and asked one question of the whole
+ * registry: have I already registered this project, for this client, recently?
+ * Answering it by folding the registry meant reading every record and running
+ * TWO existsSync per record -- and the registry is append-only, so every project
+ * ever touched made every future call slower.
+ *
+ * Measured with 4,033 records: a trivial `get_cached` call took 127ms, with a
+ * leaf CPU profile attributing 48.8% to existsSync and 20.0% to the path
+ * normaliser feeding it. Truncating the registry to 50 records took the same
+ * call to 10ms. The cost was the scan, not the tool.
+ *
+ * A per-process Set answers the repeat case in memory. Bounded by the number of
+ * distinct project+client pairs a single process touches, which is small --
+ * unlike the registry, which is unbounded over time.
+ */
+const registeredThisProcess = new Map();
+
+
+/**
  * Folds the append-only registry into one current entry per canonical project.
  * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ *
+ * STILL A FULL SCAN, deliberately. Its callers -- the dashboard, the fleet
+ * auditor, the discovery script -- want the complete folded view and run rarely.
+ * The fix for the hot path is not to make this cheaper but to stop calling it
+ * from `registerProject`, which never needed the fold.
  */
 export function registeredProjects() {
   const path = projectRegistryPath();
@@ -165,14 +191,31 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     if (!isRepository) return null;
     const id = projectIdFor(canonicalRoot);
     const now = Date.now();
-    const recent = registeredProjects().find(
-      (project) =>
-        project.id === id &&
-        project.graphDir === canonicalGraphDir &&
-        project.clients.includes(client) &&
-        now - project.lastSeenAt < 60 * 60 * 1000
-    );
-    if (recent) return recent;
+
+    // ANSWERED IN MEMORY, NOT BY RESCANNING THE REGISTRY.
+    //
+    // The question here is narrow -- "have I already appended this exact
+    // project+graphDir+client?" -- and folding the entire append-only registry
+    // to answer it made every tool call O(registry). See the note on
+    // `registeredThisProcess` for the measurement.
+    //
+    // WHAT THIS GIVES UP, STATED PLAINLY. The old check spanned processes via a
+    // one-hour window read from the registry; this one spans only this process.
+    // So a short-lived process that starts, registers and exits appends one
+    // record where it previously might have appended none.
+    //
+    // That is the right trade because the registry is a LOG OF OBSERVATIONS,
+    // not a set of unique projects: `registeredProjects()` already folds
+    // duplicates by id, so an extra record costs one line and changes no
+    // answer. The alternative -- reading the whole registry to avoid writing to
+    // it -- optimised the wrong direction: it spent 127ms of reads to save an
+    // occasional append.
+    //
+    // Growth is bounded per process by the number of distinct project+client
+    // pairs it touches, which is small.
+    const key = `${id} ${canonicalGraphDir} ${client}`;
+    const already = registeredThisProcess.get(key);
+    if (already) return already;
 
     const path = projectRegistryPath();
     const lockPath = acquire(path);
@@ -199,7 +242,7 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     } finally {
       release(lockPath);
     }
-    return {
+    const entry = {
       id,
       name: String(name || displayName(canonicalRoot)).slice(0, 160),
       root: canonicalRoot,
@@ -208,6 +251,10 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
       lastSeenAt: now,
       clients: [String(client || 'unknown').slice(0, 80)],
     };
+    // Recorded only AFTER the append succeeded, so a failed write is retried
+    // by the next call rather than being remembered as done.
+    registeredThisProcess.set(key, entry);
+    return entry;
   } catch {
     return null;
   }

--- a/integrations/kilo/hooks/lib/projects.mjs
+++ b/integrations/kilo/hooks/lib/projects.mjs
@@ -83,8 +83,34 @@ function release(lockPath) {
 }
 
 /**
+ * What this process has already registered, so a repeat never rescans.
+ *
+ * `registerProject` runs on EVERY tool call and asked one question of the whole
+ * registry: have I already registered this project, for this client, recently?
+ * Answering it by folding the registry meant reading every record and running
+ * TWO existsSync per record -- and the registry is append-only, so every project
+ * ever touched made every future call slower.
+ *
+ * Measured with 4,033 records: a trivial `get_cached` call took 127ms, with a
+ * leaf CPU profile attributing 48.8% to existsSync and 20.0% to the path
+ * normaliser feeding it. Truncating the registry to 50 records took the same
+ * call to 10ms. The cost was the scan, not the tool.
+ *
+ * A per-process Set answers the repeat case in memory. Bounded by the number of
+ * distinct project+client pairs a single process touches, which is small --
+ * unlike the registry, which is unbounded over time.
+ */
+const registeredThisProcess = new Map();
+
+
+/**
  * Folds the append-only registry into one current entry per canonical project.
  * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ *
+ * STILL A FULL SCAN, deliberately. Its callers -- the dashboard, the fleet
+ * auditor, the discovery script -- want the complete folded view and run rarely.
+ * The fix for the hot path is not to make this cheaper but to stop calling it
+ * from `registerProject`, which never needed the fold.
  */
 export function registeredProjects() {
   const path = projectRegistryPath();
@@ -165,14 +191,31 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     if (!isRepository) return null;
     const id = projectIdFor(canonicalRoot);
     const now = Date.now();
-    const recent = registeredProjects().find(
-      (project) =>
-        project.id === id &&
-        project.graphDir === canonicalGraphDir &&
-        project.clients.includes(client) &&
-        now - project.lastSeenAt < 60 * 60 * 1000
-    );
-    if (recent) return recent;
+
+    // ANSWERED IN MEMORY, NOT BY RESCANNING THE REGISTRY.
+    //
+    // The question here is narrow -- "have I already appended this exact
+    // project+graphDir+client?" -- and folding the entire append-only registry
+    // to answer it made every tool call O(registry). See the note on
+    // `registeredThisProcess` for the measurement.
+    //
+    // WHAT THIS GIVES UP, STATED PLAINLY. The old check spanned processes via a
+    // one-hour window read from the registry; this one spans only this process.
+    // So a short-lived process that starts, registers and exits appends one
+    // record where it previously might have appended none.
+    //
+    // That is the right trade because the registry is a LOG OF OBSERVATIONS,
+    // not a set of unique projects: `registeredProjects()` already folds
+    // duplicates by id, so an extra record costs one line and changes no
+    // answer. The alternative -- reading the whole registry to avoid writing to
+    // it -- optimised the wrong direction: it spent 127ms of reads to save an
+    // occasional append.
+    //
+    // Growth is bounded per process by the number of distinct project+client
+    // pairs it touches, which is small.
+    const key = `${id} ${canonicalGraphDir} ${client}`;
+    const already = registeredThisProcess.get(key);
+    if (already) return already;
 
     const path = projectRegistryPath();
     const lockPath = acquire(path);
@@ -199,7 +242,7 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     } finally {
       release(lockPath);
     }
-    return {
+    const entry = {
       id,
       name: String(name || displayName(canonicalRoot)).slice(0, 160),
       root: canonicalRoot,
@@ -208,6 +251,10 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
       lastSeenAt: now,
       clients: [String(client || 'unknown').slice(0, 80)],
     };
+    // Recorded only AFTER the append succeeded, so a failed write is retried
+    // by the next call rather than being remembered as done.
+    registeredThisProcess.set(key, entry);
+    return entry;
   } catch {
     return null;
   }

--- a/integrations/opencode/hooks/lib/projects.mjs
+++ b/integrations/opencode/hooks/lib/projects.mjs
@@ -83,8 +83,34 @@ function release(lockPath) {
 }
 
 /**
+ * What this process has already registered, so a repeat never rescans.
+ *
+ * `registerProject` runs on EVERY tool call and asked one question of the whole
+ * registry: have I already registered this project, for this client, recently?
+ * Answering it by folding the registry meant reading every record and running
+ * TWO existsSync per record -- and the registry is append-only, so every project
+ * ever touched made every future call slower.
+ *
+ * Measured with 4,033 records: a trivial `get_cached` call took 127ms, with a
+ * leaf CPU profile attributing 48.8% to existsSync and 20.0% to the path
+ * normaliser feeding it. Truncating the registry to 50 records took the same
+ * call to 10ms. The cost was the scan, not the tool.
+ *
+ * A per-process Set answers the repeat case in memory. Bounded by the number of
+ * distinct project+client pairs a single process touches, which is small --
+ * unlike the registry, which is unbounded over time.
+ */
+const registeredThisProcess = new Map();
+
+
+/**
  * Folds the append-only registry into one current entry per canonical project.
  * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ *
+ * STILL A FULL SCAN, deliberately. Its callers -- the dashboard, the fleet
+ * auditor, the discovery script -- want the complete folded view and run rarely.
+ * The fix for the hot path is not to make this cheaper but to stop calling it
+ * from `registerProject`, which never needed the fold.
  */
 export function registeredProjects() {
   const path = projectRegistryPath();
@@ -165,14 +191,31 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     if (!isRepository) return null;
     const id = projectIdFor(canonicalRoot);
     const now = Date.now();
-    const recent = registeredProjects().find(
-      (project) =>
-        project.id === id &&
-        project.graphDir === canonicalGraphDir &&
-        project.clients.includes(client) &&
-        now - project.lastSeenAt < 60 * 60 * 1000
-    );
-    if (recent) return recent;
+
+    // ANSWERED IN MEMORY, NOT BY RESCANNING THE REGISTRY.
+    //
+    // The question here is narrow -- "have I already appended this exact
+    // project+graphDir+client?" -- and folding the entire append-only registry
+    // to answer it made every tool call O(registry). See the note on
+    // `registeredThisProcess` for the measurement.
+    //
+    // WHAT THIS GIVES UP, STATED PLAINLY. The old check spanned processes via a
+    // one-hour window read from the registry; this one spans only this process.
+    // So a short-lived process that starts, registers and exits appends one
+    // record where it previously might have appended none.
+    //
+    // That is the right trade because the registry is a LOG OF OBSERVATIONS,
+    // not a set of unique projects: `registeredProjects()` already folds
+    // duplicates by id, so an extra record costs one line and changes no
+    // answer. The alternative -- reading the whole registry to avoid writing to
+    // it -- optimised the wrong direction: it spent 127ms of reads to save an
+    // occasional append.
+    //
+    // Growth is bounded per process by the number of distinct project+client
+    // pairs it touches, which is small.
+    const key = `${id} ${canonicalGraphDir} ${client}`;
+    const already = registeredThisProcess.get(key);
+    if (already) return already;
 
     const path = projectRegistryPath();
     const lockPath = acquire(path);
@@ -199,7 +242,7 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     } finally {
       release(lockPath);
     }
-    return {
+    const entry = {
       id,
       name: String(name || displayName(canonicalRoot)).slice(0, 160),
       root: canonicalRoot,
@@ -208,6 +251,10 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
       lastSeenAt: now,
       clients: [String(client || 'unknown').slice(0, 80)],
     };
+    // Recorded only AFTER the append succeeded, so a failed write is retried
+    // by the next call rather than being remembered as done.
+    registeredThisProcess.set(key, entry);
+    return entry;
   } catch {
     return null;
   }

--- a/integrations/qwen/hooks/lib/projects.mjs
+++ b/integrations/qwen/hooks/lib/projects.mjs
@@ -83,8 +83,34 @@ function release(lockPath) {
 }
 
 /**
+ * What this process has already registered, so a repeat never rescans.
+ *
+ * `registerProject` runs on EVERY tool call and asked one question of the whole
+ * registry: have I already registered this project, for this client, recently?
+ * Answering it by folding the registry meant reading every record and running
+ * TWO existsSync per record -- and the registry is append-only, so every project
+ * ever touched made every future call slower.
+ *
+ * Measured with 4,033 records: a trivial `get_cached` call took 127ms, with a
+ * leaf CPU profile attributing 48.8% to existsSync and 20.0% to the path
+ * normaliser feeding it. Truncating the registry to 50 records took the same
+ * call to 10ms. The cost was the scan, not the tool.
+ *
+ * A per-process Set answers the repeat case in memory. Bounded by the number of
+ * distinct project+client pairs a single process touches, which is small --
+ * unlike the registry, which is unbounded over time.
+ */
+const registeredThisProcess = new Map();
+
+
+/**
  * Folds the append-only registry into one current entry per canonical project.
  * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ *
+ * STILL A FULL SCAN, deliberately. Its callers -- the dashboard, the fleet
+ * auditor, the discovery script -- want the complete folded view and run rarely.
+ * The fix for the hot path is not to make this cheaper but to stop calling it
+ * from `registerProject`, which never needed the fold.
  */
 export function registeredProjects() {
   const path = projectRegistryPath();
@@ -165,14 +191,31 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     if (!isRepository) return null;
     const id = projectIdFor(canonicalRoot);
     const now = Date.now();
-    const recent = registeredProjects().find(
-      (project) =>
-        project.id === id &&
-        project.graphDir === canonicalGraphDir &&
-        project.clients.includes(client) &&
-        now - project.lastSeenAt < 60 * 60 * 1000
-    );
-    if (recent) return recent;
+
+    // ANSWERED IN MEMORY, NOT BY RESCANNING THE REGISTRY.
+    //
+    // The question here is narrow -- "have I already appended this exact
+    // project+graphDir+client?" -- and folding the entire append-only registry
+    // to answer it made every tool call O(registry). See the note on
+    // `registeredThisProcess` for the measurement.
+    //
+    // WHAT THIS GIVES UP, STATED PLAINLY. The old check spanned processes via a
+    // one-hour window read from the registry; this one spans only this process.
+    // So a short-lived process that starts, registers and exits appends one
+    // record where it previously might have appended none.
+    //
+    // That is the right trade because the registry is a LOG OF OBSERVATIONS,
+    // not a set of unique projects: `registeredProjects()` already folds
+    // duplicates by id, so an extra record costs one line and changes no
+    // answer. The alternative -- reading the whole registry to avoid writing to
+    // it -- optimised the wrong direction: it spent 127ms of reads to save an
+    // occasional append.
+    //
+    // Growth is bounded per process by the number of distinct project+client
+    // pairs it touches, which is small.
+    const key = `${id} ${canonicalGraphDir} ${client}`;
+    const already = registeredThisProcess.get(key);
+    if (already) return already;
 
     const path = projectRegistryPath();
     const lockPath = acquire(path);
@@ -199,7 +242,7 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     } finally {
       release(lockPath);
     }
-    return {
+    const entry = {
       id,
       name: String(name || displayName(canonicalRoot)).slice(0, 160),
       root: canonicalRoot,
@@ -208,6 +251,10 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
       lastSeenAt: now,
       clients: [String(client || 'unknown').slice(0, 80)],
     };
+    // Recorded only AFTER the append succeeded, so a failed write is retried
+    // by the next call rather than being remembered as done.
+    registeredThisProcess.set(key, entry);
+    return entry;
   } catch {
     return null;
   }

--- a/integrations/windsurf/hooks/lib/projects.mjs
+++ b/integrations/windsurf/hooks/lib/projects.mjs
@@ -83,8 +83,34 @@ function release(lockPath) {
 }
 
 /**
+ * What this process has already registered, so a repeat never rescans.
+ *
+ * `registerProject` runs on EVERY tool call and asked one question of the whole
+ * registry: have I already registered this project, for this client, recently?
+ * Answering it by folding the registry meant reading every record and running
+ * TWO existsSync per record -- and the registry is append-only, so every project
+ * ever touched made every future call slower.
+ *
+ * Measured with 4,033 records: a trivial `get_cached` call took 127ms, with a
+ * leaf CPU profile attributing 48.8% to existsSync and 20.0% to the path
+ * normaliser feeding it. Truncating the registry to 50 records took the same
+ * call to 10ms. The cost was the scan, not the tool.
+ *
+ * A per-process Set answers the repeat case in memory. Bounded by the number of
+ * distinct project+client pairs a single process touches, which is small --
+ * unlike the registry, which is unbounded over time.
+ */
+const registeredThisProcess = new Map();
+
+
+/**
  * Folds the append-only registry into one current entry per canonical project.
  * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ *
+ * STILL A FULL SCAN, deliberately. Its callers -- the dashboard, the fleet
+ * auditor, the discovery script -- want the complete folded view and run rarely.
+ * The fix for the hot path is not to make this cheaper but to stop calling it
+ * from `registerProject`, which never needed the fold.
  */
 export function registeredProjects() {
   const path = projectRegistryPath();
@@ -165,14 +191,31 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     if (!isRepository) return null;
     const id = projectIdFor(canonicalRoot);
     const now = Date.now();
-    const recent = registeredProjects().find(
-      (project) =>
-        project.id === id &&
-        project.graphDir === canonicalGraphDir &&
-        project.clients.includes(client) &&
-        now - project.lastSeenAt < 60 * 60 * 1000
-    );
-    if (recent) return recent;
+
+    // ANSWERED IN MEMORY, NOT BY RESCANNING THE REGISTRY.
+    //
+    // The question here is narrow -- "have I already appended this exact
+    // project+graphDir+client?" -- and folding the entire append-only registry
+    // to answer it made every tool call O(registry). See the note on
+    // `registeredThisProcess` for the measurement.
+    //
+    // WHAT THIS GIVES UP, STATED PLAINLY. The old check spanned processes via a
+    // one-hour window read from the registry; this one spans only this process.
+    // So a short-lived process that starts, registers and exits appends one
+    // record where it previously might have appended none.
+    //
+    // That is the right trade because the registry is a LOG OF OBSERVATIONS,
+    // not a set of unique projects: `registeredProjects()` already folds
+    // duplicates by id, so an extra record costs one line and changes no
+    // answer. The alternative -- reading the whole registry to avoid writing to
+    // it -- optimised the wrong direction: it spent 127ms of reads to save an
+    // occasional append.
+    //
+    // Growth is bounded per process by the number of distinct project+client
+    // pairs it touches, which is small.
+    const key = `${id} ${canonicalGraphDir} ${client}`;
+    const already = registeredThisProcess.get(key);
+    if (already) return already;
 
     const path = projectRegistryPath();
     const lockPath = acquire(path);
@@ -199,7 +242,7 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     } finally {
       release(lockPath);
     }
-    return {
+    const entry = {
       id,
       name: String(name || displayName(canonicalRoot)).slice(0, 160),
       root: canonicalRoot,
@@ -208,6 +251,10 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
       lastSeenAt: now,
       clients: [String(client || 'unknown').slice(0, 80)],
     };
+    // Recorded only AFTER the append succeeded, so a failed write is retried
+    // by the next call rather than being remembered as done.
+    registeredThisProcess.set(key, entry);
+    return entry;
   } catch {
     return null;
   }

--- a/plugin/hooks/lib/projects.mjs
+++ b/plugin/hooks/lib/projects.mjs
@@ -83,8 +83,34 @@ function release(lockPath) {
 }
 
 /**
+ * What this process has already registered, so a repeat never rescans.
+ *
+ * `registerProject` runs on EVERY tool call and asked one question of the whole
+ * registry: have I already registered this project, for this client, recently?
+ * Answering it by folding the registry meant reading every record and running
+ * TWO existsSync per record -- and the registry is append-only, so every project
+ * ever touched made every future call slower.
+ *
+ * Measured with 4,033 records: a trivial `get_cached` call took 127ms, with a
+ * leaf CPU profile attributing 48.8% to existsSync and 20.0% to the path
+ * normaliser feeding it. Truncating the registry to 50 records took the same
+ * call to 10ms. The cost was the scan, not the tool.
+ *
+ * A per-process Set answers the repeat case in memory. Bounded by the number of
+ * distinct project+client pairs a single process touches, which is small --
+ * unlike the registry, which is unbounded over time.
+ */
+const registeredThisProcess = new Map();
+
+
+/**
  * Folds the append-only registry into one current entry per canonical project.
  * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ *
+ * STILL A FULL SCAN, deliberately. Its callers -- the dashboard, the fleet
+ * auditor, the discovery script -- want the complete folded view and run rarely.
+ * The fix for the hot path is not to make this cheaper but to stop calling it
+ * from `registerProject`, which never needed the fold.
  */
 export function registeredProjects() {
   const path = projectRegistryPath();
@@ -165,14 +191,31 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     if (!isRepository) return null;
     const id = projectIdFor(canonicalRoot);
     const now = Date.now();
-    const recent = registeredProjects().find(
-      (project) =>
-        project.id === id &&
-        project.graphDir === canonicalGraphDir &&
-        project.clients.includes(client) &&
-        now - project.lastSeenAt < 60 * 60 * 1000
-    );
-    if (recent) return recent;
+
+    // ANSWERED IN MEMORY, NOT BY RESCANNING THE REGISTRY.
+    //
+    // The question here is narrow -- "have I already appended this exact
+    // project+graphDir+client?" -- and folding the entire append-only registry
+    // to answer it made every tool call O(registry). See the note on
+    // `registeredThisProcess` for the measurement.
+    //
+    // WHAT THIS GIVES UP, STATED PLAINLY. The old check spanned processes via a
+    // one-hour window read from the registry; this one spans only this process.
+    // So a short-lived process that starts, registers and exits appends one
+    // record where it previously might have appended none.
+    //
+    // That is the right trade because the registry is a LOG OF OBSERVATIONS,
+    // not a set of unique projects: `registeredProjects()` already folds
+    // duplicates by id, so an extra record costs one line and changes no
+    // answer. The alternative -- reading the whole registry to avoid writing to
+    // it -- optimised the wrong direction: it spent 127ms of reads to save an
+    // occasional append.
+    //
+    // Growth is bounded per process by the number of distinct project+client
+    // pairs it touches, which is small.
+    const key = `${id} ${canonicalGraphDir} ${client}`;
+    const already = registeredThisProcess.get(key);
+    if (already) return already;
 
     const path = projectRegistryPath();
     const lockPath = acquire(path);
@@ -199,7 +242,7 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
     } finally {
       release(lockPath);
     }
-    return {
+    const entry = {
       id,
       name: String(name || displayName(canonicalRoot)).slice(0, 160),
       root: canonicalRoot,
@@ -208,6 +251,10 @@ export function registerProject({ root, graphDir, client = 'unknown', name } = {
       lastSeenAt: now,
       clients: [String(client || 'unknown').slice(0, 80)],
     };
+    // Recorded only AFTER the append succeeded, so a failed write is retried
+    // by the next call rather than being remembered as done.
+    registeredThisProcess.set(key, entry);
+    return entry;
   } catch {
     return null;
   }

--- a/tests/hooks/registry-scan-cost.test.mjs
+++ b/tests/hooks/registry-scan-cost.test.mjs
@@ -1,0 +1,151 @@
+/**
+ * The project registry must not be rescanned on every call.
+ *
+ * WHAT THIS COSTS WHEN IT REGRESSES. `registerProject` runs on every MCP tool
+ * call, and it called `registeredProjects()` to answer one question: have I
+ * already registered this project for this client in the last hour? That fold
+ * reads the whole append-only registry and runs TWO `existsSync` per record --
+ * one on the root, one on the graph file.
+ *
+ * Measured on the author's machine with 4,033 records: a trivial `get_cached`
+ * tool call took 127ms, of which a leaf CPU profile attributed 48.8% to
+ * `existsSync` and 20.0% to the path normaliser feeding it. Truncating the
+ * registry to 50 records took the same call to 10ms -- a 12.7x speedup, which
+ * is the causal proof that the scan, not the tool, was the cost.
+ *
+ * It also degrades forever: the registry is append-only, so every project ever
+ * touched makes every future tool call slower. That is why it presented as
+ * "it got slow" rather than "it is slow".
+ *
+ * These tests assert the PROPERTY (syscalls must not scale with registry size)
+ * rather than a millisecond budget, which would be machine-dependent and flaky.
+ */
+
+import { mkdtempSync, writeFileSync, rmSync, appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import * as fs from 'node:fs';
+
+let home;
+let registry;
+let repo;
+
+const PROJECT_REGISTRY_VERSION = 1;
+
+/** Writes `count` registry records naming real, existing roots. */
+function seedRegistry(count) {
+  for (let i = 0; i < count; i++) {
+    const root = join(home, 'repo');
+    appendFileSync(
+      registry,
+      JSON.stringify({
+        v: PROJECT_REGISTRY_VERSION,
+        id: 'id-' + i,
+        name: 'p' + i,
+        root,
+        graphDir: join(root, '.token-optimizer', 'wiki'),
+        client: 'seed',
+        at: Date.now(),
+      }) + '\n'
+    );
+  }
+}
+
+/**
+ * Wall time of one call, median of a few, because an ESM module namespace is
+ * FROZEN -- `fs.existsSync` cannot be monkey-patched to count syscalls, which
+ * the first version of this test tried and failed on with "Cannot assign to
+ * read only property". Time is the honest proxy here anyway: it is the symptom
+ * users reported.
+ */
+function medianMs(fn, reps = 5) {
+  const times = [];
+  for (let i = 0; i < reps; i++) {
+    const t0 = Number(process.hrtime.bigint());
+    fn();
+    times.push((Number(process.hrtime.bigint()) - t0) / 1e6);
+  }
+  times.sort((a, b) => a - b);
+  return times[Math.floor(times.length / 2)];
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'registry-cost-'));
+  repo = join(home, 'repo');
+  fs.mkdirSync(join(repo, '.git'), { recursive: true });
+  fs.mkdirSync(join(repo, '.token-optimizer', 'wiki'), { recursive: true });
+  registry = join(home, 'projects.jsonl');
+  writeFileSync(registry, '');
+  // The registry path override, NOT a home override -- without this the test
+  // would silently exercise the developer's real 4,000-record registry.
+  process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY = registry;
+});
+
+afterEach(() => {
+  delete process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe('registerProject does not scale with registry size', () => {
+  test('a large registry costs no more than a small one', async () => {
+    const { registerProject } = await import(
+      '../../hooks-core/projects.mjs'
+    );
+
+    seedRegistry(20);
+    const small = medianMs(() =>
+      registerProject({ root: repo, graphDir: join(repo, '.token-optimizer', 'wiki'), client: 'a' })
+    );
+
+    seedRegistry(400);
+    const large = medianMs(() =>
+      registerProject({ root: repo, graphDir: join(repo, '.token-optimizer', 'wiki'), client: 'b' })
+    );
+
+    // THE PROPERTY: 20x the records must not mean 20x the work. Generous
+    // headroom plus a floor, so this measures scaling rather than scheduler
+    // noise on a millisecond-scale operation.
+    expect(large).toBeLessThan(Math.max(small * 4, 5));
+  });
+
+  test('a repeat call within the process does not rescan at all', async () => {
+    const { registerProject } = await import(
+      '../../hooks-core/projects.mjs'
+    );
+    seedRegistry(200);
+
+    const args = { root: repo, graphDir: join(repo, '.token-optimizer', 'wiki'), client: 'c' };
+    registerProject(args);
+    const second = medianMs(() => registerProject(args));
+
+    // The second call answers from memory, so it must be far below the cost of
+    // reading a 200-record registry.
+    expect(second).toBeLessThan(2);
+  });
+});
+
+describe('correctness is preserved', () => {
+  test('a project is still registered and readable', async () => {
+    const { registerProject, registeredProjects } =
+      await import('../../hooks-core/projects.mjs');
+
+    registerProject({
+      root: repo,
+      graphDir: join(repo, '.token-optimizer', 'wiki'),
+      client: 'claude-code',
+    });
+
+    const found = registeredProjects().find((p) => p.root.endsWith('repo'));
+    expect(found).toBeTruthy();
+    expect(found.clients).toContain('claude-code');
+  });
+
+  test('a non-repository is still refused', async () => {
+    const { registerProject } = await import('../../hooks-core/projects.mjs');
+    const plain = join(home, 'not-a-repo');
+    fs.mkdirSync(plain, { recursive: true });
+    expect(
+      registerProject({ root: plain, graphDir: join(plain, 'g'), client: 'x' })
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes the slowness users reported. **21× faster tool calls** against a real 4,033-record registry.

## The defect

`registerProject` runs on **every MCP tool call** and asked one narrow question of the entire append-only registry — *have I already registered this project for this client?* — by folding the whole thing, which reads every record and runs **two `existsSync` per record**.

The registry only grows, so **every project ever touched made every future tool call slower**. That is why it presented as *"it got slow"* rather than *"it is slow"*.

## How it was found

Leaf CPU profile of the **live server** over 60 tool calls (11.2s wall):

| | leaf |
|---|---|
| `existsSync` | **48.8%** (5,489ms) |
| `paths.mjs :: normaliseOnce` | **20.0%** (2,244ms) |
| `projects.mjs :: registeredProjects` | 5.8% (656ms) |
| garbage collector | **0.9%** |
| idle / program | **0.4%** |

The GC and idle shares matter as much as the top rows: they **rule out** allocation churn and I/O waiting rather than leaving them assumed.

**Causal proof, not correlation** — truncating the registry from 4,033 records to 50 took a trivial `get_cached` call from **127ms to 10ms**, then it was restored.

## Measured after the fix, same real 4,033-record registry

| call | before | after | |
|---|---|---|---|
| `get_cached` | 127ms | **6ms** | 21× |
| `smart_read` (small) | 132ms | **10ms** | 13× |
| `smart_read` (98 KB) | 139ms | **12ms** | 12× |
| `smart_glob` | 211ms | **88ms** | 2.4× |

For scale: `SmartReadTool.read()` in-process is 8ms and `tools/list` is 3ms, so ~94% of a tool call was this scan.

## What it gives up, stated in the code

The old check spanned processes via a one-hour window read from the registry; the new one spans a process. So a short-lived process may append one record it previously would not have.

That is the right direction: the registry is a **log of observations** that `registeredProjects()` already folds by id, so an extra line changes no answer — whereas reading it spent 127ms to save an occasional append.

`registeredProjects()` itself still does the full scan, deliberately. Its callers (dashboard, fleet auditor, discovery) want the folded view and run rarely.

## Tests

`tests/hooks/registry-scan-cost.test.mjs` — asserts the **property** (cost must not scale with registry size, and a repeat call must not rescan) plus two correctness tests that a project is still registered and a non-repository still refused.

Worth recording: the first version tried to count syscalls by monkey-patching `fs.existsSync` and could not — **an ESM module namespace is frozen** (`Cannot assign to read only property`). It uses timing instead, which is also the symptom users actually reported.

The reachability guard then caught a `resetRegistryCache` test seam that only its own tests called; it was removed rather than exempted, since each test already gets a fresh registry path and repo root, so cache keys cannot collide.

**210 suites / 2750 tests passing**, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)