### PR TITLE
feat(policy): bound a command's output instead of refusing the command

### DIFF
--- a/bench/debug-loop/run.mjs
+++ b/bench/debug-loop/run.mjs
@@ -1,0 +1,282 @@
+/**
+ * A debug loop, measured locally, for nothing.
+ *
+ * WHY THIS EXISTS. Debug loops are the family that decides the ranking: ours
+ * measured 1.248 against tokenade's 0.611, and closing that gap alone moves the
+ * aggregate from 0.928 to 0.811. The only harness that could tell us anything
+ * about it was THOL -- ~$13 and an hour per screen -- which is far too coarse a
+ * loop to design against. This runs the same shape locally, deterministically,
+ * and free.
+ *
+ * IT MEASURES THE PREMISE BEFORE THE FIX. The proposed lever is deduplication:
+ * a debug loop reruns a suite and each run dumps a wall of output that is
+ * *nearly identical* to the last one. "Nearly" is doing all the work in that
+ * sentence, and nobody had measured it. If consecutive runs share 95% of their
+ * lines, dedup is the lever. If they share 40%, it is not, and bounding is all
+ * there is. So the first number this prints is redundancy, not savings.
+ *
+ * REAL OUTPUT, NOT A SYNTHETIC WALL. Whoever writes the fixture chooses the
+ * redundancy, and then the measurement just reports back the assumption it was
+ * given. So this drives the repository's own jest against a real source file it
+ * temporarily breaks, and reads the real failures.
+ *
+ * WHAT THE NUMBERS DO NOT SAY, and three hazards for whoever implements this:
+ *
+ *   1. DEDUP CAN HIDE A PERSISTENT FAILURE. If run 2 fails exactly as run 1
+ *      did, every FAIL line is "repeated" and dedup omits all of them -- and a
+ *      model reading "[963 lines identical, omitted]" may conclude the suite
+ *      now passes. That is the same class of error as a pipeline swallowing a
+ *      non-zero exit: it does not cost tokens, it costs correctness, and it
+ *      stops the debugging. Any real implementation must always retain the
+ *      verdict lines, however many times they repeat.
+ *   2. OUR BOUND IS TAIL-ONLY; THE CLIENT'S IS NOT. The client truncates from
+ *      the middle and keeps the head, where a jest run lists WHICH suites
+ *      failed. An 8 KB tail is cheaper and can still be worse for the model.
+ *      Cost is not the only axis, and this harness only measures cost.
+ *   3. ONE FIXTURE, ONE PROJECT, ONE LOOP SHAPE. Redundancy near 94% is what
+ *      THIS suite does when THIS file breaks. A loop that edits between runs in
+ *      a way that shifts line numbers would repeat far less.
+ *
+ * THE SOURCE FILE IS RESTORED IN A `finally`, AND VERIFIED BY HASH. A harness
+ * that edits real source has to be paranoid: an earlier benchmark in this
+ * project pointed a write-capable tool at the repository root and overwrote
+ * package.json.
+ */
+import { execFileSync } from 'node:child_process';
+import {
+  readFileSync,
+  writeFileSync,
+  mkdtempSync,
+  rmSync,
+  writeSync,
+} from 'node:fs';
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const say = (line) => writeSync(1, `${line}\n`);
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/** The client's own cap on Bash output: 30,000 characters, max 150,000. */
+const CLIENT_CAP_CHARS = 30_000;
+
+/** The subject: a small module with a focused suite that fails loudly. */
+const SOURCE = join(ROOT, 'hooks-core', 'redact.mjs');
+const SUITE = process.env.DEBUG_LOOP_SUITE || 'tests/hooks/redact.test.mjs';
+
+/**
+ * Three iterations of a debug loop, as an agent would actually produce them:
+ * a first failure, a partial fix that changes which assertions fail, and the
+ * real fix. Each mutation is a single replacement in the real source.
+ */
+const ITERATIONS = [
+  { label: 'broken', from: "let out = String(text ?? '');", to: "let out = '';" },
+  {
+    label: 'partial fix',
+    from: "let out = String(text ?? '');",
+    to: "let out = String(text ?? '').slice(0, 4);",
+  },
+  { label: 'fixed', from: null, to: null },
+];
+
+function runSuite() {
+  try {
+    return execFileSync(
+      process.execPath,
+      [
+        '--experimental-vm-modules',
+        join('node_modules', 'jest', 'bin', 'jest.js'),
+        SUITE,
+      ],
+      { cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 180_000 }
+    );
+  } catch (error) {
+    // A failing suite exits non-zero and its report is on stderr. That report
+    // IS the measurement -- this is the wall of output a debug loop pays for.
+    return `${error.stdout ?? ''}${error.stderr ?? ''}`;
+  }
+}
+
+/**
+ * Two transforms, kept apart because only ONE of them is shippable.
+ *
+ * `stripColour` removes ANSI escapes. They are pure presentation -- a model
+ * gains nothing from them -- and they are not a rounding error: a real failing
+ * `jest tests/hooks` run measured 67,634 bytes containing 3,080 ANSI sequences,
+ * so stripping alone removes 22.5% of the output. Safe, free, and it applies to
+ * every coloured command rather than only to tests.
+ *
+ * `maskTimings` is NOT shippable and is used only to decide whether two lines
+ * are "the same line": a run prints `(3 ms)` where the last printed `(4 ms)`,
+ * and treating those as different would understate redundancy and make dedup
+ * look worse than it is. Masking real timings in what the MODEL sees would
+ * discard content it may want, so it never reaches an arm's output. Measured
+ * worth 0.2% as a saving -- noise there, load-bearing as a comparison key.
+ *
+ * An earlier version of this file applied BOTH to the dedup arms and NEITHER to
+ * the control arms, silently crediting dedup with a saving no arm performed.
+ */
+/**
+ * How the client itself truncates: from the MIDDLE, keeping head and tail.
+ *
+ * Read out of the client binary, which carries both the marker format
+ * `\n\n... [N characters truncated] ...\n\n` and the string `truncate-middle`.
+ * Modelling it as a tail cut -- which this harness did at first -- understates
+ * the baseline's quality, because the head of a failing jest run holds the FAIL
+ * list while the tail holds the summary, and middle truncation keeps both.
+ *
+ * It also carries a warning for our own bound, which is tail-only: against a
+ * baseline that preserves the head, an 8 KB tail can be WORSE for the model
+ * even while being cheaper. Cost is not the only axis.
+ */
+function truncateMiddle(text, cap) {
+  if (text.length <= cap) return text;
+  const marker = `\n\n... [${text.length - cap} characters truncated] ...\n\n`;
+  const half = Math.max(0, Math.floor((cap - marker.length) / 2));
+  return text.slice(0, half) + marker + text.slice(text.length - half);
+}
+
+const stripColour = (text) => text.replace(/\x1b\[[0-9;]*m/g, '');
+const maskTimings = (text) =>
+  text.replace(/\d+(\.\d+)?\s*m?s\b/g, 'Xms').replace(/\(\d+ ms\)/g, '(Xms)');
+
+/** Comparison keys, not output: timings masked so re-runs line up. */
+const lines = (text) => maskTimings(stripColour(text)).split('\n');
+
+const main = async () => {
+  const { TokenCounter } = await import(
+    `file:///${join(ROOT, 'dist', 'core', 'token-counter.js').replace(/\\/g, '/')}`
+  );
+  const counter = new TokenCounter();
+  const { boundedRewrite } = await import(
+    `file:///${join(ROOT, 'hooks-core', 'rewrite.mjs').replace(/\\/g, '/')}`
+  );
+  const bound = boundedRewrite('jest').maxBytes;
+
+  const original = readFileSync(SOURCE, 'utf8');
+  const originalHash = createHash('sha256').update(original).digest('hex');
+  const scratch = mkdtempSync(join(tmpdir(), 'debug-loop-'));
+  writeFileSync(join(scratch, 'source.bak'), original);
+
+  const captures = [];
+  try {
+    for (const step of ITERATIONS) {
+      if (step.from) {
+        if (!original.includes(step.from)) {
+          throw new Error(`fixture drift: source no longer contains ${step.from}`);
+        }
+        writeFileSync(SOURCE, original.replace(step.from, step.to));
+      } else {
+        writeFileSync(SOURCE, original);
+      }
+      captures.push({ label: step.label, output: runSuite() });
+    }
+  } finally {
+    writeFileSync(SOURCE, original);
+    const restored = createHash('sha256')
+      .update(readFileSync(SOURCE, 'utf8'))
+      .digest('hex');
+    if (restored !== originalHash) {
+      say(`RESTORE FAILED -- source backup is at ${join(scratch, 'source.bak')}`);
+      process.exit(1);
+    }
+    rmSync(scratch, { recursive: true, force: true });
+  }
+
+  /* ---------------------------------------------------- the premise */
+
+  say('');
+  say('REDUNDANCY between consecutive runs (the premise dedup rests on)');
+  say('');
+  say('iteration'.padEnd(16) + 'lines'.padStart(8) + 'repeated'.padStart(10) + 'new'.padStart(8) + '   % repeated');
+  say('-'.repeat(62));
+
+  let previous = null;
+  const arms = { raw: 0, control: 0, bounded: 0, deduped: 0, combined: 0 };
+
+  for (const capture of captures) {
+    const current = lines(capture.output);
+    const seen = previous ? new Set(previous) : new Set();
+    const repeated = previous ? current.filter((l) => seen.has(l)).length : 0;
+    const fresh = current.length - repeated;
+
+    say(
+      capture.label.padEnd(16) +
+        String(current.length).padStart(8) +
+        String(repeated).padStart(10) +
+        String(fresh).padStart(8) +
+        `   ${previous ? ((repeated / current.length) * 100).toFixed(1) + '%' : '-'}`
+    );
+
+    // EVERY ARM MEASURES THE SAME BASE TEXT. An earlier version of this file
+    // built the dedup arms from normalised lines while control and bounded used
+    // the raw capture -- so dedup was silently credited with stripping ANSI
+    // colour and masking timings, work no arm had actually done. The comparison
+    // has to isolate each arm's OWN transform or it flatters whichever arm the
+    // author happened to normalise.
+    //
+    // `raw` is kept as a separate row precisely so the normalisation saving is
+    // visible rather than smuggled into one arm.
+    const base = stripColour(capture.output);
+    // Emitted lines keep their real timings; only the comparison KEY is masked.
+    const emitLines = base.split('\n');
+
+    // raw: exactly what the client delivers, ANSI and all, at its own cap.
+    const raw = truncateMiddle(capture.output, CLIENT_CAP_CHARS);
+    // control: the same wall with ANSI colour stripped. Nothing else.
+    const control = truncateMiddle(base, CLIENT_CAP_CHARS);
+    // bounded: what this project now does -- the last 8 KB.
+    const bounded = base.slice(-bound);
+    // deduped: only lines this run did not repeat, plus a one-line summary.
+    const deduped = previous
+      ? `[${repeated} lines identical to the previous run, omitted]\n` +
+        emitLines.filter((_line, i) => !seen.has(current[i])).join('\n')
+      : truncateMiddle(base, CLIENT_CAP_CHARS);
+
+    // combined: dedup FIRST, then bound what is left. They are not rivals --
+    // dedup keeps the first run in full and saves on later ones, bounding caps
+    // every run including the first. Each covers the other's blind spot.
+    const combined = deduped.slice(-bound);
+
+    arms.raw += counter.count(raw).tokens;
+    arms.control += counter.count(control).tokens;
+    arms.bounded += counter.count(bounded).tokens;
+    arms.deduped += counter.count(deduped).tokens;
+    arms.combined += counter.count(combined).tokens;
+
+    previous = current;
+  }
+
+  /* ------------------------------------------------------- the arms */
+
+  say('');
+  say('TOKENS reaching the model across the whole loop');
+  say('');
+  say('arm'.padEnd(28) + 'tokens'.padStart(10) + '   vs raw');
+  say('-'.repeat(56));
+  for (const [name, tokens] of Object.entries(arms)) {
+    const ratio = tokens / arms.raw;
+    say(
+      name.padEnd(28) +
+        String(tokens).padStart(10) +
+        `   ${ratio.toFixed(3)}${name === 'raw' ? '' : ratio < 1 ? ' better' : ' WORSE'}`
+    );
+  }
+  say('');
+  say(
+    `raw = the client's own ${CLIENT_CAP_CHARS}-char MIDDLE truncation, ANSI included; ` +
+      `control = same, colour stripped; bounded = ${bound} bytes; ` +
+      `deduped = new lines only; combined = both.`
+  );
+  say(
+    'raw -> control is ANSI stripping alone: presentation, safe, free, and'
+  );
+  say('available to every arm. Timings are masked only to compare lines.');
+  say('This is one loop on one suite. It is a design instrument, not a result.');
+};
+
+main().catch((error) => {
+  writeSync(2, `FAILED ${error?.stack || error}\n`);
+  process.exit(1);
+});

--- a/bench/debug-loop/run.mjs
+++ b/bench/debug-loop/run.mjs
@@ -42,7 +42,7 @@
  * project pointed a write-capable tool at the repository root and overwrote
  * package.json.
  */
-import { execFileSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import {
   readFileSync,
   writeFileSync,
@@ -80,22 +80,29 @@ const ITERATIONS = [
   { label: 'fixed', from: null, to: null },
 ];
 
+/**
+ * BOTH STREAMS, EVERY RUN. The first version returned only stdout when the
+ * suite passed and stdout+stderr when it failed, so the passing iteration was
+ * measured on a different quantity from the failing ones -- and jest writes its
+ * report to stderr, which is exactly the wall of output a debug loop pays for.
+ * A measurement whose input changes shape between arms is not a measurement.
+ *
+ * `spawnSync` rather than `execFileSync` because it does not throw on a
+ * non-zero exit: a failing suite is the NORMAL case here, not an error. Only a
+ * failure to spawn at all is worth throwing for.
+ */
 function runSuite() {
-  try {
-    return execFileSync(
-      process.execPath,
-      [
-        '--experimental-vm-modules',
-        join('node_modules', 'jest', 'bin', 'jest.js'),
-        SUITE,
-      ],
-      { cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 180_000 }
-    );
-  } catch (error) {
-    // A failing suite exits non-zero and its report is on stderr. That report
-    // IS the measurement -- this is the wall of output a debug loop pays for.
-    return `${error.stdout ?? ''}${error.stderr ?? ''}`;
-  }
+  const result = spawnSync(
+    process.execPath,
+    [
+      '--experimental-vm-modules',
+      join('node_modules', 'jest', 'bin', 'jest.js'),
+      SUITE,
+    ],
+    { cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 180_000 }
+  );
+  if (result.error) throw result.error;
+  return `${result.stdout ?? ''}${result.stderr ?? ''}`;
 }
 
 /**
@@ -135,6 +142,26 @@ function truncateMiddle(text, cap) {
   const marker = `\n\n... [${text.length - cap} characters truncated] ...\n\n`;
   const half = Math.max(0, Math.floor((cap - marker.length) / 2));
   return text.slice(0, half) + marker + text.slice(text.length - half);
+}
+
+/**
+ * The head+tail byte bound production applies, modelled honestly.
+ *
+ * BYTES, because the shell's `head -c` / `tail -c` count bytes; slicing
+ * characters would model a bigger budget than the command really gets on any
+ * multibyte output. And head+tail rather than a tail, because that is what
+ * `boundedRewrite` emits -- the client's own truncation keeps both ends, so a
+ * tail-only model would misrepresent both production and the baseline.
+ */
+function boundBytes(text, maxBytes) {
+  const buffer = Buffer.from(text, 'utf8');
+  if (buffer.length <= maxBytes) return text;
+  const half = Math.max(1, Math.floor(maxBytes / 2));
+  return (
+    buffer.subarray(0, half).toString('utf8') +
+    '\n... [middle omitted by token-optimizer] ...\n' +
+    buffer.subarray(buffer.length - half).toString('utf8')
+  );
 }
 
 const stripColour = (text) => text.replace(/\x1b\[[0-9;]*m/g, '');
@@ -226,8 +253,17 @@ const main = async () => {
     const raw = truncateMiddle(capture.output, CLIENT_CAP_CHARS);
     // control: the same wall with ANSI colour stripped. Nothing else.
     const control = truncateMiddle(base, CLIENT_CAP_CHARS);
-    // bounded: what this project now does -- the last 8 KB.
-    const bounded = base.slice(-bound);
+    // bounded: what production ACTUALLY does, which is not what this arm used
+    // to model. `boundedRewrite` does not strip ANSI, and it now keeps the head
+    // AND the tail rather than the tail alone. Modelling it as a colour-stripped
+    // tail credited the bounded arm with the 36% that stripping is worth on its
+    // own -- the same arm-asymmetry defect this file already had once, in the
+    // dedup arms, and missed here.
+    //
+    // Byte-based, not character-based, because `head -c`/`tail -c` count bytes:
+    // on multibyte output a character slice would model a larger budget than
+    // the shell actually applies.
+    const bounded = boundBytes(capture.output, bound);
     // deduped: only lines this run did not repeat, plus a one-line summary.
     const deduped = previous
       ? `[${repeated} lines identical to the previous run, omitted]\n` +
@@ -237,7 +273,7 @@ const main = async () => {
     // combined: dedup FIRST, then bound what is left. They are not rivals --
     // dedup keeps the first run in full and saves on later ones, bounding caps
     // every run including the first. Each covers the other's blind spot.
-    const combined = deduped.slice(-bound);
+    const combined = boundBytes(deduped, bound);
 
     arms.raw += counter.count(raw).tokens;
     arms.control += counter.count(control).tokens;
@@ -266,7 +302,7 @@ const main = async () => {
   say('');
   say(
     `raw = the client's own ${CLIENT_CAP_CHARS}-char MIDDLE truncation, ANSI included; ` +
-      `control = same, colour stripped; bounded = ${bound} bytes; ` +
+      `control = same, colour stripped; bounded = ${bound} bytes head+tail, colour KEPT; ` +
       `deduped = new lines only; combined = both.`
   );
   say(

--- a/hooks-core/policy.mjs
+++ b/hooks-core/policy.mjs
@@ -699,6 +699,41 @@ export function allowWithContext(context) {
 }
 
 /**
+ * Lets the call run, but with a rewritten input -- the zero-turn alternative to
+ * a refusal.
+ *
+ * `updatedInput` is a real PreToolUse field and the rewritten call really runs;
+ * docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md has the end-to-end
+ * verification. This emitter is what makes it usable. A refusal costs about one
+ * extra turn, and turns are the whole measured deficit -- 12.6 to 20.9 under
+ * enforcement, for a task-mean 1.633x -- so a bound applied here is free where
+ * the same bound applied by refusing is not.
+ *
+ * The notice rides along as `additionalContext` rather than being baked into
+ * the command, so the command's own output is never mangled to carry a message.
+ *
+ * IT IS NOT OPTIONAL. The spike's model noticed an unannounced rewrite and
+ * distrusted the result -- "the output does not match the command ... I'm
+ * reporting what I actually received" -- and a model that distrusts its output
+ * re-runs the command, spending the exact turn this exists to save.
+ */
+export function allowWithRewrite(updatedInput, notice) {
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'allow',
+      permissionDecisionReason: 'token-optimizer bounded this output',
+      updatedInput,
+      ...(notice ? { additionalContext: withEscape(notice) } : {}),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
+  process.exit(0);
+}
+
+/**
  * Blocks the call and tells the model exactly what to call instead.
  *
  * The reason string is the whole user interface of this product for an agent.

--- a/hooks-core/rewrite.mjs
+++ b/hooks-core/rewrite.mjs
@@ -87,7 +87,16 @@ function unsafeToBound(command) {
   // `tail --follow=name`. The flag does not have to come first and does not
   // have to be short, so the guard looks anywhere in the `tail` invocation --
   // bounded to that command by stopping at a `;`, `|` or `&`.
-  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+  // CLUSTERED SHORT OPTIONS TOO. GNU tail accepts `-fn 1` and `-fF`, and a
+  // guard anchored on `-f\b` matches neither, because the `\b` fails against
+  // the next clustered letter. Both keep following and never reach EOF, so the
+  // bound waits forever. The character class therefore looks for f or F
+  // ANYWHERE in a short-option cluster.
+  if (
+    /\btail\b[^;|&]*(\s-[a-zA-Z]*[fF][a-zA-Z]*\b|\s--follow\b|\s--follow=)/.test(
+      command
+    )
+  ) {
     return 'follow-mode';
   }
 
@@ -110,11 +119,19 @@ function unsafeToBound(command) {
  * exited 1 once wrapped. Silently changing a command's exit status is the same
  * defect as masking one, in the other direction.
  *
- * The command therefore runs inside a subshell that restores the shell default
- * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
- * properties hold at once, and an explicit `set -o pipefail` written by the
- * caller still takes effect, because it executes inside that subshell after
- * the reset.
+ * The command therefore runs inside a subshell that restores THE CALLER'S OWN
+ * state, while the OUTER pipeline -- ours -- keeps pipefail. `set +o` prints
+ * the current options in re-inputtable form, so the one `pipefail` line is
+ * captured before we change anything and eval'd back inside the subshell.
+ *
+ * Restoring rather than CLEARING, because clearing is the same bug mirrored: a
+ * caller running under `bash -o pipefail` would have had `false | true` return
+ * 1, and a hard `set +o pipefail` would hand them 0. Either direction is a
+ * silent change to an exit status we were only supposed to be bounding the
+ * output of.
+ *
+ * An explicit `set -o pipefail` written inside the command still takes effect,
+ * because it executes inside that subshell after the restore.
  *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
@@ -174,8 +191,9 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
+      `_tok_pf=$(set +o 2>/dev/null | grep pipefail); ` +
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
+      `( eval "$_tok_pf" 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };

--- a/hooks-core/rewrite.mjs
+++ b/hooks-core/rewrite.mjs
@@ -1,0 +1,135 @@
+/**
+ * Bounding a command's output instead of refusing the command.
+ *
+ * WHY THIS EXISTS. A refusal costs approximately ONE EXTRA TURN. Measured on
+ * the THOL battery, enforcement took turns from 12.6 to 20.9 and cost a
+ * task-mean 1.633x vanilla Claude Code -- last of fifteen -- while the same
+ * build without refusals measured 0.928. The tokens a refusal "saves" are
+ * smaller than the round trip it spends, so the mechanism, not the policy, is
+ * what loses.
+ *
+ * A PreToolUse hook can return `updatedInput`, and the rewritten call runs.
+ * Verified end to end (docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md):
+ * a hook that rewrote `echo PROBE_ORIGINAL` to `echo PROBE_REWRITTEN` produced
+ * PROBE_REWRITTEN in the model's context, with no refusal and no retry. So the
+ * same bound can be applied for zero turns.
+ *
+ * PostToolUse cannot do this. Its output schema carries only `additionalContext`
+ * and `classifierContext` -- there is no field that replaces a tool result --
+ * and it never fires for a failed call at all (4,499 of 4,499 live outcomes
+ * report success, every exit code null). Bounding has to happen BEFORE the
+ * command runs, which is also the only way it can reach the failing test runs a
+ * debug loop is made of.
+ */
+
+/**
+ * Default bound, in bytes.
+ *
+ * The client's own cap is the reference point: `BASH_MAX_OUTPUT_LENGTH`
+ * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
+ * output is already bounded -- generously. This default is deliberately well
+ * under it, because the family being targeted is the debug loop, where the SAME
+ * wall of test output arrives on every iteration and the tail is the part that
+ * says what failed.
+ */
+export const DEFAULT_BOUND_BYTES = 8_000;
+
+export function boundBytes() {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_BOUND_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_BOUND_BYTES;
+}
+
+/**
+ * Shapes that must never be rewritten.
+ *
+ * Every one of these is a case where wrapping the command changes what it
+ * MEANS, not just how much of it is shown. Rewriting is a silent mutation of
+ * somebody's command; the bar for doing it is that the result is unarguably the
+ * same command with less output, and anything short of that is left alone.
+ */
+function unsafeToBound(command) {
+  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
+  // relative to the braces. Getting this wrong corrupts the payload rather than
+  // failing loudly -- the same class of damage a greedy regex does to source.
+  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+
+  // Backgrounding detaches the process; a pipeline cannot bound what it no
+  // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
+  if (/(?<![&|>])&(?!&)/.test(command)) return 'background';
+
+  // stdout already going somewhere other than the model's context. Bounding it
+  // would change what lands in the FILE, which is the opposite of harmless.
+  if (/(?<![0-9])>>?\s*(?!&)\S/.test(command)) return 'redirected';
+
+  // Already bounded by its author. Re-bounding buys nothing and risks changing
+  // a deliberate `head -n 5` into something else.
+  if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
+
+  // An interactive or streaming command has no meaningful tail, and buffering
+  // it through a pipe can hang.
+  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+    return 'interactive';
+  }
+
+  return null;
+}
+
+/**
+ * The bounded form of a command, or null when it must be left alone.
+ *
+ * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
+ * puts its verdict at the END -- the failure summary, the counts -- so the tail
+ * is the part worth keeping. And `head` closes the pipe early, which sends
+ * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
+ * then report exit 141 and read as a failure. `tail` consumes its input, so the
+ * real exit status survives.
+ *
+ * `pipefail` itself is what keeps the exit status honest. Without it the
+ * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * run would look like a passing one -- a far worse outcome than any number of
+ * wasted tokens, because the model would stop debugging.
+ *
+ * The `set -o` is wrapped so a shell without `pipefail` degrades to an
+ * unbounded-status pipeline rather than erroring out before the command runs.
+ */
+export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
+  if (typeof command !== 'string') return null;
+  const trimmed = command.trim();
+  if (!trimmed) return null;
+
+  const unsafe = unsafeToBound(trimmed);
+  if (unsafe) return null;
+
+  return {
+    command:
+      `{ set -o pipefail; } 2>/dev/null; ` +
+      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+    maxBytes,
+  };
+}
+
+/**
+ * What the model is told, so the bound is never a silent mutation.
+ *
+ * THE PROBE'S OWN MODEL CAUGHT US DOING THIS. In the spike, a rewritten command
+ * produced output that did not match what had been asked for, and the model
+ * flagged it as suspicious rather than trusting it:
+ *
+ *   "the output does not match the command ... Something in this session's
+ *    tooling chain either rewrote the command before execution or rewrote the
+ *    result. I'm reporting what I actually received rather than the expected
+ *    string."
+ *
+ * A model that distrusts its own tool output re-runs the command, which spends
+ * exactly the turn this mechanism exists to save. So the rewrite announces
+ * itself, says what was kept, and says how to opt out -- compaction the agent
+ * cannot see is compaction it will fight.
+ */
+export function boundNotice(maxBytes) {
+  return (
+    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
+    `the command ran unchanged but only its tail reached you. The tail is ` +
+    `where a test run puts its verdict. Re-run with the output redirected to ` +
+    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+  );
+}

--- a/hooks-core/rewrite.mjs
+++ b/hooks-core/rewrite.mjs
@@ -29,8 +29,9 @@
  * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
  * output is already bounded -- generously. This default is deliberately well
  * under it, because the family being targeted is the debug loop, where the SAME
- * wall of test output arrives on every iteration and the tail is the part that
- * says what failed.
+ * wall of test output arrives on every iteration. It is split evenly between
+ * the head and the tail of the output, which is where a run says what failed
+ * and how it ended.
  */
 export const DEFAULT_BOUND_BYTES = 8_000;
 
@@ -77,20 +78,19 @@ function unsafeToBound(command) {
 /**
  * The bounded form of a command, or null when it must be left alone.
  *
- * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
- * puts its verdict at the END -- the failure summary, the counts -- so the tail
- * is the part worth keeping. And `head` closes the pipe early, which sends
- * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
- * then report exit 141 and read as a failure. `tail` consumes its input, so the
- * real exit status survives.
- *
- * `pipefail` itself is what keeps the exit status honest. Without it the
- * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * `pipefail` is what keeps the exit status honest. Without it the pipeline
+ * reports the LAST stage's status, which is always 0, and every failing test
  * run would look like a passing one -- a far worse outcome than any number of
- * wasted tokens, because the model would stop debugging.
+ * wasted tokens, because the model would stop debugging. The `set -o` is
+ * wrapped so a shell without `pipefail` degrades to an unbounded-status
+ * pipeline rather than erroring out before the command runs.
  *
- * The `set -o` is wrapped so a shell without `pipefail` degrades to an
- * unbounded-status pipeline rather than erroring out before the command runs.
+ * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
+ * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
+ * turns a perfectly successful command into exit 141. Inside
+ * `{ head -c N; ...; tail -c N; }` the group keeps reading, so the producer is
+ * never signalled and the real status survives -- asserted by pushing `exit 3`
+ * and `exit 7` through it.
  */
 export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   if (typeof command !== 'string') return null;
@@ -100,10 +100,46 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const unsafe = unsafeToBound(trimmed);
   if (unsafe) return null;
 
+  // A NEWLINE BEFORE THE CLOSING BRACE, NEVER `; }`. Two ordinary commands
+  // broke under the semicolon form, both of which run fine unwrapped:
+  //
+  //   echo hi # explain   ->  { echo hi # explain; }   the `; }` is INSIDE the
+  //                           comment, so the group is never closed
+  //   echo hi;            ->  { echo hi;; }            `;;` is a syntax error
+  //
+  // A newline terminates a comment and satisfies bash's requirement for a
+  // separator before `}`, so it handles both. Breaking a command that would
+  // have worked is the worst thing this module can do -- worse than any number
+  // of tokens -- because the failure looks like the user's own command is wrong.
+  //
+  // HEAD *AND* TAIL, because the client's own truncation keeps both. Claude
+  // Code caps Bash output at 30,000 characters and truncates from the MIDDLE
+  // (its binary carries `... [N characters truncated] ...` and
+  // `truncate-middle`). A tail-only bound is cheaper AND drops the head, where
+  // a failing jest run lists WHICH suites failed -- so it could read as an
+  // improvement on cost while being a regression for the model.
+  //
+  // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
+  // then keeps the last half of what remains. Verified to preserve a non-zero
+  // exit status through both stages.
+  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
+  // "middle omitted" after a two-line command claims a truncation that never
+  // happened -- the same class of error as a reader reporting a windowed event
+  // log it did not actually window. A model told its output was cut will go
+  // looking for the rest, which costs the turn this whole module exists to save.
+  //
+  // `read -r -N1` is the test: it succeeds only if a byte remains after the
+  // head, which means there really is a middle. That byte is then printed back
+  // so it is not swallowed.
+  const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+      `{ ${trimmed}\n} 2>&1 | ` +
+      `{ head -c ${half}; ` +
+      `if IFS= read -r -N1 _tok_rest; then ` +
+      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
+      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
     maxBytes,
   };
 }
@@ -127,9 +163,10 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
-    `the command ran unchanged but only its tail reached you. The tail is ` +
-    `where a test run puts its verdict. Re-run with the output redirected to ` +
-    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
+    `command ran unchanged, and you were given its beginning and its end with ` +
+    `the middle omitted and marked. Those are the two ends that carry a ` +
+    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
+    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/hooks-core/rewrite.mjs
+++ b/hooks-core/rewrite.mjs
@@ -104,6 +104,18 @@ function unsafeToBound(command) {
  * wrapped so a shell without `pipefail` degrades to an unbounded-status
  * pipeline rather than erroring out before the command runs.
  *
+ * BUT IT MUST NOT LEAK INTO THE CALLER'S OWN PIPELINE. `pipefail` is a shell
+ * option, not a property of one pipe, so enabling it changed the meaning of any
+ * command that already contained a pipe: `false | true` exits 0 normally and
+ * exited 1 once wrapped. Silently changing a command's exit status is the same
+ * defect as masking one, in the other direction.
+ *
+ * The command therefore runs inside a subshell that restores the shell default
+ * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
+ * properties hold at once, and an explicit `set -o pipefail` written by the
+ * caller still takes effect, because it executes inside that subshell after
+ * the reset.
+ *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
  * turns a perfectly successful command into exit 141. Inside
@@ -154,7 +166,7 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}\n} 2>&1 | ` +
+      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; ` +
       `if IFS= read -r -N1 _tok_rest; then ` +
       `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +

--- a/hooks-core/rewrite.mjs
+++ b/hooks-core/rewrite.mjs
@@ -153,24 +153,30 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
   // then keeps the last half of what remains. Verified to preserve a non-zero
   // exit status through both stages.
-  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
-  // "middle omitted" after a two-line command claims a truncation that never
-  // happened -- the same class of error as a reader reporting a windowed event
-  // log it did not actually window. A model told its output was cut will go
-  // looking for the rest, which costs the turn this whole module exists to save.
+  // NO IN-STREAM MARKER, AND NO PROBE. `{ head -c H; tail -c H; }` is already
+  // exact in every regime, which two earlier attempts at a marker were not:
   //
-  // `read -r -N1` is the test: it succeeds only if a byte remains after the
-  // head, which means there really is a middle. That byte is then printed back
-  // so it is not swallowed.
+  //   total <= half        head prints it all, tail has nothing  -> COMPLETE
+  //   half < total <= max  head takes half, tail takes the rest  -> COMPLETE
+  //   total > max          head takes half, tail takes the last  -> exactly max
+  //
+  // An unconditional marker lied whenever the output fitted. Gating it on
+  // `read -r -N1` narrowed the lie to the middle band above -- where the output
+  // is returned COMPLETE and the marker still claimed an omission -- and the
+  // probe also relied on a bash-only `read -N`, which a POSIX shell rejects,
+  // skipping the tail entirely and leaking an error to stderr.
+  //
+  // Both defects came from trying to detect truncation from inside a pipe,
+  // which cannot see a total it has not yet consumed. So the announcement moves
+  // to `boundNotice`, stated as the POLICY ("output over N bytes is bounded")
+  // rather than as a claim about this particular output. A policy statement is
+  // true whether or not this command was cut, so it cannot lie.
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
       `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
-      `{ head -c ${half}; ` +
-      `if IFS= read -r -N1 _tok_rest; then ` +
-      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
-      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
+      `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };
 }
@@ -194,10 +200,11 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
-    `command ran unchanged, and you were given its beginning and its end with ` +
-    `the middle omitted and marked. Those are the two ends that carry a ` +
-    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
-    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
+    `token-optimizer bounds this command's output: anything over ${maxBytes} ` +
+    `bytes is returned as its beginning and its end, with the middle dropped. ` +
+    `Shorter output is returned complete and untouched. The command itself ran ` +
+    `unchanged, and those two ends are where a run says what failed and how it ` +
+    `finished. Redirect the output to a file, or raise ` +
+    `TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/hooks-core/rewrite.mjs
+++ b/hooks-core/rewrite.mjs
@@ -49,10 +49,18 @@ export function boundBytes() {
  * same command with less output, and anything short of that is left alone.
  */
 function unsafeToBound(command) {
-  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
-  // relative to the braces. Getting this wrong corrupts the payload rather than
-  // failing loudly -- the same class of damage a greedy regex does to source.
-  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+  // EVERY `<<`, not a guess at the delimiter shape. A heredoc body is data, and
+  // wrapping it moves the terminator relative to the braces -- which corrupts
+  // the payload rather than failing loudly, the same class of damage a greedy
+  // regex does to source.
+  //
+  // The first version tried to match the delimiter (`<<-?\s*['"]?\w+`) and
+  // missed the ESCAPED form: `cat <<\EOF` was rewritten. Bash accepts several
+  // spellings -- bare, single-quoted, double-quoted, backslash-escaped, `<<-`,
+  // and with arbitrary spacing -- so enumerating them is a losing game. The
+  // operator itself is unambiguous. Herestrings (`<<<`) are swept up too: they
+  // would be safe to bound, and giving that up is the cheaper mistake.
+  if (/<</.test(command)) return 'heredoc';
 
   // Backgrounding detaches the process; a pipeline cannot bound what it no
   // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
@@ -67,9 +75,20 @@ function unsafeToBound(command) {
   if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
 
   // An interactive or streaming command has no meaningful tail, and buffering
-  // it through a pipe can hang.
-  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+  // it through a pipe does not merely waste effort -- it HANGS, because the
+  // wrapper's own `tail -c` cannot emit anything until EOF and follow mode
+  // never reaches EOF.
+  if (/\b(watch|less|more|vim|nano|top|htop)\b/.test(command)) {
     return 'interactive';
+  }
+
+  // FOLLOW MODE IN ANY SPELLING. Matching only `tail -f` left four working
+  // forms to hang: `tail -F`, `tail -n 100 -f`, `tail --follow` and
+  // `tail --follow=name`. The flag does not have to come first and does not
+  // have to be short, so the guard looks anywhere in the `tail` invocation --
+  // bounded to that command by stopping at a `;`, `|` or `&`.
+  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+    return 'follow-mode';
   }
 
   return null;

--- a/integrations/cline/hooks/token-optimizer/lib/policy.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/policy.mjs
@@ -701,6 +701,41 @@ export function allowWithContext(context) {
 }
 
 /**
+ * Lets the call run, but with a rewritten input -- the zero-turn alternative to
+ * a refusal.
+ *
+ * `updatedInput` is a real PreToolUse field and the rewritten call really runs;
+ * docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md has the end-to-end
+ * verification. This emitter is what makes it usable. A refusal costs about one
+ * extra turn, and turns are the whole measured deficit -- 12.6 to 20.9 under
+ * enforcement, for a task-mean 1.633x -- so a bound applied here is free where
+ * the same bound applied by refusing is not.
+ *
+ * The notice rides along as `additionalContext` rather than being baked into
+ * the command, so the command's own output is never mangled to carry a message.
+ *
+ * IT IS NOT OPTIONAL. The spike's model noticed an unannounced rewrite and
+ * distrusted the result -- "the output does not match the command ... I'm
+ * reporting what I actually received" -- and a model that distrusts its output
+ * re-runs the command, spending the exact turn this exists to save.
+ */
+export function allowWithRewrite(updatedInput, notice) {
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'allow',
+      permissionDecisionReason: 'token-optimizer bounded this output',
+      updatedInput,
+      ...(notice ? { additionalContext: withEscape(notice) } : {}),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
+  process.exit(0);
+}
+
+/**
  * Blocks the call and tells the model exactly what to call instead.
  *
  * The reason string is the whole user interface of this product for an agent.

--- a/integrations/cline/hooks/token-optimizer/lib/rewrite.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/rewrite.mjs
@@ -106,6 +106,18 @@ function unsafeToBound(command) {
  * wrapped so a shell without `pipefail` degrades to an unbounded-status
  * pipeline rather than erroring out before the command runs.
  *
+ * BUT IT MUST NOT LEAK INTO THE CALLER'S OWN PIPELINE. `pipefail` is a shell
+ * option, not a property of one pipe, so enabling it changed the meaning of any
+ * command that already contained a pipe: `false | true` exits 0 normally and
+ * exited 1 once wrapped. Silently changing a command's exit status is the same
+ * defect as masking one, in the other direction.
+ *
+ * The command therefore runs inside a subshell that restores the shell default
+ * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
+ * properties hold at once, and an explicit `set -o pipefail` written by the
+ * caller still takes effect, because it executes inside that subshell after
+ * the reset.
+ *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
  * turns a perfectly successful command into exit 141. Inside
@@ -156,7 +168,7 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}\n} 2>&1 | ` +
+      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; ` +
       `if IFS= read -r -N1 _tok_rest; then ` +
       `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +

--- a/integrations/cline/hooks/token-optimizer/lib/rewrite.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/rewrite.mjs
@@ -31,8 +31,9 @@
  * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
  * output is already bounded -- generously. This default is deliberately well
  * under it, because the family being targeted is the debug loop, where the SAME
- * wall of test output arrives on every iteration and the tail is the part that
- * says what failed.
+ * wall of test output arrives on every iteration. It is split evenly between
+ * the head and the tail of the output, which is where a run says what failed
+ * and how it ended.
  */
 export const DEFAULT_BOUND_BYTES = 8_000;
 
@@ -79,20 +80,19 @@ function unsafeToBound(command) {
 /**
  * The bounded form of a command, or null when it must be left alone.
  *
- * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
- * puts its verdict at the END -- the failure summary, the counts -- so the tail
- * is the part worth keeping. And `head` closes the pipe early, which sends
- * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
- * then report exit 141 and read as a failure. `tail` consumes its input, so the
- * real exit status survives.
- *
- * `pipefail` itself is what keeps the exit status honest. Without it the
- * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * `pipefail` is what keeps the exit status honest. Without it the pipeline
+ * reports the LAST stage's status, which is always 0, and every failing test
  * run would look like a passing one -- a far worse outcome than any number of
- * wasted tokens, because the model would stop debugging.
+ * wasted tokens, because the model would stop debugging. The `set -o` is
+ * wrapped so a shell without `pipefail` degrades to an unbounded-status
+ * pipeline rather than erroring out before the command runs.
  *
- * The `set -o` is wrapped so a shell without `pipefail` degrades to an
- * unbounded-status pipeline rather than erroring out before the command runs.
+ * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
+ * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
+ * turns a perfectly successful command into exit 141. Inside
+ * `{ head -c N; ...; tail -c N; }` the group keeps reading, so the producer is
+ * never signalled and the real status survives -- asserted by pushing `exit 3`
+ * and `exit 7` through it.
  */
 export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   if (typeof command !== 'string') return null;
@@ -102,10 +102,46 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const unsafe = unsafeToBound(trimmed);
   if (unsafe) return null;
 
+  // A NEWLINE BEFORE THE CLOSING BRACE, NEVER `; }`. Two ordinary commands
+  // broke under the semicolon form, both of which run fine unwrapped:
+  //
+  //   echo hi # explain   ->  { echo hi # explain; }   the `; }` is INSIDE the
+  //                           comment, so the group is never closed
+  //   echo hi;            ->  { echo hi;; }            `;;` is a syntax error
+  //
+  // A newline terminates a comment and satisfies bash's requirement for a
+  // separator before `}`, so it handles both. Breaking a command that would
+  // have worked is the worst thing this module can do -- worse than any number
+  // of tokens -- because the failure looks like the user's own command is wrong.
+  //
+  // HEAD *AND* TAIL, because the client's own truncation keeps both. Claude
+  // Code caps Bash output at 30,000 characters and truncates from the MIDDLE
+  // (its binary carries `... [N characters truncated] ...` and
+  // `truncate-middle`). A tail-only bound is cheaper AND drops the head, where
+  // a failing jest run lists WHICH suites failed -- so it could read as an
+  // improvement on cost while being a regression for the model.
+  //
+  // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
+  // then keeps the last half of what remains. Verified to preserve a non-zero
+  // exit status through both stages.
+  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
+  // "middle omitted" after a two-line command claims a truncation that never
+  // happened -- the same class of error as a reader reporting a windowed event
+  // log it did not actually window. A model told its output was cut will go
+  // looking for the rest, which costs the turn this whole module exists to save.
+  //
+  // `read -r -N1` is the test: it succeeds only if a byte remains after the
+  // head, which means there really is a middle. That byte is then printed back
+  // so it is not swallowed.
+  const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+      `{ ${trimmed}\n} 2>&1 | ` +
+      `{ head -c ${half}; ` +
+      `if IFS= read -r -N1 _tok_rest; then ` +
+      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
+      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
     maxBytes,
   };
 }
@@ -129,9 +165,10 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
-    `the command ran unchanged but only its tail reached you. The tail is ` +
-    `where a test run puts its verdict. Re-run with the output redirected to ` +
-    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
+    `command ran unchanged, and you were given its beginning and its end with ` +
+    `the middle omitted and marked. Those are the two ends that carry a ` +
+    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
+    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/integrations/cline/hooks/token-optimizer/lib/rewrite.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/rewrite.mjs
@@ -1,0 +1,137 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/rewrite.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Bounding a command's output instead of refusing the command.
+ *
+ * WHY THIS EXISTS. A refusal costs approximately ONE EXTRA TURN. Measured on
+ * the THOL battery, enforcement took turns from 12.6 to 20.9 and cost a
+ * task-mean 1.633x vanilla Claude Code -- last of fifteen -- while the same
+ * build without refusals measured 0.928. The tokens a refusal "saves" are
+ * smaller than the round trip it spends, so the mechanism, not the policy, is
+ * what loses.
+ *
+ * A PreToolUse hook can return `updatedInput`, and the rewritten call runs.
+ * Verified end to end (docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md):
+ * a hook that rewrote `echo PROBE_ORIGINAL` to `echo PROBE_REWRITTEN` produced
+ * PROBE_REWRITTEN in the model's context, with no refusal and no retry. So the
+ * same bound can be applied for zero turns.
+ *
+ * PostToolUse cannot do this. Its output schema carries only `additionalContext`
+ * and `classifierContext` -- there is no field that replaces a tool result --
+ * and it never fires for a failed call at all (4,499 of 4,499 live outcomes
+ * report success, every exit code null). Bounding has to happen BEFORE the
+ * command runs, which is also the only way it can reach the failing test runs a
+ * debug loop is made of.
+ */
+
+/**
+ * Default bound, in bytes.
+ *
+ * The client's own cap is the reference point: `BASH_MAX_OUTPUT_LENGTH`
+ * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
+ * output is already bounded -- generously. This default is deliberately well
+ * under it, because the family being targeted is the debug loop, where the SAME
+ * wall of test output arrives on every iteration and the tail is the part that
+ * says what failed.
+ */
+export const DEFAULT_BOUND_BYTES = 8_000;
+
+export function boundBytes() {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_BOUND_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_BOUND_BYTES;
+}
+
+/**
+ * Shapes that must never be rewritten.
+ *
+ * Every one of these is a case where wrapping the command changes what it
+ * MEANS, not just how much of it is shown. Rewriting is a silent mutation of
+ * somebody's command; the bar for doing it is that the result is unarguably the
+ * same command with less output, and anything short of that is left alone.
+ */
+function unsafeToBound(command) {
+  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
+  // relative to the braces. Getting this wrong corrupts the payload rather than
+  // failing loudly -- the same class of damage a greedy regex does to source.
+  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+
+  // Backgrounding detaches the process; a pipeline cannot bound what it no
+  // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
+  if (/(?<![&|>])&(?!&)/.test(command)) return 'background';
+
+  // stdout already going somewhere other than the model's context. Bounding it
+  // would change what lands in the FILE, which is the opposite of harmless.
+  if (/(?<![0-9])>>?\s*(?!&)\S/.test(command)) return 'redirected';
+
+  // Already bounded by its author. Re-bounding buys nothing and risks changing
+  // a deliberate `head -n 5` into something else.
+  if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
+
+  // An interactive or streaming command has no meaningful tail, and buffering
+  // it through a pipe can hang.
+  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+    return 'interactive';
+  }
+
+  return null;
+}
+
+/**
+ * The bounded form of a command, or null when it must be left alone.
+ *
+ * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
+ * puts its verdict at the END -- the failure summary, the counts -- so the tail
+ * is the part worth keeping. And `head` closes the pipe early, which sends
+ * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
+ * then report exit 141 and read as a failure. `tail` consumes its input, so the
+ * real exit status survives.
+ *
+ * `pipefail` itself is what keeps the exit status honest. Without it the
+ * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * run would look like a passing one -- a far worse outcome than any number of
+ * wasted tokens, because the model would stop debugging.
+ *
+ * The `set -o` is wrapped so a shell without `pipefail` degrades to an
+ * unbounded-status pipeline rather than erroring out before the command runs.
+ */
+export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
+  if (typeof command !== 'string') return null;
+  const trimmed = command.trim();
+  if (!trimmed) return null;
+
+  const unsafe = unsafeToBound(trimmed);
+  if (unsafe) return null;
+
+  return {
+    command:
+      `{ set -o pipefail; } 2>/dev/null; ` +
+      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+    maxBytes,
+  };
+}
+
+/**
+ * What the model is told, so the bound is never a silent mutation.
+ *
+ * THE PROBE'S OWN MODEL CAUGHT US DOING THIS. In the spike, a rewritten command
+ * produced output that did not match what had been asked for, and the model
+ * flagged it as suspicious rather than trusting it:
+ *
+ *   "the output does not match the command ... Something in this session's
+ *    tooling chain either rewrote the command before execution or rewrote the
+ *    result. I'm reporting what I actually received rather than the expected
+ *    string."
+ *
+ * A model that distrusts its own tool output re-runs the command, which spends
+ * exactly the turn this mechanism exists to save. So the rewrite announces
+ * itself, says what was kept, and says how to opt out -- compaction the agent
+ * cannot see is compaction it will fight.
+ */
+export function boundNotice(maxBytes) {
+  return (
+    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
+    `the command ran unchanged but only its tail reached you. The tail is ` +
+    `where a test run puts its verdict. Re-run with the output redirected to ` +
+    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+  );
+}

--- a/integrations/cline/hooks/token-optimizer/lib/rewrite.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/rewrite.mjs
@@ -155,24 +155,30 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
   // then keeps the last half of what remains. Verified to preserve a non-zero
   // exit status through both stages.
-  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
-  // "middle omitted" after a two-line command claims a truncation that never
-  // happened -- the same class of error as a reader reporting a windowed event
-  // log it did not actually window. A model told its output was cut will go
-  // looking for the rest, which costs the turn this whole module exists to save.
+  // NO IN-STREAM MARKER, AND NO PROBE. `{ head -c H; tail -c H; }` is already
+  // exact in every regime, which two earlier attempts at a marker were not:
   //
-  // `read -r -N1` is the test: it succeeds only if a byte remains after the
-  // head, which means there really is a middle. That byte is then printed back
-  // so it is not swallowed.
+  //   total <= half        head prints it all, tail has nothing  -> COMPLETE
+  //   half < total <= max  head takes half, tail takes the rest  -> COMPLETE
+  //   total > max          head takes half, tail takes the last  -> exactly max
+  //
+  // An unconditional marker lied whenever the output fitted. Gating it on
+  // `read -r -N1` narrowed the lie to the middle band above -- where the output
+  // is returned COMPLETE and the marker still claimed an omission -- and the
+  // probe also relied on a bash-only `read -N`, which a POSIX shell rejects,
+  // skipping the tail entirely and leaking an error to stderr.
+  //
+  // Both defects came from trying to detect truncation from inside a pipe,
+  // which cannot see a total it has not yet consumed. So the announcement moves
+  // to `boundNotice`, stated as the POLICY ("output over N bytes is bounded")
+  // rather than as a claim about this particular output. A policy statement is
+  // true whether or not this command was cut, so it cannot lie.
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
       `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
-      `{ head -c ${half}; ` +
-      `if IFS= read -r -N1 _tok_rest; then ` +
-      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
-      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
+      `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };
 }
@@ -196,10 +202,11 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
-    `command ran unchanged, and you were given its beginning and its end with ` +
-    `the middle omitted and marked. Those are the two ends that carry a ` +
-    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
-    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
+    `token-optimizer bounds this command's output: anything over ${maxBytes} ` +
+    `bytes is returned as its beginning and its end, with the middle dropped. ` +
+    `Shorter output is returned complete and untouched. The command itself ran ` +
+    `unchanged, and those two ends are where a run says what failed and how it ` +
+    `finished. Redirect the output to a file, or raise ` +
+    `TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/integrations/cline/hooks/token-optimizer/lib/rewrite.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/rewrite.mjs
@@ -89,7 +89,16 @@ function unsafeToBound(command) {
   // `tail --follow=name`. The flag does not have to come first and does not
   // have to be short, so the guard looks anywhere in the `tail` invocation --
   // bounded to that command by stopping at a `;`, `|` or `&`.
-  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+  // CLUSTERED SHORT OPTIONS TOO. GNU tail accepts `-fn 1` and `-fF`, and a
+  // guard anchored on `-f\b` matches neither, because the `\b` fails against
+  // the next clustered letter. Both keep following and never reach EOF, so the
+  // bound waits forever. The character class therefore looks for f or F
+  // ANYWHERE in a short-option cluster.
+  if (
+    /\btail\b[^;|&]*(\s-[a-zA-Z]*[fF][a-zA-Z]*\b|\s--follow\b|\s--follow=)/.test(
+      command
+    )
+  ) {
     return 'follow-mode';
   }
 
@@ -112,11 +121,19 @@ function unsafeToBound(command) {
  * exited 1 once wrapped. Silently changing a command's exit status is the same
  * defect as masking one, in the other direction.
  *
- * The command therefore runs inside a subshell that restores the shell default
- * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
- * properties hold at once, and an explicit `set -o pipefail` written by the
- * caller still takes effect, because it executes inside that subshell after
- * the reset.
+ * The command therefore runs inside a subshell that restores THE CALLER'S OWN
+ * state, while the OUTER pipeline -- ours -- keeps pipefail. `set +o` prints
+ * the current options in re-inputtable form, so the one `pipefail` line is
+ * captured before we change anything and eval'd back inside the subshell.
+ *
+ * Restoring rather than CLEARING, because clearing is the same bug mirrored: a
+ * caller running under `bash -o pipefail` would have had `false | true` return
+ * 1, and a hard `set +o pipefail` would hand them 0. Either direction is a
+ * silent change to an exit status we were only supposed to be bounding the
+ * output of.
+ *
+ * An explicit `set -o pipefail` written inside the command still takes effect,
+ * because it executes inside that subshell after the restore.
  *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
@@ -176,8 +193,9 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
+      `_tok_pf=$(set +o 2>/dev/null | grep pipefail); ` +
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
+      `( eval "$_tok_pf" 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };

--- a/integrations/cline/hooks/token-optimizer/lib/rewrite.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/rewrite.mjs
@@ -51,10 +51,18 @@ export function boundBytes() {
  * same command with less output, and anything short of that is left alone.
  */
 function unsafeToBound(command) {
-  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
-  // relative to the braces. Getting this wrong corrupts the payload rather than
-  // failing loudly -- the same class of damage a greedy regex does to source.
-  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+  // EVERY `<<`, not a guess at the delimiter shape. A heredoc body is data, and
+  // wrapping it moves the terminator relative to the braces -- which corrupts
+  // the payload rather than failing loudly, the same class of damage a greedy
+  // regex does to source.
+  //
+  // The first version tried to match the delimiter (`<<-?\s*['"]?\w+`) and
+  // missed the ESCAPED form: `cat <<\EOF` was rewritten. Bash accepts several
+  // spellings -- bare, single-quoted, double-quoted, backslash-escaped, `<<-`,
+  // and with arbitrary spacing -- so enumerating them is a losing game. The
+  // operator itself is unambiguous. Herestrings (`<<<`) are swept up too: they
+  // would be safe to bound, and giving that up is the cheaper mistake.
+  if (/<</.test(command)) return 'heredoc';
 
   // Backgrounding detaches the process; a pipeline cannot bound what it no
   // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
@@ -69,9 +77,20 @@ function unsafeToBound(command) {
   if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
 
   // An interactive or streaming command has no meaningful tail, and buffering
-  // it through a pipe can hang.
-  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+  // it through a pipe does not merely waste effort -- it HANGS, because the
+  // wrapper's own `tail -c` cannot emit anything until EOF and follow mode
+  // never reaches EOF.
+  if (/\b(watch|less|more|vim|nano|top|htop)\b/.test(command)) {
     return 'interactive';
+  }
+
+  // FOLLOW MODE IN ANY SPELLING. Matching only `tail -f` left four working
+  // forms to hang: `tail -F`, `tail -n 100 -f`, `tail --follow` and
+  // `tail --follow=name`. The flag does not have to come first and does not
+  // have to be short, so the guard looks anywhere in the `tail` invocation --
+  // bounded to that command by stopping at a `;`, `|` or `&`.
+  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+    return 'follow-mode';
   }
 
   return null;

--- a/integrations/codex/hooks/lib/policy.mjs
+++ b/integrations/codex/hooks/lib/policy.mjs
@@ -701,6 +701,41 @@ export function allowWithContext(context) {
 }
 
 /**
+ * Lets the call run, but with a rewritten input -- the zero-turn alternative to
+ * a refusal.
+ *
+ * `updatedInput` is a real PreToolUse field and the rewritten call really runs;
+ * docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md has the end-to-end
+ * verification. This emitter is what makes it usable. A refusal costs about one
+ * extra turn, and turns are the whole measured deficit -- 12.6 to 20.9 under
+ * enforcement, for a task-mean 1.633x -- so a bound applied here is free where
+ * the same bound applied by refusing is not.
+ *
+ * The notice rides along as `additionalContext` rather than being baked into
+ * the command, so the command's own output is never mangled to carry a message.
+ *
+ * IT IS NOT OPTIONAL. The spike's model noticed an unannounced rewrite and
+ * distrusted the result -- "the output does not match the command ... I'm
+ * reporting what I actually received" -- and a model that distrusts its output
+ * re-runs the command, spending the exact turn this exists to save.
+ */
+export function allowWithRewrite(updatedInput, notice) {
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'allow',
+      permissionDecisionReason: 'token-optimizer bounded this output',
+      updatedInput,
+      ...(notice ? { additionalContext: withEscape(notice) } : {}),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
+  process.exit(0);
+}
+
+/**
  * Blocks the call and tells the model exactly what to call instead.
  *
  * The reason string is the whole user interface of this product for an agent.

--- a/integrations/codex/hooks/lib/rewrite.mjs
+++ b/integrations/codex/hooks/lib/rewrite.mjs
@@ -106,6 +106,18 @@ function unsafeToBound(command) {
  * wrapped so a shell without `pipefail` degrades to an unbounded-status
  * pipeline rather than erroring out before the command runs.
  *
+ * BUT IT MUST NOT LEAK INTO THE CALLER'S OWN PIPELINE. `pipefail` is a shell
+ * option, not a property of one pipe, so enabling it changed the meaning of any
+ * command that already contained a pipe: `false | true` exits 0 normally and
+ * exited 1 once wrapped. Silently changing a command's exit status is the same
+ * defect as masking one, in the other direction.
+ *
+ * The command therefore runs inside a subshell that restores the shell default
+ * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
+ * properties hold at once, and an explicit `set -o pipefail` written by the
+ * caller still takes effect, because it executes inside that subshell after
+ * the reset.
+ *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
  * turns a perfectly successful command into exit 141. Inside
@@ -156,7 +168,7 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}\n} 2>&1 | ` +
+      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; ` +
       `if IFS= read -r -N1 _tok_rest; then ` +
       `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +

--- a/integrations/codex/hooks/lib/rewrite.mjs
+++ b/integrations/codex/hooks/lib/rewrite.mjs
@@ -31,8 +31,9 @@
  * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
  * output is already bounded -- generously. This default is deliberately well
  * under it, because the family being targeted is the debug loop, where the SAME
- * wall of test output arrives on every iteration and the tail is the part that
- * says what failed.
+ * wall of test output arrives on every iteration. It is split evenly between
+ * the head and the tail of the output, which is where a run says what failed
+ * and how it ended.
  */
 export const DEFAULT_BOUND_BYTES = 8_000;
 
@@ -79,20 +80,19 @@ function unsafeToBound(command) {
 /**
  * The bounded form of a command, or null when it must be left alone.
  *
- * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
- * puts its verdict at the END -- the failure summary, the counts -- so the tail
- * is the part worth keeping. And `head` closes the pipe early, which sends
- * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
- * then report exit 141 and read as a failure. `tail` consumes its input, so the
- * real exit status survives.
- *
- * `pipefail` itself is what keeps the exit status honest. Without it the
- * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * `pipefail` is what keeps the exit status honest. Without it the pipeline
+ * reports the LAST stage's status, which is always 0, and every failing test
  * run would look like a passing one -- a far worse outcome than any number of
- * wasted tokens, because the model would stop debugging.
+ * wasted tokens, because the model would stop debugging. The `set -o` is
+ * wrapped so a shell without `pipefail` degrades to an unbounded-status
+ * pipeline rather than erroring out before the command runs.
  *
- * The `set -o` is wrapped so a shell without `pipefail` degrades to an
- * unbounded-status pipeline rather than erroring out before the command runs.
+ * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
+ * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
+ * turns a perfectly successful command into exit 141. Inside
+ * `{ head -c N; ...; tail -c N; }` the group keeps reading, so the producer is
+ * never signalled and the real status survives -- asserted by pushing `exit 3`
+ * and `exit 7` through it.
  */
 export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   if (typeof command !== 'string') return null;
@@ -102,10 +102,46 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const unsafe = unsafeToBound(trimmed);
   if (unsafe) return null;
 
+  // A NEWLINE BEFORE THE CLOSING BRACE, NEVER `; }`. Two ordinary commands
+  // broke under the semicolon form, both of which run fine unwrapped:
+  //
+  //   echo hi # explain   ->  { echo hi # explain; }   the `; }` is INSIDE the
+  //                           comment, so the group is never closed
+  //   echo hi;            ->  { echo hi;; }            `;;` is a syntax error
+  //
+  // A newline terminates a comment and satisfies bash's requirement for a
+  // separator before `}`, so it handles both. Breaking a command that would
+  // have worked is the worst thing this module can do -- worse than any number
+  // of tokens -- because the failure looks like the user's own command is wrong.
+  //
+  // HEAD *AND* TAIL, because the client's own truncation keeps both. Claude
+  // Code caps Bash output at 30,000 characters and truncates from the MIDDLE
+  // (its binary carries `... [N characters truncated] ...` and
+  // `truncate-middle`). A tail-only bound is cheaper AND drops the head, where
+  // a failing jest run lists WHICH suites failed -- so it could read as an
+  // improvement on cost while being a regression for the model.
+  //
+  // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
+  // then keeps the last half of what remains. Verified to preserve a non-zero
+  // exit status through both stages.
+  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
+  // "middle omitted" after a two-line command claims a truncation that never
+  // happened -- the same class of error as a reader reporting a windowed event
+  // log it did not actually window. A model told its output was cut will go
+  // looking for the rest, which costs the turn this whole module exists to save.
+  //
+  // `read -r -N1` is the test: it succeeds only if a byte remains after the
+  // head, which means there really is a middle. That byte is then printed back
+  // so it is not swallowed.
+  const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+      `{ ${trimmed}\n} 2>&1 | ` +
+      `{ head -c ${half}; ` +
+      `if IFS= read -r -N1 _tok_rest; then ` +
+      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
+      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
     maxBytes,
   };
 }
@@ -129,9 +165,10 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
-    `the command ran unchanged but only its tail reached you. The tail is ` +
-    `where a test run puts its verdict. Re-run with the output redirected to ` +
-    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
+    `command ran unchanged, and you were given its beginning and its end with ` +
+    `the middle omitted and marked. Those are the two ends that carry a ` +
+    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
+    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/integrations/codex/hooks/lib/rewrite.mjs
+++ b/integrations/codex/hooks/lib/rewrite.mjs
@@ -1,0 +1,137 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/rewrite.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Bounding a command's output instead of refusing the command.
+ *
+ * WHY THIS EXISTS. A refusal costs approximately ONE EXTRA TURN. Measured on
+ * the THOL battery, enforcement took turns from 12.6 to 20.9 and cost a
+ * task-mean 1.633x vanilla Claude Code -- last of fifteen -- while the same
+ * build without refusals measured 0.928. The tokens a refusal "saves" are
+ * smaller than the round trip it spends, so the mechanism, not the policy, is
+ * what loses.
+ *
+ * A PreToolUse hook can return `updatedInput`, and the rewritten call runs.
+ * Verified end to end (docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md):
+ * a hook that rewrote `echo PROBE_ORIGINAL` to `echo PROBE_REWRITTEN` produced
+ * PROBE_REWRITTEN in the model's context, with no refusal and no retry. So the
+ * same bound can be applied for zero turns.
+ *
+ * PostToolUse cannot do this. Its output schema carries only `additionalContext`
+ * and `classifierContext` -- there is no field that replaces a tool result --
+ * and it never fires for a failed call at all (4,499 of 4,499 live outcomes
+ * report success, every exit code null). Bounding has to happen BEFORE the
+ * command runs, which is also the only way it can reach the failing test runs a
+ * debug loop is made of.
+ */
+
+/**
+ * Default bound, in bytes.
+ *
+ * The client's own cap is the reference point: `BASH_MAX_OUTPUT_LENGTH`
+ * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
+ * output is already bounded -- generously. This default is deliberately well
+ * under it, because the family being targeted is the debug loop, where the SAME
+ * wall of test output arrives on every iteration and the tail is the part that
+ * says what failed.
+ */
+export const DEFAULT_BOUND_BYTES = 8_000;
+
+export function boundBytes() {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_BOUND_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_BOUND_BYTES;
+}
+
+/**
+ * Shapes that must never be rewritten.
+ *
+ * Every one of these is a case where wrapping the command changes what it
+ * MEANS, not just how much of it is shown. Rewriting is a silent mutation of
+ * somebody's command; the bar for doing it is that the result is unarguably the
+ * same command with less output, and anything short of that is left alone.
+ */
+function unsafeToBound(command) {
+  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
+  // relative to the braces. Getting this wrong corrupts the payload rather than
+  // failing loudly -- the same class of damage a greedy regex does to source.
+  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+
+  // Backgrounding detaches the process; a pipeline cannot bound what it no
+  // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
+  if (/(?<![&|>])&(?!&)/.test(command)) return 'background';
+
+  // stdout already going somewhere other than the model's context. Bounding it
+  // would change what lands in the FILE, which is the opposite of harmless.
+  if (/(?<![0-9])>>?\s*(?!&)\S/.test(command)) return 'redirected';
+
+  // Already bounded by its author. Re-bounding buys nothing and risks changing
+  // a deliberate `head -n 5` into something else.
+  if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
+
+  // An interactive or streaming command has no meaningful tail, and buffering
+  // it through a pipe can hang.
+  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+    return 'interactive';
+  }
+
+  return null;
+}
+
+/**
+ * The bounded form of a command, or null when it must be left alone.
+ *
+ * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
+ * puts its verdict at the END -- the failure summary, the counts -- so the tail
+ * is the part worth keeping. And `head` closes the pipe early, which sends
+ * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
+ * then report exit 141 and read as a failure. `tail` consumes its input, so the
+ * real exit status survives.
+ *
+ * `pipefail` itself is what keeps the exit status honest. Without it the
+ * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * run would look like a passing one -- a far worse outcome than any number of
+ * wasted tokens, because the model would stop debugging.
+ *
+ * The `set -o` is wrapped so a shell without `pipefail` degrades to an
+ * unbounded-status pipeline rather than erroring out before the command runs.
+ */
+export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
+  if (typeof command !== 'string') return null;
+  const trimmed = command.trim();
+  if (!trimmed) return null;
+
+  const unsafe = unsafeToBound(trimmed);
+  if (unsafe) return null;
+
+  return {
+    command:
+      `{ set -o pipefail; } 2>/dev/null; ` +
+      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+    maxBytes,
+  };
+}
+
+/**
+ * What the model is told, so the bound is never a silent mutation.
+ *
+ * THE PROBE'S OWN MODEL CAUGHT US DOING THIS. In the spike, a rewritten command
+ * produced output that did not match what had been asked for, and the model
+ * flagged it as suspicious rather than trusting it:
+ *
+ *   "the output does not match the command ... Something in this session's
+ *    tooling chain either rewrote the command before execution or rewrote the
+ *    result. I'm reporting what I actually received rather than the expected
+ *    string."
+ *
+ * A model that distrusts its own tool output re-runs the command, which spends
+ * exactly the turn this mechanism exists to save. So the rewrite announces
+ * itself, says what was kept, and says how to opt out -- compaction the agent
+ * cannot see is compaction it will fight.
+ */
+export function boundNotice(maxBytes) {
+  return (
+    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
+    `the command ran unchanged but only its tail reached you. The tail is ` +
+    `where a test run puts its verdict. Re-run with the output redirected to ` +
+    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+  );
+}

--- a/integrations/codex/hooks/lib/rewrite.mjs
+++ b/integrations/codex/hooks/lib/rewrite.mjs
@@ -155,24 +155,30 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
   // then keeps the last half of what remains. Verified to preserve a non-zero
   // exit status through both stages.
-  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
-  // "middle omitted" after a two-line command claims a truncation that never
-  // happened -- the same class of error as a reader reporting a windowed event
-  // log it did not actually window. A model told its output was cut will go
-  // looking for the rest, which costs the turn this whole module exists to save.
+  // NO IN-STREAM MARKER, AND NO PROBE. `{ head -c H; tail -c H; }` is already
+  // exact in every regime, which two earlier attempts at a marker were not:
   //
-  // `read -r -N1` is the test: it succeeds only if a byte remains after the
-  // head, which means there really is a middle. That byte is then printed back
-  // so it is not swallowed.
+  //   total <= half        head prints it all, tail has nothing  -> COMPLETE
+  //   half < total <= max  head takes half, tail takes the rest  -> COMPLETE
+  //   total > max          head takes half, tail takes the last  -> exactly max
+  //
+  // An unconditional marker lied whenever the output fitted. Gating it on
+  // `read -r -N1` narrowed the lie to the middle band above -- where the output
+  // is returned COMPLETE and the marker still claimed an omission -- and the
+  // probe also relied on a bash-only `read -N`, which a POSIX shell rejects,
+  // skipping the tail entirely and leaking an error to stderr.
+  //
+  // Both defects came from trying to detect truncation from inside a pipe,
+  // which cannot see a total it has not yet consumed. So the announcement moves
+  // to `boundNotice`, stated as the POLICY ("output over N bytes is bounded")
+  // rather than as a claim about this particular output. A policy statement is
+  // true whether or not this command was cut, so it cannot lie.
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
       `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
-      `{ head -c ${half}; ` +
-      `if IFS= read -r -N1 _tok_rest; then ` +
-      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
-      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
+      `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };
 }
@@ -196,10 +202,11 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
-    `command ran unchanged, and you were given its beginning and its end with ` +
-    `the middle omitted and marked. Those are the two ends that carry a ` +
-    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
-    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
+    `token-optimizer bounds this command's output: anything over ${maxBytes} ` +
+    `bytes is returned as its beginning and its end, with the middle dropped. ` +
+    `Shorter output is returned complete and untouched. The command itself ran ` +
+    `unchanged, and those two ends are where a run says what failed and how it ` +
+    `finished. Redirect the output to a file, or raise ` +
+    `TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/integrations/codex/hooks/lib/rewrite.mjs
+++ b/integrations/codex/hooks/lib/rewrite.mjs
@@ -89,7 +89,16 @@ function unsafeToBound(command) {
   // `tail --follow=name`. The flag does not have to come first and does not
   // have to be short, so the guard looks anywhere in the `tail` invocation --
   // bounded to that command by stopping at a `;`, `|` or `&`.
-  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+  // CLUSTERED SHORT OPTIONS TOO. GNU tail accepts `-fn 1` and `-fF`, and a
+  // guard anchored on `-f\b` matches neither, because the `\b` fails against
+  // the next clustered letter. Both keep following and never reach EOF, so the
+  // bound waits forever. The character class therefore looks for f or F
+  // ANYWHERE in a short-option cluster.
+  if (
+    /\btail\b[^;|&]*(\s-[a-zA-Z]*[fF][a-zA-Z]*\b|\s--follow\b|\s--follow=)/.test(
+      command
+    )
+  ) {
     return 'follow-mode';
   }
 
@@ -112,11 +121,19 @@ function unsafeToBound(command) {
  * exited 1 once wrapped. Silently changing a command's exit status is the same
  * defect as masking one, in the other direction.
  *
- * The command therefore runs inside a subshell that restores the shell default
- * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
- * properties hold at once, and an explicit `set -o pipefail` written by the
- * caller still takes effect, because it executes inside that subshell after
- * the reset.
+ * The command therefore runs inside a subshell that restores THE CALLER'S OWN
+ * state, while the OUTER pipeline -- ours -- keeps pipefail. `set +o` prints
+ * the current options in re-inputtable form, so the one `pipefail` line is
+ * captured before we change anything and eval'd back inside the subshell.
+ *
+ * Restoring rather than CLEARING, because clearing is the same bug mirrored: a
+ * caller running under `bash -o pipefail` would have had `false | true` return
+ * 1, and a hard `set +o pipefail` would hand them 0. Either direction is a
+ * silent change to an exit status we were only supposed to be bounding the
+ * output of.
+ *
+ * An explicit `set -o pipefail` written inside the command still takes effect,
+ * because it executes inside that subshell after the restore.
  *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
@@ -176,8 +193,9 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
+      `_tok_pf=$(set +o 2>/dev/null | grep pipefail); ` +
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
+      `( eval "$_tok_pf" 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };

--- a/integrations/codex/hooks/lib/rewrite.mjs
+++ b/integrations/codex/hooks/lib/rewrite.mjs
@@ -51,10 +51,18 @@ export function boundBytes() {
  * same command with less output, and anything short of that is left alone.
  */
 function unsafeToBound(command) {
-  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
-  // relative to the braces. Getting this wrong corrupts the payload rather than
-  // failing loudly -- the same class of damage a greedy regex does to source.
-  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+  // EVERY `<<`, not a guess at the delimiter shape. A heredoc body is data, and
+  // wrapping it moves the terminator relative to the braces -- which corrupts
+  // the payload rather than failing loudly, the same class of damage a greedy
+  // regex does to source.
+  //
+  // The first version tried to match the delimiter (`<<-?\s*['"]?\w+`) and
+  // missed the ESCAPED form: `cat <<\EOF` was rewritten. Bash accepts several
+  // spellings -- bare, single-quoted, double-quoted, backslash-escaped, `<<-`,
+  // and with arbitrary spacing -- so enumerating them is a losing game. The
+  // operator itself is unambiguous. Herestrings (`<<<`) are swept up too: they
+  // would be safe to bound, and giving that up is the cheaper mistake.
+  if (/<</.test(command)) return 'heredoc';
 
   // Backgrounding detaches the process; a pipeline cannot bound what it no
   // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
@@ -69,9 +77,20 @@ function unsafeToBound(command) {
   if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
 
   // An interactive or streaming command has no meaningful tail, and buffering
-  // it through a pipe can hang.
-  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+  // it through a pipe does not merely waste effort -- it HANGS, because the
+  // wrapper's own `tail -c` cannot emit anything until EOF and follow mode
+  // never reaches EOF.
+  if (/\b(watch|less|more|vim|nano|top|htop)\b/.test(command)) {
     return 'interactive';
+  }
+
+  // FOLLOW MODE IN ANY SPELLING. Matching only `tail -f` left four working
+  // forms to hang: `tail -F`, `tail -n 100 -f`, `tail --follow` and
+  // `tail --follow=name`. The flag does not have to come first and does not
+  // have to be short, so the guard looks anywhere in the `tail` invocation --
+  // bounded to that command by stopping at a `;`, `|` or `&`.
+  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+    return 'follow-mode';
   }
 
   return null;

--- a/integrations/codex/plugin/hooks/lib/policy.mjs
+++ b/integrations/codex/plugin/hooks/lib/policy.mjs
@@ -701,6 +701,41 @@ export function allowWithContext(context) {
 }
 
 /**
+ * Lets the call run, but with a rewritten input -- the zero-turn alternative to
+ * a refusal.
+ *
+ * `updatedInput` is a real PreToolUse field and the rewritten call really runs;
+ * docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md has the end-to-end
+ * verification. This emitter is what makes it usable. A refusal costs about one
+ * extra turn, and turns are the whole measured deficit -- 12.6 to 20.9 under
+ * enforcement, for a task-mean 1.633x -- so a bound applied here is free where
+ * the same bound applied by refusing is not.
+ *
+ * The notice rides along as `additionalContext` rather than being baked into
+ * the command, so the command's own output is never mangled to carry a message.
+ *
+ * IT IS NOT OPTIONAL. The spike's model noticed an unannounced rewrite and
+ * distrusted the result -- "the output does not match the command ... I'm
+ * reporting what I actually received" -- and a model that distrusts its output
+ * re-runs the command, spending the exact turn this exists to save.
+ */
+export function allowWithRewrite(updatedInput, notice) {
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'allow',
+      permissionDecisionReason: 'token-optimizer bounded this output',
+      updatedInput,
+      ...(notice ? { additionalContext: withEscape(notice) } : {}),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
+  process.exit(0);
+}
+
+/**
  * Blocks the call and tells the model exactly what to call instead.
  *
  * The reason string is the whole user interface of this product for an agent.

--- a/integrations/codex/plugin/hooks/lib/rewrite.mjs
+++ b/integrations/codex/plugin/hooks/lib/rewrite.mjs
@@ -106,6 +106,18 @@ function unsafeToBound(command) {
  * wrapped so a shell without `pipefail` degrades to an unbounded-status
  * pipeline rather than erroring out before the command runs.
  *
+ * BUT IT MUST NOT LEAK INTO THE CALLER'S OWN PIPELINE. `pipefail` is a shell
+ * option, not a property of one pipe, so enabling it changed the meaning of any
+ * command that already contained a pipe: `false | true` exits 0 normally and
+ * exited 1 once wrapped. Silently changing a command's exit status is the same
+ * defect as masking one, in the other direction.
+ *
+ * The command therefore runs inside a subshell that restores the shell default
+ * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
+ * properties hold at once, and an explicit `set -o pipefail` written by the
+ * caller still takes effect, because it executes inside that subshell after
+ * the reset.
+ *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
  * turns a perfectly successful command into exit 141. Inside
@@ -156,7 +168,7 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}\n} 2>&1 | ` +
+      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; ` +
       `if IFS= read -r -N1 _tok_rest; then ` +
       `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +

--- a/integrations/codex/plugin/hooks/lib/rewrite.mjs
+++ b/integrations/codex/plugin/hooks/lib/rewrite.mjs
@@ -31,8 +31,9 @@
  * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
  * output is already bounded -- generously. This default is deliberately well
  * under it, because the family being targeted is the debug loop, where the SAME
- * wall of test output arrives on every iteration and the tail is the part that
- * says what failed.
+ * wall of test output arrives on every iteration. It is split evenly between
+ * the head and the tail of the output, which is where a run says what failed
+ * and how it ended.
  */
 export const DEFAULT_BOUND_BYTES = 8_000;
 
@@ -79,20 +80,19 @@ function unsafeToBound(command) {
 /**
  * The bounded form of a command, or null when it must be left alone.
  *
- * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
- * puts its verdict at the END -- the failure summary, the counts -- so the tail
- * is the part worth keeping. And `head` closes the pipe early, which sends
- * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
- * then report exit 141 and read as a failure. `tail` consumes its input, so the
- * real exit status survives.
- *
- * `pipefail` itself is what keeps the exit status honest. Without it the
- * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * `pipefail` is what keeps the exit status honest. Without it the pipeline
+ * reports the LAST stage's status, which is always 0, and every failing test
  * run would look like a passing one -- a far worse outcome than any number of
- * wasted tokens, because the model would stop debugging.
+ * wasted tokens, because the model would stop debugging. The `set -o` is
+ * wrapped so a shell without `pipefail` degrades to an unbounded-status
+ * pipeline rather than erroring out before the command runs.
  *
- * The `set -o` is wrapped so a shell without `pipefail` degrades to an
- * unbounded-status pipeline rather than erroring out before the command runs.
+ * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
+ * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
+ * turns a perfectly successful command into exit 141. Inside
+ * `{ head -c N; ...; tail -c N; }` the group keeps reading, so the producer is
+ * never signalled and the real status survives -- asserted by pushing `exit 3`
+ * and `exit 7` through it.
  */
 export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   if (typeof command !== 'string') return null;
@@ -102,10 +102,46 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const unsafe = unsafeToBound(trimmed);
   if (unsafe) return null;
 
+  // A NEWLINE BEFORE THE CLOSING BRACE, NEVER `; }`. Two ordinary commands
+  // broke under the semicolon form, both of which run fine unwrapped:
+  //
+  //   echo hi # explain   ->  { echo hi # explain; }   the `; }` is INSIDE the
+  //                           comment, so the group is never closed
+  //   echo hi;            ->  { echo hi;; }            `;;` is a syntax error
+  //
+  // A newline terminates a comment and satisfies bash's requirement for a
+  // separator before `}`, so it handles both. Breaking a command that would
+  // have worked is the worst thing this module can do -- worse than any number
+  // of tokens -- because the failure looks like the user's own command is wrong.
+  //
+  // HEAD *AND* TAIL, because the client's own truncation keeps both. Claude
+  // Code caps Bash output at 30,000 characters and truncates from the MIDDLE
+  // (its binary carries `... [N characters truncated] ...` and
+  // `truncate-middle`). A tail-only bound is cheaper AND drops the head, where
+  // a failing jest run lists WHICH suites failed -- so it could read as an
+  // improvement on cost while being a regression for the model.
+  //
+  // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
+  // then keeps the last half of what remains. Verified to preserve a non-zero
+  // exit status through both stages.
+  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
+  // "middle omitted" after a two-line command claims a truncation that never
+  // happened -- the same class of error as a reader reporting a windowed event
+  // log it did not actually window. A model told its output was cut will go
+  // looking for the rest, which costs the turn this whole module exists to save.
+  //
+  // `read -r -N1` is the test: it succeeds only if a byte remains after the
+  // head, which means there really is a middle. That byte is then printed back
+  // so it is not swallowed.
+  const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+      `{ ${trimmed}\n} 2>&1 | ` +
+      `{ head -c ${half}; ` +
+      `if IFS= read -r -N1 _tok_rest; then ` +
+      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
+      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
     maxBytes,
   };
 }
@@ -129,9 +165,10 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
-    `the command ran unchanged but only its tail reached you. The tail is ` +
-    `where a test run puts its verdict. Re-run with the output redirected to ` +
-    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
+    `command ran unchanged, and you were given its beginning and its end with ` +
+    `the middle omitted and marked. Those are the two ends that carry a ` +
+    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
+    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/integrations/codex/plugin/hooks/lib/rewrite.mjs
+++ b/integrations/codex/plugin/hooks/lib/rewrite.mjs
@@ -1,0 +1,137 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/rewrite.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Bounding a command's output instead of refusing the command.
+ *
+ * WHY THIS EXISTS. A refusal costs approximately ONE EXTRA TURN. Measured on
+ * the THOL battery, enforcement took turns from 12.6 to 20.9 and cost a
+ * task-mean 1.633x vanilla Claude Code -- last of fifteen -- while the same
+ * build without refusals measured 0.928. The tokens a refusal "saves" are
+ * smaller than the round trip it spends, so the mechanism, not the policy, is
+ * what loses.
+ *
+ * A PreToolUse hook can return `updatedInput`, and the rewritten call runs.
+ * Verified end to end (docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md):
+ * a hook that rewrote `echo PROBE_ORIGINAL` to `echo PROBE_REWRITTEN` produced
+ * PROBE_REWRITTEN in the model's context, with no refusal and no retry. So the
+ * same bound can be applied for zero turns.
+ *
+ * PostToolUse cannot do this. Its output schema carries only `additionalContext`
+ * and `classifierContext` -- there is no field that replaces a tool result --
+ * and it never fires for a failed call at all (4,499 of 4,499 live outcomes
+ * report success, every exit code null). Bounding has to happen BEFORE the
+ * command runs, which is also the only way it can reach the failing test runs a
+ * debug loop is made of.
+ */
+
+/**
+ * Default bound, in bytes.
+ *
+ * The client's own cap is the reference point: `BASH_MAX_OUTPUT_LENGTH`
+ * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
+ * output is already bounded -- generously. This default is deliberately well
+ * under it, because the family being targeted is the debug loop, where the SAME
+ * wall of test output arrives on every iteration and the tail is the part that
+ * says what failed.
+ */
+export const DEFAULT_BOUND_BYTES = 8_000;
+
+export function boundBytes() {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_BOUND_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_BOUND_BYTES;
+}
+
+/**
+ * Shapes that must never be rewritten.
+ *
+ * Every one of these is a case where wrapping the command changes what it
+ * MEANS, not just how much of it is shown. Rewriting is a silent mutation of
+ * somebody's command; the bar for doing it is that the result is unarguably the
+ * same command with less output, and anything short of that is left alone.
+ */
+function unsafeToBound(command) {
+  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
+  // relative to the braces. Getting this wrong corrupts the payload rather than
+  // failing loudly -- the same class of damage a greedy regex does to source.
+  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+
+  // Backgrounding detaches the process; a pipeline cannot bound what it no
+  // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
+  if (/(?<![&|>])&(?!&)/.test(command)) return 'background';
+
+  // stdout already going somewhere other than the model's context. Bounding it
+  // would change what lands in the FILE, which is the opposite of harmless.
+  if (/(?<![0-9])>>?\s*(?!&)\S/.test(command)) return 'redirected';
+
+  // Already bounded by its author. Re-bounding buys nothing and risks changing
+  // a deliberate `head -n 5` into something else.
+  if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
+
+  // An interactive or streaming command has no meaningful tail, and buffering
+  // it through a pipe can hang.
+  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+    return 'interactive';
+  }
+
+  return null;
+}
+
+/**
+ * The bounded form of a command, or null when it must be left alone.
+ *
+ * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
+ * puts its verdict at the END -- the failure summary, the counts -- so the tail
+ * is the part worth keeping. And `head` closes the pipe early, which sends
+ * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
+ * then report exit 141 and read as a failure. `tail` consumes its input, so the
+ * real exit status survives.
+ *
+ * `pipefail` itself is what keeps the exit status honest. Without it the
+ * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * run would look like a passing one -- a far worse outcome than any number of
+ * wasted tokens, because the model would stop debugging.
+ *
+ * The `set -o` is wrapped so a shell without `pipefail` degrades to an
+ * unbounded-status pipeline rather than erroring out before the command runs.
+ */
+export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
+  if (typeof command !== 'string') return null;
+  const trimmed = command.trim();
+  if (!trimmed) return null;
+
+  const unsafe = unsafeToBound(trimmed);
+  if (unsafe) return null;
+
+  return {
+    command:
+      `{ set -o pipefail; } 2>/dev/null; ` +
+      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+    maxBytes,
+  };
+}
+
+/**
+ * What the model is told, so the bound is never a silent mutation.
+ *
+ * THE PROBE'S OWN MODEL CAUGHT US DOING THIS. In the spike, a rewritten command
+ * produced output that did not match what had been asked for, and the model
+ * flagged it as suspicious rather than trusting it:
+ *
+ *   "the output does not match the command ... Something in this session's
+ *    tooling chain either rewrote the command before execution or rewrote the
+ *    result. I'm reporting what I actually received rather than the expected
+ *    string."
+ *
+ * A model that distrusts its own tool output re-runs the command, which spends
+ * exactly the turn this mechanism exists to save. So the rewrite announces
+ * itself, says what was kept, and says how to opt out -- compaction the agent
+ * cannot see is compaction it will fight.
+ */
+export function boundNotice(maxBytes) {
+  return (
+    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
+    `the command ran unchanged but only its tail reached you. The tail is ` +
+    `where a test run puts its verdict. Re-run with the output redirected to ` +
+    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+  );
+}

--- a/integrations/codex/plugin/hooks/lib/rewrite.mjs
+++ b/integrations/codex/plugin/hooks/lib/rewrite.mjs
@@ -155,24 +155,30 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
   // then keeps the last half of what remains. Verified to preserve a non-zero
   // exit status through both stages.
-  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
-  // "middle omitted" after a two-line command claims a truncation that never
-  // happened -- the same class of error as a reader reporting a windowed event
-  // log it did not actually window. A model told its output was cut will go
-  // looking for the rest, which costs the turn this whole module exists to save.
+  // NO IN-STREAM MARKER, AND NO PROBE. `{ head -c H; tail -c H; }` is already
+  // exact in every regime, which two earlier attempts at a marker were not:
   //
-  // `read -r -N1` is the test: it succeeds only if a byte remains after the
-  // head, which means there really is a middle. That byte is then printed back
-  // so it is not swallowed.
+  //   total <= half        head prints it all, tail has nothing  -> COMPLETE
+  //   half < total <= max  head takes half, tail takes the rest  -> COMPLETE
+  //   total > max          head takes half, tail takes the last  -> exactly max
+  //
+  // An unconditional marker lied whenever the output fitted. Gating it on
+  // `read -r -N1` narrowed the lie to the middle band above -- where the output
+  // is returned COMPLETE and the marker still claimed an omission -- and the
+  // probe also relied on a bash-only `read -N`, which a POSIX shell rejects,
+  // skipping the tail entirely and leaking an error to stderr.
+  //
+  // Both defects came from trying to detect truncation from inside a pipe,
+  // which cannot see a total it has not yet consumed. So the announcement moves
+  // to `boundNotice`, stated as the POLICY ("output over N bytes is bounded")
+  // rather than as a claim about this particular output. A policy statement is
+  // true whether or not this command was cut, so it cannot lie.
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
       `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
-      `{ head -c ${half}; ` +
-      `if IFS= read -r -N1 _tok_rest; then ` +
-      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
-      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
+      `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };
 }
@@ -196,10 +202,11 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
-    `command ran unchanged, and you were given its beginning and its end with ` +
-    `the middle omitted and marked. Those are the two ends that carry a ` +
-    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
-    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
+    `token-optimizer bounds this command's output: anything over ${maxBytes} ` +
+    `bytes is returned as its beginning and its end, with the middle dropped. ` +
+    `Shorter output is returned complete and untouched. The command itself ran ` +
+    `unchanged, and those two ends are where a run says what failed and how it ` +
+    `finished. Redirect the output to a file, or raise ` +
+    `TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/integrations/codex/plugin/hooks/lib/rewrite.mjs
+++ b/integrations/codex/plugin/hooks/lib/rewrite.mjs
@@ -89,7 +89,16 @@ function unsafeToBound(command) {
   // `tail --follow=name`. The flag does not have to come first and does not
   // have to be short, so the guard looks anywhere in the `tail` invocation --
   // bounded to that command by stopping at a `;`, `|` or `&`.
-  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+  // CLUSTERED SHORT OPTIONS TOO. GNU tail accepts `-fn 1` and `-fF`, and a
+  // guard anchored on `-f\b` matches neither, because the `\b` fails against
+  // the next clustered letter. Both keep following and never reach EOF, so the
+  // bound waits forever. The character class therefore looks for f or F
+  // ANYWHERE in a short-option cluster.
+  if (
+    /\btail\b[^;|&]*(\s-[a-zA-Z]*[fF][a-zA-Z]*\b|\s--follow\b|\s--follow=)/.test(
+      command
+    )
+  ) {
     return 'follow-mode';
   }
 
@@ -112,11 +121,19 @@ function unsafeToBound(command) {
  * exited 1 once wrapped. Silently changing a command's exit status is the same
  * defect as masking one, in the other direction.
  *
- * The command therefore runs inside a subshell that restores the shell default
- * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
- * properties hold at once, and an explicit `set -o pipefail` written by the
- * caller still takes effect, because it executes inside that subshell after
- * the reset.
+ * The command therefore runs inside a subshell that restores THE CALLER'S OWN
+ * state, while the OUTER pipeline -- ours -- keeps pipefail. `set +o` prints
+ * the current options in re-inputtable form, so the one `pipefail` line is
+ * captured before we change anything and eval'd back inside the subshell.
+ *
+ * Restoring rather than CLEARING, because clearing is the same bug mirrored: a
+ * caller running under `bash -o pipefail` would have had `false | true` return
+ * 1, and a hard `set +o pipefail` would hand them 0. Either direction is a
+ * silent change to an exit status we were only supposed to be bounding the
+ * output of.
+ *
+ * An explicit `set -o pipefail` written inside the command still takes effect,
+ * because it executes inside that subshell after the restore.
  *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
@@ -176,8 +193,9 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
+      `_tok_pf=$(set +o 2>/dev/null | grep pipefail); ` +
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
+      `( eval "$_tok_pf" 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };

--- a/integrations/codex/plugin/hooks/lib/rewrite.mjs
+++ b/integrations/codex/plugin/hooks/lib/rewrite.mjs
@@ -51,10 +51,18 @@ export function boundBytes() {
  * same command with less output, and anything short of that is left alone.
  */
 function unsafeToBound(command) {
-  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
-  // relative to the braces. Getting this wrong corrupts the payload rather than
-  // failing loudly -- the same class of damage a greedy regex does to source.
-  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+  // EVERY `<<`, not a guess at the delimiter shape. A heredoc body is data, and
+  // wrapping it moves the terminator relative to the braces -- which corrupts
+  // the payload rather than failing loudly, the same class of damage a greedy
+  // regex does to source.
+  //
+  // The first version tried to match the delimiter (`<<-?\s*['"]?\w+`) and
+  // missed the ESCAPED form: `cat <<\EOF` was rewritten. Bash accepts several
+  // spellings -- bare, single-quoted, double-quoted, backslash-escaped, `<<-`,
+  // and with arbitrary spacing -- so enumerating them is a losing game. The
+  // operator itself is unambiguous. Herestrings (`<<<`) are swept up too: they
+  // would be safe to bound, and giving that up is the cheaper mistake.
+  if (/<</.test(command)) return 'heredoc';
 
   // Backgrounding detaches the process; a pipeline cannot bound what it no
   // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
@@ -69,9 +77,20 @@ function unsafeToBound(command) {
   if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
 
   // An interactive or streaming command has no meaningful tail, and buffering
-  // it through a pipe can hang.
-  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+  // it through a pipe does not merely waste effort -- it HANGS, because the
+  // wrapper's own `tail -c` cannot emit anything until EOF and follow mode
+  // never reaches EOF.
+  if (/\b(watch|less|more|vim|nano|top|htop)\b/.test(command)) {
     return 'interactive';
+  }
+
+  // FOLLOW MODE IN ANY SPELLING. Matching only `tail -f` left four working
+  // forms to hang: `tail -F`, `tail -n 100 -f`, `tail --follow` and
+  // `tail --follow=name`. The flag does not have to come first and does not
+  // have to be short, so the guard looks anywhere in the `tail` invocation --
+  // bounded to that command by stopping at a `;`, `|` or `&`.
+  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+    return 'follow-mode';
   }
 
   return null;

--- a/integrations/copilot/.github/hooks/lib/policy.mjs
+++ b/integrations/copilot/.github/hooks/lib/policy.mjs
@@ -701,6 +701,41 @@ export function allowWithContext(context) {
 }
 
 /**
+ * Lets the call run, but with a rewritten input -- the zero-turn alternative to
+ * a refusal.
+ *
+ * `updatedInput` is a real PreToolUse field and the rewritten call really runs;
+ * docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md has the end-to-end
+ * verification. This emitter is what makes it usable. A refusal costs about one
+ * extra turn, and turns are the whole measured deficit -- 12.6 to 20.9 under
+ * enforcement, for a task-mean 1.633x -- so a bound applied here is free where
+ * the same bound applied by refusing is not.
+ *
+ * The notice rides along as `additionalContext` rather than being baked into
+ * the command, so the command's own output is never mangled to carry a message.
+ *
+ * IT IS NOT OPTIONAL. The spike's model noticed an unannounced rewrite and
+ * distrusted the result -- "the output does not match the command ... I'm
+ * reporting what I actually received" -- and a model that distrusts its output
+ * re-runs the command, spending the exact turn this exists to save.
+ */
+export function allowWithRewrite(updatedInput, notice) {
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'allow',
+      permissionDecisionReason: 'token-optimizer bounded this output',
+      updatedInput,
+      ...(notice ? { additionalContext: withEscape(notice) } : {}),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
+  process.exit(0);
+}
+
+/**
  * Blocks the call and tells the model exactly what to call instead.
  *
  * The reason string is the whole user interface of this product for an agent.

--- a/integrations/copilot/.github/hooks/lib/rewrite.mjs
+++ b/integrations/copilot/.github/hooks/lib/rewrite.mjs
@@ -106,6 +106,18 @@ function unsafeToBound(command) {
  * wrapped so a shell without `pipefail` degrades to an unbounded-status
  * pipeline rather than erroring out before the command runs.
  *
+ * BUT IT MUST NOT LEAK INTO THE CALLER'S OWN PIPELINE. `pipefail` is a shell
+ * option, not a property of one pipe, so enabling it changed the meaning of any
+ * command that already contained a pipe: `false | true` exits 0 normally and
+ * exited 1 once wrapped. Silently changing a command's exit status is the same
+ * defect as masking one, in the other direction.
+ *
+ * The command therefore runs inside a subshell that restores the shell default
+ * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
+ * properties hold at once, and an explicit `set -o pipefail` written by the
+ * caller still takes effect, because it executes inside that subshell after
+ * the reset.
+ *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
  * turns a perfectly successful command into exit 141. Inside
@@ -156,7 +168,7 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}\n} 2>&1 | ` +
+      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; ` +
       `if IFS= read -r -N1 _tok_rest; then ` +
       `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +

--- a/integrations/copilot/.github/hooks/lib/rewrite.mjs
+++ b/integrations/copilot/.github/hooks/lib/rewrite.mjs
@@ -31,8 +31,9 @@
  * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
  * output is already bounded -- generously. This default is deliberately well
  * under it, because the family being targeted is the debug loop, where the SAME
- * wall of test output arrives on every iteration and the tail is the part that
- * says what failed.
+ * wall of test output arrives on every iteration. It is split evenly between
+ * the head and the tail of the output, which is where a run says what failed
+ * and how it ended.
  */
 export const DEFAULT_BOUND_BYTES = 8_000;
 
@@ -79,20 +80,19 @@ function unsafeToBound(command) {
 /**
  * The bounded form of a command, or null when it must be left alone.
  *
- * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
- * puts its verdict at the END -- the failure summary, the counts -- so the tail
- * is the part worth keeping. And `head` closes the pipe early, which sends
- * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
- * then report exit 141 and read as a failure. `tail` consumes its input, so the
- * real exit status survives.
- *
- * `pipefail` itself is what keeps the exit status honest. Without it the
- * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * `pipefail` is what keeps the exit status honest. Without it the pipeline
+ * reports the LAST stage's status, which is always 0, and every failing test
  * run would look like a passing one -- a far worse outcome than any number of
- * wasted tokens, because the model would stop debugging.
+ * wasted tokens, because the model would stop debugging. The `set -o` is
+ * wrapped so a shell without `pipefail` degrades to an unbounded-status
+ * pipeline rather than erroring out before the command runs.
  *
- * The `set -o` is wrapped so a shell without `pipefail` degrades to an
- * unbounded-status pipeline rather than erroring out before the command runs.
+ * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
+ * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
+ * turns a perfectly successful command into exit 141. Inside
+ * `{ head -c N; ...; tail -c N; }` the group keeps reading, so the producer is
+ * never signalled and the real status survives -- asserted by pushing `exit 3`
+ * and `exit 7` through it.
  */
 export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   if (typeof command !== 'string') return null;
@@ -102,10 +102,46 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const unsafe = unsafeToBound(trimmed);
   if (unsafe) return null;
 
+  // A NEWLINE BEFORE THE CLOSING BRACE, NEVER `; }`. Two ordinary commands
+  // broke under the semicolon form, both of which run fine unwrapped:
+  //
+  //   echo hi # explain   ->  { echo hi # explain; }   the `; }` is INSIDE the
+  //                           comment, so the group is never closed
+  //   echo hi;            ->  { echo hi;; }            `;;` is a syntax error
+  //
+  // A newline terminates a comment and satisfies bash's requirement for a
+  // separator before `}`, so it handles both. Breaking a command that would
+  // have worked is the worst thing this module can do -- worse than any number
+  // of tokens -- because the failure looks like the user's own command is wrong.
+  //
+  // HEAD *AND* TAIL, because the client's own truncation keeps both. Claude
+  // Code caps Bash output at 30,000 characters and truncates from the MIDDLE
+  // (its binary carries `... [N characters truncated] ...` and
+  // `truncate-middle`). A tail-only bound is cheaper AND drops the head, where
+  // a failing jest run lists WHICH suites failed -- so it could read as an
+  // improvement on cost while being a regression for the model.
+  //
+  // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
+  // then keeps the last half of what remains. Verified to preserve a non-zero
+  // exit status through both stages.
+  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
+  // "middle omitted" after a two-line command claims a truncation that never
+  // happened -- the same class of error as a reader reporting a windowed event
+  // log it did not actually window. A model told its output was cut will go
+  // looking for the rest, which costs the turn this whole module exists to save.
+  //
+  // `read -r -N1` is the test: it succeeds only if a byte remains after the
+  // head, which means there really is a middle. That byte is then printed back
+  // so it is not swallowed.
+  const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+      `{ ${trimmed}\n} 2>&1 | ` +
+      `{ head -c ${half}; ` +
+      `if IFS= read -r -N1 _tok_rest; then ` +
+      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
+      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
     maxBytes,
   };
 }
@@ -129,9 +165,10 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
-    `the command ran unchanged but only its tail reached you. The tail is ` +
-    `where a test run puts its verdict. Re-run with the output redirected to ` +
-    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
+    `command ran unchanged, and you were given its beginning and its end with ` +
+    `the middle omitted and marked. Those are the two ends that carry a ` +
+    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
+    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/integrations/copilot/.github/hooks/lib/rewrite.mjs
+++ b/integrations/copilot/.github/hooks/lib/rewrite.mjs
@@ -1,0 +1,137 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/rewrite.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Bounding a command's output instead of refusing the command.
+ *
+ * WHY THIS EXISTS. A refusal costs approximately ONE EXTRA TURN. Measured on
+ * the THOL battery, enforcement took turns from 12.6 to 20.9 and cost a
+ * task-mean 1.633x vanilla Claude Code -- last of fifteen -- while the same
+ * build without refusals measured 0.928. The tokens a refusal "saves" are
+ * smaller than the round trip it spends, so the mechanism, not the policy, is
+ * what loses.
+ *
+ * A PreToolUse hook can return `updatedInput`, and the rewritten call runs.
+ * Verified end to end (docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md):
+ * a hook that rewrote `echo PROBE_ORIGINAL` to `echo PROBE_REWRITTEN` produced
+ * PROBE_REWRITTEN in the model's context, with no refusal and no retry. So the
+ * same bound can be applied for zero turns.
+ *
+ * PostToolUse cannot do this. Its output schema carries only `additionalContext`
+ * and `classifierContext` -- there is no field that replaces a tool result --
+ * and it never fires for a failed call at all (4,499 of 4,499 live outcomes
+ * report success, every exit code null). Bounding has to happen BEFORE the
+ * command runs, which is also the only way it can reach the failing test runs a
+ * debug loop is made of.
+ */
+
+/**
+ * Default bound, in bytes.
+ *
+ * The client's own cap is the reference point: `BASH_MAX_OUTPUT_LENGTH`
+ * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
+ * output is already bounded -- generously. This default is deliberately well
+ * under it, because the family being targeted is the debug loop, where the SAME
+ * wall of test output arrives on every iteration and the tail is the part that
+ * says what failed.
+ */
+export const DEFAULT_BOUND_BYTES = 8_000;
+
+export function boundBytes() {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_BOUND_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_BOUND_BYTES;
+}
+
+/**
+ * Shapes that must never be rewritten.
+ *
+ * Every one of these is a case where wrapping the command changes what it
+ * MEANS, not just how much of it is shown. Rewriting is a silent mutation of
+ * somebody's command; the bar for doing it is that the result is unarguably the
+ * same command with less output, and anything short of that is left alone.
+ */
+function unsafeToBound(command) {
+  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
+  // relative to the braces. Getting this wrong corrupts the payload rather than
+  // failing loudly -- the same class of damage a greedy regex does to source.
+  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+
+  // Backgrounding detaches the process; a pipeline cannot bound what it no
+  // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
+  if (/(?<![&|>])&(?!&)/.test(command)) return 'background';
+
+  // stdout already going somewhere other than the model's context. Bounding it
+  // would change what lands in the FILE, which is the opposite of harmless.
+  if (/(?<![0-9])>>?\s*(?!&)\S/.test(command)) return 'redirected';
+
+  // Already bounded by its author. Re-bounding buys nothing and risks changing
+  // a deliberate `head -n 5` into something else.
+  if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
+
+  // An interactive or streaming command has no meaningful tail, and buffering
+  // it through a pipe can hang.
+  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+    return 'interactive';
+  }
+
+  return null;
+}
+
+/**
+ * The bounded form of a command, or null when it must be left alone.
+ *
+ * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
+ * puts its verdict at the END -- the failure summary, the counts -- so the tail
+ * is the part worth keeping. And `head` closes the pipe early, which sends
+ * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
+ * then report exit 141 and read as a failure. `tail` consumes its input, so the
+ * real exit status survives.
+ *
+ * `pipefail` itself is what keeps the exit status honest. Without it the
+ * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * run would look like a passing one -- a far worse outcome than any number of
+ * wasted tokens, because the model would stop debugging.
+ *
+ * The `set -o` is wrapped so a shell without `pipefail` degrades to an
+ * unbounded-status pipeline rather than erroring out before the command runs.
+ */
+export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
+  if (typeof command !== 'string') return null;
+  const trimmed = command.trim();
+  if (!trimmed) return null;
+
+  const unsafe = unsafeToBound(trimmed);
+  if (unsafe) return null;
+
+  return {
+    command:
+      `{ set -o pipefail; } 2>/dev/null; ` +
+      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+    maxBytes,
+  };
+}
+
+/**
+ * What the model is told, so the bound is never a silent mutation.
+ *
+ * THE PROBE'S OWN MODEL CAUGHT US DOING THIS. In the spike, a rewritten command
+ * produced output that did not match what had been asked for, and the model
+ * flagged it as suspicious rather than trusting it:
+ *
+ *   "the output does not match the command ... Something in this session's
+ *    tooling chain either rewrote the command before execution or rewrote the
+ *    result. I'm reporting what I actually received rather than the expected
+ *    string."
+ *
+ * A model that distrusts its own tool output re-runs the command, which spends
+ * exactly the turn this mechanism exists to save. So the rewrite announces
+ * itself, says what was kept, and says how to opt out -- compaction the agent
+ * cannot see is compaction it will fight.
+ */
+export function boundNotice(maxBytes) {
+  return (
+    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
+    `the command ran unchanged but only its tail reached you. The tail is ` +
+    `where a test run puts its verdict. Re-run with the output redirected to ` +
+    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+  );
+}

--- a/integrations/copilot/.github/hooks/lib/rewrite.mjs
+++ b/integrations/copilot/.github/hooks/lib/rewrite.mjs
@@ -155,24 +155,30 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
   // then keeps the last half of what remains. Verified to preserve a non-zero
   // exit status through both stages.
-  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
-  // "middle omitted" after a two-line command claims a truncation that never
-  // happened -- the same class of error as a reader reporting a windowed event
-  // log it did not actually window. A model told its output was cut will go
-  // looking for the rest, which costs the turn this whole module exists to save.
+  // NO IN-STREAM MARKER, AND NO PROBE. `{ head -c H; tail -c H; }` is already
+  // exact in every regime, which two earlier attempts at a marker were not:
   //
-  // `read -r -N1` is the test: it succeeds only if a byte remains after the
-  // head, which means there really is a middle. That byte is then printed back
-  // so it is not swallowed.
+  //   total <= half        head prints it all, tail has nothing  -> COMPLETE
+  //   half < total <= max  head takes half, tail takes the rest  -> COMPLETE
+  //   total > max          head takes half, tail takes the last  -> exactly max
+  //
+  // An unconditional marker lied whenever the output fitted. Gating it on
+  // `read -r -N1` narrowed the lie to the middle band above -- where the output
+  // is returned COMPLETE and the marker still claimed an omission -- and the
+  // probe also relied on a bash-only `read -N`, which a POSIX shell rejects,
+  // skipping the tail entirely and leaking an error to stderr.
+  //
+  // Both defects came from trying to detect truncation from inside a pipe,
+  // which cannot see a total it has not yet consumed. So the announcement moves
+  // to `boundNotice`, stated as the POLICY ("output over N bytes is bounded")
+  // rather than as a claim about this particular output. A policy statement is
+  // true whether or not this command was cut, so it cannot lie.
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
       `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
-      `{ head -c ${half}; ` +
-      `if IFS= read -r -N1 _tok_rest; then ` +
-      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
-      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
+      `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };
 }
@@ -196,10 +202,11 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
-    `command ran unchanged, and you were given its beginning and its end with ` +
-    `the middle omitted and marked. Those are the two ends that carry a ` +
-    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
-    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
+    `token-optimizer bounds this command's output: anything over ${maxBytes} ` +
+    `bytes is returned as its beginning and its end, with the middle dropped. ` +
+    `Shorter output is returned complete and untouched. The command itself ran ` +
+    `unchanged, and those two ends are where a run says what failed and how it ` +
+    `finished. Redirect the output to a file, or raise ` +
+    `TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/integrations/copilot/.github/hooks/lib/rewrite.mjs
+++ b/integrations/copilot/.github/hooks/lib/rewrite.mjs
@@ -89,7 +89,16 @@ function unsafeToBound(command) {
   // `tail --follow=name`. The flag does not have to come first and does not
   // have to be short, so the guard looks anywhere in the `tail` invocation --
   // bounded to that command by stopping at a `;`, `|` or `&`.
-  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+  // CLUSTERED SHORT OPTIONS TOO. GNU tail accepts `-fn 1` and `-fF`, and a
+  // guard anchored on `-f\b` matches neither, because the `\b` fails against
+  // the next clustered letter. Both keep following and never reach EOF, so the
+  // bound waits forever. The character class therefore looks for f or F
+  // ANYWHERE in a short-option cluster.
+  if (
+    /\btail\b[^;|&]*(\s-[a-zA-Z]*[fF][a-zA-Z]*\b|\s--follow\b|\s--follow=)/.test(
+      command
+    )
+  ) {
     return 'follow-mode';
   }
 
@@ -112,11 +121,19 @@ function unsafeToBound(command) {
  * exited 1 once wrapped. Silently changing a command's exit status is the same
  * defect as masking one, in the other direction.
  *
- * The command therefore runs inside a subshell that restores the shell default
- * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
- * properties hold at once, and an explicit `set -o pipefail` written by the
- * caller still takes effect, because it executes inside that subshell after
- * the reset.
+ * The command therefore runs inside a subshell that restores THE CALLER'S OWN
+ * state, while the OUTER pipeline -- ours -- keeps pipefail. `set +o` prints
+ * the current options in re-inputtable form, so the one `pipefail` line is
+ * captured before we change anything and eval'd back inside the subshell.
+ *
+ * Restoring rather than CLEARING, because clearing is the same bug mirrored: a
+ * caller running under `bash -o pipefail` would have had `false | true` return
+ * 1, and a hard `set +o pipefail` would hand them 0. Either direction is a
+ * silent change to an exit status we were only supposed to be bounding the
+ * output of.
+ *
+ * An explicit `set -o pipefail` written inside the command still takes effect,
+ * because it executes inside that subshell after the restore.
  *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
@@ -176,8 +193,9 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
+      `_tok_pf=$(set +o 2>/dev/null | grep pipefail); ` +
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
+      `( eval "$_tok_pf" 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };

--- a/integrations/copilot/.github/hooks/lib/rewrite.mjs
+++ b/integrations/copilot/.github/hooks/lib/rewrite.mjs
@@ -51,10 +51,18 @@ export function boundBytes() {
  * same command with less output, and anything short of that is left alone.
  */
 function unsafeToBound(command) {
-  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
-  // relative to the braces. Getting this wrong corrupts the payload rather than
-  // failing loudly -- the same class of damage a greedy regex does to source.
-  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+  // EVERY `<<`, not a guess at the delimiter shape. A heredoc body is data, and
+  // wrapping it moves the terminator relative to the braces -- which corrupts
+  // the payload rather than failing loudly, the same class of damage a greedy
+  // regex does to source.
+  //
+  // The first version tried to match the delimiter (`<<-?\s*['"]?\w+`) and
+  // missed the ESCAPED form: `cat <<\EOF` was rewritten. Bash accepts several
+  // spellings -- bare, single-quoted, double-quoted, backslash-escaped, `<<-`,
+  // and with arbitrary spacing -- so enumerating them is a losing game. The
+  // operator itself is unambiguous. Herestrings (`<<<`) are swept up too: they
+  // would be safe to bound, and giving that up is the cheaper mistake.
+  if (/<</.test(command)) return 'heredoc';
 
   // Backgrounding detaches the process; a pipeline cannot bound what it no
   // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
@@ -69,9 +77,20 @@ function unsafeToBound(command) {
   if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
 
   // An interactive or streaming command has no meaningful tail, and buffering
-  // it through a pipe can hang.
-  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+  // it through a pipe does not merely waste effort -- it HANGS, because the
+  // wrapper's own `tail -c` cannot emit anything until EOF and follow mode
+  // never reaches EOF.
+  if (/\b(watch|less|more|vim|nano|top|htop)\b/.test(command)) {
     return 'interactive';
+  }
+
+  // FOLLOW MODE IN ANY SPELLING. Matching only `tail -f` left four working
+  // forms to hang: `tail -F`, `tail -n 100 -f`, `tail --follow` and
+  // `tail --follow=name`. The flag does not have to come first and does not
+  // have to be short, so the guard looks anywhere in the `tail` invocation --
+  // bounded to that command by stopping at a `;`, `|` or `&`.
+  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+    return 'follow-mode';
   }
 
   return null;

--- a/integrations/cursor/hooks/lib/policy.mjs
+++ b/integrations/cursor/hooks/lib/policy.mjs
@@ -701,6 +701,41 @@ export function allowWithContext(context) {
 }
 
 /**
+ * Lets the call run, but with a rewritten input -- the zero-turn alternative to
+ * a refusal.
+ *
+ * `updatedInput` is a real PreToolUse field and the rewritten call really runs;
+ * docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md has the end-to-end
+ * verification. This emitter is what makes it usable. A refusal costs about one
+ * extra turn, and turns are the whole measured deficit -- 12.6 to 20.9 under
+ * enforcement, for a task-mean 1.633x -- so a bound applied here is free where
+ * the same bound applied by refusing is not.
+ *
+ * The notice rides along as `additionalContext` rather than being baked into
+ * the command, so the command's own output is never mangled to carry a message.
+ *
+ * IT IS NOT OPTIONAL. The spike's model noticed an unannounced rewrite and
+ * distrusted the result -- "the output does not match the command ... I'm
+ * reporting what I actually received" -- and a model that distrusts its output
+ * re-runs the command, spending the exact turn this exists to save.
+ */
+export function allowWithRewrite(updatedInput, notice) {
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'allow',
+      permissionDecisionReason: 'token-optimizer bounded this output',
+      updatedInput,
+      ...(notice ? { additionalContext: withEscape(notice) } : {}),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
+  process.exit(0);
+}
+
+/**
  * Blocks the call and tells the model exactly what to call instead.
  *
  * The reason string is the whole user interface of this product for an agent.

--- a/integrations/cursor/hooks/lib/rewrite.mjs
+++ b/integrations/cursor/hooks/lib/rewrite.mjs
@@ -106,6 +106,18 @@ function unsafeToBound(command) {
  * wrapped so a shell without `pipefail` degrades to an unbounded-status
  * pipeline rather than erroring out before the command runs.
  *
+ * BUT IT MUST NOT LEAK INTO THE CALLER'S OWN PIPELINE. `pipefail` is a shell
+ * option, not a property of one pipe, so enabling it changed the meaning of any
+ * command that already contained a pipe: `false | true` exits 0 normally and
+ * exited 1 once wrapped. Silently changing a command's exit status is the same
+ * defect as masking one, in the other direction.
+ *
+ * The command therefore runs inside a subshell that restores the shell default
+ * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
+ * properties hold at once, and an explicit `set -o pipefail` written by the
+ * caller still takes effect, because it executes inside that subshell after
+ * the reset.
+ *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
  * turns a perfectly successful command into exit 141. Inside
@@ -156,7 +168,7 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}\n} 2>&1 | ` +
+      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; ` +
       `if IFS= read -r -N1 _tok_rest; then ` +
       `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +

--- a/integrations/cursor/hooks/lib/rewrite.mjs
+++ b/integrations/cursor/hooks/lib/rewrite.mjs
@@ -31,8 +31,9 @@
  * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
  * output is already bounded -- generously. This default is deliberately well
  * under it, because the family being targeted is the debug loop, where the SAME
- * wall of test output arrives on every iteration and the tail is the part that
- * says what failed.
+ * wall of test output arrives on every iteration. It is split evenly between
+ * the head and the tail of the output, which is where a run says what failed
+ * and how it ended.
  */
 export const DEFAULT_BOUND_BYTES = 8_000;
 
@@ -79,20 +80,19 @@ function unsafeToBound(command) {
 /**
  * The bounded form of a command, or null when it must be left alone.
  *
- * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
- * puts its verdict at the END -- the failure summary, the counts -- so the tail
- * is the part worth keeping. And `head` closes the pipe early, which sends
- * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
- * then report exit 141 and read as a failure. `tail` consumes its input, so the
- * real exit status survives.
- *
- * `pipefail` itself is what keeps the exit status honest. Without it the
- * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * `pipefail` is what keeps the exit status honest. Without it the pipeline
+ * reports the LAST stage's status, which is always 0, and every failing test
  * run would look like a passing one -- a far worse outcome than any number of
- * wasted tokens, because the model would stop debugging.
+ * wasted tokens, because the model would stop debugging. The `set -o` is
+ * wrapped so a shell without `pipefail` degrades to an unbounded-status
+ * pipeline rather than erroring out before the command runs.
  *
- * The `set -o` is wrapped so a shell without `pipefail` degrades to an
- * unbounded-status pipeline rather than erroring out before the command runs.
+ * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
+ * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
+ * turns a perfectly successful command into exit 141. Inside
+ * `{ head -c N; ...; tail -c N; }` the group keeps reading, so the producer is
+ * never signalled and the real status survives -- asserted by pushing `exit 3`
+ * and `exit 7` through it.
  */
 export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   if (typeof command !== 'string') return null;
@@ -102,10 +102,46 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const unsafe = unsafeToBound(trimmed);
   if (unsafe) return null;
 
+  // A NEWLINE BEFORE THE CLOSING BRACE, NEVER `; }`. Two ordinary commands
+  // broke under the semicolon form, both of which run fine unwrapped:
+  //
+  //   echo hi # explain   ->  { echo hi # explain; }   the `; }` is INSIDE the
+  //                           comment, so the group is never closed
+  //   echo hi;            ->  { echo hi;; }            `;;` is a syntax error
+  //
+  // A newline terminates a comment and satisfies bash's requirement for a
+  // separator before `}`, so it handles both. Breaking a command that would
+  // have worked is the worst thing this module can do -- worse than any number
+  // of tokens -- because the failure looks like the user's own command is wrong.
+  //
+  // HEAD *AND* TAIL, because the client's own truncation keeps both. Claude
+  // Code caps Bash output at 30,000 characters and truncates from the MIDDLE
+  // (its binary carries `... [N characters truncated] ...` and
+  // `truncate-middle`). A tail-only bound is cheaper AND drops the head, where
+  // a failing jest run lists WHICH suites failed -- so it could read as an
+  // improvement on cost while being a regression for the model.
+  //
+  // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
+  // then keeps the last half of what remains. Verified to preserve a non-zero
+  // exit status through both stages.
+  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
+  // "middle omitted" after a two-line command claims a truncation that never
+  // happened -- the same class of error as a reader reporting a windowed event
+  // log it did not actually window. A model told its output was cut will go
+  // looking for the rest, which costs the turn this whole module exists to save.
+  //
+  // `read -r -N1` is the test: it succeeds only if a byte remains after the
+  // head, which means there really is a middle. That byte is then printed back
+  // so it is not swallowed.
+  const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+      `{ ${trimmed}\n} 2>&1 | ` +
+      `{ head -c ${half}; ` +
+      `if IFS= read -r -N1 _tok_rest; then ` +
+      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
+      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
     maxBytes,
   };
 }
@@ -129,9 +165,10 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
-    `the command ran unchanged but only its tail reached you. The tail is ` +
-    `where a test run puts its verdict. Re-run with the output redirected to ` +
-    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
+    `command ran unchanged, and you were given its beginning and its end with ` +
+    `the middle omitted and marked. Those are the two ends that carry a ` +
+    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
+    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/integrations/cursor/hooks/lib/rewrite.mjs
+++ b/integrations/cursor/hooks/lib/rewrite.mjs
@@ -1,0 +1,137 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/rewrite.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Bounding a command's output instead of refusing the command.
+ *
+ * WHY THIS EXISTS. A refusal costs approximately ONE EXTRA TURN. Measured on
+ * the THOL battery, enforcement took turns from 12.6 to 20.9 and cost a
+ * task-mean 1.633x vanilla Claude Code -- last of fifteen -- while the same
+ * build without refusals measured 0.928. The tokens a refusal "saves" are
+ * smaller than the round trip it spends, so the mechanism, not the policy, is
+ * what loses.
+ *
+ * A PreToolUse hook can return `updatedInput`, and the rewritten call runs.
+ * Verified end to end (docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md):
+ * a hook that rewrote `echo PROBE_ORIGINAL` to `echo PROBE_REWRITTEN` produced
+ * PROBE_REWRITTEN in the model's context, with no refusal and no retry. So the
+ * same bound can be applied for zero turns.
+ *
+ * PostToolUse cannot do this. Its output schema carries only `additionalContext`
+ * and `classifierContext` -- there is no field that replaces a tool result --
+ * and it never fires for a failed call at all (4,499 of 4,499 live outcomes
+ * report success, every exit code null). Bounding has to happen BEFORE the
+ * command runs, which is also the only way it can reach the failing test runs a
+ * debug loop is made of.
+ */
+
+/**
+ * Default bound, in bytes.
+ *
+ * The client's own cap is the reference point: `BASH_MAX_OUTPUT_LENGTH`
+ * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
+ * output is already bounded -- generously. This default is deliberately well
+ * under it, because the family being targeted is the debug loop, where the SAME
+ * wall of test output arrives on every iteration and the tail is the part that
+ * says what failed.
+ */
+export const DEFAULT_BOUND_BYTES = 8_000;
+
+export function boundBytes() {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_BOUND_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_BOUND_BYTES;
+}
+
+/**
+ * Shapes that must never be rewritten.
+ *
+ * Every one of these is a case where wrapping the command changes what it
+ * MEANS, not just how much of it is shown. Rewriting is a silent mutation of
+ * somebody's command; the bar for doing it is that the result is unarguably the
+ * same command with less output, and anything short of that is left alone.
+ */
+function unsafeToBound(command) {
+  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
+  // relative to the braces. Getting this wrong corrupts the payload rather than
+  // failing loudly -- the same class of damage a greedy regex does to source.
+  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+
+  // Backgrounding detaches the process; a pipeline cannot bound what it no
+  // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
+  if (/(?<![&|>])&(?!&)/.test(command)) return 'background';
+
+  // stdout already going somewhere other than the model's context. Bounding it
+  // would change what lands in the FILE, which is the opposite of harmless.
+  if (/(?<![0-9])>>?\s*(?!&)\S/.test(command)) return 'redirected';
+
+  // Already bounded by its author. Re-bounding buys nothing and risks changing
+  // a deliberate `head -n 5` into something else.
+  if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
+
+  // An interactive or streaming command has no meaningful tail, and buffering
+  // it through a pipe can hang.
+  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+    return 'interactive';
+  }
+
+  return null;
+}
+
+/**
+ * The bounded form of a command, or null when it must be left alone.
+ *
+ * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
+ * puts its verdict at the END -- the failure summary, the counts -- so the tail
+ * is the part worth keeping. And `head` closes the pipe early, which sends
+ * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
+ * then report exit 141 and read as a failure. `tail` consumes its input, so the
+ * real exit status survives.
+ *
+ * `pipefail` itself is what keeps the exit status honest. Without it the
+ * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * run would look like a passing one -- a far worse outcome than any number of
+ * wasted tokens, because the model would stop debugging.
+ *
+ * The `set -o` is wrapped so a shell without `pipefail` degrades to an
+ * unbounded-status pipeline rather than erroring out before the command runs.
+ */
+export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
+  if (typeof command !== 'string') return null;
+  const trimmed = command.trim();
+  if (!trimmed) return null;
+
+  const unsafe = unsafeToBound(trimmed);
+  if (unsafe) return null;
+
+  return {
+    command:
+      `{ set -o pipefail; } 2>/dev/null; ` +
+      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+    maxBytes,
+  };
+}
+
+/**
+ * What the model is told, so the bound is never a silent mutation.
+ *
+ * THE PROBE'S OWN MODEL CAUGHT US DOING THIS. In the spike, a rewritten command
+ * produced output that did not match what had been asked for, and the model
+ * flagged it as suspicious rather than trusting it:
+ *
+ *   "the output does not match the command ... Something in this session's
+ *    tooling chain either rewrote the command before execution or rewrote the
+ *    result. I'm reporting what I actually received rather than the expected
+ *    string."
+ *
+ * A model that distrusts its own tool output re-runs the command, which spends
+ * exactly the turn this mechanism exists to save. So the rewrite announces
+ * itself, says what was kept, and says how to opt out -- compaction the agent
+ * cannot see is compaction it will fight.
+ */
+export function boundNotice(maxBytes) {
+  return (
+    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
+    `the command ran unchanged but only its tail reached you. The tail is ` +
+    `where a test run puts its verdict. Re-run with the output redirected to ` +
+    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+  );
+}

--- a/integrations/cursor/hooks/lib/rewrite.mjs
+++ b/integrations/cursor/hooks/lib/rewrite.mjs
@@ -155,24 +155,30 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
   // then keeps the last half of what remains. Verified to preserve a non-zero
   // exit status through both stages.
-  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
-  // "middle omitted" after a two-line command claims a truncation that never
-  // happened -- the same class of error as a reader reporting a windowed event
-  // log it did not actually window. A model told its output was cut will go
-  // looking for the rest, which costs the turn this whole module exists to save.
+  // NO IN-STREAM MARKER, AND NO PROBE. `{ head -c H; tail -c H; }` is already
+  // exact in every regime, which two earlier attempts at a marker were not:
   //
-  // `read -r -N1` is the test: it succeeds only if a byte remains after the
-  // head, which means there really is a middle. That byte is then printed back
-  // so it is not swallowed.
+  //   total <= half        head prints it all, tail has nothing  -> COMPLETE
+  //   half < total <= max  head takes half, tail takes the rest  -> COMPLETE
+  //   total > max          head takes half, tail takes the last  -> exactly max
+  //
+  // An unconditional marker lied whenever the output fitted. Gating it on
+  // `read -r -N1` narrowed the lie to the middle band above -- where the output
+  // is returned COMPLETE and the marker still claimed an omission -- and the
+  // probe also relied on a bash-only `read -N`, which a POSIX shell rejects,
+  // skipping the tail entirely and leaking an error to stderr.
+  //
+  // Both defects came from trying to detect truncation from inside a pipe,
+  // which cannot see a total it has not yet consumed. So the announcement moves
+  // to `boundNotice`, stated as the POLICY ("output over N bytes is bounded")
+  // rather than as a claim about this particular output. A policy statement is
+  // true whether or not this command was cut, so it cannot lie.
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
       `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
-      `{ head -c ${half}; ` +
-      `if IFS= read -r -N1 _tok_rest; then ` +
-      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
-      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
+      `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };
 }
@@ -196,10 +202,11 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
-    `command ran unchanged, and you were given its beginning and its end with ` +
-    `the middle omitted and marked. Those are the two ends that carry a ` +
-    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
-    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
+    `token-optimizer bounds this command's output: anything over ${maxBytes} ` +
+    `bytes is returned as its beginning and its end, with the middle dropped. ` +
+    `Shorter output is returned complete and untouched. The command itself ran ` +
+    `unchanged, and those two ends are where a run says what failed and how it ` +
+    `finished. Redirect the output to a file, or raise ` +
+    `TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/integrations/cursor/hooks/lib/rewrite.mjs
+++ b/integrations/cursor/hooks/lib/rewrite.mjs
@@ -89,7 +89,16 @@ function unsafeToBound(command) {
   // `tail --follow=name`. The flag does not have to come first and does not
   // have to be short, so the guard looks anywhere in the `tail` invocation --
   // bounded to that command by stopping at a `;`, `|` or `&`.
-  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+  // CLUSTERED SHORT OPTIONS TOO. GNU tail accepts `-fn 1` and `-fF`, and a
+  // guard anchored on `-f\b` matches neither, because the `\b` fails against
+  // the next clustered letter. Both keep following and never reach EOF, so the
+  // bound waits forever. The character class therefore looks for f or F
+  // ANYWHERE in a short-option cluster.
+  if (
+    /\btail\b[^;|&]*(\s-[a-zA-Z]*[fF][a-zA-Z]*\b|\s--follow\b|\s--follow=)/.test(
+      command
+    )
+  ) {
     return 'follow-mode';
   }
 
@@ -112,11 +121,19 @@ function unsafeToBound(command) {
  * exited 1 once wrapped. Silently changing a command's exit status is the same
  * defect as masking one, in the other direction.
  *
- * The command therefore runs inside a subshell that restores the shell default
- * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
- * properties hold at once, and an explicit `set -o pipefail` written by the
- * caller still takes effect, because it executes inside that subshell after
- * the reset.
+ * The command therefore runs inside a subshell that restores THE CALLER'S OWN
+ * state, while the OUTER pipeline -- ours -- keeps pipefail. `set +o` prints
+ * the current options in re-inputtable form, so the one `pipefail` line is
+ * captured before we change anything and eval'd back inside the subshell.
+ *
+ * Restoring rather than CLEARING, because clearing is the same bug mirrored: a
+ * caller running under `bash -o pipefail` would have had `false | true` return
+ * 1, and a hard `set +o pipefail` would hand them 0. Either direction is a
+ * silent change to an exit status we were only supposed to be bounding the
+ * output of.
+ *
+ * An explicit `set -o pipefail` written inside the command still takes effect,
+ * because it executes inside that subshell after the restore.
  *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
@@ -176,8 +193,9 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
+      `_tok_pf=$(set +o 2>/dev/null | grep pipefail); ` +
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
+      `( eval "$_tok_pf" 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };

--- a/integrations/cursor/hooks/lib/rewrite.mjs
+++ b/integrations/cursor/hooks/lib/rewrite.mjs
@@ -51,10 +51,18 @@ export function boundBytes() {
  * same command with less output, and anything short of that is left alone.
  */
 function unsafeToBound(command) {
-  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
-  // relative to the braces. Getting this wrong corrupts the payload rather than
-  // failing loudly -- the same class of damage a greedy regex does to source.
-  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+  // EVERY `<<`, not a guess at the delimiter shape. A heredoc body is data, and
+  // wrapping it moves the terminator relative to the braces -- which corrupts
+  // the payload rather than failing loudly, the same class of damage a greedy
+  // regex does to source.
+  //
+  // The first version tried to match the delimiter (`<<-?\s*['"]?\w+`) and
+  // missed the ESCAPED form: `cat <<\EOF` was rewritten. Bash accepts several
+  // spellings -- bare, single-quoted, double-quoted, backslash-escaped, `<<-`,
+  // and with arbitrary spacing -- so enumerating them is a losing game. The
+  // operator itself is unambiguous. Herestrings (`<<<`) are swept up too: they
+  // would be safe to bound, and giving that up is the cheaper mistake.
+  if (/<</.test(command)) return 'heredoc';
 
   // Backgrounding detaches the process; a pipeline cannot bound what it no
   // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
@@ -69,9 +77,20 @@ function unsafeToBound(command) {
   if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
 
   // An interactive or streaming command has no meaningful tail, and buffering
-  // it through a pipe can hang.
-  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+  // it through a pipe does not merely waste effort -- it HANGS, because the
+  // wrapper's own `tail -c` cannot emit anything until EOF and follow mode
+  // never reaches EOF.
+  if (/\b(watch|less|more|vim|nano|top|htop)\b/.test(command)) {
     return 'interactive';
+  }
+
+  // FOLLOW MODE IN ANY SPELLING. Matching only `tail -f` left four working
+  // forms to hang: `tail -F`, `tail -n 100 -f`, `tail --follow` and
+  // `tail --follow=name`. The flag does not have to come first and does not
+  // have to be short, so the guard looks anywhere in the `tail` invocation --
+  // bounded to that command by stopping at a `;`, `|` or `&`.
+  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+    return 'follow-mode';
   }
 
   return null;

--- a/integrations/gemini/hooks/lib/policy.mjs
+++ b/integrations/gemini/hooks/lib/policy.mjs
@@ -701,6 +701,41 @@ export function allowWithContext(context) {
 }
 
 /**
+ * Lets the call run, but with a rewritten input -- the zero-turn alternative to
+ * a refusal.
+ *
+ * `updatedInput` is a real PreToolUse field and the rewritten call really runs;
+ * docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md has the end-to-end
+ * verification. This emitter is what makes it usable. A refusal costs about one
+ * extra turn, and turns are the whole measured deficit -- 12.6 to 20.9 under
+ * enforcement, for a task-mean 1.633x -- so a bound applied here is free where
+ * the same bound applied by refusing is not.
+ *
+ * The notice rides along as `additionalContext` rather than being baked into
+ * the command, so the command's own output is never mangled to carry a message.
+ *
+ * IT IS NOT OPTIONAL. The spike's model noticed an unannounced rewrite and
+ * distrusted the result -- "the output does not match the command ... I'm
+ * reporting what I actually received" -- and a model that distrusts its output
+ * re-runs the command, spending the exact turn this exists to save.
+ */
+export function allowWithRewrite(updatedInput, notice) {
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'allow',
+      permissionDecisionReason: 'token-optimizer bounded this output',
+      updatedInput,
+      ...(notice ? { additionalContext: withEscape(notice) } : {}),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
+  process.exit(0);
+}
+
+/**
  * Blocks the call and tells the model exactly what to call instead.
  *
  * The reason string is the whole user interface of this product for an agent.

--- a/integrations/gemini/hooks/lib/rewrite.mjs
+++ b/integrations/gemini/hooks/lib/rewrite.mjs
@@ -106,6 +106,18 @@ function unsafeToBound(command) {
  * wrapped so a shell without `pipefail` degrades to an unbounded-status
  * pipeline rather than erroring out before the command runs.
  *
+ * BUT IT MUST NOT LEAK INTO THE CALLER'S OWN PIPELINE. `pipefail` is a shell
+ * option, not a property of one pipe, so enabling it changed the meaning of any
+ * command that already contained a pipe: `false | true` exits 0 normally and
+ * exited 1 once wrapped. Silently changing a command's exit status is the same
+ * defect as masking one, in the other direction.
+ *
+ * The command therefore runs inside a subshell that restores the shell default
+ * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
+ * properties hold at once, and an explicit `set -o pipefail` written by the
+ * caller still takes effect, because it executes inside that subshell after
+ * the reset.
+ *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
  * turns a perfectly successful command into exit 141. Inside
@@ -156,7 +168,7 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}\n} 2>&1 | ` +
+      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; ` +
       `if IFS= read -r -N1 _tok_rest; then ` +
       `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +

--- a/integrations/gemini/hooks/lib/rewrite.mjs
+++ b/integrations/gemini/hooks/lib/rewrite.mjs
@@ -31,8 +31,9 @@
  * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
  * output is already bounded -- generously. This default is deliberately well
  * under it, because the family being targeted is the debug loop, where the SAME
- * wall of test output arrives on every iteration and the tail is the part that
- * says what failed.
+ * wall of test output arrives on every iteration. It is split evenly between
+ * the head and the tail of the output, which is where a run says what failed
+ * and how it ended.
  */
 export const DEFAULT_BOUND_BYTES = 8_000;
 
@@ -79,20 +80,19 @@ function unsafeToBound(command) {
 /**
  * The bounded form of a command, or null when it must be left alone.
  *
- * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
- * puts its verdict at the END -- the failure summary, the counts -- so the tail
- * is the part worth keeping. And `head` closes the pipe early, which sends
- * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
- * then report exit 141 and read as a failure. `tail` consumes its input, so the
- * real exit status survives.
- *
- * `pipefail` itself is what keeps the exit status honest. Without it the
- * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * `pipefail` is what keeps the exit status honest. Without it the pipeline
+ * reports the LAST stage's status, which is always 0, and every failing test
  * run would look like a passing one -- a far worse outcome than any number of
- * wasted tokens, because the model would stop debugging.
+ * wasted tokens, because the model would stop debugging. The `set -o` is
+ * wrapped so a shell without `pipefail` degrades to an unbounded-status
+ * pipeline rather than erroring out before the command runs.
  *
- * The `set -o` is wrapped so a shell without `pipefail` degrades to an
- * unbounded-status pipeline rather than erroring out before the command runs.
+ * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
+ * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
+ * turns a perfectly successful command into exit 141. Inside
+ * `{ head -c N; ...; tail -c N; }` the group keeps reading, so the producer is
+ * never signalled and the real status survives -- asserted by pushing `exit 3`
+ * and `exit 7` through it.
  */
 export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   if (typeof command !== 'string') return null;
@@ -102,10 +102,46 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const unsafe = unsafeToBound(trimmed);
   if (unsafe) return null;
 
+  // A NEWLINE BEFORE THE CLOSING BRACE, NEVER `; }`. Two ordinary commands
+  // broke under the semicolon form, both of which run fine unwrapped:
+  //
+  //   echo hi # explain   ->  { echo hi # explain; }   the `; }` is INSIDE the
+  //                           comment, so the group is never closed
+  //   echo hi;            ->  { echo hi;; }            `;;` is a syntax error
+  //
+  // A newline terminates a comment and satisfies bash's requirement for a
+  // separator before `}`, so it handles both. Breaking a command that would
+  // have worked is the worst thing this module can do -- worse than any number
+  // of tokens -- because the failure looks like the user's own command is wrong.
+  //
+  // HEAD *AND* TAIL, because the client's own truncation keeps both. Claude
+  // Code caps Bash output at 30,000 characters and truncates from the MIDDLE
+  // (its binary carries `... [N characters truncated] ...` and
+  // `truncate-middle`). A tail-only bound is cheaper AND drops the head, where
+  // a failing jest run lists WHICH suites failed -- so it could read as an
+  // improvement on cost while being a regression for the model.
+  //
+  // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
+  // then keeps the last half of what remains. Verified to preserve a non-zero
+  // exit status through both stages.
+  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
+  // "middle omitted" after a two-line command claims a truncation that never
+  // happened -- the same class of error as a reader reporting a windowed event
+  // log it did not actually window. A model told its output was cut will go
+  // looking for the rest, which costs the turn this whole module exists to save.
+  //
+  // `read -r -N1` is the test: it succeeds only if a byte remains after the
+  // head, which means there really is a middle. That byte is then printed back
+  // so it is not swallowed.
+  const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+      `{ ${trimmed}\n} 2>&1 | ` +
+      `{ head -c ${half}; ` +
+      `if IFS= read -r -N1 _tok_rest; then ` +
+      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
+      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
     maxBytes,
   };
 }
@@ -129,9 +165,10 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
-    `the command ran unchanged but only its tail reached you. The tail is ` +
-    `where a test run puts its verdict. Re-run with the output redirected to ` +
-    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
+    `command ran unchanged, and you were given its beginning and its end with ` +
+    `the middle omitted and marked. Those are the two ends that carry a ` +
+    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
+    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/integrations/gemini/hooks/lib/rewrite.mjs
+++ b/integrations/gemini/hooks/lib/rewrite.mjs
@@ -1,0 +1,137 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/rewrite.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Bounding a command's output instead of refusing the command.
+ *
+ * WHY THIS EXISTS. A refusal costs approximately ONE EXTRA TURN. Measured on
+ * the THOL battery, enforcement took turns from 12.6 to 20.9 and cost a
+ * task-mean 1.633x vanilla Claude Code -- last of fifteen -- while the same
+ * build without refusals measured 0.928. The tokens a refusal "saves" are
+ * smaller than the round trip it spends, so the mechanism, not the policy, is
+ * what loses.
+ *
+ * A PreToolUse hook can return `updatedInput`, and the rewritten call runs.
+ * Verified end to end (docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md):
+ * a hook that rewrote `echo PROBE_ORIGINAL` to `echo PROBE_REWRITTEN` produced
+ * PROBE_REWRITTEN in the model's context, with no refusal and no retry. So the
+ * same bound can be applied for zero turns.
+ *
+ * PostToolUse cannot do this. Its output schema carries only `additionalContext`
+ * and `classifierContext` -- there is no field that replaces a tool result --
+ * and it never fires for a failed call at all (4,499 of 4,499 live outcomes
+ * report success, every exit code null). Bounding has to happen BEFORE the
+ * command runs, which is also the only way it can reach the failing test runs a
+ * debug loop is made of.
+ */
+
+/**
+ * Default bound, in bytes.
+ *
+ * The client's own cap is the reference point: `BASH_MAX_OUTPUT_LENGTH`
+ * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
+ * output is already bounded -- generously. This default is deliberately well
+ * under it, because the family being targeted is the debug loop, where the SAME
+ * wall of test output arrives on every iteration and the tail is the part that
+ * says what failed.
+ */
+export const DEFAULT_BOUND_BYTES = 8_000;
+
+export function boundBytes() {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_BOUND_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_BOUND_BYTES;
+}
+
+/**
+ * Shapes that must never be rewritten.
+ *
+ * Every one of these is a case where wrapping the command changes what it
+ * MEANS, not just how much of it is shown. Rewriting is a silent mutation of
+ * somebody's command; the bar for doing it is that the result is unarguably the
+ * same command with less output, and anything short of that is left alone.
+ */
+function unsafeToBound(command) {
+  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
+  // relative to the braces. Getting this wrong corrupts the payload rather than
+  // failing loudly -- the same class of damage a greedy regex does to source.
+  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+
+  // Backgrounding detaches the process; a pipeline cannot bound what it no
+  // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
+  if (/(?<![&|>])&(?!&)/.test(command)) return 'background';
+
+  // stdout already going somewhere other than the model's context. Bounding it
+  // would change what lands in the FILE, which is the opposite of harmless.
+  if (/(?<![0-9])>>?\s*(?!&)\S/.test(command)) return 'redirected';
+
+  // Already bounded by its author. Re-bounding buys nothing and risks changing
+  // a deliberate `head -n 5` into something else.
+  if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
+
+  // An interactive or streaming command has no meaningful tail, and buffering
+  // it through a pipe can hang.
+  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+    return 'interactive';
+  }
+
+  return null;
+}
+
+/**
+ * The bounded form of a command, or null when it must be left alone.
+ *
+ * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
+ * puts its verdict at the END -- the failure summary, the counts -- so the tail
+ * is the part worth keeping. And `head` closes the pipe early, which sends
+ * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
+ * then report exit 141 and read as a failure. `tail` consumes its input, so the
+ * real exit status survives.
+ *
+ * `pipefail` itself is what keeps the exit status honest. Without it the
+ * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * run would look like a passing one -- a far worse outcome than any number of
+ * wasted tokens, because the model would stop debugging.
+ *
+ * The `set -o` is wrapped so a shell without `pipefail` degrades to an
+ * unbounded-status pipeline rather than erroring out before the command runs.
+ */
+export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
+  if (typeof command !== 'string') return null;
+  const trimmed = command.trim();
+  if (!trimmed) return null;
+
+  const unsafe = unsafeToBound(trimmed);
+  if (unsafe) return null;
+
+  return {
+    command:
+      `{ set -o pipefail; } 2>/dev/null; ` +
+      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+    maxBytes,
+  };
+}
+
+/**
+ * What the model is told, so the bound is never a silent mutation.
+ *
+ * THE PROBE'S OWN MODEL CAUGHT US DOING THIS. In the spike, a rewritten command
+ * produced output that did not match what had been asked for, and the model
+ * flagged it as suspicious rather than trusting it:
+ *
+ *   "the output does not match the command ... Something in this session's
+ *    tooling chain either rewrote the command before execution or rewrote the
+ *    result. I'm reporting what I actually received rather than the expected
+ *    string."
+ *
+ * A model that distrusts its own tool output re-runs the command, which spends
+ * exactly the turn this mechanism exists to save. So the rewrite announces
+ * itself, says what was kept, and says how to opt out -- compaction the agent
+ * cannot see is compaction it will fight.
+ */
+export function boundNotice(maxBytes) {
+  return (
+    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
+    `the command ran unchanged but only its tail reached you. The tail is ` +
+    `where a test run puts its verdict. Re-run with the output redirected to ` +
+    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+  );
+}

--- a/integrations/gemini/hooks/lib/rewrite.mjs
+++ b/integrations/gemini/hooks/lib/rewrite.mjs
@@ -155,24 +155,30 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
   // then keeps the last half of what remains. Verified to preserve a non-zero
   // exit status through both stages.
-  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
-  // "middle omitted" after a two-line command claims a truncation that never
-  // happened -- the same class of error as a reader reporting a windowed event
-  // log it did not actually window. A model told its output was cut will go
-  // looking for the rest, which costs the turn this whole module exists to save.
+  // NO IN-STREAM MARKER, AND NO PROBE. `{ head -c H; tail -c H; }` is already
+  // exact in every regime, which two earlier attempts at a marker were not:
   //
-  // `read -r -N1` is the test: it succeeds only if a byte remains after the
-  // head, which means there really is a middle. That byte is then printed back
-  // so it is not swallowed.
+  //   total <= half        head prints it all, tail has nothing  -> COMPLETE
+  //   half < total <= max  head takes half, tail takes the rest  -> COMPLETE
+  //   total > max          head takes half, tail takes the last  -> exactly max
+  //
+  // An unconditional marker lied whenever the output fitted. Gating it on
+  // `read -r -N1` narrowed the lie to the middle band above -- where the output
+  // is returned COMPLETE and the marker still claimed an omission -- and the
+  // probe also relied on a bash-only `read -N`, which a POSIX shell rejects,
+  // skipping the tail entirely and leaking an error to stderr.
+  //
+  // Both defects came from trying to detect truncation from inside a pipe,
+  // which cannot see a total it has not yet consumed. So the announcement moves
+  // to `boundNotice`, stated as the POLICY ("output over N bytes is bounded")
+  // rather than as a claim about this particular output. A policy statement is
+  // true whether or not this command was cut, so it cannot lie.
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
       `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
-      `{ head -c ${half}; ` +
-      `if IFS= read -r -N1 _tok_rest; then ` +
-      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
-      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
+      `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };
 }
@@ -196,10 +202,11 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
-    `command ran unchanged, and you were given its beginning and its end with ` +
-    `the middle omitted and marked. Those are the two ends that carry a ` +
-    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
-    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
+    `token-optimizer bounds this command's output: anything over ${maxBytes} ` +
+    `bytes is returned as its beginning and its end, with the middle dropped. ` +
+    `Shorter output is returned complete and untouched. The command itself ran ` +
+    `unchanged, and those two ends are where a run says what failed and how it ` +
+    `finished. Redirect the output to a file, or raise ` +
+    `TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/integrations/gemini/hooks/lib/rewrite.mjs
+++ b/integrations/gemini/hooks/lib/rewrite.mjs
@@ -89,7 +89,16 @@ function unsafeToBound(command) {
   // `tail --follow=name`. The flag does not have to come first and does not
   // have to be short, so the guard looks anywhere in the `tail` invocation --
   // bounded to that command by stopping at a `;`, `|` or `&`.
-  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+  // CLUSTERED SHORT OPTIONS TOO. GNU tail accepts `-fn 1` and `-fF`, and a
+  // guard anchored on `-f\b` matches neither, because the `\b` fails against
+  // the next clustered letter. Both keep following and never reach EOF, so the
+  // bound waits forever. The character class therefore looks for f or F
+  // ANYWHERE in a short-option cluster.
+  if (
+    /\btail\b[^;|&]*(\s-[a-zA-Z]*[fF][a-zA-Z]*\b|\s--follow\b|\s--follow=)/.test(
+      command
+    )
+  ) {
     return 'follow-mode';
   }
 
@@ -112,11 +121,19 @@ function unsafeToBound(command) {
  * exited 1 once wrapped. Silently changing a command's exit status is the same
  * defect as masking one, in the other direction.
  *
- * The command therefore runs inside a subshell that restores the shell default
- * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
- * properties hold at once, and an explicit `set -o pipefail` written by the
- * caller still takes effect, because it executes inside that subshell after
- * the reset.
+ * The command therefore runs inside a subshell that restores THE CALLER'S OWN
+ * state, while the OUTER pipeline -- ours -- keeps pipefail. `set +o` prints
+ * the current options in re-inputtable form, so the one `pipefail` line is
+ * captured before we change anything and eval'd back inside the subshell.
+ *
+ * Restoring rather than CLEARING, because clearing is the same bug mirrored: a
+ * caller running under `bash -o pipefail` would have had `false | true` return
+ * 1, and a hard `set +o pipefail` would hand them 0. Either direction is a
+ * silent change to an exit status we were only supposed to be bounding the
+ * output of.
+ *
+ * An explicit `set -o pipefail` written inside the command still takes effect,
+ * because it executes inside that subshell after the restore.
  *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
@@ -176,8 +193,9 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
+      `_tok_pf=$(set +o 2>/dev/null | grep pipefail); ` +
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
+      `( eval "$_tok_pf" 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };

--- a/integrations/gemini/hooks/lib/rewrite.mjs
+++ b/integrations/gemini/hooks/lib/rewrite.mjs
@@ -51,10 +51,18 @@ export function boundBytes() {
  * same command with less output, and anything short of that is left alone.
  */
 function unsafeToBound(command) {
-  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
-  // relative to the braces. Getting this wrong corrupts the payload rather than
-  // failing loudly -- the same class of damage a greedy regex does to source.
-  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+  // EVERY `<<`, not a guess at the delimiter shape. A heredoc body is data, and
+  // wrapping it moves the terminator relative to the braces -- which corrupts
+  // the payload rather than failing loudly, the same class of damage a greedy
+  // regex does to source.
+  //
+  // The first version tried to match the delimiter (`<<-?\s*['"]?\w+`) and
+  // missed the ESCAPED form: `cat <<\EOF` was rewritten. Bash accepts several
+  // spellings -- bare, single-quoted, double-quoted, backslash-escaped, `<<-`,
+  // and with arbitrary spacing -- so enumerating them is a losing game. The
+  // operator itself is unambiguous. Herestrings (`<<<`) are swept up too: they
+  // would be safe to bound, and giving that up is the cheaper mistake.
+  if (/<</.test(command)) return 'heredoc';
 
   // Backgrounding detaches the process; a pipeline cannot bound what it no
   // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
@@ -69,9 +77,20 @@ function unsafeToBound(command) {
   if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
 
   // An interactive or streaming command has no meaningful tail, and buffering
-  // it through a pipe can hang.
-  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+  // it through a pipe does not merely waste effort -- it HANGS, because the
+  // wrapper's own `tail -c` cannot emit anything until EOF and follow mode
+  // never reaches EOF.
+  if (/\b(watch|less|more|vim|nano|top|htop)\b/.test(command)) {
     return 'interactive';
+  }
+
+  // FOLLOW MODE IN ANY SPELLING. Matching only `tail -f` left four working
+  // forms to hang: `tail -F`, `tail -n 100 -f`, `tail --follow` and
+  // `tail --follow=name`. The flag does not have to come first and does not
+  // have to be short, so the guard looks anywhere in the `tail` invocation --
+  // bounded to that command by stopping at a `;`, `|` or `&`.
+  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+    return 'follow-mode';
   }
 
   return null;

--- a/integrations/kilo/hooks/lib/policy.mjs
+++ b/integrations/kilo/hooks/lib/policy.mjs
@@ -701,6 +701,41 @@ export function allowWithContext(context) {
 }
 
 /**
+ * Lets the call run, but with a rewritten input -- the zero-turn alternative to
+ * a refusal.
+ *
+ * `updatedInput` is a real PreToolUse field and the rewritten call really runs;
+ * docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md has the end-to-end
+ * verification. This emitter is what makes it usable. A refusal costs about one
+ * extra turn, and turns are the whole measured deficit -- 12.6 to 20.9 under
+ * enforcement, for a task-mean 1.633x -- so a bound applied here is free where
+ * the same bound applied by refusing is not.
+ *
+ * The notice rides along as `additionalContext` rather than being baked into
+ * the command, so the command's own output is never mangled to carry a message.
+ *
+ * IT IS NOT OPTIONAL. The spike's model noticed an unannounced rewrite and
+ * distrusted the result -- "the output does not match the command ... I'm
+ * reporting what I actually received" -- and a model that distrusts its output
+ * re-runs the command, spending the exact turn this exists to save.
+ */
+export function allowWithRewrite(updatedInput, notice) {
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'allow',
+      permissionDecisionReason: 'token-optimizer bounded this output',
+      updatedInput,
+      ...(notice ? { additionalContext: withEscape(notice) } : {}),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
+  process.exit(0);
+}
+
+/**
  * Blocks the call and tells the model exactly what to call instead.
  *
  * The reason string is the whole user interface of this product for an agent.

--- a/integrations/kilo/hooks/lib/rewrite.mjs
+++ b/integrations/kilo/hooks/lib/rewrite.mjs
@@ -106,6 +106,18 @@ function unsafeToBound(command) {
  * wrapped so a shell without `pipefail` degrades to an unbounded-status
  * pipeline rather than erroring out before the command runs.
  *
+ * BUT IT MUST NOT LEAK INTO THE CALLER'S OWN PIPELINE. `pipefail` is a shell
+ * option, not a property of one pipe, so enabling it changed the meaning of any
+ * command that already contained a pipe: `false | true` exits 0 normally and
+ * exited 1 once wrapped. Silently changing a command's exit status is the same
+ * defect as masking one, in the other direction.
+ *
+ * The command therefore runs inside a subshell that restores the shell default
+ * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
+ * properties hold at once, and an explicit `set -o pipefail` written by the
+ * caller still takes effect, because it executes inside that subshell after
+ * the reset.
+ *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
  * turns a perfectly successful command into exit 141. Inside
@@ -156,7 +168,7 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}\n} 2>&1 | ` +
+      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; ` +
       `if IFS= read -r -N1 _tok_rest; then ` +
       `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +

--- a/integrations/kilo/hooks/lib/rewrite.mjs
+++ b/integrations/kilo/hooks/lib/rewrite.mjs
@@ -31,8 +31,9 @@
  * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
  * output is already bounded -- generously. This default is deliberately well
  * under it, because the family being targeted is the debug loop, where the SAME
- * wall of test output arrives on every iteration and the tail is the part that
- * says what failed.
+ * wall of test output arrives on every iteration. It is split evenly between
+ * the head and the tail of the output, which is where a run says what failed
+ * and how it ended.
  */
 export const DEFAULT_BOUND_BYTES = 8_000;
 
@@ -79,20 +80,19 @@ function unsafeToBound(command) {
 /**
  * The bounded form of a command, or null when it must be left alone.
  *
- * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
- * puts its verdict at the END -- the failure summary, the counts -- so the tail
- * is the part worth keeping. And `head` closes the pipe early, which sends
- * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
- * then report exit 141 and read as a failure. `tail` consumes its input, so the
- * real exit status survives.
- *
- * `pipefail` itself is what keeps the exit status honest. Without it the
- * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * `pipefail` is what keeps the exit status honest. Without it the pipeline
+ * reports the LAST stage's status, which is always 0, and every failing test
  * run would look like a passing one -- a far worse outcome than any number of
- * wasted tokens, because the model would stop debugging.
+ * wasted tokens, because the model would stop debugging. The `set -o` is
+ * wrapped so a shell without `pipefail` degrades to an unbounded-status
+ * pipeline rather than erroring out before the command runs.
  *
- * The `set -o` is wrapped so a shell without `pipefail` degrades to an
- * unbounded-status pipeline rather than erroring out before the command runs.
+ * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
+ * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
+ * turns a perfectly successful command into exit 141. Inside
+ * `{ head -c N; ...; tail -c N; }` the group keeps reading, so the producer is
+ * never signalled and the real status survives -- asserted by pushing `exit 3`
+ * and `exit 7` through it.
  */
 export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   if (typeof command !== 'string') return null;
@@ -102,10 +102,46 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const unsafe = unsafeToBound(trimmed);
   if (unsafe) return null;
 
+  // A NEWLINE BEFORE THE CLOSING BRACE, NEVER `; }`. Two ordinary commands
+  // broke under the semicolon form, both of which run fine unwrapped:
+  //
+  //   echo hi # explain   ->  { echo hi # explain; }   the `; }` is INSIDE the
+  //                           comment, so the group is never closed
+  //   echo hi;            ->  { echo hi;; }            `;;` is a syntax error
+  //
+  // A newline terminates a comment and satisfies bash's requirement for a
+  // separator before `}`, so it handles both. Breaking a command that would
+  // have worked is the worst thing this module can do -- worse than any number
+  // of tokens -- because the failure looks like the user's own command is wrong.
+  //
+  // HEAD *AND* TAIL, because the client's own truncation keeps both. Claude
+  // Code caps Bash output at 30,000 characters and truncates from the MIDDLE
+  // (its binary carries `... [N characters truncated] ...` and
+  // `truncate-middle`). A tail-only bound is cheaper AND drops the head, where
+  // a failing jest run lists WHICH suites failed -- so it could read as an
+  // improvement on cost while being a regression for the model.
+  //
+  // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
+  // then keeps the last half of what remains. Verified to preserve a non-zero
+  // exit status through both stages.
+  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
+  // "middle omitted" after a two-line command claims a truncation that never
+  // happened -- the same class of error as a reader reporting a windowed event
+  // log it did not actually window. A model told its output was cut will go
+  // looking for the rest, which costs the turn this whole module exists to save.
+  //
+  // `read -r -N1` is the test: it succeeds only if a byte remains after the
+  // head, which means there really is a middle. That byte is then printed back
+  // so it is not swallowed.
+  const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+      `{ ${trimmed}\n} 2>&1 | ` +
+      `{ head -c ${half}; ` +
+      `if IFS= read -r -N1 _tok_rest; then ` +
+      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
+      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
     maxBytes,
   };
 }
@@ -129,9 +165,10 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
-    `the command ran unchanged but only its tail reached you. The tail is ` +
-    `where a test run puts its verdict. Re-run with the output redirected to ` +
-    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
+    `command ran unchanged, and you were given its beginning and its end with ` +
+    `the middle omitted and marked. Those are the two ends that carry a ` +
+    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
+    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/integrations/kilo/hooks/lib/rewrite.mjs
+++ b/integrations/kilo/hooks/lib/rewrite.mjs
@@ -1,0 +1,137 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/rewrite.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Bounding a command's output instead of refusing the command.
+ *
+ * WHY THIS EXISTS. A refusal costs approximately ONE EXTRA TURN. Measured on
+ * the THOL battery, enforcement took turns from 12.6 to 20.9 and cost a
+ * task-mean 1.633x vanilla Claude Code -- last of fifteen -- while the same
+ * build without refusals measured 0.928. The tokens a refusal "saves" are
+ * smaller than the round trip it spends, so the mechanism, not the policy, is
+ * what loses.
+ *
+ * A PreToolUse hook can return `updatedInput`, and the rewritten call runs.
+ * Verified end to end (docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md):
+ * a hook that rewrote `echo PROBE_ORIGINAL` to `echo PROBE_REWRITTEN` produced
+ * PROBE_REWRITTEN in the model's context, with no refusal and no retry. So the
+ * same bound can be applied for zero turns.
+ *
+ * PostToolUse cannot do this. Its output schema carries only `additionalContext`
+ * and `classifierContext` -- there is no field that replaces a tool result --
+ * and it never fires for a failed call at all (4,499 of 4,499 live outcomes
+ * report success, every exit code null). Bounding has to happen BEFORE the
+ * command runs, which is also the only way it can reach the failing test runs a
+ * debug loop is made of.
+ */
+
+/**
+ * Default bound, in bytes.
+ *
+ * The client's own cap is the reference point: `BASH_MAX_OUTPUT_LENGTH`
+ * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
+ * output is already bounded -- generously. This default is deliberately well
+ * under it, because the family being targeted is the debug loop, where the SAME
+ * wall of test output arrives on every iteration and the tail is the part that
+ * says what failed.
+ */
+export const DEFAULT_BOUND_BYTES = 8_000;
+
+export function boundBytes() {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_BOUND_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_BOUND_BYTES;
+}
+
+/**
+ * Shapes that must never be rewritten.
+ *
+ * Every one of these is a case where wrapping the command changes what it
+ * MEANS, not just how much of it is shown. Rewriting is a silent mutation of
+ * somebody's command; the bar for doing it is that the result is unarguably the
+ * same command with less output, and anything short of that is left alone.
+ */
+function unsafeToBound(command) {
+  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
+  // relative to the braces. Getting this wrong corrupts the payload rather than
+  // failing loudly -- the same class of damage a greedy regex does to source.
+  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+
+  // Backgrounding detaches the process; a pipeline cannot bound what it no
+  // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
+  if (/(?<![&|>])&(?!&)/.test(command)) return 'background';
+
+  // stdout already going somewhere other than the model's context. Bounding it
+  // would change what lands in the FILE, which is the opposite of harmless.
+  if (/(?<![0-9])>>?\s*(?!&)\S/.test(command)) return 'redirected';
+
+  // Already bounded by its author. Re-bounding buys nothing and risks changing
+  // a deliberate `head -n 5` into something else.
+  if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
+
+  // An interactive or streaming command has no meaningful tail, and buffering
+  // it through a pipe can hang.
+  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+    return 'interactive';
+  }
+
+  return null;
+}
+
+/**
+ * The bounded form of a command, or null when it must be left alone.
+ *
+ * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
+ * puts its verdict at the END -- the failure summary, the counts -- so the tail
+ * is the part worth keeping. And `head` closes the pipe early, which sends
+ * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
+ * then report exit 141 and read as a failure. `tail` consumes its input, so the
+ * real exit status survives.
+ *
+ * `pipefail` itself is what keeps the exit status honest. Without it the
+ * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * run would look like a passing one -- a far worse outcome than any number of
+ * wasted tokens, because the model would stop debugging.
+ *
+ * The `set -o` is wrapped so a shell without `pipefail` degrades to an
+ * unbounded-status pipeline rather than erroring out before the command runs.
+ */
+export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
+  if (typeof command !== 'string') return null;
+  const trimmed = command.trim();
+  if (!trimmed) return null;
+
+  const unsafe = unsafeToBound(trimmed);
+  if (unsafe) return null;
+
+  return {
+    command:
+      `{ set -o pipefail; } 2>/dev/null; ` +
+      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+    maxBytes,
+  };
+}
+
+/**
+ * What the model is told, so the bound is never a silent mutation.
+ *
+ * THE PROBE'S OWN MODEL CAUGHT US DOING THIS. In the spike, a rewritten command
+ * produced output that did not match what had been asked for, and the model
+ * flagged it as suspicious rather than trusting it:
+ *
+ *   "the output does not match the command ... Something in this session's
+ *    tooling chain either rewrote the command before execution or rewrote the
+ *    result. I'm reporting what I actually received rather than the expected
+ *    string."
+ *
+ * A model that distrusts its own tool output re-runs the command, which spends
+ * exactly the turn this mechanism exists to save. So the rewrite announces
+ * itself, says what was kept, and says how to opt out -- compaction the agent
+ * cannot see is compaction it will fight.
+ */
+export function boundNotice(maxBytes) {
+  return (
+    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
+    `the command ran unchanged but only its tail reached you. The tail is ` +
+    `where a test run puts its verdict. Re-run with the output redirected to ` +
+    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+  );
+}

--- a/integrations/kilo/hooks/lib/rewrite.mjs
+++ b/integrations/kilo/hooks/lib/rewrite.mjs
@@ -155,24 +155,30 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
   // then keeps the last half of what remains. Verified to preserve a non-zero
   // exit status through both stages.
-  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
-  // "middle omitted" after a two-line command claims a truncation that never
-  // happened -- the same class of error as a reader reporting a windowed event
-  // log it did not actually window. A model told its output was cut will go
-  // looking for the rest, which costs the turn this whole module exists to save.
+  // NO IN-STREAM MARKER, AND NO PROBE. `{ head -c H; tail -c H; }` is already
+  // exact in every regime, which two earlier attempts at a marker were not:
   //
-  // `read -r -N1` is the test: it succeeds only if a byte remains after the
-  // head, which means there really is a middle. That byte is then printed back
-  // so it is not swallowed.
+  //   total <= half        head prints it all, tail has nothing  -> COMPLETE
+  //   half < total <= max  head takes half, tail takes the rest  -> COMPLETE
+  //   total > max          head takes half, tail takes the last  -> exactly max
+  //
+  // An unconditional marker lied whenever the output fitted. Gating it on
+  // `read -r -N1` narrowed the lie to the middle band above -- where the output
+  // is returned COMPLETE and the marker still claimed an omission -- and the
+  // probe also relied on a bash-only `read -N`, which a POSIX shell rejects,
+  // skipping the tail entirely and leaking an error to stderr.
+  //
+  // Both defects came from trying to detect truncation from inside a pipe,
+  // which cannot see a total it has not yet consumed. So the announcement moves
+  // to `boundNotice`, stated as the POLICY ("output over N bytes is bounded")
+  // rather than as a claim about this particular output. A policy statement is
+  // true whether or not this command was cut, so it cannot lie.
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
       `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
-      `{ head -c ${half}; ` +
-      `if IFS= read -r -N1 _tok_rest; then ` +
-      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
-      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
+      `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };
 }
@@ -196,10 +202,11 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
-    `command ran unchanged, and you were given its beginning and its end with ` +
-    `the middle omitted and marked. Those are the two ends that carry a ` +
-    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
-    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
+    `token-optimizer bounds this command's output: anything over ${maxBytes} ` +
+    `bytes is returned as its beginning and its end, with the middle dropped. ` +
+    `Shorter output is returned complete and untouched. The command itself ran ` +
+    `unchanged, and those two ends are where a run says what failed and how it ` +
+    `finished. Redirect the output to a file, or raise ` +
+    `TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/integrations/kilo/hooks/lib/rewrite.mjs
+++ b/integrations/kilo/hooks/lib/rewrite.mjs
@@ -89,7 +89,16 @@ function unsafeToBound(command) {
   // `tail --follow=name`. The flag does not have to come first and does not
   // have to be short, so the guard looks anywhere in the `tail` invocation --
   // bounded to that command by stopping at a `;`, `|` or `&`.
-  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+  // CLUSTERED SHORT OPTIONS TOO. GNU tail accepts `-fn 1` and `-fF`, and a
+  // guard anchored on `-f\b` matches neither, because the `\b` fails against
+  // the next clustered letter. Both keep following and never reach EOF, so the
+  // bound waits forever. The character class therefore looks for f or F
+  // ANYWHERE in a short-option cluster.
+  if (
+    /\btail\b[^;|&]*(\s-[a-zA-Z]*[fF][a-zA-Z]*\b|\s--follow\b|\s--follow=)/.test(
+      command
+    )
+  ) {
     return 'follow-mode';
   }
 
@@ -112,11 +121,19 @@ function unsafeToBound(command) {
  * exited 1 once wrapped. Silently changing a command's exit status is the same
  * defect as masking one, in the other direction.
  *
- * The command therefore runs inside a subshell that restores the shell default
- * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
- * properties hold at once, and an explicit `set -o pipefail` written by the
- * caller still takes effect, because it executes inside that subshell after
- * the reset.
+ * The command therefore runs inside a subshell that restores THE CALLER'S OWN
+ * state, while the OUTER pipeline -- ours -- keeps pipefail. `set +o` prints
+ * the current options in re-inputtable form, so the one `pipefail` line is
+ * captured before we change anything and eval'd back inside the subshell.
+ *
+ * Restoring rather than CLEARING, because clearing is the same bug mirrored: a
+ * caller running under `bash -o pipefail` would have had `false | true` return
+ * 1, and a hard `set +o pipefail` would hand them 0. Either direction is a
+ * silent change to an exit status we were only supposed to be bounding the
+ * output of.
+ *
+ * An explicit `set -o pipefail` written inside the command still takes effect,
+ * because it executes inside that subshell after the restore.
  *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
@@ -176,8 +193,9 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
+      `_tok_pf=$(set +o 2>/dev/null | grep pipefail); ` +
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
+      `( eval "$_tok_pf" 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };

--- a/integrations/kilo/hooks/lib/rewrite.mjs
+++ b/integrations/kilo/hooks/lib/rewrite.mjs
@@ -51,10 +51,18 @@ export function boundBytes() {
  * same command with less output, and anything short of that is left alone.
  */
 function unsafeToBound(command) {
-  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
-  // relative to the braces. Getting this wrong corrupts the payload rather than
-  // failing loudly -- the same class of damage a greedy regex does to source.
-  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+  // EVERY `<<`, not a guess at the delimiter shape. A heredoc body is data, and
+  // wrapping it moves the terminator relative to the braces -- which corrupts
+  // the payload rather than failing loudly, the same class of damage a greedy
+  // regex does to source.
+  //
+  // The first version tried to match the delimiter (`<<-?\s*['"]?\w+`) and
+  // missed the ESCAPED form: `cat <<\EOF` was rewritten. Bash accepts several
+  // spellings -- bare, single-quoted, double-quoted, backslash-escaped, `<<-`,
+  // and with arbitrary spacing -- so enumerating them is a losing game. The
+  // operator itself is unambiguous. Herestrings (`<<<`) are swept up too: they
+  // would be safe to bound, and giving that up is the cheaper mistake.
+  if (/<</.test(command)) return 'heredoc';
 
   // Backgrounding detaches the process; a pipeline cannot bound what it no
   // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
@@ -69,9 +77,20 @@ function unsafeToBound(command) {
   if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
 
   // An interactive or streaming command has no meaningful tail, and buffering
-  // it through a pipe can hang.
-  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+  // it through a pipe does not merely waste effort -- it HANGS, because the
+  // wrapper's own `tail -c` cannot emit anything until EOF and follow mode
+  // never reaches EOF.
+  if (/\b(watch|less|more|vim|nano|top|htop)\b/.test(command)) {
     return 'interactive';
+  }
+
+  // FOLLOW MODE IN ANY SPELLING. Matching only `tail -f` left four working
+  // forms to hang: `tail -F`, `tail -n 100 -f`, `tail --follow` and
+  // `tail --follow=name`. The flag does not have to come first and does not
+  // have to be short, so the guard looks anywhere in the `tail` invocation --
+  // bounded to that command by stopping at a `;`, `|` or `&`.
+  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+    return 'follow-mode';
   }
 
   return null;

--- a/integrations/opencode/hooks/lib/policy.mjs
+++ b/integrations/opencode/hooks/lib/policy.mjs
@@ -701,6 +701,41 @@ export function allowWithContext(context) {
 }
 
 /**
+ * Lets the call run, but with a rewritten input -- the zero-turn alternative to
+ * a refusal.
+ *
+ * `updatedInput` is a real PreToolUse field and the rewritten call really runs;
+ * docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md has the end-to-end
+ * verification. This emitter is what makes it usable. A refusal costs about one
+ * extra turn, and turns are the whole measured deficit -- 12.6 to 20.9 under
+ * enforcement, for a task-mean 1.633x -- so a bound applied here is free where
+ * the same bound applied by refusing is not.
+ *
+ * The notice rides along as `additionalContext` rather than being baked into
+ * the command, so the command's own output is never mangled to carry a message.
+ *
+ * IT IS NOT OPTIONAL. The spike's model noticed an unannounced rewrite and
+ * distrusted the result -- "the output does not match the command ... I'm
+ * reporting what I actually received" -- and a model that distrusts its output
+ * re-runs the command, spending the exact turn this exists to save.
+ */
+export function allowWithRewrite(updatedInput, notice) {
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'allow',
+      permissionDecisionReason: 'token-optimizer bounded this output',
+      updatedInput,
+      ...(notice ? { additionalContext: withEscape(notice) } : {}),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
+  process.exit(0);
+}
+
+/**
  * Blocks the call and tells the model exactly what to call instead.
  *
  * The reason string is the whole user interface of this product for an agent.

--- a/integrations/opencode/hooks/lib/rewrite.mjs
+++ b/integrations/opencode/hooks/lib/rewrite.mjs
@@ -106,6 +106,18 @@ function unsafeToBound(command) {
  * wrapped so a shell without `pipefail` degrades to an unbounded-status
  * pipeline rather than erroring out before the command runs.
  *
+ * BUT IT MUST NOT LEAK INTO THE CALLER'S OWN PIPELINE. `pipefail` is a shell
+ * option, not a property of one pipe, so enabling it changed the meaning of any
+ * command that already contained a pipe: `false | true` exits 0 normally and
+ * exited 1 once wrapped. Silently changing a command's exit status is the same
+ * defect as masking one, in the other direction.
+ *
+ * The command therefore runs inside a subshell that restores the shell default
+ * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
+ * properties hold at once, and an explicit `set -o pipefail` written by the
+ * caller still takes effect, because it executes inside that subshell after
+ * the reset.
+ *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
  * turns a perfectly successful command into exit 141. Inside
@@ -156,7 +168,7 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}\n} 2>&1 | ` +
+      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; ` +
       `if IFS= read -r -N1 _tok_rest; then ` +
       `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +

--- a/integrations/opencode/hooks/lib/rewrite.mjs
+++ b/integrations/opencode/hooks/lib/rewrite.mjs
@@ -31,8 +31,9 @@
  * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
  * output is already bounded -- generously. This default is deliberately well
  * under it, because the family being targeted is the debug loop, where the SAME
- * wall of test output arrives on every iteration and the tail is the part that
- * says what failed.
+ * wall of test output arrives on every iteration. It is split evenly between
+ * the head and the tail of the output, which is where a run says what failed
+ * and how it ended.
  */
 export const DEFAULT_BOUND_BYTES = 8_000;
 
@@ -79,20 +80,19 @@ function unsafeToBound(command) {
 /**
  * The bounded form of a command, or null when it must be left alone.
  *
- * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
- * puts its verdict at the END -- the failure summary, the counts -- so the tail
- * is the part worth keeping. And `head` closes the pipe early, which sends
- * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
- * then report exit 141 and read as a failure. `tail` consumes its input, so the
- * real exit status survives.
- *
- * `pipefail` itself is what keeps the exit status honest. Without it the
- * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * `pipefail` is what keeps the exit status honest. Without it the pipeline
+ * reports the LAST stage's status, which is always 0, and every failing test
  * run would look like a passing one -- a far worse outcome than any number of
- * wasted tokens, because the model would stop debugging.
+ * wasted tokens, because the model would stop debugging. The `set -o` is
+ * wrapped so a shell without `pipefail` degrades to an unbounded-status
+ * pipeline rather than erroring out before the command runs.
  *
- * The `set -o` is wrapped so a shell without `pipefail` degrades to an
- * unbounded-status pipeline rather than erroring out before the command runs.
+ * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
+ * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
+ * turns a perfectly successful command into exit 141. Inside
+ * `{ head -c N; ...; tail -c N; }` the group keeps reading, so the producer is
+ * never signalled and the real status survives -- asserted by pushing `exit 3`
+ * and `exit 7` through it.
  */
 export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   if (typeof command !== 'string') return null;
@@ -102,10 +102,46 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const unsafe = unsafeToBound(trimmed);
   if (unsafe) return null;
 
+  // A NEWLINE BEFORE THE CLOSING BRACE, NEVER `; }`. Two ordinary commands
+  // broke under the semicolon form, both of which run fine unwrapped:
+  //
+  //   echo hi # explain   ->  { echo hi # explain; }   the `; }` is INSIDE the
+  //                           comment, so the group is never closed
+  //   echo hi;            ->  { echo hi;; }            `;;` is a syntax error
+  //
+  // A newline terminates a comment and satisfies bash's requirement for a
+  // separator before `}`, so it handles both. Breaking a command that would
+  // have worked is the worst thing this module can do -- worse than any number
+  // of tokens -- because the failure looks like the user's own command is wrong.
+  //
+  // HEAD *AND* TAIL, because the client's own truncation keeps both. Claude
+  // Code caps Bash output at 30,000 characters and truncates from the MIDDLE
+  // (its binary carries `... [N characters truncated] ...` and
+  // `truncate-middle`). A tail-only bound is cheaper AND drops the head, where
+  // a failing jest run lists WHICH suites failed -- so it could read as an
+  // improvement on cost while being a regression for the model.
+  //
+  // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
+  // then keeps the last half of what remains. Verified to preserve a non-zero
+  // exit status through both stages.
+  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
+  // "middle omitted" after a two-line command claims a truncation that never
+  // happened -- the same class of error as a reader reporting a windowed event
+  // log it did not actually window. A model told its output was cut will go
+  // looking for the rest, which costs the turn this whole module exists to save.
+  //
+  // `read -r -N1` is the test: it succeeds only if a byte remains after the
+  // head, which means there really is a middle. That byte is then printed back
+  // so it is not swallowed.
+  const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+      `{ ${trimmed}\n} 2>&1 | ` +
+      `{ head -c ${half}; ` +
+      `if IFS= read -r -N1 _tok_rest; then ` +
+      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
+      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
     maxBytes,
   };
 }
@@ -129,9 +165,10 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
-    `the command ran unchanged but only its tail reached you. The tail is ` +
-    `where a test run puts its verdict. Re-run with the output redirected to ` +
-    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
+    `command ran unchanged, and you were given its beginning and its end with ` +
+    `the middle omitted and marked. Those are the two ends that carry a ` +
+    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
+    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/integrations/opencode/hooks/lib/rewrite.mjs
+++ b/integrations/opencode/hooks/lib/rewrite.mjs
@@ -1,0 +1,137 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/rewrite.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Bounding a command's output instead of refusing the command.
+ *
+ * WHY THIS EXISTS. A refusal costs approximately ONE EXTRA TURN. Measured on
+ * the THOL battery, enforcement took turns from 12.6 to 20.9 and cost a
+ * task-mean 1.633x vanilla Claude Code -- last of fifteen -- while the same
+ * build without refusals measured 0.928. The tokens a refusal "saves" are
+ * smaller than the round trip it spends, so the mechanism, not the policy, is
+ * what loses.
+ *
+ * A PreToolUse hook can return `updatedInput`, and the rewritten call runs.
+ * Verified end to end (docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md):
+ * a hook that rewrote `echo PROBE_ORIGINAL` to `echo PROBE_REWRITTEN` produced
+ * PROBE_REWRITTEN in the model's context, with no refusal and no retry. So the
+ * same bound can be applied for zero turns.
+ *
+ * PostToolUse cannot do this. Its output schema carries only `additionalContext`
+ * and `classifierContext` -- there is no field that replaces a tool result --
+ * and it never fires for a failed call at all (4,499 of 4,499 live outcomes
+ * report success, every exit code null). Bounding has to happen BEFORE the
+ * command runs, which is also the only way it can reach the failing test runs a
+ * debug loop is made of.
+ */
+
+/**
+ * Default bound, in bytes.
+ *
+ * The client's own cap is the reference point: `BASH_MAX_OUTPUT_LENGTH`
+ * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
+ * output is already bounded -- generously. This default is deliberately well
+ * under it, because the family being targeted is the debug loop, where the SAME
+ * wall of test output arrives on every iteration and the tail is the part that
+ * says what failed.
+ */
+export const DEFAULT_BOUND_BYTES = 8_000;
+
+export function boundBytes() {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_BOUND_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_BOUND_BYTES;
+}
+
+/**
+ * Shapes that must never be rewritten.
+ *
+ * Every one of these is a case where wrapping the command changes what it
+ * MEANS, not just how much of it is shown. Rewriting is a silent mutation of
+ * somebody's command; the bar for doing it is that the result is unarguably the
+ * same command with less output, and anything short of that is left alone.
+ */
+function unsafeToBound(command) {
+  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
+  // relative to the braces. Getting this wrong corrupts the payload rather than
+  // failing loudly -- the same class of damage a greedy regex does to source.
+  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+
+  // Backgrounding detaches the process; a pipeline cannot bound what it no
+  // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
+  if (/(?<![&|>])&(?!&)/.test(command)) return 'background';
+
+  // stdout already going somewhere other than the model's context. Bounding it
+  // would change what lands in the FILE, which is the opposite of harmless.
+  if (/(?<![0-9])>>?\s*(?!&)\S/.test(command)) return 'redirected';
+
+  // Already bounded by its author. Re-bounding buys nothing and risks changing
+  // a deliberate `head -n 5` into something else.
+  if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
+
+  // An interactive or streaming command has no meaningful tail, and buffering
+  // it through a pipe can hang.
+  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+    return 'interactive';
+  }
+
+  return null;
+}
+
+/**
+ * The bounded form of a command, or null when it must be left alone.
+ *
+ * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
+ * puts its verdict at the END -- the failure summary, the counts -- so the tail
+ * is the part worth keeping. And `head` closes the pipe early, which sends
+ * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
+ * then report exit 141 and read as a failure. `tail` consumes its input, so the
+ * real exit status survives.
+ *
+ * `pipefail` itself is what keeps the exit status honest. Without it the
+ * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * run would look like a passing one -- a far worse outcome than any number of
+ * wasted tokens, because the model would stop debugging.
+ *
+ * The `set -o` is wrapped so a shell without `pipefail` degrades to an
+ * unbounded-status pipeline rather than erroring out before the command runs.
+ */
+export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
+  if (typeof command !== 'string') return null;
+  const trimmed = command.trim();
+  if (!trimmed) return null;
+
+  const unsafe = unsafeToBound(trimmed);
+  if (unsafe) return null;
+
+  return {
+    command:
+      `{ set -o pipefail; } 2>/dev/null; ` +
+      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+    maxBytes,
+  };
+}
+
+/**
+ * What the model is told, so the bound is never a silent mutation.
+ *
+ * THE PROBE'S OWN MODEL CAUGHT US DOING THIS. In the spike, a rewritten command
+ * produced output that did not match what had been asked for, and the model
+ * flagged it as suspicious rather than trusting it:
+ *
+ *   "the output does not match the command ... Something in this session's
+ *    tooling chain either rewrote the command before execution or rewrote the
+ *    result. I'm reporting what I actually received rather than the expected
+ *    string."
+ *
+ * A model that distrusts its own tool output re-runs the command, which spends
+ * exactly the turn this mechanism exists to save. So the rewrite announces
+ * itself, says what was kept, and says how to opt out -- compaction the agent
+ * cannot see is compaction it will fight.
+ */
+export function boundNotice(maxBytes) {
+  return (
+    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
+    `the command ran unchanged but only its tail reached you. The tail is ` +
+    `where a test run puts its verdict. Re-run with the output redirected to ` +
+    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+  );
+}

--- a/integrations/opencode/hooks/lib/rewrite.mjs
+++ b/integrations/opencode/hooks/lib/rewrite.mjs
@@ -155,24 +155,30 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
   // then keeps the last half of what remains. Verified to preserve a non-zero
   // exit status through both stages.
-  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
-  // "middle omitted" after a two-line command claims a truncation that never
-  // happened -- the same class of error as a reader reporting a windowed event
-  // log it did not actually window. A model told its output was cut will go
-  // looking for the rest, which costs the turn this whole module exists to save.
+  // NO IN-STREAM MARKER, AND NO PROBE. `{ head -c H; tail -c H; }` is already
+  // exact in every regime, which two earlier attempts at a marker were not:
   //
-  // `read -r -N1` is the test: it succeeds only if a byte remains after the
-  // head, which means there really is a middle. That byte is then printed back
-  // so it is not swallowed.
+  //   total <= half        head prints it all, tail has nothing  -> COMPLETE
+  //   half < total <= max  head takes half, tail takes the rest  -> COMPLETE
+  //   total > max          head takes half, tail takes the last  -> exactly max
+  //
+  // An unconditional marker lied whenever the output fitted. Gating it on
+  // `read -r -N1` narrowed the lie to the middle band above -- where the output
+  // is returned COMPLETE and the marker still claimed an omission -- and the
+  // probe also relied on a bash-only `read -N`, which a POSIX shell rejects,
+  // skipping the tail entirely and leaking an error to stderr.
+  //
+  // Both defects came from trying to detect truncation from inside a pipe,
+  // which cannot see a total it has not yet consumed. So the announcement moves
+  // to `boundNotice`, stated as the POLICY ("output over N bytes is bounded")
+  // rather than as a claim about this particular output. A policy statement is
+  // true whether or not this command was cut, so it cannot lie.
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
       `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
-      `{ head -c ${half}; ` +
-      `if IFS= read -r -N1 _tok_rest; then ` +
-      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
-      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
+      `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };
 }
@@ -196,10 +202,11 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
-    `command ran unchanged, and you were given its beginning and its end with ` +
-    `the middle omitted and marked. Those are the two ends that carry a ` +
-    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
-    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
+    `token-optimizer bounds this command's output: anything over ${maxBytes} ` +
+    `bytes is returned as its beginning and its end, with the middle dropped. ` +
+    `Shorter output is returned complete and untouched. The command itself ran ` +
+    `unchanged, and those two ends are where a run says what failed and how it ` +
+    `finished. Redirect the output to a file, or raise ` +
+    `TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/integrations/opencode/hooks/lib/rewrite.mjs
+++ b/integrations/opencode/hooks/lib/rewrite.mjs
@@ -89,7 +89,16 @@ function unsafeToBound(command) {
   // `tail --follow=name`. The flag does not have to come first and does not
   // have to be short, so the guard looks anywhere in the `tail` invocation --
   // bounded to that command by stopping at a `;`, `|` or `&`.
-  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+  // CLUSTERED SHORT OPTIONS TOO. GNU tail accepts `-fn 1` and `-fF`, and a
+  // guard anchored on `-f\b` matches neither, because the `\b` fails against
+  // the next clustered letter. Both keep following and never reach EOF, so the
+  // bound waits forever. The character class therefore looks for f or F
+  // ANYWHERE in a short-option cluster.
+  if (
+    /\btail\b[^;|&]*(\s-[a-zA-Z]*[fF][a-zA-Z]*\b|\s--follow\b|\s--follow=)/.test(
+      command
+    )
+  ) {
     return 'follow-mode';
   }
 
@@ -112,11 +121,19 @@ function unsafeToBound(command) {
  * exited 1 once wrapped. Silently changing a command's exit status is the same
  * defect as masking one, in the other direction.
  *
- * The command therefore runs inside a subshell that restores the shell default
- * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
- * properties hold at once, and an explicit `set -o pipefail` written by the
- * caller still takes effect, because it executes inside that subshell after
- * the reset.
+ * The command therefore runs inside a subshell that restores THE CALLER'S OWN
+ * state, while the OUTER pipeline -- ours -- keeps pipefail. `set +o` prints
+ * the current options in re-inputtable form, so the one `pipefail` line is
+ * captured before we change anything and eval'd back inside the subshell.
+ *
+ * Restoring rather than CLEARING, because clearing is the same bug mirrored: a
+ * caller running under `bash -o pipefail` would have had `false | true` return
+ * 1, and a hard `set +o pipefail` would hand them 0. Either direction is a
+ * silent change to an exit status we were only supposed to be bounding the
+ * output of.
+ *
+ * An explicit `set -o pipefail` written inside the command still takes effect,
+ * because it executes inside that subshell after the restore.
  *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
@@ -176,8 +193,9 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
+      `_tok_pf=$(set +o 2>/dev/null | grep pipefail); ` +
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
+      `( eval "$_tok_pf" 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };

--- a/integrations/opencode/hooks/lib/rewrite.mjs
+++ b/integrations/opencode/hooks/lib/rewrite.mjs
@@ -51,10 +51,18 @@ export function boundBytes() {
  * same command with less output, and anything short of that is left alone.
  */
 function unsafeToBound(command) {
-  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
-  // relative to the braces. Getting this wrong corrupts the payload rather than
-  // failing loudly -- the same class of damage a greedy regex does to source.
-  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+  // EVERY `<<`, not a guess at the delimiter shape. A heredoc body is data, and
+  // wrapping it moves the terminator relative to the braces -- which corrupts
+  // the payload rather than failing loudly, the same class of damage a greedy
+  // regex does to source.
+  //
+  // The first version tried to match the delimiter (`<<-?\s*['"]?\w+`) and
+  // missed the ESCAPED form: `cat <<\EOF` was rewritten. Bash accepts several
+  // spellings -- bare, single-quoted, double-quoted, backslash-escaped, `<<-`,
+  // and with arbitrary spacing -- so enumerating them is a losing game. The
+  // operator itself is unambiguous. Herestrings (`<<<`) are swept up too: they
+  // would be safe to bound, and giving that up is the cheaper mistake.
+  if (/<</.test(command)) return 'heredoc';
 
   // Backgrounding detaches the process; a pipeline cannot bound what it no
   // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
@@ -69,9 +77,20 @@ function unsafeToBound(command) {
   if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
 
   // An interactive or streaming command has no meaningful tail, and buffering
-  // it through a pipe can hang.
-  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+  // it through a pipe does not merely waste effort -- it HANGS, because the
+  // wrapper's own `tail -c` cannot emit anything until EOF and follow mode
+  // never reaches EOF.
+  if (/\b(watch|less|more|vim|nano|top|htop)\b/.test(command)) {
     return 'interactive';
+  }
+
+  // FOLLOW MODE IN ANY SPELLING. Matching only `tail -f` left four working
+  // forms to hang: `tail -F`, `tail -n 100 -f`, `tail --follow` and
+  // `tail --follow=name`. The flag does not have to come first and does not
+  // have to be short, so the guard looks anywhere in the `tail` invocation --
+  // bounded to that command by stopping at a `;`, `|` or `&`.
+  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+    return 'follow-mode';
   }
 
   return null;

--- a/integrations/qwen/hooks/lib/policy.mjs
+++ b/integrations/qwen/hooks/lib/policy.mjs
@@ -701,6 +701,41 @@ export function allowWithContext(context) {
 }
 
 /**
+ * Lets the call run, but with a rewritten input -- the zero-turn alternative to
+ * a refusal.
+ *
+ * `updatedInput` is a real PreToolUse field and the rewritten call really runs;
+ * docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md has the end-to-end
+ * verification. This emitter is what makes it usable. A refusal costs about one
+ * extra turn, and turns are the whole measured deficit -- 12.6 to 20.9 under
+ * enforcement, for a task-mean 1.633x -- so a bound applied here is free where
+ * the same bound applied by refusing is not.
+ *
+ * The notice rides along as `additionalContext` rather than being baked into
+ * the command, so the command's own output is never mangled to carry a message.
+ *
+ * IT IS NOT OPTIONAL. The spike's model noticed an unannounced rewrite and
+ * distrusted the result -- "the output does not match the command ... I'm
+ * reporting what I actually received" -- and a model that distrusts its output
+ * re-runs the command, spending the exact turn this exists to save.
+ */
+export function allowWithRewrite(updatedInput, notice) {
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'allow',
+      permissionDecisionReason: 'token-optimizer bounded this output',
+      updatedInput,
+      ...(notice ? { additionalContext: withEscape(notice) } : {}),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
+  process.exit(0);
+}
+
+/**
  * Blocks the call and tells the model exactly what to call instead.
  *
  * The reason string is the whole user interface of this product for an agent.

--- a/integrations/qwen/hooks/lib/rewrite.mjs
+++ b/integrations/qwen/hooks/lib/rewrite.mjs
@@ -106,6 +106,18 @@ function unsafeToBound(command) {
  * wrapped so a shell without `pipefail` degrades to an unbounded-status
  * pipeline rather than erroring out before the command runs.
  *
+ * BUT IT MUST NOT LEAK INTO THE CALLER'S OWN PIPELINE. `pipefail` is a shell
+ * option, not a property of one pipe, so enabling it changed the meaning of any
+ * command that already contained a pipe: `false | true` exits 0 normally and
+ * exited 1 once wrapped. Silently changing a command's exit status is the same
+ * defect as masking one, in the other direction.
+ *
+ * The command therefore runs inside a subshell that restores the shell default
+ * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
+ * properties hold at once, and an explicit `set -o pipefail` written by the
+ * caller still takes effect, because it executes inside that subshell after
+ * the reset.
+ *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
  * turns a perfectly successful command into exit 141. Inside
@@ -156,7 +168,7 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}\n} 2>&1 | ` +
+      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; ` +
       `if IFS= read -r -N1 _tok_rest; then ` +
       `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +

--- a/integrations/qwen/hooks/lib/rewrite.mjs
+++ b/integrations/qwen/hooks/lib/rewrite.mjs
@@ -31,8 +31,9 @@
  * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
  * output is already bounded -- generously. This default is deliberately well
  * under it, because the family being targeted is the debug loop, where the SAME
- * wall of test output arrives on every iteration and the tail is the part that
- * says what failed.
+ * wall of test output arrives on every iteration. It is split evenly between
+ * the head and the tail of the output, which is where a run says what failed
+ * and how it ended.
  */
 export const DEFAULT_BOUND_BYTES = 8_000;
 
@@ -79,20 +80,19 @@ function unsafeToBound(command) {
 /**
  * The bounded form of a command, or null when it must be left alone.
  *
- * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
- * puts its verdict at the END -- the failure summary, the counts -- so the tail
- * is the part worth keeping. And `head` closes the pipe early, which sends
- * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
- * then report exit 141 and read as a failure. `tail` consumes its input, so the
- * real exit status survives.
- *
- * `pipefail` itself is what keeps the exit status honest. Without it the
- * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * `pipefail` is what keeps the exit status honest. Without it the pipeline
+ * reports the LAST stage's status, which is always 0, and every failing test
  * run would look like a passing one -- a far worse outcome than any number of
- * wasted tokens, because the model would stop debugging.
+ * wasted tokens, because the model would stop debugging. The `set -o` is
+ * wrapped so a shell without `pipefail` degrades to an unbounded-status
+ * pipeline rather than erroring out before the command runs.
  *
- * The `set -o` is wrapped so a shell without `pipefail` degrades to an
- * unbounded-status pipeline rather than erroring out before the command runs.
+ * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
+ * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
+ * turns a perfectly successful command into exit 141. Inside
+ * `{ head -c N; ...; tail -c N; }` the group keeps reading, so the producer is
+ * never signalled and the real status survives -- asserted by pushing `exit 3`
+ * and `exit 7` through it.
  */
 export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   if (typeof command !== 'string') return null;
@@ -102,10 +102,46 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const unsafe = unsafeToBound(trimmed);
   if (unsafe) return null;
 
+  // A NEWLINE BEFORE THE CLOSING BRACE, NEVER `; }`. Two ordinary commands
+  // broke under the semicolon form, both of which run fine unwrapped:
+  //
+  //   echo hi # explain   ->  { echo hi # explain; }   the `; }` is INSIDE the
+  //                           comment, so the group is never closed
+  //   echo hi;            ->  { echo hi;; }            `;;` is a syntax error
+  //
+  // A newline terminates a comment and satisfies bash's requirement for a
+  // separator before `}`, so it handles both. Breaking a command that would
+  // have worked is the worst thing this module can do -- worse than any number
+  // of tokens -- because the failure looks like the user's own command is wrong.
+  //
+  // HEAD *AND* TAIL, because the client's own truncation keeps both. Claude
+  // Code caps Bash output at 30,000 characters and truncates from the MIDDLE
+  // (its binary carries `... [N characters truncated] ...` and
+  // `truncate-middle`). A tail-only bound is cheaper AND drops the head, where
+  // a failing jest run lists WHICH suites failed -- so it could read as an
+  // improvement on cost while being a regression for the model.
+  //
+  // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
+  // then keeps the last half of what remains. Verified to preserve a non-zero
+  // exit status through both stages.
+  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
+  // "middle omitted" after a two-line command claims a truncation that never
+  // happened -- the same class of error as a reader reporting a windowed event
+  // log it did not actually window. A model told its output was cut will go
+  // looking for the rest, which costs the turn this whole module exists to save.
+  //
+  // `read -r -N1` is the test: it succeeds only if a byte remains after the
+  // head, which means there really is a middle. That byte is then printed back
+  // so it is not swallowed.
+  const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+      `{ ${trimmed}\n} 2>&1 | ` +
+      `{ head -c ${half}; ` +
+      `if IFS= read -r -N1 _tok_rest; then ` +
+      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
+      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
     maxBytes,
   };
 }
@@ -129,9 +165,10 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
-    `the command ran unchanged but only its tail reached you. The tail is ` +
-    `where a test run puts its verdict. Re-run with the output redirected to ` +
-    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
+    `command ran unchanged, and you were given its beginning and its end with ` +
+    `the middle omitted and marked. Those are the two ends that carry a ` +
+    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
+    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/integrations/qwen/hooks/lib/rewrite.mjs
+++ b/integrations/qwen/hooks/lib/rewrite.mjs
@@ -1,0 +1,137 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/rewrite.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Bounding a command's output instead of refusing the command.
+ *
+ * WHY THIS EXISTS. A refusal costs approximately ONE EXTRA TURN. Measured on
+ * the THOL battery, enforcement took turns from 12.6 to 20.9 and cost a
+ * task-mean 1.633x vanilla Claude Code -- last of fifteen -- while the same
+ * build without refusals measured 0.928. The tokens a refusal "saves" are
+ * smaller than the round trip it spends, so the mechanism, not the policy, is
+ * what loses.
+ *
+ * A PreToolUse hook can return `updatedInput`, and the rewritten call runs.
+ * Verified end to end (docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md):
+ * a hook that rewrote `echo PROBE_ORIGINAL` to `echo PROBE_REWRITTEN` produced
+ * PROBE_REWRITTEN in the model's context, with no refusal and no retry. So the
+ * same bound can be applied for zero turns.
+ *
+ * PostToolUse cannot do this. Its output schema carries only `additionalContext`
+ * and `classifierContext` -- there is no field that replaces a tool result --
+ * and it never fires for a failed call at all (4,499 of 4,499 live outcomes
+ * report success, every exit code null). Bounding has to happen BEFORE the
+ * command runs, which is also the only way it can reach the failing test runs a
+ * debug loop is made of.
+ */
+
+/**
+ * Default bound, in bytes.
+ *
+ * The client's own cap is the reference point: `BASH_MAX_OUTPUT_LENGTH`
+ * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
+ * output is already bounded -- generously. This default is deliberately well
+ * under it, because the family being targeted is the debug loop, where the SAME
+ * wall of test output arrives on every iteration and the tail is the part that
+ * says what failed.
+ */
+export const DEFAULT_BOUND_BYTES = 8_000;
+
+export function boundBytes() {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_BOUND_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_BOUND_BYTES;
+}
+
+/**
+ * Shapes that must never be rewritten.
+ *
+ * Every one of these is a case where wrapping the command changes what it
+ * MEANS, not just how much of it is shown. Rewriting is a silent mutation of
+ * somebody's command; the bar for doing it is that the result is unarguably the
+ * same command with less output, and anything short of that is left alone.
+ */
+function unsafeToBound(command) {
+  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
+  // relative to the braces. Getting this wrong corrupts the payload rather than
+  // failing loudly -- the same class of damage a greedy regex does to source.
+  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+
+  // Backgrounding detaches the process; a pipeline cannot bound what it no
+  // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
+  if (/(?<![&|>])&(?!&)/.test(command)) return 'background';
+
+  // stdout already going somewhere other than the model's context. Bounding it
+  // would change what lands in the FILE, which is the opposite of harmless.
+  if (/(?<![0-9])>>?\s*(?!&)\S/.test(command)) return 'redirected';
+
+  // Already bounded by its author. Re-bounding buys nothing and risks changing
+  // a deliberate `head -n 5` into something else.
+  if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
+
+  // An interactive or streaming command has no meaningful tail, and buffering
+  // it through a pipe can hang.
+  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+    return 'interactive';
+  }
+
+  return null;
+}
+
+/**
+ * The bounded form of a command, or null when it must be left alone.
+ *
+ * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
+ * puts its verdict at the END -- the failure summary, the counts -- so the tail
+ * is the part worth keeping. And `head` closes the pipe early, which sends
+ * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
+ * then report exit 141 and read as a failure. `tail` consumes its input, so the
+ * real exit status survives.
+ *
+ * `pipefail` itself is what keeps the exit status honest. Without it the
+ * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * run would look like a passing one -- a far worse outcome than any number of
+ * wasted tokens, because the model would stop debugging.
+ *
+ * The `set -o` is wrapped so a shell without `pipefail` degrades to an
+ * unbounded-status pipeline rather than erroring out before the command runs.
+ */
+export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
+  if (typeof command !== 'string') return null;
+  const trimmed = command.trim();
+  if (!trimmed) return null;
+
+  const unsafe = unsafeToBound(trimmed);
+  if (unsafe) return null;
+
+  return {
+    command:
+      `{ set -o pipefail; } 2>/dev/null; ` +
+      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+    maxBytes,
+  };
+}
+
+/**
+ * What the model is told, so the bound is never a silent mutation.
+ *
+ * THE PROBE'S OWN MODEL CAUGHT US DOING THIS. In the spike, a rewritten command
+ * produced output that did not match what had been asked for, and the model
+ * flagged it as suspicious rather than trusting it:
+ *
+ *   "the output does not match the command ... Something in this session's
+ *    tooling chain either rewrote the command before execution or rewrote the
+ *    result. I'm reporting what I actually received rather than the expected
+ *    string."
+ *
+ * A model that distrusts its own tool output re-runs the command, which spends
+ * exactly the turn this mechanism exists to save. So the rewrite announces
+ * itself, says what was kept, and says how to opt out -- compaction the agent
+ * cannot see is compaction it will fight.
+ */
+export function boundNotice(maxBytes) {
+  return (
+    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
+    `the command ran unchanged but only its tail reached you. The tail is ` +
+    `where a test run puts its verdict. Re-run with the output redirected to ` +
+    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+  );
+}

--- a/integrations/qwen/hooks/lib/rewrite.mjs
+++ b/integrations/qwen/hooks/lib/rewrite.mjs
@@ -155,24 +155,30 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
   // then keeps the last half of what remains. Verified to preserve a non-zero
   // exit status through both stages.
-  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
-  // "middle omitted" after a two-line command claims a truncation that never
-  // happened -- the same class of error as a reader reporting a windowed event
-  // log it did not actually window. A model told its output was cut will go
-  // looking for the rest, which costs the turn this whole module exists to save.
+  // NO IN-STREAM MARKER, AND NO PROBE. `{ head -c H; tail -c H; }` is already
+  // exact in every regime, which two earlier attempts at a marker were not:
   //
-  // `read -r -N1` is the test: it succeeds only if a byte remains after the
-  // head, which means there really is a middle. That byte is then printed back
-  // so it is not swallowed.
+  //   total <= half        head prints it all, tail has nothing  -> COMPLETE
+  //   half < total <= max  head takes half, tail takes the rest  -> COMPLETE
+  //   total > max          head takes half, tail takes the last  -> exactly max
+  //
+  // An unconditional marker lied whenever the output fitted. Gating it on
+  // `read -r -N1` narrowed the lie to the middle band above -- where the output
+  // is returned COMPLETE and the marker still claimed an omission -- and the
+  // probe also relied on a bash-only `read -N`, which a POSIX shell rejects,
+  // skipping the tail entirely and leaking an error to stderr.
+  //
+  // Both defects came from trying to detect truncation from inside a pipe,
+  // which cannot see a total it has not yet consumed. So the announcement moves
+  // to `boundNotice`, stated as the POLICY ("output over N bytes is bounded")
+  // rather than as a claim about this particular output. A policy statement is
+  // true whether or not this command was cut, so it cannot lie.
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
       `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
-      `{ head -c ${half}; ` +
-      `if IFS= read -r -N1 _tok_rest; then ` +
-      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
-      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
+      `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };
 }
@@ -196,10 +202,11 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
-    `command ran unchanged, and you were given its beginning and its end with ` +
-    `the middle omitted and marked. Those are the two ends that carry a ` +
-    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
-    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
+    `token-optimizer bounds this command's output: anything over ${maxBytes} ` +
+    `bytes is returned as its beginning and its end, with the middle dropped. ` +
+    `Shorter output is returned complete and untouched. The command itself ran ` +
+    `unchanged, and those two ends are where a run says what failed and how it ` +
+    `finished. Redirect the output to a file, or raise ` +
+    `TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/integrations/qwen/hooks/lib/rewrite.mjs
+++ b/integrations/qwen/hooks/lib/rewrite.mjs
@@ -89,7 +89,16 @@ function unsafeToBound(command) {
   // `tail --follow=name`. The flag does not have to come first and does not
   // have to be short, so the guard looks anywhere in the `tail` invocation --
   // bounded to that command by stopping at a `;`, `|` or `&`.
-  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+  // CLUSTERED SHORT OPTIONS TOO. GNU tail accepts `-fn 1` and `-fF`, and a
+  // guard anchored on `-f\b` matches neither, because the `\b` fails against
+  // the next clustered letter. Both keep following and never reach EOF, so the
+  // bound waits forever. The character class therefore looks for f or F
+  // ANYWHERE in a short-option cluster.
+  if (
+    /\btail\b[^;|&]*(\s-[a-zA-Z]*[fF][a-zA-Z]*\b|\s--follow\b|\s--follow=)/.test(
+      command
+    )
+  ) {
     return 'follow-mode';
   }
 
@@ -112,11 +121,19 @@ function unsafeToBound(command) {
  * exited 1 once wrapped. Silently changing a command's exit status is the same
  * defect as masking one, in the other direction.
  *
- * The command therefore runs inside a subshell that restores the shell default
- * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
- * properties hold at once, and an explicit `set -o pipefail` written by the
- * caller still takes effect, because it executes inside that subshell after
- * the reset.
+ * The command therefore runs inside a subshell that restores THE CALLER'S OWN
+ * state, while the OUTER pipeline -- ours -- keeps pipefail. `set +o` prints
+ * the current options in re-inputtable form, so the one `pipefail` line is
+ * captured before we change anything and eval'd back inside the subshell.
+ *
+ * Restoring rather than CLEARING, because clearing is the same bug mirrored: a
+ * caller running under `bash -o pipefail` would have had `false | true` return
+ * 1, and a hard `set +o pipefail` would hand them 0. Either direction is a
+ * silent change to an exit status we were only supposed to be bounding the
+ * output of.
+ *
+ * An explicit `set -o pipefail` written inside the command still takes effect,
+ * because it executes inside that subshell after the restore.
  *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
@@ -176,8 +193,9 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
+      `_tok_pf=$(set +o 2>/dev/null | grep pipefail); ` +
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
+      `( eval "$_tok_pf" 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };

--- a/integrations/qwen/hooks/lib/rewrite.mjs
+++ b/integrations/qwen/hooks/lib/rewrite.mjs
@@ -51,10 +51,18 @@ export function boundBytes() {
  * same command with less output, and anything short of that is left alone.
  */
 function unsafeToBound(command) {
-  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
-  // relative to the braces. Getting this wrong corrupts the payload rather than
-  // failing loudly -- the same class of damage a greedy regex does to source.
-  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+  // EVERY `<<`, not a guess at the delimiter shape. A heredoc body is data, and
+  // wrapping it moves the terminator relative to the braces -- which corrupts
+  // the payload rather than failing loudly, the same class of damage a greedy
+  // regex does to source.
+  //
+  // The first version tried to match the delimiter (`<<-?\s*['"]?\w+`) and
+  // missed the ESCAPED form: `cat <<\EOF` was rewritten. Bash accepts several
+  // spellings -- bare, single-quoted, double-quoted, backslash-escaped, `<<-`,
+  // and with arbitrary spacing -- so enumerating them is a losing game. The
+  // operator itself is unambiguous. Herestrings (`<<<`) are swept up too: they
+  // would be safe to bound, and giving that up is the cheaper mistake.
+  if (/<</.test(command)) return 'heredoc';
 
   // Backgrounding detaches the process; a pipeline cannot bound what it no
   // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
@@ -69,9 +77,20 @@ function unsafeToBound(command) {
   if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
 
   // An interactive or streaming command has no meaningful tail, and buffering
-  // it through a pipe can hang.
-  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+  // it through a pipe does not merely waste effort -- it HANGS, because the
+  // wrapper's own `tail -c` cannot emit anything until EOF and follow mode
+  // never reaches EOF.
+  if (/\b(watch|less|more|vim|nano|top|htop)\b/.test(command)) {
     return 'interactive';
+  }
+
+  // FOLLOW MODE IN ANY SPELLING. Matching only `tail -f` left four working
+  // forms to hang: `tail -F`, `tail -n 100 -f`, `tail --follow` and
+  // `tail --follow=name`. The flag does not have to come first and does not
+  // have to be short, so the guard looks anywhere in the `tail` invocation --
+  // bounded to that command by stopping at a `;`, `|` or `&`.
+  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+    return 'follow-mode';
   }
 
   return null;

--- a/integrations/windsurf/hooks/lib/policy.mjs
+++ b/integrations/windsurf/hooks/lib/policy.mjs
@@ -701,6 +701,41 @@ export function allowWithContext(context) {
 }
 
 /**
+ * Lets the call run, but with a rewritten input -- the zero-turn alternative to
+ * a refusal.
+ *
+ * `updatedInput` is a real PreToolUse field and the rewritten call really runs;
+ * docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md has the end-to-end
+ * verification. This emitter is what makes it usable. A refusal costs about one
+ * extra turn, and turns are the whole measured deficit -- 12.6 to 20.9 under
+ * enforcement, for a task-mean 1.633x -- so a bound applied here is free where
+ * the same bound applied by refusing is not.
+ *
+ * The notice rides along as `additionalContext` rather than being baked into
+ * the command, so the command's own output is never mangled to carry a message.
+ *
+ * IT IS NOT OPTIONAL. The spike's model noticed an unannounced rewrite and
+ * distrusted the result -- "the output does not match the command ... I'm
+ * reporting what I actually received" -- and a model that distrusts its output
+ * re-runs the command, spending the exact turn this exists to save.
+ */
+export function allowWithRewrite(updatedInput, notice) {
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'allow',
+      permissionDecisionReason: 'token-optimizer bounded this output',
+      updatedInput,
+      ...(notice ? { additionalContext: withEscape(notice) } : {}),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
+  process.exit(0);
+}
+
+/**
  * Blocks the call and tells the model exactly what to call instead.
  *
  * The reason string is the whole user interface of this product for an agent.

--- a/integrations/windsurf/hooks/lib/rewrite.mjs
+++ b/integrations/windsurf/hooks/lib/rewrite.mjs
@@ -106,6 +106,18 @@ function unsafeToBound(command) {
  * wrapped so a shell without `pipefail` degrades to an unbounded-status
  * pipeline rather than erroring out before the command runs.
  *
+ * BUT IT MUST NOT LEAK INTO THE CALLER'S OWN PIPELINE. `pipefail` is a shell
+ * option, not a property of one pipe, so enabling it changed the meaning of any
+ * command that already contained a pipe: `false | true` exits 0 normally and
+ * exited 1 once wrapped. Silently changing a command's exit status is the same
+ * defect as masking one, in the other direction.
+ *
+ * The command therefore runs inside a subshell that restores the shell default
+ * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
+ * properties hold at once, and an explicit `set -o pipefail` written by the
+ * caller still takes effect, because it executes inside that subshell after
+ * the reset.
+ *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
  * turns a perfectly successful command into exit 141. Inside
@@ -156,7 +168,7 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}\n} 2>&1 | ` +
+      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; ` +
       `if IFS= read -r -N1 _tok_rest; then ` +
       `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +

--- a/integrations/windsurf/hooks/lib/rewrite.mjs
+++ b/integrations/windsurf/hooks/lib/rewrite.mjs
@@ -31,8 +31,9 @@
  * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
  * output is already bounded -- generously. This default is deliberately well
  * under it, because the family being targeted is the debug loop, where the SAME
- * wall of test output arrives on every iteration and the tail is the part that
- * says what failed.
+ * wall of test output arrives on every iteration. It is split evenly between
+ * the head and the tail of the output, which is where a run says what failed
+ * and how it ended.
  */
 export const DEFAULT_BOUND_BYTES = 8_000;
 
@@ -79,20 +80,19 @@ function unsafeToBound(command) {
 /**
  * The bounded form of a command, or null when it must be left alone.
  *
- * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
- * puts its verdict at the END -- the failure summary, the counts -- so the tail
- * is the part worth keeping. And `head` closes the pipe early, which sends
- * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
- * then report exit 141 and read as a failure. `tail` consumes its input, so the
- * real exit status survives.
- *
- * `pipefail` itself is what keeps the exit status honest. Without it the
- * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * `pipefail` is what keeps the exit status honest. Without it the pipeline
+ * reports the LAST stage's status, which is always 0, and every failing test
  * run would look like a passing one -- a far worse outcome than any number of
- * wasted tokens, because the model would stop debugging.
+ * wasted tokens, because the model would stop debugging. The `set -o` is
+ * wrapped so a shell without `pipefail` degrades to an unbounded-status
+ * pipeline rather than erroring out before the command runs.
  *
- * The `set -o` is wrapped so a shell without `pipefail` degrades to an
- * unbounded-status pipeline rather than erroring out before the command runs.
+ * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
+ * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
+ * turns a perfectly successful command into exit 141. Inside
+ * `{ head -c N; ...; tail -c N; }` the group keeps reading, so the producer is
+ * never signalled and the real status survives -- asserted by pushing `exit 3`
+ * and `exit 7` through it.
  */
 export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   if (typeof command !== 'string') return null;
@@ -102,10 +102,46 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const unsafe = unsafeToBound(trimmed);
   if (unsafe) return null;
 
+  // A NEWLINE BEFORE THE CLOSING BRACE, NEVER `; }`. Two ordinary commands
+  // broke under the semicolon form, both of which run fine unwrapped:
+  //
+  //   echo hi # explain   ->  { echo hi # explain; }   the `; }` is INSIDE the
+  //                           comment, so the group is never closed
+  //   echo hi;            ->  { echo hi;; }            `;;` is a syntax error
+  //
+  // A newline terminates a comment and satisfies bash's requirement for a
+  // separator before `}`, so it handles both. Breaking a command that would
+  // have worked is the worst thing this module can do -- worse than any number
+  // of tokens -- because the failure looks like the user's own command is wrong.
+  //
+  // HEAD *AND* TAIL, because the client's own truncation keeps both. Claude
+  // Code caps Bash output at 30,000 characters and truncates from the MIDDLE
+  // (its binary carries `... [N characters truncated] ...` and
+  // `truncate-middle`). A tail-only bound is cheaper AND drops the head, where
+  // a failing jest run lists WHICH suites failed -- so it could read as an
+  // improvement on cost while being a regression for the model.
+  //
+  // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
+  // then keeps the last half of what remains. Verified to preserve a non-zero
+  // exit status through both stages.
+  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
+  // "middle omitted" after a two-line command claims a truncation that never
+  // happened -- the same class of error as a reader reporting a windowed event
+  // log it did not actually window. A model told its output was cut will go
+  // looking for the rest, which costs the turn this whole module exists to save.
+  //
+  // `read -r -N1` is the test: it succeeds only if a byte remains after the
+  // head, which means there really is a middle. That byte is then printed back
+  // so it is not swallowed.
+  const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+      `{ ${trimmed}\n} 2>&1 | ` +
+      `{ head -c ${half}; ` +
+      `if IFS= read -r -N1 _tok_rest; then ` +
+      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
+      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
     maxBytes,
   };
 }
@@ -129,9 +165,10 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
-    `the command ran unchanged but only its tail reached you. The tail is ` +
-    `where a test run puts its verdict. Re-run with the output redirected to ` +
-    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
+    `command ran unchanged, and you were given its beginning and its end with ` +
+    `the middle omitted and marked. Those are the two ends that carry a ` +
+    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
+    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/integrations/windsurf/hooks/lib/rewrite.mjs
+++ b/integrations/windsurf/hooks/lib/rewrite.mjs
@@ -1,0 +1,137 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/rewrite.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Bounding a command's output instead of refusing the command.
+ *
+ * WHY THIS EXISTS. A refusal costs approximately ONE EXTRA TURN. Measured on
+ * the THOL battery, enforcement took turns from 12.6 to 20.9 and cost a
+ * task-mean 1.633x vanilla Claude Code -- last of fifteen -- while the same
+ * build without refusals measured 0.928. The tokens a refusal "saves" are
+ * smaller than the round trip it spends, so the mechanism, not the policy, is
+ * what loses.
+ *
+ * A PreToolUse hook can return `updatedInput`, and the rewritten call runs.
+ * Verified end to end (docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md):
+ * a hook that rewrote `echo PROBE_ORIGINAL` to `echo PROBE_REWRITTEN` produced
+ * PROBE_REWRITTEN in the model's context, with no refusal and no retry. So the
+ * same bound can be applied for zero turns.
+ *
+ * PostToolUse cannot do this. Its output schema carries only `additionalContext`
+ * and `classifierContext` -- there is no field that replaces a tool result --
+ * and it never fires for a failed call at all (4,499 of 4,499 live outcomes
+ * report success, every exit code null). Bounding has to happen BEFORE the
+ * command runs, which is also the only way it can reach the failing test runs a
+ * debug loop is made of.
+ */
+
+/**
+ * Default bound, in bytes.
+ *
+ * The client's own cap is the reference point: `BASH_MAX_OUTPUT_LENGTH`
+ * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
+ * output is already bounded -- generously. This default is deliberately well
+ * under it, because the family being targeted is the debug loop, where the SAME
+ * wall of test output arrives on every iteration and the tail is the part that
+ * says what failed.
+ */
+export const DEFAULT_BOUND_BYTES = 8_000;
+
+export function boundBytes() {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_BOUND_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_BOUND_BYTES;
+}
+
+/**
+ * Shapes that must never be rewritten.
+ *
+ * Every one of these is a case where wrapping the command changes what it
+ * MEANS, not just how much of it is shown. Rewriting is a silent mutation of
+ * somebody's command; the bar for doing it is that the result is unarguably the
+ * same command with less output, and anything short of that is left alone.
+ */
+function unsafeToBound(command) {
+  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
+  // relative to the braces. Getting this wrong corrupts the payload rather than
+  // failing loudly -- the same class of damage a greedy regex does to source.
+  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+
+  // Backgrounding detaches the process; a pipeline cannot bound what it no
+  // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
+  if (/(?<![&|>])&(?!&)/.test(command)) return 'background';
+
+  // stdout already going somewhere other than the model's context. Bounding it
+  // would change what lands in the FILE, which is the opposite of harmless.
+  if (/(?<![0-9])>>?\s*(?!&)\S/.test(command)) return 'redirected';
+
+  // Already bounded by its author. Re-bounding buys nothing and risks changing
+  // a deliberate `head -n 5` into something else.
+  if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
+
+  // An interactive or streaming command has no meaningful tail, and buffering
+  // it through a pipe can hang.
+  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+    return 'interactive';
+  }
+
+  return null;
+}
+
+/**
+ * The bounded form of a command, or null when it must be left alone.
+ *
+ * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
+ * puts its verdict at the END -- the failure summary, the counts -- so the tail
+ * is the part worth keeping. And `head` closes the pipe early, which sends
+ * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
+ * then report exit 141 and read as a failure. `tail` consumes its input, so the
+ * real exit status survives.
+ *
+ * `pipefail` itself is what keeps the exit status honest. Without it the
+ * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * run would look like a passing one -- a far worse outcome than any number of
+ * wasted tokens, because the model would stop debugging.
+ *
+ * The `set -o` is wrapped so a shell without `pipefail` degrades to an
+ * unbounded-status pipeline rather than erroring out before the command runs.
+ */
+export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
+  if (typeof command !== 'string') return null;
+  const trimmed = command.trim();
+  if (!trimmed) return null;
+
+  const unsafe = unsafeToBound(trimmed);
+  if (unsafe) return null;
+
+  return {
+    command:
+      `{ set -o pipefail; } 2>/dev/null; ` +
+      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+    maxBytes,
+  };
+}
+
+/**
+ * What the model is told, so the bound is never a silent mutation.
+ *
+ * THE PROBE'S OWN MODEL CAUGHT US DOING THIS. In the spike, a rewritten command
+ * produced output that did not match what had been asked for, and the model
+ * flagged it as suspicious rather than trusting it:
+ *
+ *   "the output does not match the command ... Something in this session's
+ *    tooling chain either rewrote the command before execution or rewrote the
+ *    result. I'm reporting what I actually received rather than the expected
+ *    string."
+ *
+ * A model that distrusts its own tool output re-runs the command, which spends
+ * exactly the turn this mechanism exists to save. So the rewrite announces
+ * itself, says what was kept, and says how to opt out -- compaction the agent
+ * cannot see is compaction it will fight.
+ */
+export function boundNotice(maxBytes) {
+  return (
+    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
+    `the command ran unchanged but only its tail reached you. The tail is ` +
+    `where a test run puts its verdict. Re-run with the output redirected to ` +
+    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+  );
+}

--- a/integrations/windsurf/hooks/lib/rewrite.mjs
+++ b/integrations/windsurf/hooks/lib/rewrite.mjs
@@ -155,24 +155,30 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
   // then keeps the last half of what remains. Verified to preserve a non-zero
   // exit status through both stages.
-  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
-  // "middle omitted" after a two-line command claims a truncation that never
-  // happened -- the same class of error as a reader reporting a windowed event
-  // log it did not actually window. A model told its output was cut will go
-  // looking for the rest, which costs the turn this whole module exists to save.
+  // NO IN-STREAM MARKER, AND NO PROBE. `{ head -c H; tail -c H; }` is already
+  // exact in every regime, which two earlier attempts at a marker were not:
   //
-  // `read -r -N1` is the test: it succeeds only if a byte remains after the
-  // head, which means there really is a middle. That byte is then printed back
-  // so it is not swallowed.
+  //   total <= half        head prints it all, tail has nothing  -> COMPLETE
+  //   half < total <= max  head takes half, tail takes the rest  -> COMPLETE
+  //   total > max          head takes half, tail takes the last  -> exactly max
+  //
+  // An unconditional marker lied whenever the output fitted. Gating it on
+  // `read -r -N1` narrowed the lie to the middle band above -- where the output
+  // is returned COMPLETE and the marker still claimed an omission -- and the
+  // probe also relied on a bash-only `read -N`, which a POSIX shell rejects,
+  // skipping the tail entirely and leaking an error to stderr.
+  //
+  // Both defects came from trying to detect truncation from inside a pipe,
+  // which cannot see a total it has not yet consumed. So the announcement moves
+  // to `boundNotice`, stated as the POLICY ("output over N bytes is bounded")
+  // rather than as a claim about this particular output. A policy statement is
+  // true whether or not this command was cut, so it cannot lie.
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
       `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
-      `{ head -c ${half}; ` +
-      `if IFS= read -r -N1 _tok_rest; then ` +
-      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
-      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
+      `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };
 }
@@ -196,10 +202,11 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
-    `command ran unchanged, and you were given its beginning and its end with ` +
-    `the middle omitted and marked. Those are the two ends that carry a ` +
-    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
-    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
+    `token-optimizer bounds this command's output: anything over ${maxBytes} ` +
+    `bytes is returned as its beginning and its end, with the middle dropped. ` +
+    `Shorter output is returned complete and untouched. The command itself ran ` +
+    `unchanged, and those two ends are where a run says what failed and how it ` +
+    `finished. Redirect the output to a file, or raise ` +
+    `TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/integrations/windsurf/hooks/lib/rewrite.mjs
+++ b/integrations/windsurf/hooks/lib/rewrite.mjs
@@ -89,7 +89,16 @@ function unsafeToBound(command) {
   // `tail --follow=name`. The flag does not have to come first and does not
   // have to be short, so the guard looks anywhere in the `tail` invocation --
   // bounded to that command by stopping at a `;`, `|` or `&`.
-  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+  // CLUSTERED SHORT OPTIONS TOO. GNU tail accepts `-fn 1` and `-fF`, and a
+  // guard anchored on `-f\b` matches neither, because the `\b` fails against
+  // the next clustered letter. Both keep following and never reach EOF, so the
+  // bound waits forever. The character class therefore looks for f or F
+  // ANYWHERE in a short-option cluster.
+  if (
+    /\btail\b[^;|&]*(\s-[a-zA-Z]*[fF][a-zA-Z]*\b|\s--follow\b|\s--follow=)/.test(
+      command
+    )
+  ) {
     return 'follow-mode';
   }
 
@@ -112,11 +121,19 @@ function unsafeToBound(command) {
  * exited 1 once wrapped. Silently changing a command's exit status is the same
  * defect as masking one, in the other direction.
  *
- * The command therefore runs inside a subshell that restores the shell default
- * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
- * properties hold at once, and an explicit `set -o pipefail` written by the
- * caller still takes effect, because it executes inside that subshell after
- * the reset.
+ * The command therefore runs inside a subshell that restores THE CALLER'S OWN
+ * state, while the OUTER pipeline -- ours -- keeps pipefail. `set +o` prints
+ * the current options in re-inputtable form, so the one `pipefail` line is
+ * captured before we change anything and eval'd back inside the subshell.
+ *
+ * Restoring rather than CLEARING, because clearing is the same bug mirrored: a
+ * caller running under `bash -o pipefail` would have had `false | true` return
+ * 1, and a hard `set +o pipefail` would hand them 0. Either direction is a
+ * silent change to an exit status we were only supposed to be bounding the
+ * output of.
+ *
+ * An explicit `set -o pipefail` written inside the command still takes effect,
+ * because it executes inside that subshell after the restore.
  *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
@@ -176,8 +193,9 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
+      `_tok_pf=$(set +o 2>/dev/null | grep pipefail); ` +
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
+      `( eval "$_tok_pf" 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };

--- a/integrations/windsurf/hooks/lib/rewrite.mjs
+++ b/integrations/windsurf/hooks/lib/rewrite.mjs
@@ -51,10 +51,18 @@ export function boundBytes() {
  * same command with less output, and anything short of that is left alone.
  */
 function unsafeToBound(command) {
-  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
-  // relative to the braces. Getting this wrong corrupts the payload rather than
-  // failing loudly -- the same class of damage a greedy regex does to source.
-  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+  // EVERY `<<`, not a guess at the delimiter shape. A heredoc body is data, and
+  // wrapping it moves the terminator relative to the braces -- which corrupts
+  // the payload rather than failing loudly, the same class of damage a greedy
+  // regex does to source.
+  //
+  // The first version tried to match the delimiter (`<<-?\s*['"]?\w+`) and
+  // missed the ESCAPED form: `cat <<\EOF` was rewritten. Bash accepts several
+  // spellings -- bare, single-quoted, double-quoted, backslash-escaped, `<<-`,
+  // and with arbitrary spacing -- so enumerating them is a losing game. The
+  // operator itself is unambiguous. Herestrings (`<<<`) are swept up too: they
+  // would be safe to bound, and giving that up is the cheaper mistake.
+  if (/<</.test(command)) return 'heredoc';
 
   // Backgrounding detaches the process; a pipeline cannot bound what it no
   // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
@@ -69,9 +77,20 @@ function unsafeToBound(command) {
   if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
 
   // An interactive or streaming command has no meaningful tail, and buffering
-  // it through a pipe can hang.
-  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+  // it through a pipe does not merely waste effort -- it HANGS, because the
+  // wrapper's own `tail -c` cannot emit anything until EOF and follow mode
+  // never reaches EOF.
+  if (/\b(watch|less|more|vim|nano|top|htop)\b/.test(command)) {
     return 'interactive';
+  }
+
+  // FOLLOW MODE IN ANY SPELLING. Matching only `tail -f` left four working
+  // forms to hang: `tail -F`, `tail -n 100 -f`, `tail --follow` and
+  // `tail --follow=name`. The flag does not have to come first and does not
+  // have to be short, so the guard looks anywhere in the `tail` invocation --
+  // bounded to that command by stopping at a `;`, `|` or `&`.
+  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+    return 'follow-mode';
   }
 
   return null;

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "bench:build": "npm run bench:pack && docker build -f bench/thol/Dockerfile -t thol-rig:local bench/",
     "bench:screen": "bash bench/thol/run-campaign.sh",
     "bench:confirm": "REPS=3 bash bench/thol/run-campaign.sh",
+    "bench:debug-loop": "node bench/debug-loop/run.mjs",
     "bench:pack": "node scripts/bench-pack.mjs"
   },
   "repository": {

--- a/plugin/hooks/lib/policy.mjs
+++ b/plugin/hooks/lib/policy.mjs
@@ -701,6 +701,41 @@ export function allowWithContext(context) {
 }
 
 /**
+ * Lets the call run, but with a rewritten input -- the zero-turn alternative to
+ * a refusal.
+ *
+ * `updatedInput` is a real PreToolUse field and the rewritten call really runs;
+ * docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md has the end-to-end
+ * verification. This emitter is what makes it usable. A refusal costs about one
+ * extra turn, and turns are the whole measured deficit -- 12.6 to 20.9 under
+ * enforcement, for a task-mean 1.633x -- so a bound applied here is free where
+ * the same bound applied by refusing is not.
+ *
+ * The notice rides along as `additionalContext` rather than being baked into
+ * the command, so the command's own output is never mangled to carry a message.
+ *
+ * IT IS NOT OPTIONAL. The spike's model noticed an unannounced rewrite and
+ * distrusted the result -- "the output does not match the command ... I'm
+ * reporting what I actually received" -- and a model that distrusts its output
+ * re-runs the command, spending the exact turn this exists to save.
+ */
+export function allowWithRewrite(updatedInput, notice) {
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'allow',
+      permissionDecisionReason: 'token-optimizer bounded this output',
+      updatedInput,
+      ...(notice ? { additionalContext: withEscape(notice) } : {}),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
+  process.exit(0);
+}
+
+/**
  * Blocks the call and tells the model exactly what to call instead.
  *
  * The reason string is the whole user interface of this product for an agent.

--- a/plugin/hooks/lib/rewrite.mjs
+++ b/plugin/hooks/lib/rewrite.mjs
@@ -106,6 +106,18 @@ function unsafeToBound(command) {
  * wrapped so a shell without `pipefail` degrades to an unbounded-status
  * pipeline rather than erroring out before the command runs.
  *
+ * BUT IT MUST NOT LEAK INTO THE CALLER'S OWN PIPELINE. `pipefail` is a shell
+ * option, not a property of one pipe, so enabling it changed the meaning of any
+ * command that already contained a pipe: `false | true` exits 0 normally and
+ * exited 1 once wrapped. Silently changing a command's exit status is the same
+ * defect as masking one, in the other direction.
+ *
+ * The command therefore runs inside a subshell that restores the shell default
+ * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
+ * properties hold at once, and an explicit `set -o pipefail` written by the
+ * caller still takes effect, because it executes inside that subshell after
+ * the reset.
+ *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
  * turns a perfectly successful command into exit 141. Inside
@@ -156,7 +168,7 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}\n} 2>&1 | ` +
+      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; ` +
       `if IFS= read -r -N1 _tok_rest; then ` +
       `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +

--- a/plugin/hooks/lib/rewrite.mjs
+++ b/plugin/hooks/lib/rewrite.mjs
@@ -31,8 +31,9 @@
  * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
  * output is already bounded -- generously. This default is deliberately well
  * under it, because the family being targeted is the debug loop, where the SAME
- * wall of test output arrives on every iteration and the tail is the part that
- * says what failed.
+ * wall of test output arrives on every iteration. It is split evenly between
+ * the head and the tail of the output, which is where a run says what failed
+ * and how it ended.
  */
 export const DEFAULT_BOUND_BYTES = 8_000;
 
@@ -79,20 +80,19 @@ function unsafeToBound(command) {
 /**
  * The bounded form of a command, or null when it must be left alone.
  *
- * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
- * puts its verdict at the END -- the failure summary, the counts -- so the tail
- * is the part worth keeping. And `head` closes the pipe early, which sends
- * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
- * then report exit 141 and read as a failure. `tail` consumes its input, so the
- * real exit status survives.
- *
- * `pipefail` itself is what keeps the exit status honest. Without it the
- * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * `pipefail` is what keeps the exit status honest. Without it the pipeline
+ * reports the LAST stage's status, which is always 0, and every failing test
  * run would look like a passing one -- a far worse outcome than any number of
- * wasted tokens, because the model would stop debugging.
+ * wasted tokens, because the model would stop debugging. The `set -o` is
+ * wrapped so a shell without `pipefail` degrades to an unbounded-status
+ * pipeline rather than erroring out before the command runs.
  *
- * The `set -o` is wrapped so a shell without `pipefail` degrades to an
- * unbounded-status pipeline rather than erroring out before the command runs.
+ * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
+ * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
+ * turns a perfectly successful command into exit 141. Inside
+ * `{ head -c N; ...; tail -c N; }` the group keeps reading, so the producer is
+ * never signalled and the real status survives -- asserted by pushing `exit 3`
+ * and `exit 7` through it.
  */
 export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   if (typeof command !== 'string') return null;
@@ -102,10 +102,46 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const unsafe = unsafeToBound(trimmed);
   if (unsafe) return null;
 
+  // A NEWLINE BEFORE THE CLOSING BRACE, NEVER `; }`. Two ordinary commands
+  // broke under the semicolon form, both of which run fine unwrapped:
+  //
+  //   echo hi # explain   ->  { echo hi # explain; }   the `; }` is INSIDE the
+  //                           comment, so the group is never closed
+  //   echo hi;            ->  { echo hi;; }            `;;` is a syntax error
+  //
+  // A newline terminates a comment and satisfies bash's requirement for a
+  // separator before `}`, so it handles both. Breaking a command that would
+  // have worked is the worst thing this module can do -- worse than any number
+  // of tokens -- because the failure looks like the user's own command is wrong.
+  //
+  // HEAD *AND* TAIL, because the client's own truncation keeps both. Claude
+  // Code caps Bash output at 30,000 characters and truncates from the MIDDLE
+  // (its binary carries `... [N characters truncated] ...` and
+  // `truncate-middle`). A tail-only bound is cheaper AND drops the head, where
+  // a failing jest run lists WHICH suites failed -- so it could read as an
+  // improvement on cost while being a regression for the model.
+  //
+  // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
+  // then keeps the last half of what remains. Verified to preserve a non-zero
+  // exit status through both stages.
+  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
+  // "middle omitted" after a two-line command claims a truncation that never
+  // happened -- the same class of error as a reader reporting a windowed event
+  // log it did not actually window. A model told its output was cut will go
+  // looking for the rest, which costs the turn this whole module exists to save.
+  //
+  // `read -r -N1` is the test: it succeeds only if a byte remains after the
+  // head, which means there really is a middle. That byte is then printed back
+  // so it is not swallowed.
+  const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+      `{ ${trimmed}\n} 2>&1 | ` +
+      `{ head -c ${half}; ` +
+      `if IFS= read -r -N1 _tok_rest; then ` +
+      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
+      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
     maxBytes,
   };
 }
@@ -129,9 +165,10 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
-    `the command ran unchanged but only its tail reached you. The tail is ` +
-    `where a test run puts its verdict. Re-run with the output redirected to ` +
-    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
+    `command ran unchanged, and you were given its beginning and its end with ` +
+    `the middle omitted and marked. Those are the two ends that carry a ` +
+    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
+    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/plugin/hooks/lib/rewrite.mjs
+++ b/plugin/hooks/lib/rewrite.mjs
@@ -1,0 +1,137 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/rewrite.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Bounding a command's output instead of refusing the command.
+ *
+ * WHY THIS EXISTS. A refusal costs approximately ONE EXTRA TURN. Measured on
+ * the THOL battery, enforcement took turns from 12.6 to 20.9 and cost a
+ * task-mean 1.633x vanilla Claude Code -- last of fifteen -- while the same
+ * build without refusals measured 0.928. The tokens a refusal "saves" are
+ * smaller than the round trip it spends, so the mechanism, not the policy, is
+ * what loses.
+ *
+ * A PreToolUse hook can return `updatedInput`, and the rewritten call runs.
+ * Verified end to end (docs/superpowers/spikes/2026-08-30-posttooluse-rewrite.md):
+ * a hook that rewrote `echo PROBE_ORIGINAL` to `echo PROBE_REWRITTEN` produced
+ * PROBE_REWRITTEN in the model's context, with no refusal and no retry. So the
+ * same bound can be applied for zero turns.
+ *
+ * PostToolUse cannot do this. Its output schema carries only `additionalContext`
+ * and `classifierContext` -- there is no field that replaces a tool result --
+ * and it never fires for a failed call at all (4,499 of 4,499 live outcomes
+ * report success, every exit code null). Bounding has to happen BEFORE the
+ * command runs, which is also the only way it can reach the failing test runs a
+ * debug loop is made of.
+ */
+
+/**
+ * Default bound, in bytes.
+ *
+ * The client's own cap is the reference point: `BASH_MAX_OUTPUT_LENGTH`
+ * defaults to 30,000 characters (~7,500 tokens) and is capped at 150,000. So
+ * output is already bounded -- generously. This default is deliberately well
+ * under it, because the family being targeted is the debug loop, where the SAME
+ * wall of test output arrives on every iteration and the tail is the part that
+ * says what failed.
+ */
+export const DEFAULT_BOUND_BYTES = 8_000;
+
+export function boundBytes() {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_BOUND_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_BOUND_BYTES;
+}
+
+/**
+ * Shapes that must never be rewritten.
+ *
+ * Every one of these is a case where wrapping the command changes what it
+ * MEANS, not just how much of it is shown. Rewriting is a silent mutation of
+ * somebody's command; the bar for doing it is that the result is unarguably the
+ * same command with less output, and anything short of that is left alone.
+ */
+function unsafeToBound(command) {
+  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
+  // relative to the braces. Getting this wrong corrupts the payload rather than
+  // failing loudly -- the same class of damage a greedy regex does to source.
+  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+
+  // Backgrounding detaches the process; a pipeline cannot bound what it no
+  // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
+  if (/(?<![&|>])&(?!&)/.test(command)) return 'background';
+
+  // stdout already going somewhere other than the model's context. Bounding it
+  // would change what lands in the FILE, which is the opposite of harmless.
+  if (/(?<![0-9])>>?\s*(?!&)\S/.test(command)) return 'redirected';
+
+  // Already bounded by its author. Re-bounding buys nothing and risks changing
+  // a deliberate `head -n 5` into something else.
+  if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
+
+  // An interactive or streaming command has no meaningful tail, and buffering
+  // it through a pipe can hang.
+  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+    return 'interactive';
+  }
+
+  return null;
+}
+
+/**
+ * The bounded form of a command, or null when it must be left alone.
+ *
+ * `tail`, NOT `head`, and that choice is load-bearing twice over. A test run
+ * puts its verdict at the END -- the failure summary, the counts -- so the tail
+ * is the part worth keeping. And `head` closes the pipe early, which sends
+ * SIGPIPE to the producer: under `pipefail` a perfectly successful search would
+ * then report exit 141 and read as a failure. `tail` consumes its input, so the
+ * real exit status survives.
+ *
+ * `pipefail` itself is what keeps the exit status honest. Without it the
+ * pipeline reports `tail`'s status, which is always 0, and every failing test
+ * run would look like a passing one -- a far worse outcome than any number of
+ * wasted tokens, because the model would stop debugging.
+ *
+ * The `set -o` is wrapped so a shell without `pipefail` degrades to an
+ * unbounded-status pipeline rather than erroring out before the command runs.
+ */
+export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
+  if (typeof command !== 'string') return null;
+  const trimmed = command.trim();
+  if (!trimmed) return null;
+
+  const unsafe = unsafeToBound(trimmed);
+  if (unsafe) return null;
+
+  return {
+    command:
+      `{ set -o pipefail; } 2>/dev/null; ` +
+      `{ ${trimmed}; } 2>&1 | tail -c ${maxBytes}`,
+    maxBytes,
+  };
+}
+
+/**
+ * What the model is told, so the bound is never a silent mutation.
+ *
+ * THE PROBE'S OWN MODEL CAUGHT US DOING THIS. In the spike, a rewritten command
+ * produced output that did not match what had been asked for, and the model
+ * flagged it as suspicious rather than trusting it:
+ *
+ *   "the output does not match the command ... Something in this session's
+ *    tooling chain either rewrote the command before execution or rewrote the
+ *    result. I'm reporting what I actually received rather than the expected
+ *    string."
+ *
+ * A model that distrusts its own tool output re-runs the command, which spends
+ * exactly the turn this mechanism exists to save. So the rewrite announces
+ * itself, says what was kept, and says how to opt out -- compaction the agent
+ * cannot see is compaction it will fight.
+ */
+export function boundNotice(maxBytes) {
+  return (
+    `Output is bounded to the last ${maxBytes} bytes by token-optimizer, so ` +
+    `the command ran unchanged but only its tail reached you. The tail is ` +
+    `where a test run puts its verdict. Re-run with the output redirected to ` +
+    `a file, or set TOKEN_OPTIMIZER_BOUND_BYTES higher, if you need the rest.`
+  );
+}

--- a/plugin/hooks/lib/rewrite.mjs
+++ b/plugin/hooks/lib/rewrite.mjs
@@ -155,24 +155,30 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   // `head -c` takes the first half and leaves the rest in the pipe; `tail -c`
   // then keeps the last half of what remains. Verified to preserve a non-zero
   // exit status through both stages.
-  // THE MARKER IS CONDITIONAL, because an unconditional one LIES. Printing
-  // "middle omitted" after a two-line command claims a truncation that never
-  // happened -- the same class of error as a reader reporting a windowed event
-  // log it did not actually window. A model told its output was cut will go
-  // looking for the rest, which costs the turn this whole module exists to save.
+  // NO IN-STREAM MARKER, AND NO PROBE. `{ head -c H; tail -c H; }` is already
+  // exact in every regime, which two earlier attempts at a marker were not:
   //
-  // `read -r -N1` is the test: it succeeds only if a byte remains after the
-  // head, which means there really is a middle. That byte is then printed back
-  // so it is not swallowed.
+  //   total <= half        head prints it all, tail has nothing  -> COMPLETE
+  //   half < total <= max  head takes half, tail takes the rest  -> COMPLETE
+  //   total > max          head takes half, tail takes the last  -> exactly max
+  //
+  // An unconditional marker lied whenever the output fitted. Gating it on
+  // `read -r -N1` narrowed the lie to the middle band above -- where the output
+  // is returned COMPLETE and the marker still claimed an omission -- and the
+  // probe also relied on a bash-only `read -N`, which a POSIX shell rejects,
+  // skipping the tail entirely and leaking an error to stderr.
+  //
+  // Both defects came from trying to detect truncation from inside a pipe,
+  // which cannot see a total it has not yet consumed. So the announcement moves
+  // to `boundNotice`, stated as the POLICY ("output over N bytes is bounded")
+  // rather than as a claim about this particular output. A policy statement is
+  // true whether or not this command was cut, so it cannot lie.
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
       `{ set -o pipefail; } 2>/dev/null; ` +
       `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
-      `{ head -c ${half}; ` +
-      `if IFS= read -r -N1 _tok_rest; then ` +
-      `printf '\\n... [middle omitted by token-optimizer] ...\\n'; ` +
-      `printf '%s' "$_tok_rest"; tail -c ${half}; fi; }`,
+      `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };
 }
@@ -196,10 +202,11 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
  */
 export function boundNotice(maxBytes) {
   return (
-    `Output is bounded to about ${maxBytes} bytes by token-optimizer: the ` +
-    `command ran unchanged, and you were given its beginning and its end with ` +
-    `the middle omitted and marked. Those are the two ends that carry a ` +
-    `verdict -- what failed, and the summary. Redirect the output to a file, ` +
-    `or raise TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
+    `token-optimizer bounds this command's output: anything over ${maxBytes} ` +
+    `bytes is returned as its beginning and its end, with the middle dropped. ` +
+    `Shorter output is returned complete and untouched. The command itself ran ` +
+    `unchanged, and those two ends are where a run says what failed and how it ` +
+    `finished. Redirect the output to a file, or raise ` +
+    `TOKEN_OPTIMIZER_BOUND_BYTES, if you need the middle.`
   );
 }

--- a/plugin/hooks/lib/rewrite.mjs
+++ b/plugin/hooks/lib/rewrite.mjs
@@ -89,7 +89,16 @@ function unsafeToBound(command) {
   // `tail --follow=name`. The flag does not have to come first and does not
   // have to be short, so the guard looks anywhere in the `tail` invocation --
   // bounded to that command by stopping at a `;`, `|` or `&`.
-  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+  // CLUSTERED SHORT OPTIONS TOO. GNU tail accepts `-fn 1` and `-fF`, and a
+  // guard anchored on `-f\b` matches neither, because the `\b` fails against
+  // the next clustered letter. Both keep following and never reach EOF, so the
+  // bound waits forever. The character class therefore looks for f or F
+  // ANYWHERE in a short-option cluster.
+  if (
+    /\btail\b[^;|&]*(\s-[a-zA-Z]*[fF][a-zA-Z]*\b|\s--follow\b|\s--follow=)/.test(
+      command
+    )
+  ) {
     return 'follow-mode';
   }
 
@@ -112,11 +121,19 @@ function unsafeToBound(command) {
  * exited 1 once wrapped. Silently changing a command's exit status is the same
  * defect as masking one, in the other direction.
  *
- * The command therefore runs inside a subshell that restores the shell default
- * (`set +o pipefail`), while the OUTER pipeline -- ours -- keeps it. Both
- * properties hold at once, and an explicit `set -o pipefail` written by the
- * caller still takes effect, because it executes inside that subshell after
- * the reset.
+ * The command therefore runs inside a subshell that restores THE CALLER'S OWN
+ * state, while the OUTER pipeline -- ours -- keeps pipefail. `set +o` prints
+ * the current options in re-inputtable form, so the one `pipefail` line is
+ * captured before we change anything and eval'd back inside the subshell.
+ *
+ * Restoring rather than CLEARING, because clearing is the same bug mirrored: a
+ * caller running under `bash -o pipefail` would have had `false | true` return
+ * 1, and a hard `set +o pipefail` would hand them 0. Either direction is a
+ * silent change to an exit status we were only supposed to be bounding the
+ * output of.
+ *
+ * An explicit `set -o pipefail` written inside the command still takes effect,
+ * because it executes inside that subshell after the restore.
  *
  * THE PIPE STAGE IS A GROUP, NOT A BARE `head`. A bare `head -c N` exits as
  * soon as it has its bytes and SIGPIPEs the producer, which under `pipefail`
@@ -176,8 +193,9 @@ export function boundedRewrite(command, { maxBytes = boundBytes() } = {}) {
   const half = Math.max(1, Math.floor(maxBytes / 2));
   return {
     command:
+      `_tok_pf=$(set +o 2>/dev/null | grep pipefail); ` +
       `{ set -o pipefail; } 2>/dev/null; ` +
-      `( { set +o pipefail; } 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
+      `( eval "$_tok_pf" 2>/dev/null; ${trimmed}\n) 2>&1 | ` +
       `{ head -c ${half}; tail -c ${half}; }`,
     maxBytes,
   };

--- a/plugin/hooks/lib/rewrite.mjs
+++ b/plugin/hooks/lib/rewrite.mjs
@@ -51,10 +51,18 @@ export function boundBytes() {
  * same command with less output, and anything short of that is left alone.
  */
 function unsafeToBound(command) {
-  // A heredoc body is data, and `{ cmd <<'EOF' ; }` moves the terminator
-  // relative to the braces. Getting this wrong corrupts the payload rather than
-  // failing loudly -- the same class of damage a greedy regex does to source.
-  if (/<<-?\s*['"]?\w+/.test(command)) return 'heredoc';
+  // EVERY `<<`, not a guess at the delimiter shape. A heredoc body is data, and
+  // wrapping it moves the terminator relative to the braces -- which corrupts
+  // the payload rather than failing loudly, the same class of damage a greedy
+  // regex does to source.
+  //
+  // The first version tried to match the delimiter (`<<-?\s*['"]?\w+`) and
+  // missed the ESCAPED form: `cat <<\EOF` was rewritten. Bash accepts several
+  // spellings -- bare, single-quoted, double-quoted, backslash-escaped, `<<-`,
+  // and with arbitrary spacing -- so enumerating them is a losing game. The
+  // operator itself is unambiguous. Herestrings (`<<<`) are swept up too: they
+  // would be safe to bound, and giving that up is the cheaper mistake.
+  if (/<</.test(command)) return 'heredoc';
 
   // Backgrounding detaches the process; a pipeline cannot bound what it no
   // longer owns. `&&` and `||` are not this, hence the negative lookarounds.
@@ -69,9 +77,20 @@ function unsafeToBound(command) {
   if (/\|\s*(head|tail)\b/.test(command)) return 'already-bounded';
 
   // An interactive or streaming command has no meaningful tail, and buffering
-  // it through a pipe can hang.
-  if (/\b(watch|tail\s+-f|less|more|vim|nano|top|htop)\b/.test(command)) {
+  // it through a pipe does not merely waste effort -- it HANGS, because the
+  // wrapper's own `tail -c` cannot emit anything until EOF and follow mode
+  // never reaches EOF.
+  if (/\b(watch|less|more|vim|nano|top|htop)\b/.test(command)) {
     return 'interactive';
+  }
+
+  // FOLLOW MODE IN ANY SPELLING. Matching only `tail -f` left four working
+  // forms to hang: `tail -F`, `tail -n 100 -f`, `tail --follow` and
+  // `tail --follow=name`. The flag does not have to come first and does not
+  // have to be short, so the guard looks anywhere in the `tail` invocation --
+  // bounded to that command by stopping at a `;`, `|` or `&`.
+  if (/\btail\b[^;|&]*(\s-{1,2}(f|F|follow)\b|\s--follow=)/.test(command)) {
+    return 'follow-mode';
   }
 
   return null;

--- a/plugin/hooks/pretooluse-router.mjs
+++ b/plugin/hooks/pretooluse-router.mjs
@@ -18,7 +18,9 @@ import {
   alreadyDenied,
   allow,
   allowWithContext,
+  allowWithRewrite,
   enforce,
+  refusalsEnabled,
   mode,
   MODE_OFF,
 } from './lib/policy.mjs';
@@ -52,6 +54,7 @@ import {
 } from './lib/inject.mjs';
 import { indexFile } from './lib/staleness.mjs';
 import { isArchived } from './lib/transcript.mjs';
+import { boundedRewrite, boundNotice } from './lib/rewrite.mjs';
 import { isFsSafePath } from './lib/paths.mjs';
 import { readFileSync } from 'node:fs';
 import { episodeMeta, featuresForArm } from './lib/experiment.mjs';
@@ -488,6 +491,33 @@ ${nudge}`
       }
     } catch {
       // Any failure here falls back to the plain redirect, which always works.
+    }
+  }
+
+  // BOUND IT INSTEAD OF REFUSING IT.
+  //
+  // Reaching here means a verdict exists -- the no-verdict path allowed and
+  // returned long ago -- so this is a call we were about to refuse. For Bash we
+  // do not have to. A PreToolUse hook can rewrite the command through
+  // `updatedInput` and the rewritten command runs, so the same limit can be
+  // applied for ZERO extra turns instead of one.
+  //
+  // That distinction is the entire measured deficit: enforcement took turns
+  // from 12.6 to 20.9 -- about one per refusal -- for a task-mean 1.633x
+  // vanilla Claude Code, while the same build without refusals measured 0.928.
+  // A refusal "saves" fewer tokens than the round trip it spends.
+  //
+  // Only where a refusal would actually have happened. In assist and off the
+  // call was already going through untouched, and silently bounding output
+  // there would be a new behaviour rather than a cheaper spelling of an
+  // existing one.
+  if (payload.tool_name === 'Bash' && refusalsEnabled()) {
+    const bounded = boundedRewrite(payload.tool_input?.command);
+    if (bounded) {
+      allowWithRewrite(
+        { ...payload.tool_input, command: bounded.command },
+        boundNotice(bounded.maxBytes)
+      );
     }
   }
 

--- a/tests/hooks/bounded-rewrite.test.mjs
+++ b/tests/hooks/bounded-rewrite.test.mjs
@@ -132,12 +132,36 @@ describe('commands it refuses to touch', () => {
   // Returning null leaves the call exactly as the author wrote it.
   it.each([
     ['a heredoc, whose body is data', "cat <<'EOF'\nhello\nEOF"],
+    // Bash spells the delimiter several ways, and the first guard matched the
+    // DELIMITER rather than the operator -- so the escaped form slipped past it
+    // and was rewritten. Every one of these must be refused.
+    ['an escaped heredoc delimiter', 'cat <<' + String.fromCharCode(92) + 'EOF\nx\nEOF'],
+    ['a double-quoted delimiter', 'cat <<"EOF"\nx\nEOF'],
+    ['a dash heredoc', 'cat <<-EOF\nx\nEOF'],
+    ['a herestring', 'cat <<< "hello"'],
     ['a backgrounded process it no longer owns', 'npm run dev &'],
     ['output already redirected to a file', 'npm test > out.log'],
     ['an author-supplied bound', 'npm test | head -n 20'],
-    ['a streaming or interactive command', 'tail -f server.log'],
+        ['a streaming or interactive command', 'tail -f server.log'],
+    // Follow mode does not merely waste effort, it HANGS: the wrapper's own
+    // `tail -c` cannot emit until EOF and follow mode never reaches EOF. The
+    // flag need not come first and need not be short, and matching only
+    // `tail -f` left all four of these to hang.
+    ['tail -F', 'tail -F server.log'],
+    ['a follow flag that is not first', 'tail -n 100 -f server.log'],
+    ['the long follow flag', 'tail --follow server.log'],
+    ['the long follow flag with a value', 'tail --follow=name server.log'],
   ])('leaves %s alone', (_why, command) => {
     expect(boundedRewrite(command)).toBeNull();
+  });
+
+  it.each([
+    ['tail -n 5 build.log'],
+    ['tail -c 100 build.log'],
+  ])('still bounds %s, which is not follow mode', (command) => {
+    // Guards against over-correction: the follow-mode check must not swallow
+    // every use of `tail`, or an ordinary bounded read stops being bounded.
+    expect(boundedRewrite(command)).not.toBeNull();
   });
 
   it('still bounds a command containing && and ||, which are not backgrounding', () => {

--- a/tests/hooks/bounded-rewrite.test.mjs
+++ b/tests/hooks/bounded-rewrite.test.mjs
@@ -100,8 +100,25 @@ describe('the rewritten command still means what it meant', () => {
 
     expect(bounded.stdout.startsWith('1\n2\n3')).toBe(true);
     expect(bounded.stdout.trimEnd().endsWith('2000')).toBe(true);
-    // And it says so, rather than silently splicing two halves together.
-    expect(bounded.stdout).toContain('middle omitted');
+    expect(Buffer.byteLength(bounded.stdout, 'utf8')).toBeLessThanOrEqual(60);
+  });
+
+  it.each([
+    ['well under the bound', 'printf abcdefghij', 10],
+    ['between half and the bound', 'printf %.0sx $(seq 1 30)', 30],
+  ])('returns output %s COMPLETE and untouched', (_why, command, expected) => {
+    // The middle band is the one two earlier marker attempts got wrong. An
+    // unconditional marker lied about every output that fitted; gating it on a
+    // one-byte probe narrowed the lie to exactly this band, where head takes
+    // its half and tail takes the whole remainder -- so nothing is dropped and
+    // an omission was still announced.
+    const { command: bounded } = boundedRewrite(command, { maxBytes: 40 });
+
+    const plain = run(command);
+    const result = run(bounded);
+
+    expect(plain.stdout.length).toBe(expected);
+    expect(result.stdout).toBe(plain.stdout);
   });
 
   it.each([
@@ -129,10 +146,11 @@ describe('the rewritten command still means what it meant', () => {
     const bounded = run(command);
 
     expect(bounded.stdout.trim()).toBe('short');
-    // AND CLAIMS NOTHING. An unconditional marker would announce a truncation
-    // that never happened, sending the model looking for a middle that does
-    // not exist -- which costs the turn this module exists to save.
+    // AND CLAIMS NOTHING. Nothing is injected into output that fitted, so the
+    // model is never sent looking for a middle that does not exist -- which
+    // would cost the turn this module exists to save.
     expect(bounded.stdout).not.toContain('omitted');
+    expect(bounded.stdout).not.toContain('token-optimizer');
   });
 
   it('bounds a compound command as one unit, not just its last part', () => {
@@ -212,8 +230,11 @@ describe('the bound announces itself', () => {
 
     expect(notice).toContain(String(DEFAULT_BOUND_BYTES));
     expect(notice).toMatch(/TOKEN_OPTIMIZER_BOUND_BYTES/);
-    // And that BOTH ends were kept, not just the tail.
+    // BOTH ends, not just the tail.
     expect(notice).toMatch(/beginning and its end/);
+    // Stated as the POLICY, not as a claim about this particular output --
+    // which is what lets it be true whether or not this command was cut.
+    expect(notice).toMatch(/Shorter output is returned complete/);
   });
 });
 
@@ -281,7 +302,7 @@ describe('the shipped router bounds instead of refusing', () => {
   it('tells the model what it did, so the rewrite is not silent', () => {
     const r = router(SEARCH, { TOKEN_OPTIMIZER_MODE: 'enforce' });
 
-    expect(r.context).toMatch(/bounded/i);
+    expect(r.context).toMatch(/bounds this command/i);
     expect(r.context).toContain('TOKEN_OPTIMIZER_BOUND_BYTES');
   });
 

--- a/tests/hooks/bounded-rewrite.test.mjs
+++ b/tests/hooks/bounded-rewrite.test.mjs
@@ -66,32 +66,64 @@ describe('the rewritten command still means what it meant', () => {
     expect(bounded.status).toBe(1);
   });
 
-  it('keeps the TAIL, which is where a test run puts its verdict', () => {
-    // 200 numbered lines: the bound must drop the beginning and keep the end.
-    const { command } = boundedRewrite('seq 1 200', { maxBytes: 40 });
+  it('keeps BOTH ENDS, because the client itself truncates from the middle', () => {
+    // Claude Code caps Bash output at 30,000 characters and cuts the MIDDLE,
+    // keeping head and tail. A tail-only bound would be cheaper AND lose the
+    // head -- where a failing jest run lists WHICH suites failed -- so it could
+    // read as a cost win while being a regression for the model.
+    const { command } = boundedRewrite('seq 1 2000', { maxBytes: 60 });
 
     const bounded = run(command);
 
-    expect(bounded.stdout).toContain('200');
-    expect(bounded.stdout).not.toContain('\n1\n');
-    expect(Buffer.byteLength(bounded.stdout, 'utf8')).toBeLessThanOrEqual(40);
+    expect(bounded.stdout.startsWith('1\n2\n3')).toBe(true);
+    expect(bounded.stdout.trimEnd().endsWith('2000')).toBe(true);
+    // And it says so, rather than silently splicing two halves together.
+    expect(bounded.stdout).toContain('middle omitted');
+  });
+
+  it.each([
+    ['a trailing comment', 'echo hi # explain'],
+    ['a trailing semicolon', 'echo hi;'],
+  ])('does not BREAK a working command ending in %s', (_why, command) => {
+    // Both of these ran fine unwrapped and were syntax errors under the first
+    // implementation, which closed the group with `; }`:
+    //   echo hi # explain  ->  { echo hi # explain; }   `; }` is inside the
+    //                          comment, so the group never closes
+    //   echo hi;           ->  { echo hi;; }            `;;` is a syntax error
+    // Breaking a command that would have worked is the worst thing this module
+    // can do: the failure looks like the user's own command is at fault.
+    const original = run(command);
+    const bounded = run(boundedRewrite(command).command);
+
+    expect(original.status).toBe(0);
+    expect(bounded.status).toBe(0);
+    expect(bounded.stdout).toContain('hi');
   });
 
   it('leaves output shorter than the bound completely untouched', () => {
     const { command } = boundedRewrite('echo short', { maxBytes: 8000 });
 
-    expect(run(command).stdout.trim()).toBe('short');
+    const bounded = run(command);
+
+    expect(bounded.stdout.trim()).toBe('short');
+    // AND CLAIMS NOTHING. An unconditional marker would announce a truncation
+    // that never happened, sending the model looking for a middle that does
+    // not exist -- which costs the turn this module exists to save.
+    expect(bounded.stdout).not.toContain('omitted');
   });
 
   it('bounds a compound command as one unit, not just its last part', () => {
     // `{ a; b; } | tail` and `a; b | tail` are different commands. The braces
     // are what make the bound apply to everything the call produces.
-    const { command } = boundedRewrite('seq 1 100; echo LAST', { maxBytes: 30 });
+    const { command } = boundedRewrite('seq 1 100; echo LAST', { maxBytes: 60 });
 
     const bounded = run(command);
 
+    // `LAST` is produced by the SECOND command in the group; seeing it proves
+    // the bound wrapped the whole call rather than only its last part.
     expect(bounded.stdout).toContain('LAST');
-    expect(Buffer.byteLength(bounded.stdout, 'utf8')).toBeLessThanOrEqual(30);
+    // Bounded, not unbounded: the full sequence is ~292 bytes.
+    expect(Buffer.byteLength(bounded.stdout, 'utf8')).toBeLessThan(200);
   });
 });
 
@@ -133,6 +165,8 @@ describe('the bound announces itself', () => {
 
     expect(notice).toContain(String(DEFAULT_BOUND_BYTES));
     expect(notice).toMatch(/TOKEN_OPTIMIZER_BOUND_BYTES/);
+    // And that BOTH ends were kept, not just the tail.
+    expect(notice).toMatch(/beginning and its end/);
   });
 });
 

--- a/tests/hooks/bounded-rewrite.test.mjs
+++ b/tests/hooks/bounded-rewrite.test.mjs
@@ -57,6 +57,29 @@ describe('the rewritten command still means what it meant', () => {
     expect(bounded.stdout).toContain('boom');
   });
 
+  it.each([
+    ['false | true', 0],
+    ['true | false', 1],
+    ['echo a | grep -q a', 0],
+  ])('leaves %s exiting %i, as it does unwrapped', (command, expected) => {
+    // `pipefail` is a SHELL option, not a property of one pipe, so enabling it
+    // changed the meaning of any command that already contained a pipe:
+    // `false | true` exits 0 normally and exited 1 once wrapped. Silently
+    // changing a command's exit status is the same defect as masking one, just
+    // in the other direction.
+    expect(run(command).status).toBe(expected);
+    expect(run(boundedRewrite(command).command).status).toBe(expected);
+  });
+
+  it('still honours a pipefail the caller asked for themselves', () => {
+    // The reset must not override an explicit intent: the caller's `set -o`
+    // runs inside the subshell, after ours is undone.
+    const command = 'set -o pipefail; false | true';
+
+    expect(run(command).status).toBe(1);
+    expect(run(boundedRewrite(command).command).status).toBe(1);
+  });
+
   it('captures stderr, where a failing build says what went wrong', () => {
     const { command } = boundedRewrite('echo to-stderr 1>&2; exit 1');
 

--- a/tests/hooks/bounded-rewrite.test.mjs
+++ b/tests/hooks/bounded-rewrite.test.mjs
@@ -1,0 +1,229 @@
+/**
+ * Bounding a command's output instead of refusing the command.
+ *
+ * THE ASSERTIONS RUN THE REWRITTEN COMMANDS. A rewrite is a silent mutation of
+ * somebody's command, so the only assertion worth making is that the rewritten
+ * form still MEANS the same thing -- same stdout content at the tail, same exit
+ * status, stderr still captured. Pattern-matching the generated string would
+ * pass just as well for a rewrite that breaks every command it touches.
+ */
+import { describe, it, expect, afterAll } from '@jest/globals';
+import { execFileSync, spawnSync } from 'child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { boundedRewrite, boundNotice, DEFAULT_BOUND_BYTES } from '../../hooks-core/rewrite.mjs';
+
+/** Runs a command through bash exactly as the client's Bash tool would. */
+function run(command) {
+  try {
+    const stdout = execFileSync('bash', ['-c', command], {
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+    return { stdout, status: 0 };
+  } catch (error) {
+    return {
+      stdout: String(error.stdout ?? ''),
+      status: typeof error.status === 'number' ? error.status : -1,
+    };
+  }
+}
+
+describe('the rewritten command still means what it meant', () => {
+  it('keeps a successful command successful, and its output intact', () => {
+    const original = run('echo hello');
+    const { command } = boundedRewrite('echo hello');
+
+    const bounded = run(command);
+
+    expect(original.status).toBe(0);
+    expect(bounded.status).toBe(0);
+    expect(bounded.stdout.trim()).toBe('hello');
+  });
+
+  it('PRESERVES A NON-ZERO EXIT, which is the whole reason pipefail is there', () => {
+    // Without `set -o pipefail` the pipeline reports tail's status -- always 0 --
+    // and every failing test run would read as a passing one. That is far worse
+    // than any wasted tokens: the model would simply stop debugging.
+    const original = run('echo boom; exit 3');
+    expect(original.status).toBe(3);
+
+    const { command } = boundedRewrite('echo boom; exit 3');
+    const bounded = run(command);
+
+    expect(bounded.status).toBe(3);
+    expect(bounded.stdout).toContain('boom');
+  });
+
+  it('captures stderr, where a failing build says what went wrong', () => {
+    const { command } = boundedRewrite('echo to-stderr 1>&2; exit 1');
+
+    const bounded = run(command);
+
+    expect(bounded.stdout).toContain('to-stderr');
+    expect(bounded.status).toBe(1);
+  });
+
+  it('keeps the TAIL, which is where a test run puts its verdict', () => {
+    // 200 numbered lines: the bound must drop the beginning and keep the end.
+    const { command } = boundedRewrite('seq 1 200', { maxBytes: 40 });
+
+    const bounded = run(command);
+
+    expect(bounded.stdout).toContain('200');
+    expect(bounded.stdout).not.toContain('\n1\n');
+    expect(Buffer.byteLength(bounded.stdout, 'utf8')).toBeLessThanOrEqual(40);
+  });
+
+  it('leaves output shorter than the bound completely untouched', () => {
+    const { command } = boundedRewrite('echo short', { maxBytes: 8000 });
+
+    expect(run(command).stdout.trim()).toBe('short');
+  });
+
+  it('bounds a compound command as one unit, not just its last part', () => {
+    // `{ a; b; } | tail` and `a; b | tail` are different commands. The braces
+    // are what make the bound apply to everything the call produces.
+    const { command } = boundedRewrite('seq 1 100; echo LAST', { maxBytes: 30 });
+
+    const bounded = run(command);
+
+    expect(bounded.stdout).toContain('LAST');
+    expect(Buffer.byteLength(bounded.stdout, 'utf8')).toBeLessThanOrEqual(30);
+  });
+});
+
+describe('commands it refuses to touch', () => {
+  // Each of these is a case where wrapping changes what the command MEANS.
+  // Returning null leaves the call exactly as the author wrote it.
+  it.each([
+    ['a heredoc, whose body is data', "cat <<'EOF'\nhello\nEOF"],
+    ['a backgrounded process it no longer owns', 'npm run dev &'],
+    ['output already redirected to a file', 'npm test > out.log'],
+    ['an author-supplied bound', 'npm test | head -n 20'],
+    ['a streaming or interactive command', 'tail -f server.log'],
+  ])('leaves %s alone', (_why, command) => {
+    expect(boundedRewrite(command)).toBeNull();
+  });
+
+  it('still bounds a command containing && and ||, which are not backgrounding', () => {
+    // The backgrounding guard must not swallow ordinary control operators.
+    // Harmless operands on purpose: an earlier version used a real
+    // `npm run build && npm test`, and the test DID run them and timed out.
+    const rewritten = boundedRewrite('true && false || echo failed');
+
+    expect(rewritten).not.toBeNull();
+    expect(run(rewritten.command).stdout).toContain('failed');
+  });
+
+  it('does not bound an empty or non-string command', () => {
+    expect(boundedRewrite('   ')).toBeNull();
+    expect(boundedRewrite(undefined)).toBeNull();
+  });
+});
+
+describe('the bound announces itself', () => {
+  it('names the limit and a way out, because a silent rewrite gets distrusted', () => {
+    // The spike's model noticed an unannounced rewrite and reported the output
+    // as suspect rather than using it. A model that distrusts its output
+    // re-runs the command, spending the turn this mechanism exists to save.
+    const notice = boundNotice(DEFAULT_BOUND_BYTES);
+
+    expect(notice).toContain(String(DEFAULT_BOUND_BYTES));
+    expect(notice).toMatch(/TOKEN_OPTIMIZER_BOUND_BYTES/);
+  });
+});
+
+
+/* ------------------------------------------------------------------ *
+ * The real router, end to end
+ * ------------------------------------------------------------------ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROUTER = join(HERE, '..', '..', 'plugin', 'hooks', 'pretooluse-router.mjs');
+
+/** An empty graph, so no stored finding can influence the decision. */
+const GRAPH = mkdtempSync(join(tmpdir(), 'bounded-graph-'));
+
+afterAll(() => {
+  try {
+    rmSync(GRAPH, { recursive: true, force: true });
+  } catch {
+    /* windows can hold a handle briefly */
+  }
+});
+
+/** Drives the shipped router exactly as the client does. */
+function router(payload, env = {}) {
+  const result = spawnSync(process.execPath, [ROUTER], {
+    input: JSON.stringify({ session_id: 's-bound', cwd: process.cwd(), ...payload }),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      TOKEN_OPTIMIZER_MCP_CAPABILITIES:
+        'smart_read,smart_write,smart_edit,smart_glob,smart_grep,wiki_write',
+      TOKEN_OPTIMIZER_WIKI_DIR: GRAPH,
+      TOKEN_OPTIMIZER_SHARED_DIR: GRAPH,
+      ...env,
+    },
+  });
+  // A silent allow emits nothing at all. Spelled out with the same shape as
+  // the parsed path so a caller cannot tell them apart by accident.
+  if (!result.stdout.trim()) {
+    return { decision: 'allow', reason: '', context: '', updatedInput: null };
+  }
+  const out = JSON.parse(result.stdout).hookSpecificOutput || {};
+  return {
+    decision: out.permissionDecision || (out.additionalContext ? 'advise' : 'allow'),
+    reason: out.permissionDecisionReason || '',
+    context: out.additionalContext || '',
+    updatedInput: out.updatedInput || null,
+  };
+}
+
+describe('the shipped router bounds instead of refusing', () => {
+  const SEARCH = { tool_name: 'Bash', tool_input: { command: 'grep -rn needle .' } };
+
+  it('allows a recursive search WITH a rewritten command, where it used to deny', () => {
+    // The whole point of the change: this exact call was a refusal, and a
+    // refusal costs about one turn. Now it runs, bounded, for zero.
+    const r = router(SEARCH, { TOKEN_OPTIMIZER_MODE: 'enforce' });
+
+    expect(r.decision).toBe('allow');
+    expect(r.updatedInput).not.toBeNull();
+    expect(r.updatedInput.command).toContain('grep -rn needle .');
+    expect(r.updatedInput.command).toContain('tail -c');
+  });
+
+  it('tells the model what it did, so the rewrite is not silent', () => {
+    const r = router(SEARCH, { TOKEN_OPTIMIZER_MODE: 'enforce' });
+
+    expect(r.context).toMatch(/bounded/i);
+    expect(r.context).toContain('TOKEN_OPTIMIZER_BOUND_BYTES');
+  });
+
+  it('leaves the command alone in assist, which was already letting it through', () => {
+    // Bounding here would be a NEW behaviour, not a cheaper spelling of an old
+    // one -- assist's contract is that the call proceeds untouched.
+    const r = router(SEARCH, { TOKEN_OPTIMIZER_MODE: 'assist' });
+
+    expect(r.updatedInput).toBeNull();
+    expect(r.decision).toBe('allow');
+  });
+
+  it('does not rewrite a command it cannot bound safely', () => {
+    // A heredoc body is data; wrapping it in braces moves the terminator. The
+    // router must fall back to its previous behaviour rather than mangle it.
+    const r = router(
+      {
+        tool_name: 'Bash',
+        tool_input: { command: "grep -rn needle . <<'EOF'\nbody\nEOF" },
+      },
+      { TOKEN_OPTIMIZER_MODE: 'enforce' }
+    );
+
+    expect(r.updatedInput).toBeNull();
+  });
+});

--- a/tests/hooks/bounded-rewrite.test.mjs
+++ b/tests/hooks/bounded-rewrite.test.mjs
@@ -16,9 +16,9 @@ import { fileURLToPath } from 'url';
 import { boundedRewrite, boundNotice, DEFAULT_BOUND_BYTES } from '../../hooks-core/rewrite.mjs';
 
 /** Runs a command through bash exactly as the client's Bash tool would. */
-function run(command) {
+function run(command, shellFlags = []) {
   try {
-    const stdout = execFileSync('bash', ['-c', command], {
+    const stdout = execFileSync('bash', [...shellFlags, '-c', command], {
       encoding: 'utf8',
       timeout: 30_000,
     });
@@ -69,6 +69,19 @@ describe('the rewritten command still means what it meant', () => {
     // in the other direction.
     expect(run(command).status).toBe(expected);
     expect(run(boundedRewrite(command).command).status).toBe(expected);
+  });
+
+  it('preserves the pipefail state the CALLER was already running under', () => {
+    // The mirror of the leak above, and just as wrong. Under `bash -o pipefail`
+    // a caller's `false | true` returns 1; hard-clearing the option inside the
+    // subshell would hand them 0. Either direction is a silent change to an
+    // exit status we were only supposed to be bounding the output of.
+    const command = 'false | true';
+    const underPipefail = (c) =>
+      run(c, ['-o', 'pipefail']).status;
+
+    expect(underPipefail(command)).toBe(1);
+    expect(underPipefail(boundedRewrite(command).command)).toBe(1);
   });
 
   it('still honours a pipefail the caller asked for themselves', () => {
@@ -192,6 +205,11 @@ describe('commands it refuses to touch', () => {
     ['a follow flag that is not first', 'tail -n 100 -f server.log'],
     ['the long follow flag', 'tail --follow server.log'],
     ['the long follow flag with a value', 'tail --follow=name server.log'],
+    // Clustered short options: GNU tail accepts both, and a guard anchored on
+    // `-f\b` matches neither because the word boundary fails against the next
+    // letter in the cluster.
+    ['a clustered follow flag', 'tail -fn 1 server.log'],
+    ['two clustered follow flags', 'tail -fF server.log'],
   ])('leaves %s alone', (_why, command) => {
     expect(boundedRewrite(command)).toBeNull();
   });

--- a/tests/hooks/enforcement.test.mjs
+++ b/tests/hooks/enforcement.test.mjs
@@ -81,6 +81,10 @@ function run(payload, env = {}) {
     decision:
       out.permissionDecision || (out.additionalContext ? 'advise' : 'allow'),
     reason: out.permissionDecisionReason || out.additionalContext || '',
+    // The command that will ACTUALLY run. A Bash dump is now bounded rather
+    // than refused, so the assertion that the bypass is closed has to look at
+    // the rewritten command, not at a decision string.
+    updatedInput: out.updatedInput || null,
   };
 }
 
@@ -142,14 +146,23 @@ describe('loop breaking bounds every failure mode', () => {
 });
 
 describe('the shell bypass is closed', () => {
-  test('cat of a large file is denied', () => {
+  test('cat of a large file is bounded, so the dump cannot reach context', () => {
+    // THE MECHANISM CHANGED, THE GUARANTEE DID NOT. This used to be a refusal.
+    // A refusal costs about one extra turn -- enforcement measured 12.6 to 20.9
+    // turns and a task-mean 1.633x -- so the same limit is now applied by
+    // rewriting the command through `updatedInput`, which costs none.
+    //
+    // Stated plainly, because it IS a trade: a refusal let zero bytes through,
+    // a bound lets the tail through. That is deliberate. The tail of a dump is
+    // worth far less than the round trip refusing it spends.
     const r = run({
       tool_name: 'Bash',
       tool_input: { command: `cat ${big}` },
       session_id: 'bash-1',
     });
-    expect(r.decision).toBe('deny');
-    expect(r.reason).toContain('smart_read');
+    expect(r.decision).toBe('allow');
+    expect(r.updatedInput.command).toContain(`cat ${big}`);
+    expect(r.updatedInput.command).toContain('tail -c');
   });
 
   test('a pipeline with no file operand is untouched', () => {
@@ -182,8 +195,12 @@ describe('the shell bypass is closed', () => {
       tool_input: { command: `cat ${msys}` },
       session_id: 'msys-1',
     });
-    expect(r.decision).toBe('deny');
-    expect(r.reason).toContain('smart_read');
+    // Bounded, not refused -- see the `cat` case above for why. The guarantee
+    // under test is unchanged and is what the rewrite proves: the MSYS path was
+    // RESOLVED. An unresolved path produces no verdict at all, so the router
+    // would have allowed the call untouched and there would be no rewrite here.
+    expect(r.decision).toBe('allow');
+    expect(r.updatedInput.command).toContain('tail -c');
   });
 
   test('the two spellings of one path are one identity, on every platform', () => {


### PR DESCRIPTION
Part of #357 (M4). Builds on the spike in #364.

## The problem, measured

A refusal costs about **one extra turn**. Enforcement took turns from **12.6 → 20.9** and measured a task-mean **1.633× vanilla Claude Code — last of fifteen**; the same build without refusals measured 0.928. The tokens a refusal saves are smaller than the round trip it spends. **The mechanism is what loses, not the policy.**

## The change

A `PreToolUse` hook can return `updatedInput`, and the rewritten call runs (verified end-to-end in #364). So Bash calls the router was about to refuse now **run with their output bounded to the last 8 KB** instead — same limit, zero turns.

Only where a refusal would actually have happened. `assist` and `off` already let the call through untouched; bounding there would be a new behaviour rather than a cheaper spelling of an existing one.

## What keeps it honest

- **`pipefail`** — a failing command still reports its failure. Without it the pipeline reports `tail`'s status (always 0) and **every failing test run would read as passing**, which is far worse than wasted tokens: the model would stop debugging. Asserted by running `exit 3` through the rewrite.
- **`tail`, not `head`** — a test run puts its verdict at the end, and `head` closes the pipe early, which under `pipefail` turns a successful search into exit 141.
- **Braces** — a compound command is bounded as one unit, not just its last part.
- **It announces itself.** The spike's model *noticed* an unannounced rewrite and distrusted the output. A model that distrusts its output re-runs the command, spending the exact turn this saves.
- **Five shapes are never rewritten** — heredocs, backgrounding, existing redirection, an author's own bound, streaming commands — because wrapping those changes what the command *means*.

The tests **run** the rewritten commands rather than pattern-matching the generated string, which would pass equally well for a rewrite that breaks everything it touches.

## One trade, stated plainly

`enforcement.test.mjs` asserted `deny` for two Bash dumps. The guarantee ("the shell bypass is closed") is unchanged, and is now proved against the command that will actually run — stronger than a decision string. But it *is* a trade and the tests say so: a refusal let **zero** bytes through, a bound lets the **tail** through. Deliberate — the tail of a dump is worth far less than the round trip refusing it spends.

## Not claimed

No cost ratio is measured here. This makes the mechanism available and safe; whether it moves the debug-loop family is M4's job, and `bench/results/` is still empty.

Full suite: 3,248 passed. eslint: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)