### PR TITLE
feat!: default to assist, and make the graph actually deliver under it

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/enforced-by%20default-2ea043" alt="Enforced by default">
+  <img src="https://img.shields.io/badge/measured-on%20two%20harnesses-2ea043" alt="Measured on two independent harnesses">
   <img src="https://img.shields.io/badge/clients-16-8b5cf6" alt="16 clients">
   <img src="https://img.shields.io/badge/direct%20savings-before%20%2F%20actual%20return-3b82f6" alt="Direct savings measured before and after">
   <img src="https://img.shields.io/badge/telemetry-none-2ea043" alt="No telemetry">
@@ -578,9 +578,10 @@ enforcement.
 ### Enforcing tier — the wasteful call is refused
 
 These ten clients expose a pre-execution hook. Their packaged lifecycle bundle
-defaults to enforcement and shares one capability-aware decision engine; set
-`TOKEN_OPTIMIZER_MODE=advise` or `off` only when you deliberately want the
-escape hatch.
+shares one capability-aware decision engine and defaults to `assist`: routing,
+retrieval, capture and harvest all on, no refusals. Set
+`TOKEN_OPTIMIZER_MODE=enforce` if you want expensive built-in calls vetoed, or
+`off` to disable the hooks entirely.
 
 | Client                 | Installable lifecycle surface                                                                                                                    |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -649,7 +650,7 @@ Start a new Codex conversation after installation so the new tools are discovere
 
 The plugin supplies both automatically. For an MCP-only installation, add the guidance from [`integrations/AGENTS.md`](./integrations/AGENTS.md) to a project or global `AGENTS.md`. A ready-made standalone hook is also available under [`integrations/codex/hooks`](./integrations/codex/hooks); merge its `hooks.json` into `~/.codex/hooks.json`, copy the script to `~/.codex/hooks/`, and review it once with `/hooks`.
 
-The Codex hook injects guidance at `SessionStart` and blocks expensive native operations by default when the bundled MCP has an exact replacement. That includes a single unambiguous code-mode shell call such as `cat` or `Get-Content`; multi-operation orchestration remains advisory so unrelated work is not discarded. A second attempt at the same target passes through if the MCP is unavailable. Set `TOKEN_OPTIMIZER_MODE=advise` for guidance without vetoes or `TOKEN_OPTIMIZER_MODE=off` to disable the hooks. The `AGENTS.md`/skill guidance remains important.
+The Codex hook injects guidance at `SessionStart`. Under `TOKEN_OPTIMIZER_MODE=enforce` it blocks expensive native operations when the bundled MCP has an exact replacement, including a single unambiguous code-mode shell call such as `cat` or `Get-Content`; multi-operation orchestration remains advisory so unrelated work is not discarded, and a second attempt at the same target passes through if the MCP is unavailable. The default is `assist`, which keeps retrieval and capture but never vetoes; `TOKEN_OPTIMIZER_MODE=advise` adds the routing advisory without vetoes, and `off` disables the hooks. The `AGENTS.md`/skill guidance remains important.
 
 If you prefer a smaller instruction block:
 
@@ -819,7 +820,7 @@ New-Item -ItemType Directory -Force .github/hooks | Out-Null
 Copy-Item integrations/copilot/.github/hooks/token-optimizer* .github/hooks/
 ```
 
-The hooks inject optimization guidance at `sessionStart` and deny a large built-in `view` by default so Copilot retries with `smart_read`. Partial reads and files below 25 KB pass through unchanged, and `TOKEN_OPTIMIZER_MODE=advise` restores non-blocking guidance. Repository hooks work without overwriting user-level files; global hooks can instead be placed in `~/.copilot/hooks/` with their script paths adjusted for that directory.
+The hooks inject optimization guidance at `sessionStart`. Under `TOKEN_OPTIMIZER_MODE=enforce` they deny a large built-in `view` so Copilot retries with `smart_read`; the default `assist` leaves the call alone. Partial reads and files below 25 KB always pass through unchanged, and `TOKEN_OPTIMIZER_MODE=advise` gives recommendations without vetoes. Repository hooks work without overwriting user-level files; global hooks can instead be placed in `~/.copilot/hooks/` with their script paths adjusted for that directory.
 
 Restart Copilot CLI after changing hook files. See GitHub's official [MCP setup guide](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers) and [hooks reference](https://docs.github.com/en/copilot/reference/hooks-reference).
 
@@ -904,7 +905,7 @@ New-Item -ItemType Directory -Force .opencode/plugins | Out-Null
 Copy-Item integrations/opencode/.opencode/plugins/token-optimizer.js .opencode/plugins/
 ```
 
-The plugin preserves Token Optimizer usage state in OpenCode's compaction prompt. Its `tool.execute.before` hook rejects full-file reads over 25 KB by default and steers the agent to `smart_read`; small and partial reads pass normally. Set `TOKEN_OPTIMIZER_MODE=advise` for non-blocking guidance. Restart OpenCode after adding the plugin. See the official [OpenCode MCP guide](https://opencode.ai/docs/mcp-servers/) and [plugin hook guide](https://opencode.ai/docs/plugins/).
+The plugin preserves Token Optimizer usage state in OpenCode's compaction prompt. Under `TOKEN_OPTIMIZER_MODE=enforce` its `tool.execute.before` hook rejects full-file reads over 25 KB and steers the agent to `smart_read`; the default `assist` lets them through. Small and partial reads always pass normally, and `TOKEN_OPTIMIZER_MODE=advise` gives non-blocking guidance. Restart OpenCode after adding the plugin. See the official [OpenCode MCP guide](https://opencode.ai/docs/mcp-servers/) and [plugin hook guide](https://opencode.ai/docs/plugins/).
 
 ### Generic MCP configuration
 
@@ -1343,7 +1344,7 @@ get_session_stats({});
 
 The MCP server is identical in every client, but lifecycle APIs are not. The repository ships client-native adapters instead of copying Claude event names into tools that would silently ignore them.
 
-| Client             | Native integration events                   | Default enforcement                                    | Non-blocking mode             |
+| Client             | Native integration events                   | Refusal under `MODE=enforce`                           | Advisory escape hatch         |
 | ------------------ | ------------------------------------------- | ------------------------------------------------------ | ----------------------------- |
 | Codex              | `SessionStart`, `PreToolUse`                | Deny replaceable large reads and single shell dumps    | `TOKEN_OPTIMIZER_MODE=advise` |
 | Claude Code        | `PreToolUse` plus optional global pipeline  | Deny replaceable large reads and noisy searches        | `TOKEN_OPTIMIZER_MODE=advise` |
@@ -1351,7 +1352,7 @@ The MCP server is identical in every client, but lifecycle APIs are not. The rep
 | Gemini CLI         | `SessionStart`, `BeforeTool`, `AfterTool`   | Deny replaceable large reads before they enter context | `TOKEN_OPTIMIZER_MODE=advise` |
 | OpenCode           | `tool.execute.before`, compaction hook      | Reject large full-file reads and steer to `smart_read` | `TOKEN_OPTIMIZER_MODE=advise` |
 
-Enforcement is the default and uses a 25,600-byte threshold. Override the threshold with `TOKEN_OPTIMIZER_LARGE_READ_BYTES`, use `TOKEN_OPTIMIZER_MODE=advise` to keep recommendations without vetoes, or use `TOKEN_OPTIMIZER_MODE=off` to disable the lifecycle integration. Partial reads pass through because they may already be more efficient than a full cached read, and one repeated attempt is allowed so a failed MCP server cannot permanently block work.
+The default is `assist`: routing, retrieval, capture and harvest are on and nothing is ever refused. That is the posture two independent harnesses measured as our best -- on THOL, assist ran $20.48 at score 0.971 against control's $21.13 at 0.969, while enforce ran $23.33 at 0.935 and lost 12 of 17 tasks. Set `TOKEN_OPTIMIZER_MODE=enforce` for the refusals described above, which use a 25,600-byte threshold; override it with `TOKEN_OPTIMIZER_LARGE_READ_BYTES`, use `TOKEN_OPTIMIZER_MODE=advise` for the routing advisory without vetoes, or `TOKEN_OPTIMIZER_MODE=off` to disable the lifecycle integration. Partial reads always pass through because they may already be more efficient than a full cached read, and under `enforce` one repeated attempt is allowed so a failed MCP server cannot permanently block work.
 
 #### Analytics workflow and storage
 

--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -1220,6 +1220,12 @@ async function runHook(clientName, event, invocation) {
         candidates: derived.candidates.length,
         observations: derived.observations.length,
         written: derived.written.length,
+        // Whether a locate detector would have anything to catch: `named` is
+        // searches carrying an identifier, `gap` the subset the symbol index
+        // cannot answer. Recorded rather than acted on -- a `gap` that stays
+        // near zero says the detector written for it should stay unmerged.
+        searchesNamed: derived.searchGap?.named ?? 0,
+        searchGap: derived.searchGap?.gap ?? 0,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/hooks-core/advise.mjs
+++ b/hooks-core/advise.mjs
@@ -139,18 +139,45 @@ const COLOR_FLAGS = new Set(['--color', '--colour']);
 const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
- * Splits a command into tokens, honouring quotes.
+ * Splits a command into segments of tokens, honouring quotes and escapes.
+ *
+ * SEGMENTING AND TOKENIZING ARE ONE PASS, and they have to be. Splitting the raw
+ * string on `|`, `&&` and `;` before tokenizing cut straight through quoted
+ * text, so a perfectly ordinary alternation lost everything after the first
+ * branch:
+ *
+ *   grep -E "foo|bar" .   returned `foo`   -- `bar` never reached adviseSearch
+ *   rg "a;b" .            returned `a`
+ *   grep "x&&y" .         returned `x`
+ *
+ * A quote-aware scan cannot make that mistake, because an operator inside a
+ * quoted run is just a character. Pipelines still split, which is what lets
+ * `cat x | grep foo` be recognised at all -- the search is never the first
+ * segment there.
  *
  * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
  * critical path against a string the model composed, which is the exact input
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function tokenize(command) {
-  const tokens = [];
+function commandSegments(command) {
+  const segments = [];
+  let tokens = [];
   let current = '';
   let quote = null;
   let started = false;
+
+  const endToken = () => {
+    if (current || started) tokens.push(current);
+    current = '';
+    started = false;
+  };
+  const endSegment = () => {
+    endToken();
+    if (tokens.length) segments.push(tokens);
+    tokens = [];
+  };
+
   for (let i = 0; i < command.length; i += 1) {
     const ch = command[i];
     if (quote) {
@@ -169,17 +196,22 @@ function tokenize(command) {
       started = true;
       continue;
     }
-    if (ch === ' ' || ch === '\t' || ch === '\n') {
-      if (current || started) tokens.push(current);
-      current = '';
-      started = false;
+    // UNQUOTED ONLY -- reaching here means the quote branches above did not.
+    if (ch === '|' || ch === ';' || ch === '&' || ch === '\n') {
+      endSegment();
+      // `||` and `&&` are one operator, not two empty segments.
+      while (i + 1 < command.length && command[i + 1] === ch) i += 1;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t') {
+      endToken();
       continue;
     }
     current += ch;
     started = true;
   }
-  if (current || started) tokens.push(current);
-  return tokens;
+  endSegment();
+  return segments;
 }
 
 /**
@@ -201,8 +233,7 @@ export function searchPatternFromCommand(command) {
   // the advisory is an optimisation that must never become the slow path.
   if (command.length > 4_000) return null;
 
-  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
-    const tokens = tokenize(segment.trim()).filter(Boolean);
+  for (const tokens of commandSegments(command)) {
     if (!tokens.length) continue;
     // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
     // leading `git` is: `git grep` is ordinary.

--- a/hooks-core/advise.mjs
+++ b/hooks-core/advise.mjs
@@ -79,6 +79,141 @@ const STOPWORDS = new Set([
   'except', 'raise', 'throw', 'new', 'int', 'str', 'bool', 'float',
 ]);
 
+/**
+ * Search programs whose first operand is a pattern.
+ *
+ * WHY THIS LIST EXISTS AT ALL. The advisory above answers a search from the
+ * index before it runs, and it was wired only to the `Grep` and `Glob` TOOLS.
+ * Measured on the warm benchmark, that is the wrong half of the surface: in the
+ * needle-in-repo runs the agent searched entirely through Bash --
+ *
+ *   Bash  grep -rn "compute_settlement_fee" /work --include=* 2>/dev/null | head -50
+ *   Bash  cat /work/pkg/mod_047.py
+ *   Edit  /work/pkg/mod_047.py
+ *
+ * -- zero Grep calls, zero Glob calls, and so zero advisories delivered, while
+ * the graph for that very session held
+ * `compute_settlement_fee -> pkg/mod_047.py:9-12` and returned it correctly to a
+ * direct call. Two turns were spent rediscovering a fact already indexed.
+ */
+const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
+
+/**
+ * Flags that consume the NEXT token, so its value is never the pattern.
+ *
+ * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
+ * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
+ * it is one token, and the `=` test below skips it.
+ */
+const VALUED_FLAGS = new Set([
+  '-e', '--regexp', '-f', '--file', '-m', '--max-count',
+  '-A', '--after-context', '-B', '--before-context', '-C', '--context',
+  '-d', '--directories', '-t', '--type', '-g', '--glob',
+  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+]);
+
+/**
+ * Splits a command into tokens, honouring quotes.
+ *
+ * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
+ * critical path against a string the model composed, which is the exact input
+ * class this repo keeps a linearity gate for; a single forward pass cannot
+ * backtrack at all.
+ */
+function tokenize(command) {
+  const tokens = [];
+  let current = '';
+  let quote = null;
+  let started = false;
+  for (let i = 0; i < command.length; i += 1) {
+    const ch = command[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (ch === '\\' && i + 1 < command.length) {
+      current += command[i + 1];
+      i += 1;
+      started = true;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t' || ch === '\n') {
+      if (current || started) tokens.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (current || started) tokens.push(current);
+  return tokens;
+}
+
+/**
+ * The pattern a shell search command is about to look for, or null.
+ *
+ * Splits on pipeline and sequencing operators first, because `cat x | grep foo`
+ * and `a && grep foo` both carry a search the graph may be able to answer, and
+ * the search is never the first segment there. `git grep foo` is handled by
+ * skipping a leading `git`, and `find . -name "*.py"` by reading the -name
+ * value: a glob yields no identifiers and so costs nothing, but
+ * `find . -name "compute_settlement*"` does.
+ *
+ * Returns the raw pattern rather than identifiers, so the caller hands it to the
+ * same `adviseSearch` the Grep tool path uses and the two surfaces cannot drift.
+ */
+export function searchPatternFromCommand(command) {
+  if (typeof command !== 'string' || !command) return null;
+  // Bounded before any work: a pathological command is not worth parsing, and
+  // the advisory is an optimisation that must never become the slow path.
+  if (command.length > 4_000) return null;
+
+  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
+    const tokens = tokenize(segment.trim()).filter(Boolean);
+    if (!tokens.length) continue;
+    // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
+    // leading `git` is: `git grep` is ordinary.
+    let at = 0;
+    if (tokens[at] === 'git') at += 1;
+    const program = String(tokens[at] || '').split(/[/\\]/).pop();
+
+    if (program === 'find') {
+      for (let i = at + 1; i < tokens.length - 1; i += 1) {
+        if (tokens[i] === '-name' || tokens[i] === '-iname') return tokens[i + 1];
+      }
+      continue;
+    }
+    if (!SEARCH_PROGRAMS.has(program)) continue;
+
+    for (let i = at + 1; i < tokens.length; i += 1) {
+      const token = tokens[i];
+      // An explicit -e/--regexp names the pattern outright and wins over
+      // position, which is the whole reason the flag exists.
+      if (VALUED_FLAGS.has(token)) {
+        if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
+        i += 1;
+        continue;
+      }
+      if (token.startsWith('--') && token.includes('=')) {
+        const [name, ...rest] = token.split('=');
+        if (name === '--regexp') return rest.join('=') || null;
+        continue;
+      }
+      if (token.startsWith('-') && token.length > 1) continue;
+      // The first bare operand is the pattern; everything after it is a path.
+      return token || null;
+    }
+  }
+  return null;
+}
+
 /** Symbol nodes grouped by name, for one lookup per identifier. */
 export function symbolIndex(graph) {
   const byName = new Map();

--- a/hooks-core/advise.mjs
+++ b/hooks-core/advise.mjs
@@ -104,13 +104,39 @@ const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
  * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
  * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
  * it is one token, and the `=` test below skips it.
+ *
+ * THE COLOUR FLAGS ARE NOT HERE, because their arity is the one thing in this
+ * list that differs by program. See COLOR_TAKES_SEPARATE_VALUE.
  */
 const VALUED_FLAGS = new Set([
   '-e', '--regexp', '-f', '--file', '-m', '--max-count',
   '-A', '--after-context', '-B', '--before-context', '-C', '--context',
   '-d', '--directories', '-t', '--type', '-g', '--glob',
-  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+  '--include', '--exclude', '--exclude-dir',
 ]);
+
+/** The spellings of the colour option, across the programs handled here. */
+const COLOR_FLAGS = new Set(['--color', '--colour']);
+
+/**
+ * Programs whose colour flag takes a SEPARATE value token.
+ *
+ * The one option in this parser whose arity cannot be decided globally, and
+ * getting it wrong silently returns a path or a keyword as the search pattern:
+ *
+ *   grep --color needle file   GNU: the value is optional and inline-only, so
+ *                              `needle` is the pattern. Treating --color as
+ *                              valued consumed `needle` and returned `file`.
+ *   rg --color never needle .  ripgrep REQUIRES a separate WHEN, so `never` is
+ *                              the flag's value and `needle` is the pattern.
+ *                              Treating --color as valueless returns `never`.
+ *   ag --color needle .        a valueless toggle, like ack. Same failure as
+ *   ack --color needle .       grep: returned `.` instead of `needle`.
+ *
+ * So neither "always valued" nor "never valued" is correct, and the contract has
+ * to come from the program. Only ripgrep is in this set.
+ */
+const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
  * Splits a command into tokens, honouring quotes.
@@ -192,11 +218,17 @@ export function searchPatternFromCommand(command) {
     }
     if (!SEARCH_PROGRAMS.has(program)) continue;
 
+    // Whether a flag eats the next token, decided per program: only the colour
+    // option varies, and only ripgrep requires a separate value for it.
+    const consumesNext = (token) =>
+      VALUED_FLAGS.has(token) ||
+      (COLOR_FLAGS.has(token) && COLOR_TAKES_SEPARATE_VALUE.has(program));
+
     for (let i = at + 1; i < tokens.length; i += 1) {
       const token = tokens[i];
       // An explicit -e/--regexp names the pattern outright and wins over
       // position, which is the whole reason the flag exists.
-      if (VALUED_FLAGS.has(token)) {
+      if (consumesNext(token)) {
         if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
         i += 1;
         continue;

--- a/hooks-core/audit.mjs
+++ b/hooks-core/audit.mjs
@@ -76,9 +76,21 @@ export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
   const candidates = sum('candidates');
   const observations = sum('observations');
   const written = sum('written');
+  // THE SEARCH GAP RIDES HERE because a counter nobody reads is exactly the cost
+  // this note exists to prevent -- and because the number decides something: a
+  // locate detector is written and held unmerged until this says the gap is
+  // real. `named` is searches carrying an identifier, `gap` the subset the
+  // symbol index could not answer. Reported only once a search has been seen,
+  // so a project that never searches does not get a line of zeroes.
+  const named = sum('searchesNamed');
+  const gap = sum('searchGap');
+  const searchLine = named
+    ? ` ${gap.toLocaleString()} of ${named.toLocaleString()} named search(es) were ` +
+      'outside the symbol index.'
+    : '';
   return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
     `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
-    `across ${runs.length.toLocaleString()} Stop run(s).`;
+    `across ${runs.length.toLocaleString()} Stop run(s).${searchLine}`;
 }
 
 const idOf = (finding) =>

--- a/hooks-core/derive.mjs
+++ b/hooks-core/derive.mjs
@@ -47,6 +47,14 @@ import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
 import { load } from './wiki.mjs';
 import { ORIGIN_HARVESTED } from './curate.mjs';
+// Counting only -- see `searchGap` below. The SAME extractor the router advises
+// from, so what this counts as a search and what the advisory treats as one
+// cannot diverge.
+import {
+  identifiersIn,
+  searchPatternFromCommand,
+  symbolIndex,
+} from './advise.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -395,12 +403,56 @@ const storageBudget = () =>
  *   defaulting would promote any caller's string to trusted. Also returned, so a
  *   caller can see what it handed over.
  * @returns {object} `{ candidates, observations, written, selected, dropped,
- *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
- *   everything derived; `written` is the subset of keys the graph actually
- *   holds, which is smaller for three independent reasons -- the budget, the
- *   anchor discipline, and the duplicate collapse that returns an EXISTING key
- *   when a later session derives the same claim again.
+ *   selectedTokens, searchGap, sessionId, authoritativeSessionId }`.
+ *   `candidates` is everything derived; `written` is the subset of keys the
+ *   graph actually holds, which is smaller for three independent reasons -- the
+ *   budget, the anchor discipline, and the duplicate collapse that returns an
+ *   EXISTING key when a later session derives the same claim again.
  */
+
+/**
+ * How many searches this session ran that the symbol index could NOT answer.
+ *
+ * MEASUREMENT, NOT A FEATURE. A detector that turns these into findings is
+ * written and deliberately unmerged, because on the only workload we have
+ * measured it produces nothing: replayed against a real warm rep, all seven
+ * searches were for symbols the index already resolves --
+ * `compute_settlement_fee` three times, `def parse_line` once, and three terms
+ * with no identifier-shaped word at all. The search advisory answers every one
+ * of those directly, so storing them again would spend the retrieval budget
+ * restating a cheaper mechanism.
+ *
+ * The case that would justify the detector is a search for something the indexer
+ * never extracts -- a config key, an error string, a literal, a symbol in a file
+ * type it cannot parse. Eleven synthetic Python tasks cannot show whether that
+ * happens in real work. This counts it instead of guessing: `gap` is the number
+ * of searches carrying an identifier the index has no entry for, `named` the
+ * number carrying one at all. A `gap` that stays near zero says the detector
+ * should stay unmerged.
+ *
+ * Counting only. Nothing is stored, nothing is claimed, and it runs at session
+ * end where the cost is already paid.
+ */
+export function searchGap(dir, events) {
+  const out = { named: 0, gap: 0 };
+  try {
+    const index = symbolIndex(load(dir));
+    for (const event of events) {
+      if (!event || event.kind !== 'tool-outcome') continue;
+      if (event.success === false || event.surface !== 'command') continue;
+      const pattern = searchPatternFromCommand(event.anchor);
+      if (!pattern) continue;
+      const names = identifiersIn(pattern);
+      if (!names.length) continue;
+      out.named += 1;
+      if (!names.some((name) => index.has(name))) out.gap += 1;
+    }
+  } catch {
+    // A count is never worth failing a session for.
+  }
+  return out;
+}
+
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
   // `undefined`, so a caller passing an explicitly null options object -- which
@@ -429,6 +481,10 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // Measured, not stored. See `searchGap`: this decides whether the locate
+  // detector is worth merging, and nothing here acts on it.
+  result.searchGap = searchGap(dir, events);
 
   // ONE anchor for the whole run, so every candidate from this session points at
   // the same node and the duplicate collapse in `writeHarvested` can recognise

--- a/hooks-core/doctor.mjs
+++ b/hooks-core/doctor.mjs
@@ -521,6 +521,19 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
     // on the same session file, and the failure would be intermittent and
     // wrong-looking rather than loud. The concurrency win is taken in
     // diagnose(), across probes that share no state.
+    // ENFORCE IS ASKED FOR, NOT INHERITED -- for the same reason the capability
+    // evidence in `probe` is stated rather than inferred. The question this probe
+    // asks is "would enforcement fire if it were switched on", and policy.mjs#mode
+    // now defaults to `assist`, which never refuses (THOL and ledger measurement).
+    // Inheriting the default would make the probe report "not refused" on a
+    // perfectly healthy install: a false negative in the one tool whose job is to
+    // tell the user the truth.
+    //
+    // BOTH probes take it, not just the refusal one. "Small reads are left alone"
+    // is evidence of something only under a posture that COULD have refused;
+    // under assist it would pass against a hook that does nothing whatsoever,
+    // which is precisely the broken install it exists to catch.
+    const enforcing = { env: { TOKEN_OPTIMIZER_MODE: 'enforce' } };
     const denied = await probe(
       binary,
       {
@@ -528,13 +541,14 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: big },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     const deniedOk = typeof denied === 'string' && denied.includes('deny');
     checks.push(deniedOk
       ? ok('enforcement refuses a large read', 'the refusal came back from the real hook')
       : bad('enforcement refuses a large read', `hook returned: ${String(denied).slice(0, 200) || '(nothing)'}`,
-        'check TOKEN_OPTIMIZER_MODE is not "off" or "advise", then reinstall the hooks'));
+        'the probe asks for enforce explicitly, so a failure is the hook itself rather than your mode -- reinstall the hooks'));
 
     const allowed = await probe(
       binary,
@@ -543,7 +557,8 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: small },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     // `allowed === null` is "the probe never ran", NOT "the hook allowed it".
     // allow() writes nothing and exits 0, so '' is a legitimate allow -- but null

--- a/hooks-core/policy.mjs
+++ b/hooks-core/policy.mjs
@@ -8,9 +8,18 @@
  * listed in `/mcp`, and save nothing at all. The skill did not help: skills are
  * model-invoked, so it only loads if the model already decided it cared.
  *
- * The redesign inverts the default. Optimized tooling is the path of least
- * resistance: expensive built-in calls are DENIED with a message naming the
- * exact replacement to call. Everything here exists to make that safe.
+ * The redesign inverted the default so that optimized tooling was the path of
+ * least resistance: expensive built-in calls were DENIED with a message naming
+ * the exact replacement to call. Most of this module exists to make that safe.
+ *
+ * REFUSALS ARE NOW OPT-IN, because measurement did not support them. Two
+ * independent harnesses agree that enforcing is the worst posture we ship --
+ * THOL: enforce $23.33/score 0.935 against assist $20.48/0.971 and control
+ * $21.13/0.969, losing 12 of 17 tasks; ledger cold: enforce/advise 1.147
+ * [1.065, 1.235] while advise/assist-mcp is 1.028 [0.951, 1.114]. So the cost is
+ * the refusals themselves, not the routing advisory or retrieval, and the
+ * machinery below is retained and exercised rather than deleted: `enforce`
+ * remains one variable away for anyone who wants it. See `mode()`.
  *
  * FOUR SAFETY PROPERTIES, none of which are optional:
  *
@@ -25,7 +34,8 @@
  *      human intervention and no permanent breakage.
  *
  *   3. AN ESCAPE HATCH THAT IS ONE VARIABLE. TOKEN_OPTIMIZER_MODE=off disables
- *      everything; =advise restores the old non-blocking behaviour.
+ *      everything; =advise restores the old non-blocking behaviour; =enforce
+ *      turns refusals back on now that they are no longer the default.
  *
  *   4. NO BLOCKING OF CHEAP CALLS. Small files, paged reads, and searches that
  *      already read from a pipe cost little and are left alone. Blocking them
@@ -90,16 +100,40 @@ export function refusalsEnabled() {
 }
 
 /**
- * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
- * redesign. An unrecognised value falls back to enforce rather than silently
- * disabling, so a typo cannot quietly turn the product off.
+ * Reads the mode. ASSIST IS THE DEFAULT, on measurement.
+ *
+ * This said "Enforcement is the DEFAULT -- that is the entire point of the
+ * redesign". The redesign's point was to make the product pay for itself, and
+ * enforcement was the assumed way there rather than a measured one. Two
+ * independent harnesses now say it is the worst posture we ship:
+ *
+ *   THOL 2.1.251, 17 tasks x 3 reps x 3 arms, 153 runs, zero errors
+ *     control  $21.13  score 0.969  turns 16.2
+ *     assist   $20.48  score 0.971  turns 14.4   <- better on all three
+ *     enforce  $23.33  score 0.935  turns 17.6   <- worse on all three,
+ *                                                   losing 12 of 17 tasks
+ *   Ledger cold track
+ *     enforce/advise    1.147 [1.065, 1.235]  refusals cost 14.7%
+ *     advise/assist-mcp 1.028 [0.951, 1.114]  the advisory itself is free
+ *
+ * So the refusals are the whole cost: not the routing advisory, not retrieval.
+ * Enforce's worst tasks are the small cheap ones, where one refused turn is a
+ * large fraction of the total (code-bugfix-py 1.599, log-needle-zh 1.589).
+ * Shipping assist is worth ~12% cost and 3.6 score points against what users
+ * receive today.
+ *
+ * THE TYPO PROPERTY IS PRESERVED, which is what the old comment was really
+ * protecting. An unrecognised value still falls back to a posture with routing,
+ * retrieval, capture and harvest all ON -- `off` is the only value that exits
+ * the hook process, and it remains reachable only by asking for it exactly. A
+ * typo cannot quietly turn the product off; it can now only decline to refuse.
  */
 export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
-  if (raw === MODE_ASSIST) return MODE_ASSIST;
-  return MODE_ENFORCE;
+  if (raw === MODE_ENFORCE) return MODE_ENFORCE;
+  return MODE_ASSIST;
 }
 
 function intEnv(name, fallback) {

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -1222,6 +1222,12 @@ async function runHook(clientName, event, invocation) {
         candidates: derived.candidates.length,
         observations: derived.observations.length,
         written: derived.written.length,
+        // Whether a locate detector would have anything to catch: `named` is
+        // searches carrying an identifier, `gap` the subset the symbol index
+        // cannot answer. Recorded rather than acted on -- a `gap` that stays
+        // near zero says the detector written for it should stay unmerged.
+        searchesNamed: derived.searchGap?.named ?? 0,
+        searchGap: derived.searchGap?.gap ?? 0,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/integrations/cline/hooks/token-optimizer/lib/advise.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/advise.mjs
@@ -106,13 +106,39 @@ const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
  * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
  * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
  * it is one token, and the `=` test below skips it.
+ *
+ * THE COLOUR FLAGS ARE NOT HERE, because their arity is the one thing in this
+ * list that differs by program. See COLOR_TAKES_SEPARATE_VALUE.
  */
 const VALUED_FLAGS = new Set([
   '-e', '--regexp', '-f', '--file', '-m', '--max-count',
   '-A', '--after-context', '-B', '--before-context', '-C', '--context',
   '-d', '--directories', '-t', '--type', '-g', '--glob',
-  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+  '--include', '--exclude', '--exclude-dir',
 ]);
+
+/** The spellings of the colour option, across the programs handled here. */
+const COLOR_FLAGS = new Set(['--color', '--colour']);
+
+/**
+ * Programs whose colour flag takes a SEPARATE value token.
+ *
+ * The one option in this parser whose arity cannot be decided globally, and
+ * getting it wrong silently returns a path or a keyword as the search pattern:
+ *
+ *   grep --color needle file   GNU: the value is optional and inline-only, so
+ *                              `needle` is the pattern. Treating --color as
+ *                              valued consumed `needle` and returned `file`.
+ *   rg --color never needle .  ripgrep REQUIRES a separate WHEN, so `never` is
+ *                              the flag's value and `needle` is the pattern.
+ *                              Treating --color as valueless returns `never`.
+ *   ag --color needle .        a valueless toggle, like ack. Same failure as
+ *   ack --color needle .       grep: returned `.` instead of `needle`.
+ *
+ * So neither "always valued" nor "never valued" is correct, and the contract has
+ * to come from the program. Only ripgrep is in this set.
+ */
+const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
  * Splits a command into tokens, honouring quotes.
@@ -194,11 +220,17 @@ export function searchPatternFromCommand(command) {
     }
     if (!SEARCH_PROGRAMS.has(program)) continue;
 
+    // Whether a flag eats the next token, decided per program: only the colour
+    // option varies, and only ripgrep requires a separate value for it.
+    const consumesNext = (token) =>
+      VALUED_FLAGS.has(token) ||
+      (COLOR_FLAGS.has(token) && COLOR_TAKES_SEPARATE_VALUE.has(program));
+
     for (let i = at + 1; i < tokens.length; i += 1) {
       const token = tokens[i];
       // An explicit -e/--regexp names the pattern outright and wins over
       // position, which is the whole reason the flag exists.
-      if (VALUED_FLAGS.has(token)) {
+      if (consumesNext(token)) {
         if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
         i += 1;
         continue;

--- a/integrations/cline/hooks/token-optimizer/lib/advise.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/advise.mjs
@@ -81,6 +81,141 @@ const STOPWORDS = new Set([
   'except', 'raise', 'throw', 'new', 'int', 'str', 'bool', 'float',
 ]);
 
+/**
+ * Search programs whose first operand is a pattern.
+ *
+ * WHY THIS LIST EXISTS AT ALL. The advisory above answers a search from the
+ * index before it runs, and it was wired only to the `Grep` and `Glob` TOOLS.
+ * Measured on the warm benchmark, that is the wrong half of the surface: in the
+ * needle-in-repo runs the agent searched entirely through Bash --
+ *
+ *   Bash  grep -rn "compute_settlement_fee" /work --include=* 2>/dev/null | head -50
+ *   Bash  cat /work/pkg/mod_047.py
+ *   Edit  /work/pkg/mod_047.py
+ *
+ * -- zero Grep calls, zero Glob calls, and so zero advisories delivered, while
+ * the graph for that very session held
+ * `compute_settlement_fee -> pkg/mod_047.py:9-12` and returned it correctly to a
+ * direct call. Two turns were spent rediscovering a fact already indexed.
+ */
+const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
+
+/**
+ * Flags that consume the NEXT token, so its value is never the pattern.
+ *
+ * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
+ * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
+ * it is one token, and the `=` test below skips it.
+ */
+const VALUED_FLAGS = new Set([
+  '-e', '--regexp', '-f', '--file', '-m', '--max-count',
+  '-A', '--after-context', '-B', '--before-context', '-C', '--context',
+  '-d', '--directories', '-t', '--type', '-g', '--glob',
+  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+]);
+
+/**
+ * Splits a command into tokens, honouring quotes.
+ *
+ * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
+ * critical path against a string the model composed, which is the exact input
+ * class this repo keeps a linearity gate for; a single forward pass cannot
+ * backtrack at all.
+ */
+function tokenize(command) {
+  const tokens = [];
+  let current = '';
+  let quote = null;
+  let started = false;
+  for (let i = 0; i < command.length; i += 1) {
+    const ch = command[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (ch === '\\' && i + 1 < command.length) {
+      current += command[i + 1];
+      i += 1;
+      started = true;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t' || ch === '\n') {
+      if (current || started) tokens.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (current || started) tokens.push(current);
+  return tokens;
+}
+
+/**
+ * The pattern a shell search command is about to look for, or null.
+ *
+ * Splits on pipeline and sequencing operators first, because `cat x | grep foo`
+ * and `a && grep foo` both carry a search the graph may be able to answer, and
+ * the search is never the first segment there. `git grep foo` is handled by
+ * skipping a leading `git`, and `find . -name "*.py"` by reading the -name
+ * value: a glob yields no identifiers and so costs nothing, but
+ * `find . -name "compute_settlement*"` does.
+ *
+ * Returns the raw pattern rather than identifiers, so the caller hands it to the
+ * same `adviseSearch` the Grep tool path uses and the two surfaces cannot drift.
+ */
+export function searchPatternFromCommand(command) {
+  if (typeof command !== 'string' || !command) return null;
+  // Bounded before any work: a pathological command is not worth parsing, and
+  // the advisory is an optimisation that must never become the slow path.
+  if (command.length > 4_000) return null;
+
+  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
+    const tokens = tokenize(segment.trim()).filter(Boolean);
+    if (!tokens.length) continue;
+    // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
+    // leading `git` is: `git grep` is ordinary.
+    let at = 0;
+    if (tokens[at] === 'git') at += 1;
+    const program = String(tokens[at] || '').split(/[/\\]/).pop();
+
+    if (program === 'find') {
+      for (let i = at + 1; i < tokens.length - 1; i += 1) {
+        if (tokens[i] === '-name' || tokens[i] === '-iname') return tokens[i + 1];
+      }
+      continue;
+    }
+    if (!SEARCH_PROGRAMS.has(program)) continue;
+
+    for (let i = at + 1; i < tokens.length; i += 1) {
+      const token = tokens[i];
+      // An explicit -e/--regexp names the pattern outright and wins over
+      // position, which is the whole reason the flag exists.
+      if (VALUED_FLAGS.has(token)) {
+        if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
+        i += 1;
+        continue;
+      }
+      if (token.startsWith('--') && token.includes('=')) {
+        const [name, ...rest] = token.split('=');
+        if (name === '--regexp') return rest.join('=') || null;
+        continue;
+      }
+      if (token.startsWith('-') && token.length > 1) continue;
+      // The first bare operand is the pattern; everything after it is a path.
+      return token || null;
+    }
+  }
+  return null;
+}
+
 /** Symbol nodes grouped by name, for one lookup per identifier. */
 export function symbolIndex(graph) {
   const byName = new Map();

--- a/integrations/cline/hooks/token-optimizer/lib/advise.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/advise.mjs
@@ -141,18 +141,45 @@ const COLOR_FLAGS = new Set(['--color', '--colour']);
 const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
- * Splits a command into tokens, honouring quotes.
+ * Splits a command into segments of tokens, honouring quotes and escapes.
+ *
+ * SEGMENTING AND TOKENIZING ARE ONE PASS, and they have to be. Splitting the raw
+ * string on `|`, `&&` and `;` before tokenizing cut straight through quoted
+ * text, so a perfectly ordinary alternation lost everything after the first
+ * branch:
+ *
+ *   grep -E "foo|bar" .   returned `foo`   -- `bar` never reached adviseSearch
+ *   rg "a;b" .            returned `a`
+ *   grep "x&&y" .         returned `x`
+ *
+ * A quote-aware scan cannot make that mistake, because an operator inside a
+ * quoted run is just a character. Pipelines still split, which is what lets
+ * `cat x | grep foo` be recognised at all -- the search is never the first
+ * segment there.
  *
  * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
  * critical path against a string the model composed, which is the exact input
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function tokenize(command) {
-  const tokens = [];
+function commandSegments(command) {
+  const segments = [];
+  let tokens = [];
   let current = '';
   let quote = null;
   let started = false;
+
+  const endToken = () => {
+    if (current || started) tokens.push(current);
+    current = '';
+    started = false;
+  };
+  const endSegment = () => {
+    endToken();
+    if (tokens.length) segments.push(tokens);
+    tokens = [];
+  };
+
   for (let i = 0; i < command.length; i += 1) {
     const ch = command[i];
     if (quote) {
@@ -171,17 +198,22 @@ function tokenize(command) {
       started = true;
       continue;
     }
-    if (ch === ' ' || ch === '\t' || ch === '\n') {
-      if (current || started) tokens.push(current);
-      current = '';
-      started = false;
+    // UNQUOTED ONLY -- reaching here means the quote branches above did not.
+    if (ch === '|' || ch === ';' || ch === '&' || ch === '\n') {
+      endSegment();
+      // `||` and `&&` are one operator, not two empty segments.
+      while (i + 1 < command.length && command[i + 1] === ch) i += 1;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t') {
+      endToken();
       continue;
     }
     current += ch;
     started = true;
   }
-  if (current || started) tokens.push(current);
-  return tokens;
+  endSegment();
+  return segments;
 }
 
 /**
@@ -203,8 +235,7 @@ export function searchPatternFromCommand(command) {
   // the advisory is an optimisation that must never become the slow path.
   if (command.length > 4_000) return null;
 
-  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
-    const tokens = tokenize(segment.trim()).filter(Boolean);
+  for (const tokens of commandSegments(command)) {
     if (!tokens.length) continue;
     // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
     // leading `git` is: `git grep` is ordinary.

--- a/integrations/cline/hooks/token-optimizer/lib/audit.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/audit.mjs
@@ -78,9 +78,21 @@ export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
   const candidates = sum('candidates');
   const observations = sum('observations');
   const written = sum('written');
+  // THE SEARCH GAP RIDES HERE because a counter nobody reads is exactly the cost
+  // this note exists to prevent -- and because the number decides something: a
+  // locate detector is written and held unmerged until this says the gap is
+  // real. `named` is searches carrying an identifier, `gap` the subset the
+  // symbol index could not answer. Reported only once a search has been seen,
+  // so a project that never searches does not get a line of zeroes.
+  const named = sum('searchesNamed');
+  const gap = sum('searchGap');
+  const searchLine = named
+    ? ` ${gap.toLocaleString()} of ${named.toLocaleString()} named search(es) were ` +
+      'outside the symbol index.'
+    : '';
   return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
     `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
-    `across ${runs.length.toLocaleString()} Stop run(s).`;
+    `across ${runs.length.toLocaleString()} Stop run(s).${searchLine}`;
 }
 
 const idOf = (finding) =>

--- a/integrations/cline/hooks/token-optimizer/lib/derive.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/derive.mjs
@@ -49,6 +49,14 @@ import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
 import { load } from './wiki.mjs';
 import { ORIGIN_HARVESTED } from './curate.mjs';
+// Counting only -- see `searchGap` below. The SAME extractor the router advises
+// from, so what this counts as a search and what the advisory treats as one
+// cannot diverge.
+import {
+  identifiersIn,
+  searchPatternFromCommand,
+  symbolIndex,
+} from './advise.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -397,12 +405,56 @@ const storageBudget = () =>
  *   defaulting would promote any caller's string to trusted. Also returned, so a
  *   caller can see what it handed over.
  * @returns {object} `{ candidates, observations, written, selected, dropped,
- *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
- *   everything derived; `written` is the subset of keys the graph actually
- *   holds, which is smaller for three independent reasons -- the budget, the
- *   anchor discipline, and the duplicate collapse that returns an EXISTING key
- *   when a later session derives the same claim again.
+ *   selectedTokens, searchGap, sessionId, authoritativeSessionId }`.
+ *   `candidates` is everything derived; `written` is the subset of keys the
+ *   graph actually holds, which is smaller for three independent reasons -- the
+ *   budget, the anchor discipline, and the duplicate collapse that returns an
+ *   EXISTING key when a later session derives the same claim again.
  */
+
+/**
+ * How many searches this session ran that the symbol index could NOT answer.
+ *
+ * MEASUREMENT, NOT A FEATURE. A detector that turns these into findings is
+ * written and deliberately unmerged, because on the only workload we have
+ * measured it produces nothing: replayed against a real warm rep, all seven
+ * searches were for symbols the index already resolves --
+ * `compute_settlement_fee` three times, `def parse_line` once, and three terms
+ * with no identifier-shaped word at all. The search advisory answers every one
+ * of those directly, so storing them again would spend the retrieval budget
+ * restating a cheaper mechanism.
+ *
+ * The case that would justify the detector is a search for something the indexer
+ * never extracts -- a config key, an error string, a literal, a symbol in a file
+ * type it cannot parse. Eleven synthetic Python tasks cannot show whether that
+ * happens in real work. This counts it instead of guessing: `gap` is the number
+ * of searches carrying an identifier the index has no entry for, `named` the
+ * number carrying one at all. A `gap` that stays near zero says the detector
+ * should stay unmerged.
+ *
+ * Counting only. Nothing is stored, nothing is claimed, and it runs at session
+ * end where the cost is already paid.
+ */
+export function searchGap(dir, events) {
+  const out = { named: 0, gap: 0 };
+  try {
+    const index = symbolIndex(load(dir));
+    for (const event of events) {
+      if (!event || event.kind !== 'tool-outcome') continue;
+      if (event.success === false || event.surface !== 'command') continue;
+      const pattern = searchPatternFromCommand(event.anchor);
+      if (!pattern) continue;
+      const names = identifiersIn(pattern);
+      if (!names.length) continue;
+      out.named += 1;
+      if (!names.some((name) => index.has(name))) out.gap += 1;
+    }
+  } catch {
+    // A count is never worth failing a session for.
+  }
+  return out;
+}
+
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
   // `undefined`, so a caller passing an explicitly null options object -- which
@@ -431,6 +483,10 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // Measured, not stored. See `searchGap`: this decides whether the locate
+  // detector is worth merging, and nothing here acts on it.
+  result.searchGap = searchGap(dir, events);
 
   // ONE anchor for the whole run, so every candidate from this session points at
   // the same node and the duplicate collapse in `writeHarvested` can recognise

--- a/integrations/cline/hooks/token-optimizer/lib/doctor.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/doctor.mjs
@@ -523,6 +523,19 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
     // on the same session file, and the failure would be intermittent and
     // wrong-looking rather than loud. The concurrency win is taken in
     // diagnose(), across probes that share no state.
+    // ENFORCE IS ASKED FOR, NOT INHERITED -- for the same reason the capability
+    // evidence in `probe` is stated rather than inferred. The question this probe
+    // asks is "would enforcement fire if it were switched on", and policy.mjs#mode
+    // now defaults to `assist`, which never refuses (THOL and ledger measurement).
+    // Inheriting the default would make the probe report "not refused" on a
+    // perfectly healthy install: a false negative in the one tool whose job is to
+    // tell the user the truth.
+    //
+    // BOTH probes take it, not just the refusal one. "Small reads are left alone"
+    // is evidence of something only under a posture that COULD have refused;
+    // under assist it would pass against a hook that does nothing whatsoever,
+    // which is precisely the broken install it exists to catch.
+    const enforcing = { env: { TOKEN_OPTIMIZER_MODE: 'enforce' } };
     const denied = await probe(
       binary,
       {
@@ -530,13 +543,14 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: big },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     const deniedOk = typeof denied === 'string' && denied.includes('deny');
     checks.push(deniedOk
       ? ok('enforcement refuses a large read', 'the refusal came back from the real hook')
       : bad('enforcement refuses a large read', `hook returned: ${String(denied).slice(0, 200) || '(nothing)'}`,
-        'check TOKEN_OPTIMIZER_MODE is not "off" or "advise", then reinstall the hooks'));
+        'the probe asks for enforce explicitly, so a failure is the hook itself rather than your mode -- reinstall the hooks'));
 
     const allowed = await probe(
       binary,
@@ -545,7 +559,8 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: small },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     // `allowed === null` is "the probe never ran", NOT "the hook allowed it".
     // allow() writes nothing and exits 0, so '' is a legitimate allow -- but null

--- a/integrations/cline/hooks/token-optimizer/lib/policy.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/policy.mjs
@@ -10,9 +10,18 @@
  * listed in `/mcp`, and save nothing at all. The skill did not help: skills are
  * model-invoked, so it only loads if the model already decided it cared.
  *
- * The redesign inverts the default. Optimized tooling is the path of least
- * resistance: expensive built-in calls are DENIED with a message naming the
- * exact replacement to call. Everything here exists to make that safe.
+ * The redesign inverted the default so that optimized tooling was the path of
+ * least resistance: expensive built-in calls were DENIED with a message naming
+ * the exact replacement to call. Most of this module exists to make that safe.
+ *
+ * REFUSALS ARE NOW OPT-IN, because measurement did not support them. Two
+ * independent harnesses agree that enforcing is the worst posture we ship --
+ * THOL: enforce $23.33/score 0.935 against assist $20.48/0.971 and control
+ * $21.13/0.969, losing 12 of 17 tasks; ledger cold: enforce/advise 1.147
+ * [1.065, 1.235] while advise/assist-mcp is 1.028 [0.951, 1.114]. So the cost is
+ * the refusals themselves, not the routing advisory or retrieval, and the
+ * machinery below is retained and exercised rather than deleted: `enforce`
+ * remains one variable away for anyone who wants it. See `mode()`.
  *
  * FOUR SAFETY PROPERTIES, none of which are optional:
  *
@@ -27,7 +36,8 @@
  *      human intervention and no permanent breakage.
  *
  *   3. AN ESCAPE HATCH THAT IS ONE VARIABLE. TOKEN_OPTIMIZER_MODE=off disables
- *      everything; =advise restores the old non-blocking behaviour.
+ *      everything; =advise restores the old non-blocking behaviour; =enforce
+ *      turns refusals back on now that they are no longer the default.
  *
  *   4. NO BLOCKING OF CHEAP CALLS. Small files, paged reads, and searches that
  *      already read from a pipe cost little and are left alone. Blocking them
@@ -92,16 +102,40 @@ export function refusalsEnabled() {
 }
 
 /**
- * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
- * redesign. An unrecognised value falls back to enforce rather than silently
- * disabling, so a typo cannot quietly turn the product off.
+ * Reads the mode. ASSIST IS THE DEFAULT, on measurement.
+ *
+ * This said "Enforcement is the DEFAULT -- that is the entire point of the
+ * redesign". The redesign's point was to make the product pay for itself, and
+ * enforcement was the assumed way there rather than a measured one. Two
+ * independent harnesses now say it is the worst posture we ship:
+ *
+ *   THOL 2.1.251, 17 tasks x 3 reps x 3 arms, 153 runs, zero errors
+ *     control  $21.13  score 0.969  turns 16.2
+ *     assist   $20.48  score 0.971  turns 14.4   <- better on all three
+ *     enforce  $23.33  score 0.935  turns 17.6   <- worse on all three,
+ *                                                   losing 12 of 17 tasks
+ *   Ledger cold track
+ *     enforce/advise    1.147 [1.065, 1.235]  refusals cost 14.7%
+ *     advise/assist-mcp 1.028 [0.951, 1.114]  the advisory itself is free
+ *
+ * So the refusals are the whole cost: not the routing advisory, not retrieval.
+ * Enforce's worst tasks are the small cheap ones, where one refused turn is a
+ * large fraction of the total (code-bugfix-py 1.599, log-needle-zh 1.589).
+ * Shipping assist is worth ~12% cost and 3.6 score points against what users
+ * receive today.
+ *
+ * THE TYPO PROPERTY IS PRESERVED, which is what the old comment was really
+ * protecting. An unrecognised value still falls back to a posture with routing,
+ * retrieval, capture and harvest all ON -- `off` is the only value that exits
+ * the hook process, and it remains reachable only by asking for it exactly. A
+ * typo cannot quietly turn the product off; it can now only decline to refuse.
  */
 export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
-  if (raw === MODE_ASSIST) return MODE_ASSIST;
-  return MODE_ENFORCE;
+  if (raw === MODE_ENFORCE) return MODE_ENFORCE;
+  return MODE_ASSIST;
 }
 
 function intEnv(name, fallback) {

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -1222,6 +1222,12 @@ async function runHook(clientName, event, invocation) {
         candidates: derived.candidates.length,
         observations: derived.observations.length,
         written: derived.written.length,
+        // Whether a locate detector would have anything to catch: `named` is
+        // searches carrying an identifier, `gap` the subset the symbol index
+        // cannot answer. Recorded rather than acted on -- a `gap` that stays
+        // near zero says the detector written for it should stay unmerged.
+        searchesNamed: derived.searchGap?.named ?? 0,
+        searchGap: derived.searchGap?.gap ?? 0,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/integrations/codex/hooks/lib/advise.mjs
+++ b/integrations/codex/hooks/lib/advise.mjs
@@ -106,13 +106,39 @@ const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
  * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
  * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
  * it is one token, and the `=` test below skips it.
+ *
+ * THE COLOUR FLAGS ARE NOT HERE, because their arity is the one thing in this
+ * list that differs by program. See COLOR_TAKES_SEPARATE_VALUE.
  */
 const VALUED_FLAGS = new Set([
   '-e', '--regexp', '-f', '--file', '-m', '--max-count',
   '-A', '--after-context', '-B', '--before-context', '-C', '--context',
   '-d', '--directories', '-t', '--type', '-g', '--glob',
-  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+  '--include', '--exclude', '--exclude-dir',
 ]);
+
+/** The spellings of the colour option, across the programs handled here. */
+const COLOR_FLAGS = new Set(['--color', '--colour']);
+
+/**
+ * Programs whose colour flag takes a SEPARATE value token.
+ *
+ * The one option in this parser whose arity cannot be decided globally, and
+ * getting it wrong silently returns a path or a keyword as the search pattern:
+ *
+ *   grep --color needle file   GNU: the value is optional and inline-only, so
+ *                              `needle` is the pattern. Treating --color as
+ *                              valued consumed `needle` and returned `file`.
+ *   rg --color never needle .  ripgrep REQUIRES a separate WHEN, so `never` is
+ *                              the flag's value and `needle` is the pattern.
+ *                              Treating --color as valueless returns `never`.
+ *   ag --color needle .        a valueless toggle, like ack. Same failure as
+ *   ack --color needle .       grep: returned `.` instead of `needle`.
+ *
+ * So neither "always valued" nor "never valued" is correct, and the contract has
+ * to come from the program. Only ripgrep is in this set.
+ */
+const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
  * Splits a command into tokens, honouring quotes.
@@ -194,11 +220,17 @@ export function searchPatternFromCommand(command) {
     }
     if (!SEARCH_PROGRAMS.has(program)) continue;
 
+    // Whether a flag eats the next token, decided per program: only the colour
+    // option varies, and only ripgrep requires a separate value for it.
+    const consumesNext = (token) =>
+      VALUED_FLAGS.has(token) ||
+      (COLOR_FLAGS.has(token) && COLOR_TAKES_SEPARATE_VALUE.has(program));
+
     for (let i = at + 1; i < tokens.length; i += 1) {
       const token = tokens[i];
       // An explicit -e/--regexp names the pattern outright and wins over
       // position, which is the whole reason the flag exists.
-      if (VALUED_FLAGS.has(token)) {
+      if (consumesNext(token)) {
         if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
         i += 1;
         continue;

--- a/integrations/codex/hooks/lib/advise.mjs
+++ b/integrations/codex/hooks/lib/advise.mjs
@@ -81,6 +81,141 @@ const STOPWORDS = new Set([
   'except', 'raise', 'throw', 'new', 'int', 'str', 'bool', 'float',
 ]);
 
+/**
+ * Search programs whose first operand is a pattern.
+ *
+ * WHY THIS LIST EXISTS AT ALL. The advisory above answers a search from the
+ * index before it runs, and it was wired only to the `Grep` and `Glob` TOOLS.
+ * Measured on the warm benchmark, that is the wrong half of the surface: in the
+ * needle-in-repo runs the agent searched entirely through Bash --
+ *
+ *   Bash  grep -rn "compute_settlement_fee" /work --include=* 2>/dev/null | head -50
+ *   Bash  cat /work/pkg/mod_047.py
+ *   Edit  /work/pkg/mod_047.py
+ *
+ * -- zero Grep calls, zero Glob calls, and so zero advisories delivered, while
+ * the graph for that very session held
+ * `compute_settlement_fee -> pkg/mod_047.py:9-12` and returned it correctly to a
+ * direct call. Two turns were spent rediscovering a fact already indexed.
+ */
+const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
+
+/**
+ * Flags that consume the NEXT token, so its value is never the pattern.
+ *
+ * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
+ * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
+ * it is one token, and the `=` test below skips it.
+ */
+const VALUED_FLAGS = new Set([
+  '-e', '--regexp', '-f', '--file', '-m', '--max-count',
+  '-A', '--after-context', '-B', '--before-context', '-C', '--context',
+  '-d', '--directories', '-t', '--type', '-g', '--glob',
+  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+]);
+
+/**
+ * Splits a command into tokens, honouring quotes.
+ *
+ * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
+ * critical path against a string the model composed, which is the exact input
+ * class this repo keeps a linearity gate for; a single forward pass cannot
+ * backtrack at all.
+ */
+function tokenize(command) {
+  const tokens = [];
+  let current = '';
+  let quote = null;
+  let started = false;
+  for (let i = 0; i < command.length; i += 1) {
+    const ch = command[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (ch === '\\' && i + 1 < command.length) {
+      current += command[i + 1];
+      i += 1;
+      started = true;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t' || ch === '\n') {
+      if (current || started) tokens.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (current || started) tokens.push(current);
+  return tokens;
+}
+
+/**
+ * The pattern a shell search command is about to look for, or null.
+ *
+ * Splits on pipeline and sequencing operators first, because `cat x | grep foo`
+ * and `a && grep foo` both carry a search the graph may be able to answer, and
+ * the search is never the first segment there. `git grep foo` is handled by
+ * skipping a leading `git`, and `find . -name "*.py"` by reading the -name
+ * value: a glob yields no identifiers and so costs nothing, but
+ * `find . -name "compute_settlement*"` does.
+ *
+ * Returns the raw pattern rather than identifiers, so the caller hands it to the
+ * same `adviseSearch` the Grep tool path uses and the two surfaces cannot drift.
+ */
+export function searchPatternFromCommand(command) {
+  if (typeof command !== 'string' || !command) return null;
+  // Bounded before any work: a pathological command is not worth parsing, and
+  // the advisory is an optimisation that must never become the slow path.
+  if (command.length > 4_000) return null;
+
+  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
+    const tokens = tokenize(segment.trim()).filter(Boolean);
+    if (!tokens.length) continue;
+    // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
+    // leading `git` is: `git grep` is ordinary.
+    let at = 0;
+    if (tokens[at] === 'git') at += 1;
+    const program = String(tokens[at] || '').split(/[/\\]/).pop();
+
+    if (program === 'find') {
+      for (let i = at + 1; i < tokens.length - 1; i += 1) {
+        if (tokens[i] === '-name' || tokens[i] === '-iname') return tokens[i + 1];
+      }
+      continue;
+    }
+    if (!SEARCH_PROGRAMS.has(program)) continue;
+
+    for (let i = at + 1; i < tokens.length; i += 1) {
+      const token = tokens[i];
+      // An explicit -e/--regexp names the pattern outright and wins over
+      // position, which is the whole reason the flag exists.
+      if (VALUED_FLAGS.has(token)) {
+        if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
+        i += 1;
+        continue;
+      }
+      if (token.startsWith('--') && token.includes('=')) {
+        const [name, ...rest] = token.split('=');
+        if (name === '--regexp') return rest.join('=') || null;
+        continue;
+      }
+      if (token.startsWith('-') && token.length > 1) continue;
+      // The first bare operand is the pattern; everything after it is a path.
+      return token || null;
+    }
+  }
+  return null;
+}
+
 /** Symbol nodes grouped by name, for one lookup per identifier. */
 export function symbolIndex(graph) {
   const byName = new Map();

--- a/integrations/codex/hooks/lib/advise.mjs
+++ b/integrations/codex/hooks/lib/advise.mjs
@@ -141,18 +141,45 @@ const COLOR_FLAGS = new Set(['--color', '--colour']);
 const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
- * Splits a command into tokens, honouring quotes.
+ * Splits a command into segments of tokens, honouring quotes and escapes.
+ *
+ * SEGMENTING AND TOKENIZING ARE ONE PASS, and they have to be. Splitting the raw
+ * string on `|`, `&&` and `;` before tokenizing cut straight through quoted
+ * text, so a perfectly ordinary alternation lost everything after the first
+ * branch:
+ *
+ *   grep -E "foo|bar" .   returned `foo`   -- `bar` never reached adviseSearch
+ *   rg "a;b" .            returned `a`
+ *   grep "x&&y" .         returned `x`
+ *
+ * A quote-aware scan cannot make that mistake, because an operator inside a
+ * quoted run is just a character. Pipelines still split, which is what lets
+ * `cat x | grep foo` be recognised at all -- the search is never the first
+ * segment there.
  *
  * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
  * critical path against a string the model composed, which is the exact input
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function tokenize(command) {
-  const tokens = [];
+function commandSegments(command) {
+  const segments = [];
+  let tokens = [];
   let current = '';
   let quote = null;
   let started = false;
+
+  const endToken = () => {
+    if (current || started) tokens.push(current);
+    current = '';
+    started = false;
+  };
+  const endSegment = () => {
+    endToken();
+    if (tokens.length) segments.push(tokens);
+    tokens = [];
+  };
+
   for (let i = 0; i < command.length; i += 1) {
     const ch = command[i];
     if (quote) {
@@ -171,17 +198,22 @@ function tokenize(command) {
       started = true;
       continue;
     }
-    if (ch === ' ' || ch === '\t' || ch === '\n') {
-      if (current || started) tokens.push(current);
-      current = '';
-      started = false;
+    // UNQUOTED ONLY -- reaching here means the quote branches above did not.
+    if (ch === '|' || ch === ';' || ch === '&' || ch === '\n') {
+      endSegment();
+      // `||` and `&&` are one operator, not two empty segments.
+      while (i + 1 < command.length && command[i + 1] === ch) i += 1;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t') {
+      endToken();
       continue;
     }
     current += ch;
     started = true;
   }
-  if (current || started) tokens.push(current);
-  return tokens;
+  endSegment();
+  return segments;
 }
 
 /**
@@ -203,8 +235,7 @@ export function searchPatternFromCommand(command) {
   // the advisory is an optimisation that must never become the slow path.
   if (command.length > 4_000) return null;
 
-  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
-    const tokens = tokenize(segment.trim()).filter(Boolean);
+  for (const tokens of commandSegments(command)) {
     if (!tokens.length) continue;
     // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
     // leading `git` is: `git grep` is ordinary.

--- a/integrations/codex/hooks/lib/audit.mjs
+++ b/integrations/codex/hooks/lib/audit.mjs
@@ -78,9 +78,21 @@ export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
   const candidates = sum('candidates');
   const observations = sum('observations');
   const written = sum('written');
+  // THE SEARCH GAP RIDES HERE because a counter nobody reads is exactly the cost
+  // this note exists to prevent -- and because the number decides something: a
+  // locate detector is written and held unmerged until this says the gap is
+  // real. `named` is searches carrying an identifier, `gap` the subset the
+  // symbol index could not answer. Reported only once a search has been seen,
+  // so a project that never searches does not get a line of zeroes.
+  const named = sum('searchesNamed');
+  const gap = sum('searchGap');
+  const searchLine = named
+    ? ` ${gap.toLocaleString()} of ${named.toLocaleString()} named search(es) were ` +
+      'outside the symbol index.'
+    : '';
   return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
     `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
-    `across ${runs.length.toLocaleString()} Stop run(s).`;
+    `across ${runs.length.toLocaleString()} Stop run(s).${searchLine}`;
 }
 
 const idOf = (finding) =>

--- a/integrations/codex/hooks/lib/derive.mjs
+++ b/integrations/codex/hooks/lib/derive.mjs
@@ -49,6 +49,14 @@ import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
 import { load } from './wiki.mjs';
 import { ORIGIN_HARVESTED } from './curate.mjs';
+// Counting only -- see `searchGap` below. The SAME extractor the router advises
+// from, so what this counts as a search and what the advisory treats as one
+// cannot diverge.
+import {
+  identifiersIn,
+  searchPatternFromCommand,
+  symbolIndex,
+} from './advise.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -397,12 +405,56 @@ const storageBudget = () =>
  *   defaulting would promote any caller's string to trusted. Also returned, so a
  *   caller can see what it handed over.
  * @returns {object} `{ candidates, observations, written, selected, dropped,
- *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
- *   everything derived; `written` is the subset of keys the graph actually
- *   holds, which is smaller for three independent reasons -- the budget, the
- *   anchor discipline, and the duplicate collapse that returns an EXISTING key
- *   when a later session derives the same claim again.
+ *   selectedTokens, searchGap, sessionId, authoritativeSessionId }`.
+ *   `candidates` is everything derived; `written` is the subset of keys the
+ *   graph actually holds, which is smaller for three independent reasons -- the
+ *   budget, the anchor discipline, and the duplicate collapse that returns an
+ *   EXISTING key when a later session derives the same claim again.
  */
+
+/**
+ * How many searches this session ran that the symbol index could NOT answer.
+ *
+ * MEASUREMENT, NOT A FEATURE. A detector that turns these into findings is
+ * written and deliberately unmerged, because on the only workload we have
+ * measured it produces nothing: replayed against a real warm rep, all seven
+ * searches were for symbols the index already resolves --
+ * `compute_settlement_fee` three times, `def parse_line` once, and three terms
+ * with no identifier-shaped word at all. The search advisory answers every one
+ * of those directly, so storing them again would spend the retrieval budget
+ * restating a cheaper mechanism.
+ *
+ * The case that would justify the detector is a search for something the indexer
+ * never extracts -- a config key, an error string, a literal, a symbol in a file
+ * type it cannot parse. Eleven synthetic Python tasks cannot show whether that
+ * happens in real work. This counts it instead of guessing: `gap` is the number
+ * of searches carrying an identifier the index has no entry for, `named` the
+ * number carrying one at all. A `gap` that stays near zero says the detector
+ * should stay unmerged.
+ *
+ * Counting only. Nothing is stored, nothing is claimed, and it runs at session
+ * end where the cost is already paid.
+ */
+export function searchGap(dir, events) {
+  const out = { named: 0, gap: 0 };
+  try {
+    const index = symbolIndex(load(dir));
+    for (const event of events) {
+      if (!event || event.kind !== 'tool-outcome') continue;
+      if (event.success === false || event.surface !== 'command') continue;
+      const pattern = searchPatternFromCommand(event.anchor);
+      if (!pattern) continue;
+      const names = identifiersIn(pattern);
+      if (!names.length) continue;
+      out.named += 1;
+      if (!names.some((name) => index.has(name))) out.gap += 1;
+    }
+  } catch {
+    // A count is never worth failing a session for.
+  }
+  return out;
+}
+
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
   // `undefined`, so a caller passing an explicitly null options object -- which
@@ -431,6 +483,10 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // Measured, not stored. See `searchGap`: this decides whether the locate
+  // detector is worth merging, and nothing here acts on it.
+  result.searchGap = searchGap(dir, events);
 
   // ONE anchor for the whole run, so every candidate from this session points at
   // the same node and the duplicate collapse in `writeHarvested` can recognise

--- a/integrations/codex/hooks/lib/doctor.mjs
+++ b/integrations/codex/hooks/lib/doctor.mjs
@@ -523,6 +523,19 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
     // on the same session file, and the failure would be intermittent and
     // wrong-looking rather than loud. The concurrency win is taken in
     // diagnose(), across probes that share no state.
+    // ENFORCE IS ASKED FOR, NOT INHERITED -- for the same reason the capability
+    // evidence in `probe` is stated rather than inferred. The question this probe
+    // asks is "would enforcement fire if it were switched on", and policy.mjs#mode
+    // now defaults to `assist`, which never refuses (THOL and ledger measurement).
+    // Inheriting the default would make the probe report "not refused" on a
+    // perfectly healthy install: a false negative in the one tool whose job is to
+    // tell the user the truth.
+    //
+    // BOTH probes take it, not just the refusal one. "Small reads are left alone"
+    // is evidence of something only under a posture that COULD have refused;
+    // under assist it would pass against a hook that does nothing whatsoever,
+    // which is precisely the broken install it exists to catch.
+    const enforcing = { env: { TOKEN_OPTIMIZER_MODE: 'enforce' } };
     const denied = await probe(
       binary,
       {
@@ -530,13 +543,14 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: big },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     const deniedOk = typeof denied === 'string' && denied.includes('deny');
     checks.push(deniedOk
       ? ok('enforcement refuses a large read', 'the refusal came back from the real hook')
       : bad('enforcement refuses a large read', `hook returned: ${String(denied).slice(0, 200) || '(nothing)'}`,
-        'check TOKEN_OPTIMIZER_MODE is not "off" or "advise", then reinstall the hooks'));
+        'the probe asks for enforce explicitly, so a failure is the hook itself rather than your mode -- reinstall the hooks'));
 
     const allowed = await probe(
       binary,
@@ -545,7 +559,8 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: small },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     // `allowed === null` is "the probe never ran", NOT "the hook allowed it".
     // allow() writes nothing and exits 0, so '' is a legitimate allow -- but null

--- a/integrations/codex/hooks/lib/policy.mjs
+++ b/integrations/codex/hooks/lib/policy.mjs
@@ -10,9 +10,18 @@
  * listed in `/mcp`, and save nothing at all. The skill did not help: skills are
  * model-invoked, so it only loads if the model already decided it cared.
  *
- * The redesign inverts the default. Optimized tooling is the path of least
- * resistance: expensive built-in calls are DENIED with a message naming the
- * exact replacement to call. Everything here exists to make that safe.
+ * The redesign inverted the default so that optimized tooling was the path of
+ * least resistance: expensive built-in calls were DENIED with a message naming
+ * the exact replacement to call. Most of this module exists to make that safe.
+ *
+ * REFUSALS ARE NOW OPT-IN, because measurement did not support them. Two
+ * independent harnesses agree that enforcing is the worst posture we ship --
+ * THOL: enforce $23.33/score 0.935 against assist $20.48/0.971 and control
+ * $21.13/0.969, losing 12 of 17 tasks; ledger cold: enforce/advise 1.147
+ * [1.065, 1.235] while advise/assist-mcp is 1.028 [0.951, 1.114]. So the cost is
+ * the refusals themselves, not the routing advisory or retrieval, and the
+ * machinery below is retained and exercised rather than deleted: `enforce`
+ * remains one variable away for anyone who wants it. See `mode()`.
  *
  * FOUR SAFETY PROPERTIES, none of which are optional:
  *
@@ -27,7 +36,8 @@
  *      human intervention and no permanent breakage.
  *
  *   3. AN ESCAPE HATCH THAT IS ONE VARIABLE. TOKEN_OPTIMIZER_MODE=off disables
- *      everything; =advise restores the old non-blocking behaviour.
+ *      everything; =advise restores the old non-blocking behaviour; =enforce
+ *      turns refusals back on now that they are no longer the default.
  *
  *   4. NO BLOCKING OF CHEAP CALLS. Small files, paged reads, and searches that
  *      already read from a pipe cost little and are left alone. Blocking them
@@ -92,16 +102,40 @@ export function refusalsEnabled() {
 }
 
 /**
- * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
- * redesign. An unrecognised value falls back to enforce rather than silently
- * disabling, so a typo cannot quietly turn the product off.
+ * Reads the mode. ASSIST IS THE DEFAULT, on measurement.
+ *
+ * This said "Enforcement is the DEFAULT -- that is the entire point of the
+ * redesign". The redesign's point was to make the product pay for itself, and
+ * enforcement was the assumed way there rather than a measured one. Two
+ * independent harnesses now say it is the worst posture we ship:
+ *
+ *   THOL 2.1.251, 17 tasks x 3 reps x 3 arms, 153 runs, zero errors
+ *     control  $21.13  score 0.969  turns 16.2
+ *     assist   $20.48  score 0.971  turns 14.4   <- better on all three
+ *     enforce  $23.33  score 0.935  turns 17.6   <- worse on all three,
+ *                                                   losing 12 of 17 tasks
+ *   Ledger cold track
+ *     enforce/advise    1.147 [1.065, 1.235]  refusals cost 14.7%
+ *     advise/assist-mcp 1.028 [0.951, 1.114]  the advisory itself is free
+ *
+ * So the refusals are the whole cost: not the routing advisory, not retrieval.
+ * Enforce's worst tasks are the small cheap ones, where one refused turn is a
+ * large fraction of the total (code-bugfix-py 1.599, log-needle-zh 1.589).
+ * Shipping assist is worth ~12% cost and 3.6 score points against what users
+ * receive today.
+ *
+ * THE TYPO PROPERTY IS PRESERVED, which is what the old comment was really
+ * protecting. An unrecognised value still falls back to a posture with routing,
+ * retrieval, capture and harvest all ON -- `off` is the only value that exits
+ * the hook process, and it remains reachable only by asking for it exactly. A
+ * typo cannot quietly turn the product off; it can now only decline to refuse.
  */
 export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
-  if (raw === MODE_ASSIST) return MODE_ASSIST;
-  return MODE_ENFORCE;
+  if (raw === MODE_ENFORCE) return MODE_ENFORCE;
+  return MODE_ASSIST;
 }
 
 function intEnv(name, fallback) {

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -1222,6 +1222,12 @@ async function runHook(clientName, event, invocation) {
         candidates: derived.candidates.length,
         observations: derived.observations.length,
         written: derived.written.length,
+        // Whether a locate detector would have anything to catch: `named` is
+        // searches carrying an identifier, `gap` the subset the symbol index
+        // cannot answer. Recorded rather than acted on -- a `gap` that stays
+        // near zero says the detector written for it should stay unmerged.
+        searchesNamed: derived.searchGap?.named ?? 0,
+        searchGap: derived.searchGap?.gap ?? 0,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/integrations/codex/plugin/hooks/lib/advise.mjs
+++ b/integrations/codex/plugin/hooks/lib/advise.mjs
@@ -106,13 +106,39 @@ const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
  * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
  * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
  * it is one token, and the `=` test below skips it.
+ *
+ * THE COLOUR FLAGS ARE NOT HERE, because their arity is the one thing in this
+ * list that differs by program. See COLOR_TAKES_SEPARATE_VALUE.
  */
 const VALUED_FLAGS = new Set([
   '-e', '--regexp', '-f', '--file', '-m', '--max-count',
   '-A', '--after-context', '-B', '--before-context', '-C', '--context',
   '-d', '--directories', '-t', '--type', '-g', '--glob',
-  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+  '--include', '--exclude', '--exclude-dir',
 ]);
+
+/** The spellings of the colour option, across the programs handled here. */
+const COLOR_FLAGS = new Set(['--color', '--colour']);
+
+/**
+ * Programs whose colour flag takes a SEPARATE value token.
+ *
+ * The one option in this parser whose arity cannot be decided globally, and
+ * getting it wrong silently returns a path or a keyword as the search pattern:
+ *
+ *   grep --color needle file   GNU: the value is optional and inline-only, so
+ *                              `needle` is the pattern. Treating --color as
+ *                              valued consumed `needle` and returned `file`.
+ *   rg --color never needle .  ripgrep REQUIRES a separate WHEN, so `never` is
+ *                              the flag's value and `needle` is the pattern.
+ *                              Treating --color as valueless returns `never`.
+ *   ag --color needle .        a valueless toggle, like ack. Same failure as
+ *   ack --color needle .       grep: returned `.` instead of `needle`.
+ *
+ * So neither "always valued" nor "never valued" is correct, and the contract has
+ * to come from the program. Only ripgrep is in this set.
+ */
+const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
  * Splits a command into tokens, honouring quotes.
@@ -194,11 +220,17 @@ export function searchPatternFromCommand(command) {
     }
     if (!SEARCH_PROGRAMS.has(program)) continue;
 
+    // Whether a flag eats the next token, decided per program: only the colour
+    // option varies, and only ripgrep requires a separate value for it.
+    const consumesNext = (token) =>
+      VALUED_FLAGS.has(token) ||
+      (COLOR_FLAGS.has(token) && COLOR_TAKES_SEPARATE_VALUE.has(program));
+
     for (let i = at + 1; i < tokens.length; i += 1) {
       const token = tokens[i];
       // An explicit -e/--regexp names the pattern outright and wins over
       // position, which is the whole reason the flag exists.
-      if (VALUED_FLAGS.has(token)) {
+      if (consumesNext(token)) {
         if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
         i += 1;
         continue;

--- a/integrations/codex/plugin/hooks/lib/advise.mjs
+++ b/integrations/codex/plugin/hooks/lib/advise.mjs
@@ -81,6 +81,141 @@ const STOPWORDS = new Set([
   'except', 'raise', 'throw', 'new', 'int', 'str', 'bool', 'float',
 ]);
 
+/**
+ * Search programs whose first operand is a pattern.
+ *
+ * WHY THIS LIST EXISTS AT ALL. The advisory above answers a search from the
+ * index before it runs, and it was wired only to the `Grep` and `Glob` TOOLS.
+ * Measured on the warm benchmark, that is the wrong half of the surface: in the
+ * needle-in-repo runs the agent searched entirely through Bash --
+ *
+ *   Bash  grep -rn "compute_settlement_fee" /work --include=* 2>/dev/null | head -50
+ *   Bash  cat /work/pkg/mod_047.py
+ *   Edit  /work/pkg/mod_047.py
+ *
+ * -- zero Grep calls, zero Glob calls, and so zero advisories delivered, while
+ * the graph for that very session held
+ * `compute_settlement_fee -> pkg/mod_047.py:9-12` and returned it correctly to a
+ * direct call. Two turns were spent rediscovering a fact already indexed.
+ */
+const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
+
+/**
+ * Flags that consume the NEXT token, so its value is never the pattern.
+ *
+ * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
+ * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
+ * it is one token, and the `=` test below skips it.
+ */
+const VALUED_FLAGS = new Set([
+  '-e', '--regexp', '-f', '--file', '-m', '--max-count',
+  '-A', '--after-context', '-B', '--before-context', '-C', '--context',
+  '-d', '--directories', '-t', '--type', '-g', '--glob',
+  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+]);
+
+/**
+ * Splits a command into tokens, honouring quotes.
+ *
+ * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
+ * critical path against a string the model composed, which is the exact input
+ * class this repo keeps a linearity gate for; a single forward pass cannot
+ * backtrack at all.
+ */
+function tokenize(command) {
+  const tokens = [];
+  let current = '';
+  let quote = null;
+  let started = false;
+  for (let i = 0; i < command.length; i += 1) {
+    const ch = command[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (ch === '\\' && i + 1 < command.length) {
+      current += command[i + 1];
+      i += 1;
+      started = true;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t' || ch === '\n') {
+      if (current || started) tokens.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (current || started) tokens.push(current);
+  return tokens;
+}
+
+/**
+ * The pattern a shell search command is about to look for, or null.
+ *
+ * Splits on pipeline and sequencing operators first, because `cat x | grep foo`
+ * and `a && grep foo` both carry a search the graph may be able to answer, and
+ * the search is never the first segment there. `git grep foo` is handled by
+ * skipping a leading `git`, and `find . -name "*.py"` by reading the -name
+ * value: a glob yields no identifiers and so costs nothing, but
+ * `find . -name "compute_settlement*"` does.
+ *
+ * Returns the raw pattern rather than identifiers, so the caller hands it to the
+ * same `adviseSearch` the Grep tool path uses and the two surfaces cannot drift.
+ */
+export function searchPatternFromCommand(command) {
+  if (typeof command !== 'string' || !command) return null;
+  // Bounded before any work: a pathological command is not worth parsing, and
+  // the advisory is an optimisation that must never become the slow path.
+  if (command.length > 4_000) return null;
+
+  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
+    const tokens = tokenize(segment.trim()).filter(Boolean);
+    if (!tokens.length) continue;
+    // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
+    // leading `git` is: `git grep` is ordinary.
+    let at = 0;
+    if (tokens[at] === 'git') at += 1;
+    const program = String(tokens[at] || '').split(/[/\\]/).pop();
+
+    if (program === 'find') {
+      for (let i = at + 1; i < tokens.length - 1; i += 1) {
+        if (tokens[i] === '-name' || tokens[i] === '-iname') return tokens[i + 1];
+      }
+      continue;
+    }
+    if (!SEARCH_PROGRAMS.has(program)) continue;
+
+    for (let i = at + 1; i < tokens.length; i += 1) {
+      const token = tokens[i];
+      // An explicit -e/--regexp names the pattern outright and wins over
+      // position, which is the whole reason the flag exists.
+      if (VALUED_FLAGS.has(token)) {
+        if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
+        i += 1;
+        continue;
+      }
+      if (token.startsWith('--') && token.includes('=')) {
+        const [name, ...rest] = token.split('=');
+        if (name === '--regexp') return rest.join('=') || null;
+        continue;
+      }
+      if (token.startsWith('-') && token.length > 1) continue;
+      // The first bare operand is the pattern; everything after it is a path.
+      return token || null;
+    }
+  }
+  return null;
+}
+
 /** Symbol nodes grouped by name, for one lookup per identifier. */
 export function symbolIndex(graph) {
   const byName = new Map();

--- a/integrations/codex/plugin/hooks/lib/advise.mjs
+++ b/integrations/codex/plugin/hooks/lib/advise.mjs
@@ -141,18 +141,45 @@ const COLOR_FLAGS = new Set(['--color', '--colour']);
 const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
- * Splits a command into tokens, honouring quotes.
+ * Splits a command into segments of tokens, honouring quotes and escapes.
+ *
+ * SEGMENTING AND TOKENIZING ARE ONE PASS, and they have to be. Splitting the raw
+ * string on `|`, `&&` and `;` before tokenizing cut straight through quoted
+ * text, so a perfectly ordinary alternation lost everything after the first
+ * branch:
+ *
+ *   grep -E "foo|bar" .   returned `foo`   -- `bar` never reached adviseSearch
+ *   rg "a;b" .            returned `a`
+ *   grep "x&&y" .         returned `x`
+ *
+ * A quote-aware scan cannot make that mistake, because an operator inside a
+ * quoted run is just a character. Pipelines still split, which is what lets
+ * `cat x | grep foo` be recognised at all -- the search is never the first
+ * segment there.
  *
  * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
  * critical path against a string the model composed, which is the exact input
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function tokenize(command) {
-  const tokens = [];
+function commandSegments(command) {
+  const segments = [];
+  let tokens = [];
   let current = '';
   let quote = null;
   let started = false;
+
+  const endToken = () => {
+    if (current || started) tokens.push(current);
+    current = '';
+    started = false;
+  };
+  const endSegment = () => {
+    endToken();
+    if (tokens.length) segments.push(tokens);
+    tokens = [];
+  };
+
   for (let i = 0; i < command.length; i += 1) {
     const ch = command[i];
     if (quote) {
@@ -171,17 +198,22 @@ function tokenize(command) {
       started = true;
       continue;
     }
-    if (ch === ' ' || ch === '\t' || ch === '\n') {
-      if (current || started) tokens.push(current);
-      current = '';
-      started = false;
+    // UNQUOTED ONLY -- reaching here means the quote branches above did not.
+    if (ch === '|' || ch === ';' || ch === '&' || ch === '\n') {
+      endSegment();
+      // `||` and `&&` are one operator, not two empty segments.
+      while (i + 1 < command.length && command[i + 1] === ch) i += 1;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t') {
+      endToken();
       continue;
     }
     current += ch;
     started = true;
   }
-  if (current || started) tokens.push(current);
-  return tokens;
+  endSegment();
+  return segments;
 }
 
 /**
@@ -203,8 +235,7 @@ export function searchPatternFromCommand(command) {
   // the advisory is an optimisation that must never become the slow path.
   if (command.length > 4_000) return null;
 
-  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
-    const tokens = tokenize(segment.trim()).filter(Boolean);
+  for (const tokens of commandSegments(command)) {
     if (!tokens.length) continue;
     // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
     // leading `git` is: `git grep` is ordinary.

--- a/integrations/codex/plugin/hooks/lib/audit.mjs
+++ b/integrations/codex/plugin/hooks/lib/audit.mjs
@@ -78,9 +78,21 @@ export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
   const candidates = sum('candidates');
   const observations = sum('observations');
   const written = sum('written');
+  // THE SEARCH GAP RIDES HERE because a counter nobody reads is exactly the cost
+  // this note exists to prevent -- and because the number decides something: a
+  // locate detector is written and held unmerged until this says the gap is
+  // real. `named` is searches carrying an identifier, `gap` the subset the
+  // symbol index could not answer. Reported only once a search has been seen,
+  // so a project that never searches does not get a line of zeroes.
+  const named = sum('searchesNamed');
+  const gap = sum('searchGap');
+  const searchLine = named
+    ? ` ${gap.toLocaleString()} of ${named.toLocaleString()} named search(es) were ` +
+      'outside the symbol index.'
+    : '';
   return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
     `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
-    `across ${runs.length.toLocaleString()} Stop run(s).`;
+    `across ${runs.length.toLocaleString()} Stop run(s).${searchLine}`;
 }
 
 const idOf = (finding) =>

--- a/integrations/codex/plugin/hooks/lib/derive.mjs
+++ b/integrations/codex/plugin/hooks/lib/derive.mjs
@@ -49,6 +49,14 @@ import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
 import { load } from './wiki.mjs';
 import { ORIGIN_HARVESTED } from './curate.mjs';
+// Counting only -- see `searchGap` below. The SAME extractor the router advises
+// from, so what this counts as a search and what the advisory treats as one
+// cannot diverge.
+import {
+  identifiersIn,
+  searchPatternFromCommand,
+  symbolIndex,
+} from './advise.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -397,12 +405,56 @@ const storageBudget = () =>
  *   defaulting would promote any caller's string to trusted. Also returned, so a
  *   caller can see what it handed over.
  * @returns {object} `{ candidates, observations, written, selected, dropped,
- *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
- *   everything derived; `written` is the subset of keys the graph actually
- *   holds, which is smaller for three independent reasons -- the budget, the
- *   anchor discipline, and the duplicate collapse that returns an EXISTING key
- *   when a later session derives the same claim again.
+ *   selectedTokens, searchGap, sessionId, authoritativeSessionId }`.
+ *   `candidates` is everything derived; `written` is the subset of keys the
+ *   graph actually holds, which is smaller for three independent reasons -- the
+ *   budget, the anchor discipline, and the duplicate collapse that returns an
+ *   EXISTING key when a later session derives the same claim again.
  */
+
+/**
+ * How many searches this session ran that the symbol index could NOT answer.
+ *
+ * MEASUREMENT, NOT A FEATURE. A detector that turns these into findings is
+ * written and deliberately unmerged, because on the only workload we have
+ * measured it produces nothing: replayed against a real warm rep, all seven
+ * searches were for symbols the index already resolves --
+ * `compute_settlement_fee` three times, `def parse_line` once, and three terms
+ * with no identifier-shaped word at all. The search advisory answers every one
+ * of those directly, so storing them again would spend the retrieval budget
+ * restating a cheaper mechanism.
+ *
+ * The case that would justify the detector is a search for something the indexer
+ * never extracts -- a config key, an error string, a literal, a symbol in a file
+ * type it cannot parse. Eleven synthetic Python tasks cannot show whether that
+ * happens in real work. This counts it instead of guessing: `gap` is the number
+ * of searches carrying an identifier the index has no entry for, `named` the
+ * number carrying one at all. A `gap` that stays near zero says the detector
+ * should stay unmerged.
+ *
+ * Counting only. Nothing is stored, nothing is claimed, and it runs at session
+ * end where the cost is already paid.
+ */
+export function searchGap(dir, events) {
+  const out = { named: 0, gap: 0 };
+  try {
+    const index = symbolIndex(load(dir));
+    for (const event of events) {
+      if (!event || event.kind !== 'tool-outcome') continue;
+      if (event.success === false || event.surface !== 'command') continue;
+      const pattern = searchPatternFromCommand(event.anchor);
+      if (!pattern) continue;
+      const names = identifiersIn(pattern);
+      if (!names.length) continue;
+      out.named += 1;
+      if (!names.some((name) => index.has(name))) out.gap += 1;
+    }
+  } catch {
+    // A count is never worth failing a session for.
+  }
+  return out;
+}
+
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
   // `undefined`, so a caller passing an explicitly null options object -- which
@@ -431,6 +483,10 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // Measured, not stored. See `searchGap`: this decides whether the locate
+  // detector is worth merging, and nothing here acts on it.
+  result.searchGap = searchGap(dir, events);
 
   // ONE anchor for the whole run, so every candidate from this session points at
   // the same node and the duplicate collapse in `writeHarvested` can recognise

--- a/integrations/codex/plugin/hooks/lib/doctor.mjs
+++ b/integrations/codex/plugin/hooks/lib/doctor.mjs
@@ -523,6 +523,19 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
     // on the same session file, and the failure would be intermittent and
     // wrong-looking rather than loud. The concurrency win is taken in
     // diagnose(), across probes that share no state.
+    // ENFORCE IS ASKED FOR, NOT INHERITED -- for the same reason the capability
+    // evidence in `probe` is stated rather than inferred. The question this probe
+    // asks is "would enforcement fire if it were switched on", and policy.mjs#mode
+    // now defaults to `assist`, which never refuses (THOL and ledger measurement).
+    // Inheriting the default would make the probe report "not refused" on a
+    // perfectly healthy install: a false negative in the one tool whose job is to
+    // tell the user the truth.
+    //
+    // BOTH probes take it, not just the refusal one. "Small reads are left alone"
+    // is evidence of something only under a posture that COULD have refused;
+    // under assist it would pass against a hook that does nothing whatsoever,
+    // which is precisely the broken install it exists to catch.
+    const enforcing = { env: { TOKEN_OPTIMIZER_MODE: 'enforce' } };
     const denied = await probe(
       binary,
       {
@@ -530,13 +543,14 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: big },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     const deniedOk = typeof denied === 'string' && denied.includes('deny');
     checks.push(deniedOk
       ? ok('enforcement refuses a large read', 'the refusal came back from the real hook')
       : bad('enforcement refuses a large read', `hook returned: ${String(denied).slice(0, 200) || '(nothing)'}`,
-        'check TOKEN_OPTIMIZER_MODE is not "off" or "advise", then reinstall the hooks'));
+        'the probe asks for enforce explicitly, so a failure is the hook itself rather than your mode -- reinstall the hooks'));
 
     const allowed = await probe(
       binary,
@@ -545,7 +559,8 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: small },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     // `allowed === null` is "the probe never ran", NOT "the hook allowed it".
     // allow() writes nothing and exits 0, so '' is a legitimate allow -- but null

--- a/integrations/codex/plugin/hooks/lib/policy.mjs
+++ b/integrations/codex/plugin/hooks/lib/policy.mjs
@@ -10,9 +10,18 @@
  * listed in `/mcp`, and save nothing at all. The skill did not help: skills are
  * model-invoked, so it only loads if the model already decided it cared.
  *
- * The redesign inverts the default. Optimized tooling is the path of least
- * resistance: expensive built-in calls are DENIED with a message naming the
- * exact replacement to call. Everything here exists to make that safe.
+ * The redesign inverted the default so that optimized tooling was the path of
+ * least resistance: expensive built-in calls were DENIED with a message naming
+ * the exact replacement to call. Most of this module exists to make that safe.
+ *
+ * REFUSALS ARE NOW OPT-IN, because measurement did not support them. Two
+ * independent harnesses agree that enforcing is the worst posture we ship --
+ * THOL: enforce $23.33/score 0.935 against assist $20.48/0.971 and control
+ * $21.13/0.969, losing 12 of 17 tasks; ledger cold: enforce/advise 1.147
+ * [1.065, 1.235] while advise/assist-mcp is 1.028 [0.951, 1.114]. So the cost is
+ * the refusals themselves, not the routing advisory or retrieval, and the
+ * machinery below is retained and exercised rather than deleted: `enforce`
+ * remains one variable away for anyone who wants it. See `mode()`.
  *
  * FOUR SAFETY PROPERTIES, none of which are optional:
  *
@@ -27,7 +36,8 @@
  *      human intervention and no permanent breakage.
  *
  *   3. AN ESCAPE HATCH THAT IS ONE VARIABLE. TOKEN_OPTIMIZER_MODE=off disables
- *      everything; =advise restores the old non-blocking behaviour.
+ *      everything; =advise restores the old non-blocking behaviour; =enforce
+ *      turns refusals back on now that they are no longer the default.
  *
  *   4. NO BLOCKING OF CHEAP CALLS. Small files, paged reads, and searches that
  *      already read from a pipe cost little and are left alone. Blocking them
@@ -92,16 +102,40 @@ export function refusalsEnabled() {
 }
 
 /**
- * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
- * redesign. An unrecognised value falls back to enforce rather than silently
- * disabling, so a typo cannot quietly turn the product off.
+ * Reads the mode. ASSIST IS THE DEFAULT, on measurement.
+ *
+ * This said "Enforcement is the DEFAULT -- that is the entire point of the
+ * redesign". The redesign's point was to make the product pay for itself, and
+ * enforcement was the assumed way there rather than a measured one. Two
+ * independent harnesses now say it is the worst posture we ship:
+ *
+ *   THOL 2.1.251, 17 tasks x 3 reps x 3 arms, 153 runs, zero errors
+ *     control  $21.13  score 0.969  turns 16.2
+ *     assist   $20.48  score 0.971  turns 14.4   <- better on all three
+ *     enforce  $23.33  score 0.935  turns 17.6   <- worse on all three,
+ *                                                   losing 12 of 17 tasks
+ *   Ledger cold track
+ *     enforce/advise    1.147 [1.065, 1.235]  refusals cost 14.7%
+ *     advise/assist-mcp 1.028 [0.951, 1.114]  the advisory itself is free
+ *
+ * So the refusals are the whole cost: not the routing advisory, not retrieval.
+ * Enforce's worst tasks are the small cheap ones, where one refused turn is a
+ * large fraction of the total (code-bugfix-py 1.599, log-needle-zh 1.589).
+ * Shipping assist is worth ~12% cost and 3.6 score points against what users
+ * receive today.
+ *
+ * THE TYPO PROPERTY IS PRESERVED, which is what the old comment was really
+ * protecting. An unrecognised value still falls back to a posture with routing,
+ * retrieval, capture and harvest all ON -- `off` is the only value that exits
+ * the hook process, and it remains reachable only by asking for it exactly. A
+ * typo cannot quietly turn the product off; it can now only decline to refuse.
  */
 export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
-  if (raw === MODE_ASSIST) return MODE_ASSIST;
-  return MODE_ENFORCE;
+  if (raw === MODE_ENFORCE) return MODE_ENFORCE;
+  return MODE_ASSIST;
 }
 
 function intEnv(name, fallback) {

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -1222,6 +1222,12 @@ async function runHook(clientName, event, invocation) {
         candidates: derived.candidates.length,
         observations: derived.observations.length,
         written: derived.written.length,
+        // Whether a locate detector would have anything to catch: `named` is
+        // searches carrying an identifier, `gap` the subset the symbol index
+        // cannot answer. Recorded rather than acted on -- a `gap` that stays
+        // near zero says the detector written for it should stay unmerged.
+        searchesNamed: derived.searchGap?.named ?? 0,
+        searchGap: derived.searchGap?.gap ?? 0,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/integrations/copilot/.github/hooks/lib/advise.mjs
+++ b/integrations/copilot/.github/hooks/lib/advise.mjs
@@ -106,13 +106,39 @@ const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
  * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
  * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
  * it is one token, and the `=` test below skips it.
+ *
+ * THE COLOUR FLAGS ARE NOT HERE, because their arity is the one thing in this
+ * list that differs by program. See COLOR_TAKES_SEPARATE_VALUE.
  */
 const VALUED_FLAGS = new Set([
   '-e', '--regexp', '-f', '--file', '-m', '--max-count',
   '-A', '--after-context', '-B', '--before-context', '-C', '--context',
   '-d', '--directories', '-t', '--type', '-g', '--glob',
-  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+  '--include', '--exclude', '--exclude-dir',
 ]);
+
+/** The spellings of the colour option, across the programs handled here. */
+const COLOR_FLAGS = new Set(['--color', '--colour']);
+
+/**
+ * Programs whose colour flag takes a SEPARATE value token.
+ *
+ * The one option in this parser whose arity cannot be decided globally, and
+ * getting it wrong silently returns a path or a keyword as the search pattern:
+ *
+ *   grep --color needle file   GNU: the value is optional and inline-only, so
+ *                              `needle` is the pattern. Treating --color as
+ *                              valued consumed `needle` and returned `file`.
+ *   rg --color never needle .  ripgrep REQUIRES a separate WHEN, so `never` is
+ *                              the flag's value and `needle` is the pattern.
+ *                              Treating --color as valueless returns `never`.
+ *   ag --color needle .        a valueless toggle, like ack. Same failure as
+ *   ack --color needle .       grep: returned `.` instead of `needle`.
+ *
+ * So neither "always valued" nor "never valued" is correct, and the contract has
+ * to come from the program. Only ripgrep is in this set.
+ */
+const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
  * Splits a command into tokens, honouring quotes.
@@ -194,11 +220,17 @@ export function searchPatternFromCommand(command) {
     }
     if (!SEARCH_PROGRAMS.has(program)) continue;
 
+    // Whether a flag eats the next token, decided per program: only the colour
+    // option varies, and only ripgrep requires a separate value for it.
+    const consumesNext = (token) =>
+      VALUED_FLAGS.has(token) ||
+      (COLOR_FLAGS.has(token) && COLOR_TAKES_SEPARATE_VALUE.has(program));
+
     for (let i = at + 1; i < tokens.length; i += 1) {
       const token = tokens[i];
       // An explicit -e/--regexp names the pattern outright and wins over
       // position, which is the whole reason the flag exists.
-      if (VALUED_FLAGS.has(token)) {
+      if (consumesNext(token)) {
         if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
         i += 1;
         continue;

--- a/integrations/copilot/.github/hooks/lib/advise.mjs
+++ b/integrations/copilot/.github/hooks/lib/advise.mjs
@@ -81,6 +81,141 @@ const STOPWORDS = new Set([
   'except', 'raise', 'throw', 'new', 'int', 'str', 'bool', 'float',
 ]);
 
+/**
+ * Search programs whose first operand is a pattern.
+ *
+ * WHY THIS LIST EXISTS AT ALL. The advisory above answers a search from the
+ * index before it runs, and it was wired only to the `Grep` and `Glob` TOOLS.
+ * Measured on the warm benchmark, that is the wrong half of the surface: in the
+ * needle-in-repo runs the agent searched entirely through Bash --
+ *
+ *   Bash  grep -rn "compute_settlement_fee" /work --include=* 2>/dev/null | head -50
+ *   Bash  cat /work/pkg/mod_047.py
+ *   Edit  /work/pkg/mod_047.py
+ *
+ * -- zero Grep calls, zero Glob calls, and so zero advisories delivered, while
+ * the graph for that very session held
+ * `compute_settlement_fee -> pkg/mod_047.py:9-12` and returned it correctly to a
+ * direct call. Two turns were spent rediscovering a fact already indexed.
+ */
+const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
+
+/**
+ * Flags that consume the NEXT token, so its value is never the pattern.
+ *
+ * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
+ * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
+ * it is one token, and the `=` test below skips it.
+ */
+const VALUED_FLAGS = new Set([
+  '-e', '--regexp', '-f', '--file', '-m', '--max-count',
+  '-A', '--after-context', '-B', '--before-context', '-C', '--context',
+  '-d', '--directories', '-t', '--type', '-g', '--glob',
+  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+]);
+
+/**
+ * Splits a command into tokens, honouring quotes.
+ *
+ * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
+ * critical path against a string the model composed, which is the exact input
+ * class this repo keeps a linearity gate for; a single forward pass cannot
+ * backtrack at all.
+ */
+function tokenize(command) {
+  const tokens = [];
+  let current = '';
+  let quote = null;
+  let started = false;
+  for (let i = 0; i < command.length; i += 1) {
+    const ch = command[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (ch === '\\' && i + 1 < command.length) {
+      current += command[i + 1];
+      i += 1;
+      started = true;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t' || ch === '\n') {
+      if (current || started) tokens.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (current || started) tokens.push(current);
+  return tokens;
+}
+
+/**
+ * The pattern a shell search command is about to look for, or null.
+ *
+ * Splits on pipeline and sequencing operators first, because `cat x | grep foo`
+ * and `a && grep foo` both carry a search the graph may be able to answer, and
+ * the search is never the first segment there. `git grep foo` is handled by
+ * skipping a leading `git`, and `find . -name "*.py"` by reading the -name
+ * value: a glob yields no identifiers and so costs nothing, but
+ * `find . -name "compute_settlement*"` does.
+ *
+ * Returns the raw pattern rather than identifiers, so the caller hands it to the
+ * same `adviseSearch` the Grep tool path uses and the two surfaces cannot drift.
+ */
+export function searchPatternFromCommand(command) {
+  if (typeof command !== 'string' || !command) return null;
+  // Bounded before any work: a pathological command is not worth parsing, and
+  // the advisory is an optimisation that must never become the slow path.
+  if (command.length > 4_000) return null;
+
+  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
+    const tokens = tokenize(segment.trim()).filter(Boolean);
+    if (!tokens.length) continue;
+    // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
+    // leading `git` is: `git grep` is ordinary.
+    let at = 0;
+    if (tokens[at] === 'git') at += 1;
+    const program = String(tokens[at] || '').split(/[/\\]/).pop();
+
+    if (program === 'find') {
+      for (let i = at + 1; i < tokens.length - 1; i += 1) {
+        if (tokens[i] === '-name' || tokens[i] === '-iname') return tokens[i + 1];
+      }
+      continue;
+    }
+    if (!SEARCH_PROGRAMS.has(program)) continue;
+
+    for (let i = at + 1; i < tokens.length; i += 1) {
+      const token = tokens[i];
+      // An explicit -e/--regexp names the pattern outright and wins over
+      // position, which is the whole reason the flag exists.
+      if (VALUED_FLAGS.has(token)) {
+        if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
+        i += 1;
+        continue;
+      }
+      if (token.startsWith('--') && token.includes('=')) {
+        const [name, ...rest] = token.split('=');
+        if (name === '--regexp') return rest.join('=') || null;
+        continue;
+      }
+      if (token.startsWith('-') && token.length > 1) continue;
+      // The first bare operand is the pattern; everything after it is a path.
+      return token || null;
+    }
+  }
+  return null;
+}
+
 /** Symbol nodes grouped by name, for one lookup per identifier. */
 export function symbolIndex(graph) {
   const byName = new Map();

--- a/integrations/copilot/.github/hooks/lib/advise.mjs
+++ b/integrations/copilot/.github/hooks/lib/advise.mjs
@@ -141,18 +141,45 @@ const COLOR_FLAGS = new Set(['--color', '--colour']);
 const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
- * Splits a command into tokens, honouring quotes.
+ * Splits a command into segments of tokens, honouring quotes and escapes.
+ *
+ * SEGMENTING AND TOKENIZING ARE ONE PASS, and they have to be. Splitting the raw
+ * string on `|`, `&&` and `;` before tokenizing cut straight through quoted
+ * text, so a perfectly ordinary alternation lost everything after the first
+ * branch:
+ *
+ *   grep -E "foo|bar" .   returned `foo`   -- `bar` never reached adviseSearch
+ *   rg "a;b" .            returned `a`
+ *   grep "x&&y" .         returned `x`
+ *
+ * A quote-aware scan cannot make that mistake, because an operator inside a
+ * quoted run is just a character. Pipelines still split, which is what lets
+ * `cat x | grep foo` be recognised at all -- the search is never the first
+ * segment there.
  *
  * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
  * critical path against a string the model composed, which is the exact input
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function tokenize(command) {
-  const tokens = [];
+function commandSegments(command) {
+  const segments = [];
+  let tokens = [];
   let current = '';
   let quote = null;
   let started = false;
+
+  const endToken = () => {
+    if (current || started) tokens.push(current);
+    current = '';
+    started = false;
+  };
+  const endSegment = () => {
+    endToken();
+    if (tokens.length) segments.push(tokens);
+    tokens = [];
+  };
+
   for (let i = 0; i < command.length; i += 1) {
     const ch = command[i];
     if (quote) {
@@ -171,17 +198,22 @@ function tokenize(command) {
       started = true;
       continue;
     }
-    if (ch === ' ' || ch === '\t' || ch === '\n') {
-      if (current || started) tokens.push(current);
-      current = '';
-      started = false;
+    // UNQUOTED ONLY -- reaching here means the quote branches above did not.
+    if (ch === '|' || ch === ';' || ch === '&' || ch === '\n') {
+      endSegment();
+      // `||` and `&&` are one operator, not two empty segments.
+      while (i + 1 < command.length && command[i + 1] === ch) i += 1;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t') {
+      endToken();
       continue;
     }
     current += ch;
     started = true;
   }
-  if (current || started) tokens.push(current);
-  return tokens;
+  endSegment();
+  return segments;
 }
 
 /**
@@ -203,8 +235,7 @@ export function searchPatternFromCommand(command) {
   // the advisory is an optimisation that must never become the slow path.
   if (command.length > 4_000) return null;
 
-  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
-    const tokens = tokenize(segment.trim()).filter(Boolean);
+  for (const tokens of commandSegments(command)) {
     if (!tokens.length) continue;
     // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
     // leading `git` is: `git grep` is ordinary.

--- a/integrations/copilot/.github/hooks/lib/audit.mjs
+++ b/integrations/copilot/.github/hooks/lib/audit.mjs
@@ -78,9 +78,21 @@ export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
   const candidates = sum('candidates');
   const observations = sum('observations');
   const written = sum('written');
+  // THE SEARCH GAP RIDES HERE because a counter nobody reads is exactly the cost
+  // this note exists to prevent -- and because the number decides something: a
+  // locate detector is written and held unmerged until this says the gap is
+  // real. `named` is searches carrying an identifier, `gap` the subset the
+  // symbol index could not answer. Reported only once a search has been seen,
+  // so a project that never searches does not get a line of zeroes.
+  const named = sum('searchesNamed');
+  const gap = sum('searchGap');
+  const searchLine = named
+    ? ` ${gap.toLocaleString()} of ${named.toLocaleString()} named search(es) were ` +
+      'outside the symbol index.'
+    : '';
   return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
     `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
-    `across ${runs.length.toLocaleString()} Stop run(s).`;
+    `across ${runs.length.toLocaleString()} Stop run(s).${searchLine}`;
 }
 
 const idOf = (finding) =>

--- a/integrations/copilot/.github/hooks/lib/derive.mjs
+++ b/integrations/copilot/.github/hooks/lib/derive.mjs
@@ -49,6 +49,14 @@ import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
 import { load } from './wiki.mjs';
 import { ORIGIN_HARVESTED } from './curate.mjs';
+// Counting only -- see `searchGap` below. The SAME extractor the router advises
+// from, so what this counts as a search and what the advisory treats as one
+// cannot diverge.
+import {
+  identifiersIn,
+  searchPatternFromCommand,
+  symbolIndex,
+} from './advise.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -397,12 +405,56 @@ const storageBudget = () =>
  *   defaulting would promote any caller's string to trusted. Also returned, so a
  *   caller can see what it handed over.
  * @returns {object} `{ candidates, observations, written, selected, dropped,
- *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
- *   everything derived; `written` is the subset of keys the graph actually
- *   holds, which is smaller for three independent reasons -- the budget, the
- *   anchor discipline, and the duplicate collapse that returns an EXISTING key
- *   when a later session derives the same claim again.
+ *   selectedTokens, searchGap, sessionId, authoritativeSessionId }`.
+ *   `candidates` is everything derived; `written` is the subset of keys the
+ *   graph actually holds, which is smaller for three independent reasons -- the
+ *   budget, the anchor discipline, and the duplicate collapse that returns an
+ *   EXISTING key when a later session derives the same claim again.
  */
+
+/**
+ * How many searches this session ran that the symbol index could NOT answer.
+ *
+ * MEASUREMENT, NOT A FEATURE. A detector that turns these into findings is
+ * written and deliberately unmerged, because on the only workload we have
+ * measured it produces nothing: replayed against a real warm rep, all seven
+ * searches were for symbols the index already resolves --
+ * `compute_settlement_fee` three times, `def parse_line` once, and three terms
+ * with no identifier-shaped word at all. The search advisory answers every one
+ * of those directly, so storing them again would spend the retrieval budget
+ * restating a cheaper mechanism.
+ *
+ * The case that would justify the detector is a search for something the indexer
+ * never extracts -- a config key, an error string, a literal, a symbol in a file
+ * type it cannot parse. Eleven synthetic Python tasks cannot show whether that
+ * happens in real work. This counts it instead of guessing: `gap` is the number
+ * of searches carrying an identifier the index has no entry for, `named` the
+ * number carrying one at all. A `gap` that stays near zero says the detector
+ * should stay unmerged.
+ *
+ * Counting only. Nothing is stored, nothing is claimed, and it runs at session
+ * end where the cost is already paid.
+ */
+export function searchGap(dir, events) {
+  const out = { named: 0, gap: 0 };
+  try {
+    const index = symbolIndex(load(dir));
+    for (const event of events) {
+      if (!event || event.kind !== 'tool-outcome') continue;
+      if (event.success === false || event.surface !== 'command') continue;
+      const pattern = searchPatternFromCommand(event.anchor);
+      if (!pattern) continue;
+      const names = identifiersIn(pattern);
+      if (!names.length) continue;
+      out.named += 1;
+      if (!names.some((name) => index.has(name))) out.gap += 1;
+    }
+  } catch {
+    // A count is never worth failing a session for.
+  }
+  return out;
+}
+
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
   // `undefined`, so a caller passing an explicitly null options object -- which
@@ -431,6 +483,10 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // Measured, not stored. See `searchGap`: this decides whether the locate
+  // detector is worth merging, and nothing here acts on it.
+  result.searchGap = searchGap(dir, events);
 
   // ONE anchor for the whole run, so every candidate from this session points at
   // the same node and the duplicate collapse in `writeHarvested` can recognise

--- a/integrations/copilot/.github/hooks/lib/doctor.mjs
+++ b/integrations/copilot/.github/hooks/lib/doctor.mjs
@@ -523,6 +523,19 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
     // on the same session file, and the failure would be intermittent and
     // wrong-looking rather than loud. The concurrency win is taken in
     // diagnose(), across probes that share no state.
+    // ENFORCE IS ASKED FOR, NOT INHERITED -- for the same reason the capability
+    // evidence in `probe` is stated rather than inferred. The question this probe
+    // asks is "would enforcement fire if it were switched on", and policy.mjs#mode
+    // now defaults to `assist`, which never refuses (THOL and ledger measurement).
+    // Inheriting the default would make the probe report "not refused" on a
+    // perfectly healthy install: a false negative in the one tool whose job is to
+    // tell the user the truth.
+    //
+    // BOTH probes take it, not just the refusal one. "Small reads are left alone"
+    // is evidence of something only under a posture that COULD have refused;
+    // under assist it would pass against a hook that does nothing whatsoever,
+    // which is precisely the broken install it exists to catch.
+    const enforcing = { env: { TOKEN_OPTIMIZER_MODE: 'enforce' } };
     const denied = await probe(
       binary,
       {
@@ -530,13 +543,14 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: big },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     const deniedOk = typeof denied === 'string' && denied.includes('deny');
     checks.push(deniedOk
       ? ok('enforcement refuses a large read', 'the refusal came back from the real hook')
       : bad('enforcement refuses a large read', `hook returned: ${String(denied).slice(0, 200) || '(nothing)'}`,
-        'check TOKEN_OPTIMIZER_MODE is not "off" or "advise", then reinstall the hooks'));
+        'the probe asks for enforce explicitly, so a failure is the hook itself rather than your mode -- reinstall the hooks'));
 
     const allowed = await probe(
       binary,
@@ -545,7 +559,8 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: small },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     // `allowed === null` is "the probe never ran", NOT "the hook allowed it".
     // allow() writes nothing and exits 0, so '' is a legitimate allow -- but null

--- a/integrations/copilot/.github/hooks/lib/policy.mjs
+++ b/integrations/copilot/.github/hooks/lib/policy.mjs
@@ -10,9 +10,18 @@
  * listed in `/mcp`, and save nothing at all. The skill did not help: skills are
  * model-invoked, so it only loads if the model already decided it cared.
  *
- * The redesign inverts the default. Optimized tooling is the path of least
- * resistance: expensive built-in calls are DENIED with a message naming the
- * exact replacement to call. Everything here exists to make that safe.
+ * The redesign inverted the default so that optimized tooling was the path of
+ * least resistance: expensive built-in calls were DENIED with a message naming
+ * the exact replacement to call. Most of this module exists to make that safe.
+ *
+ * REFUSALS ARE NOW OPT-IN, because measurement did not support them. Two
+ * independent harnesses agree that enforcing is the worst posture we ship --
+ * THOL: enforce $23.33/score 0.935 against assist $20.48/0.971 and control
+ * $21.13/0.969, losing 12 of 17 tasks; ledger cold: enforce/advise 1.147
+ * [1.065, 1.235] while advise/assist-mcp is 1.028 [0.951, 1.114]. So the cost is
+ * the refusals themselves, not the routing advisory or retrieval, and the
+ * machinery below is retained and exercised rather than deleted: `enforce`
+ * remains one variable away for anyone who wants it. See `mode()`.
  *
  * FOUR SAFETY PROPERTIES, none of which are optional:
  *
@@ -27,7 +36,8 @@
  *      human intervention and no permanent breakage.
  *
  *   3. AN ESCAPE HATCH THAT IS ONE VARIABLE. TOKEN_OPTIMIZER_MODE=off disables
- *      everything; =advise restores the old non-blocking behaviour.
+ *      everything; =advise restores the old non-blocking behaviour; =enforce
+ *      turns refusals back on now that they are no longer the default.
  *
  *   4. NO BLOCKING OF CHEAP CALLS. Small files, paged reads, and searches that
  *      already read from a pipe cost little and are left alone. Blocking them
@@ -92,16 +102,40 @@ export function refusalsEnabled() {
 }
 
 /**
- * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
- * redesign. An unrecognised value falls back to enforce rather than silently
- * disabling, so a typo cannot quietly turn the product off.
+ * Reads the mode. ASSIST IS THE DEFAULT, on measurement.
+ *
+ * This said "Enforcement is the DEFAULT -- that is the entire point of the
+ * redesign". The redesign's point was to make the product pay for itself, and
+ * enforcement was the assumed way there rather than a measured one. Two
+ * independent harnesses now say it is the worst posture we ship:
+ *
+ *   THOL 2.1.251, 17 tasks x 3 reps x 3 arms, 153 runs, zero errors
+ *     control  $21.13  score 0.969  turns 16.2
+ *     assist   $20.48  score 0.971  turns 14.4   <- better on all three
+ *     enforce  $23.33  score 0.935  turns 17.6   <- worse on all three,
+ *                                                   losing 12 of 17 tasks
+ *   Ledger cold track
+ *     enforce/advise    1.147 [1.065, 1.235]  refusals cost 14.7%
+ *     advise/assist-mcp 1.028 [0.951, 1.114]  the advisory itself is free
+ *
+ * So the refusals are the whole cost: not the routing advisory, not retrieval.
+ * Enforce's worst tasks are the small cheap ones, where one refused turn is a
+ * large fraction of the total (code-bugfix-py 1.599, log-needle-zh 1.589).
+ * Shipping assist is worth ~12% cost and 3.6 score points against what users
+ * receive today.
+ *
+ * THE TYPO PROPERTY IS PRESERVED, which is what the old comment was really
+ * protecting. An unrecognised value still falls back to a posture with routing,
+ * retrieval, capture and harvest all ON -- `off` is the only value that exits
+ * the hook process, and it remains reachable only by asking for it exactly. A
+ * typo cannot quietly turn the product off; it can now only decline to refuse.
  */
 export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
-  if (raw === MODE_ASSIST) return MODE_ASSIST;
-  return MODE_ENFORCE;
+  if (raw === MODE_ENFORCE) return MODE_ENFORCE;
+  return MODE_ASSIST;
 }
 
 function intEnv(name, fallback) {

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -1222,6 +1222,12 @@ async function runHook(clientName, event, invocation) {
         candidates: derived.candidates.length,
         observations: derived.observations.length,
         written: derived.written.length,
+        // Whether a locate detector would have anything to catch: `named` is
+        // searches carrying an identifier, `gap` the subset the symbol index
+        // cannot answer. Recorded rather than acted on -- a `gap` that stays
+        // near zero says the detector written for it should stay unmerged.
+        searchesNamed: derived.searchGap?.named ?? 0,
+        searchGap: derived.searchGap?.gap ?? 0,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/integrations/cursor/hooks/lib/advise.mjs
+++ b/integrations/cursor/hooks/lib/advise.mjs
@@ -106,13 +106,39 @@ const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
  * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
  * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
  * it is one token, and the `=` test below skips it.
+ *
+ * THE COLOUR FLAGS ARE NOT HERE, because their arity is the one thing in this
+ * list that differs by program. See COLOR_TAKES_SEPARATE_VALUE.
  */
 const VALUED_FLAGS = new Set([
   '-e', '--regexp', '-f', '--file', '-m', '--max-count',
   '-A', '--after-context', '-B', '--before-context', '-C', '--context',
   '-d', '--directories', '-t', '--type', '-g', '--glob',
-  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+  '--include', '--exclude', '--exclude-dir',
 ]);
+
+/** The spellings of the colour option, across the programs handled here. */
+const COLOR_FLAGS = new Set(['--color', '--colour']);
+
+/**
+ * Programs whose colour flag takes a SEPARATE value token.
+ *
+ * The one option in this parser whose arity cannot be decided globally, and
+ * getting it wrong silently returns a path or a keyword as the search pattern:
+ *
+ *   grep --color needle file   GNU: the value is optional and inline-only, so
+ *                              `needle` is the pattern. Treating --color as
+ *                              valued consumed `needle` and returned `file`.
+ *   rg --color never needle .  ripgrep REQUIRES a separate WHEN, so `never` is
+ *                              the flag's value and `needle` is the pattern.
+ *                              Treating --color as valueless returns `never`.
+ *   ag --color needle .        a valueless toggle, like ack. Same failure as
+ *   ack --color needle .       grep: returned `.` instead of `needle`.
+ *
+ * So neither "always valued" nor "never valued" is correct, and the contract has
+ * to come from the program. Only ripgrep is in this set.
+ */
+const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
  * Splits a command into tokens, honouring quotes.
@@ -194,11 +220,17 @@ export function searchPatternFromCommand(command) {
     }
     if (!SEARCH_PROGRAMS.has(program)) continue;
 
+    // Whether a flag eats the next token, decided per program: only the colour
+    // option varies, and only ripgrep requires a separate value for it.
+    const consumesNext = (token) =>
+      VALUED_FLAGS.has(token) ||
+      (COLOR_FLAGS.has(token) && COLOR_TAKES_SEPARATE_VALUE.has(program));
+
     for (let i = at + 1; i < tokens.length; i += 1) {
       const token = tokens[i];
       // An explicit -e/--regexp names the pattern outright and wins over
       // position, which is the whole reason the flag exists.
-      if (VALUED_FLAGS.has(token)) {
+      if (consumesNext(token)) {
         if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
         i += 1;
         continue;

--- a/integrations/cursor/hooks/lib/advise.mjs
+++ b/integrations/cursor/hooks/lib/advise.mjs
@@ -81,6 +81,141 @@ const STOPWORDS = new Set([
   'except', 'raise', 'throw', 'new', 'int', 'str', 'bool', 'float',
 ]);
 
+/**
+ * Search programs whose first operand is a pattern.
+ *
+ * WHY THIS LIST EXISTS AT ALL. The advisory above answers a search from the
+ * index before it runs, and it was wired only to the `Grep` and `Glob` TOOLS.
+ * Measured on the warm benchmark, that is the wrong half of the surface: in the
+ * needle-in-repo runs the agent searched entirely through Bash --
+ *
+ *   Bash  grep -rn "compute_settlement_fee" /work --include=* 2>/dev/null | head -50
+ *   Bash  cat /work/pkg/mod_047.py
+ *   Edit  /work/pkg/mod_047.py
+ *
+ * -- zero Grep calls, zero Glob calls, and so zero advisories delivered, while
+ * the graph for that very session held
+ * `compute_settlement_fee -> pkg/mod_047.py:9-12` and returned it correctly to a
+ * direct call. Two turns were spent rediscovering a fact already indexed.
+ */
+const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
+
+/**
+ * Flags that consume the NEXT token, so its value is never the pattern.
+ *
+ * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
+ * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
+ * it is one token, and the `=` test below skips it.
+ */
+const VALUED_FLAGS = new Set([
+  '-e', '--regexp', '-f', '--file', '-m', '--max-count',
+  '-A', '--after-context', '-B', '--before-context', '-C', '--context',
+  '-d', '--directories', '-t', '--type', '-g', '--glob',
+  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+]);
+
+/**
+ * Splits a command into tokens, honouring quotes.
+ *
+ * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
+ * critical path against a string the model composed, which is the exact input
+ * class this repo keeps a linearity gate for; a single forward pass cannot
+ * backtrack at all.
+ */
+function tokenize(command) {
+  const tokens = [];
+  let current = '';
+  let quote = null;
+  let started = false;
+  for (let i = 0; i < command.length; i += 1) {
+    const ch = command[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (ch === '\\' && i + 1 < command.length) {
+      current += command[i + 1];
+      i += 1;
+      started = true;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t' || ch === '\n') {
+      if (current || started) tokens.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (current || started) tokens.push(current);
+  return tokens;
+}
+
+/**
+ * The pattern a shell search command is about to look for, or null.
+ *
+ * Splits on pipeline and sequencing operators first, because `cat x | grep foo`
+ * and `a && grep foo` both carry a search the graph may be able to answer, and
+ * the search is never the first segment there. `git grep foo` is handled by
+ * skipping a leading `git`, and `find . -name "*.py"` by reading the -name
+ * value: a glob yields no identifiers and so costs nothing, but
+ * `find . -name "compute_settlement*"` does.
+ *
+ * Returns the raw pattern rather than identifiers, so the caller hands it to the
+ * same `adviseSearch` the Grep tool path uses and the two surfaces cannot drift.
+ */
+export function searchPatternFromCommand(command) {
+  if (typeof command !== 'string' || !command) return null;
+  // Bounded before any work: a pathological command is not worth parsing, and
+  // the advisory is an optimisation that must never become the slow path.
+  if (command.length > 4_000) return null;
+
+  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
+    const tokens = tokenize(segment.trim()).filter(Boolean);
+    if (!tokens.length) continue;
+    // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
+    // leading `git` is: `git grep` is ordinary.
+    let at = 0;
+    if (tokens[at] === 'git') at += 1;
+    const program = String(tokens[at] || '').split(/[/\\]/).pop();
+
+    if (program === 'find') {
+      for (let i = at + 1; i < tokens.length - 1; i += 1) {
+        if (tokens[i] === '-name' || tokens[i] === '-iname') return tokens[i + 1];
+      }
+      continue;
+    }
+    if (!SEARCH_PROGRAMS.has(program)) continue;
+
+    for (let i = at + 1; i < tokens.length; i += 1) {
+      const token = tokens[i];
+      // An explicit -e/--regexp names the pattern outright and wins over
+      // position, which is the whole reason the flag exists.
+      if (VALUED_FLAGS.has(token)) {
+        if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
+        i += 1;
+        continue;
+      }
+      if (token.startsWith('--') && token.includes('=')) {
+        const [name, ...rest] = token.split('=');
+        if (name === '--regexp') return rest.join('=') || null;
+        continue;
+      }
+      if (token.startsWith('-') && token.length > 1) continue;
+      // The first bare operand is the pattern; everything after it is a path.
+      return token || null;
+    }
+  }
+  return null;
+}
+
 /** Symbol nodes grouped by name, for one lookup per identifier. */
 export function symbolIndex(graph) {
   const byName = new Map();

--- a/integrations/cursor/hooks/lib/advise.mjs
+++ b/integrations/cursor/hooks/lib/advise.mjs
@@ -141,18 +141,45 @@ const COLOR_FLAGS = new Set(['--color', '--colour']);
 const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
- * Splits a command into tokens, honouring quotes.
+ * Splits a command into segments of tokens, honouring quotes and escapes.
+ *
+ * SEGMENTING AND TOKENIZING ARE ONE PASS, and they have to be. Splitting the raw
+ * string on `|`, `&&` and `;` before tokenizing cut straight through quoted
+ * text, so a perfectly ordinary alternation lost everything after the first
+ * branch:
+ *
+ *   grep -E "foo|bar" .   returned `foo`   -- `bar` never reached adviseSearch
+ *   rg "a;b" .            returned `a`
+ *   grep "x&&y" .         returned `x`
+ *
+ * A quote-aware scan cannot make that mistake, because an operator inside a
+ * quoted run is just a character. Pipelines still split, which is what lets
+ * `cat x | grep foo` be recognised at all -- the search is never the first
+ * segment there.
  *
  * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
  * critical path against a string the model composed, which is the exact input
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function tokenize(command) {
-  const tokens = [];
+function commandSegments(command) {
+  const segments = [];
+  let tokens = [];
   let current = '';
   let quote = null;
   let started = false;
+
+  const endToken = () => {
+    if (current || started) tokens.push(current);
+    current = '';
+    started = false;
+  };
+  const endSegment = () => {
+    endToken();
+    if (tokens.length) segments.push(tokens);
+    tokens = [];
+  };
+
   for (let i = 0; i < command.length; i += 1) {
     const ch = command[i];
     if (quote) {
@@ -171,17 +198,22 @@ function tokenize(command) {
       started = true;
       continue;
     }
-    if (ch === ' ' || ch === '\t' || ch === '\n') {
-      if (current || started) tokens.push(current);
-      current = '';
-      started = false;
+    // UNQUOTED ONLY -- reaching here means the quote branches above did not.
+    if (ch === '|' || ch === ';' || ch === '&' || ch === '\n') {
+      endSegment();
+      // `||` and `&&` are one operator, not two empty segments.
+      while (i + 1 < command.length && command[i + 1] === ch) i += 1;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t') {
+      endToken();
       continue;
     }
     current += ch;
     started = true;
   }
-  if (current || started) tokens.push(current);
-  return tokens;
+  endSegment();
+  return segments;
 }
 
 /**
@@ -203,8 +235,7 @@ export function searchPatternFromCommand(command) {
   // the advisory is an optimisation that must never become the slow path.
   if (command.length > 4_000) return null;
 
-  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
-    const tokens = tokenize(segment.trim()).filter(Boolean);
+  for (const tokens of commandSegments(command)) {
     if (!tokens.length) continue;
     // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
     // leading `git` is: `git grep` is ordinary.

--- a/integrations/cursor/hooks/lib/audit.mjs
+++ b/integrations/cursor/hooks/lib/audit.mjs
@@ -78,9 +78,21 @@ export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
   const candidates = sum('candidates');
   const observations = sum('observations');
   const written = sum('written');
+  // THE SEARCH GAP RIDES HERE because a counter nobody reads is exactly the cost
+  // this note exists to prevent -- and because the number decides something: a
+  // locate detector is written and held unmerged until this says the gap is
+  // real. `named` is searches carrying an identifier, `gap` the subset the
+  // symbol index could not answer. Reported only once a search has been seen,
+  // so a project that never searches does not get a line of zeroes.
+  const named = sum('searchesNamed');
+  const gap = sum('searchGap');
+  const searchLine = named
+    ? ` ${gap.toLocaleString()} of ${named.toLocaleString()} named search(es) were ` +
+      'outside the symbol index.'
+    : '';
   return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
     `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
-    `across ${runs.length.toLocaleString()} Stop run(s).`;
+    `across ${runs.length.toLocaleString()} Stop run(s).${searchLine}`;
 }
 
 const idOf = (finding) =>

--- a/integrations/cursor/hooks/lib/derive.mjs
+++ b/integrations/cursor/hooks/lib/derive.mjs
@@ -49,6 +49,14 @@ import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
 import { load } from './wiki.mjs';
 import { ORIGIN_HARVESTED } from './curate.mjs';
+// Counting only -- see `searchGap` below. The SAME extractor the router advises
+// from, so what this counts as a search and what the advisory treats as one
+// cannot diverge.
+import {
+  identifiersIn,
+  searchPatternFromCommand,
+  symbolIndex,
+} from './advise.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -397,12 +405,56 @@ const storageBudget = () =>
  *   defaulting would promote any caller's string to trusted. Also returned, so a
  *   caller can see what it handed over.
  * @returns {object} `{ candidates, observations, written, selected, dropped,
- *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
- *   everything derived; `written` is the subset of keys the graph actually
- *   holds, which is smaller for three independent reasons -- the budget, the
- *   anchor discipline, and the duplicate collapse that returns an EXISTING key
- *   when a later session derives the same claim again.
+ *   selectedTokens, searchGap, sessionId, authoritativeSessionId }`.
+ *   `candidates` is everything derived; `written` is the subset of keys the
+ *   graph actually holds, which is smaller for three independent reasons -- the
+ *   budget, the anchor discipline, and the duplicate collapse that returns an
+ *   EXISTING key when a later session derives the same claim again.
  */
+
+/**
+ * How many searches this session ran that the symbol index could NOT answer.
+ *
+ * MEASUREMENT, NOT A FEATURE. A detector that turns these into findings is
+ * written and deliberately unmerged, because on the only workload we have
+ * measured it produces nothing: replayed against a real warm rep, all seven
+ * searches were for symbols the index already resolves --
+ * `compute_settlement_fee` three times, `def parse_line` once, and three terms
+ * with no identifier-shaped word at all. The search advisory answers every one
+ * of those directly, so storing them again would spend the retrieval budget
+ * restating a cheaper mechanism.
+ *
+ * The case that would justify the detector is a search for something the indexer
+ * never extracts -- a config key, an error string, a literal, a symbol in a file
+ * type it cannot parse. Eleven synthetic Python tasks cannot show whether that
+ * happens in real work. This counts it instead of guessing: `gap` is the number
+ * of searches carrying an identifier the index has no entry for, `named` the
+ * number carrying one at all. A `gap` that stays near zero says the detector
+ * should stay unmerged.
+ *
+ * Counting only. Nothing is stored, nothing is claimed, and it runs at session
+ * end where the cost is already paid.
+ */
+export function searchGap(dir, events) {
+  const out = { named: 0, gap: 0 };
+  try {
+    const index = symbolIndex(load(dir));
+    for (const event of events) {
+      if (!event || event.kind !== 'tool-outcome') continue;
+      if (event.success === false || event.surface !== 'command') continue;
+      const pattern = searchPatternFromCommand(event.anchor);
+      if (!pattern) continue;
+      const names = identifiersIn(pattern);
+      if (!names.length) continue;
+      out.named += 1;
+      if (!names.some((name) => index.has(name))) out.gap += 1;
+    }
+  } catch {
+    // A count is never worth failing a session for.
+  }
+  return out;
+}
+
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
   // `undefined`, so a caller passing an explicitly null options object -- which
@@ -431,6 +483,10 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // Measured, not stored. See `searchGap`: this decides whether the locate
+  // detector is worth merging, and nothing here acts on it.
+  result.searchGap = searchGap(dir, events);
 
   // ONE anchor for the whole run, so every candidate from this session points at
   // the same node and the duplicate collapse in `writeHarvested` can recognise

--- a/integrations/cursor/hooks/lib/doctor.mjs
+++ b/integrations/cursor/hooks/lib/doctor.mjs
@@ -523,6 +523,19 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
     // on the same session file, and the failure would be intermittent and
     // wrong-looking rather than loud. The concurrency win is taken in
     // diagnose(), across probes that share no state.
+    // ENFORCE IS ASKED FOR, NOT INHERITED -- for the same reason the capability
+    // evidence in `probe` is stated rather than inferred. The question this probe
+    // asks is "would enforcement fire if it were switched on", and policy.mjs#mode
+    // now defaults to `assist`, which never refuses (THOL and ledger measurement).
+    // Inheriting the default would make the probe report "not refused" on a
+    // perfectly healthy install: a false negative in the one tool whose job is to
+    // tell the user the truth.
+    //
+    // BOTH probes take it, not just the refusal one. "Small reads are left alone"
+    // is evidence of something only under a posture that COULD have refused;
+    // under assist it would pass against a hook that does nothing whatsoever,
+    // which is precisely the broken install it exists to catch.
+    const enforcing = { env: { TOKEN_OPTIMIZER_MODE: 'enforce' } };
     const denied = await probe(
       binary,
       {
@@ -530,13 +543,14 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: big },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     const deniedOk = typeof denied === 'string' && denied.includes('deny');
     checks.push(deniedOk
       ? ok('enforcement refuses a large read', 'the refusal came back from the real hook')
       : bad('enforcement refuses a large read', `hook returned: ${String(denied).slice(0, 200) || '(nothing)'}`,
-        'check TOKEN_OPTIMIZER_MODE is not "off" or "advise", then reinstall the hooks'));
+        'the probe asks for enforce explicitly, so a failure is the hook itself rather than your mode -- reinstall the hooks'));
 
     const allowed = await probe(
       binary,
@@ -545,7 +559,8 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: small },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     // `allowed === null` is "the probe never ran", NOT "the hook allowed it".
     // allow() writes nothing and exits 0, so '' is a legitimate allow -- but null

--- a/integrations/cursor/hooks/lib/policy.mjs
+++ b/integrations/cursor/hooks/lib/policy.mjs
@@ -10,9 +10,18 @@
  * listed in `/mcp`, and save nothing at all. The skill did not help: skills are
  * model-invoked, so it only loads if the model already decided it cared.
  *
- * The redesign inverts the default. Optimized tooling is the path of least
- * resistance: expensive built-in calls are DENIED with a message naming the
- * exact replacement to call. Everything here exists to make that safe.
+ * The redesign inverted the default so that optimized tooling was the path of
+ * least resistance: expensive built-in calls were DENIED with a message naming
+ * the exact replacement to call. Most of this module exists to make that safe.
+ *
+ * REFUSALS ARE NOW OPT-IN, because measurement did not support them. Two
+ * independent harnesses agree that enforcing is the worst posture we ship --
+ * THOL: enforce $23.33/score 0.935 against assist $20.48/0.971 and control
+ * $21.13/0.969, losing 12 of 17 tasks; ledger cold: enforce/advise 1.147
+ * [1.065, 1.235] while advise/assist-mcp is 1.028 [0.951, 1.114]. So the cost is
+ * the refusals themselves, not the routing advisory or retrieval, and the
+ * machinery below is retained and exercised rather than deleted: `enforce`
+ * remains one variable away for anyone who wants it. See `mode()`.
  *
  * FOUR SAFETY PROPERTIES, none of which are optional:
  *
@@ -27,7 +36,8 @@
  *      human intervention and no permanent breakage.
  *
  *   3. AN ESCAPE HATCH THAT IS ONE VARIABLE. TOKEN_OPTIMIZER_MODE=off disables
- *      everything; =advise restores the old non-blocking behaviour.
+ *      everything; =advise restores the old non-blocking behaviour; =enforce
+ *      turns refusals back on now that they are no longer the default.
  *
  *   4. NO BLOCKING OF CHEAP CALLS. Small files, paged reads, and searches that
  *      already read from a pipe cost little and are left alone. Blocking them
@@ -92,16 +102,40 @@ export function refusalsEnabled() {
 }
 
 /**
- * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
- * redesign. An unrecognised value falls back to enforce rather than silently
- * disabling, so a typo cannot quietly turn the product off.
+ * Reads the mode. ASSIST IS THE DEFAULT, on measurement.
+ *
+ * This said "Enforcement is the DEFAULT -- that is the entire point of the
+ * redesign". The redesign's point was to make the product pay for itself, and
+ * enforcement was the assumed way there rather than a measured one. Two
+ * independent harnesses now say it is the worst posture we ship:
+ *
+ *   THOL 2.1.251, 17 tasks x 3 reps x 3 arms, 153 runs, zero errors
+ *     control  $21.13  score 0.969  turns 16.2
+ *     assist   $20.48  score 0.971  turns 14.4   <- better on all three
+ *     enforce  $23.33  score 0.935  turns 17.6   <- worse on all three,
+ *                                                   losing 12 of 17 tasks
+ *   Ledger cold track
+ *     enforce/advise    1.147 [1.065, 1.235]  refusals cost 14.7%
+ *     advise/assist-mcp 1.028 [0.951, 1.114]  the advisory itself is free
+ *
+ * So the refusals are the whole cost: not the routing advisory, not retrieval.
+ * Enforce's worst tasks are the small cheap ones, where one refused turn is a
+ * large fraction of the total (code-bugfix-py 1.599, log-needle-zh 1.589).
+ * Shipping assist is worth ~12% cost and 3.6 score points against what users
+ * receive today.
+ *
+ * THE TYPO PROPERTY IS PRESERVED, which is what the old comment was really
+ * protecting. An unrecognised value still falls back to a posture with routing,
+ * retrieval, capture and harvest all ON -- `off` is the only value that exits
+ * the hook process, and it remains reachable only by asking for it exactly. A
+ * typo cannot quietly turn the product off; it can now only decline to refuse.
  */
 export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
-  if (raw === MODE_ASSIST) return MODE_ASSIST;
-  return MODE_ENFORCE;
+  if (raw === MODE_ENFORCE) return MODE_ENFORCE;
+  return MODE_ASSIST;
 }
 
 function intEnv(name, fallback) {

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -1222,6 +1222,12 @@ async function runHook(clientName, event, invocation) {
         candidates: derived.candidates.length,
         observations: derived.observations.length,
         written: derived.written.length,
+        // Whether a locate detector would have anything to catch: `named` is
+        // searches carrying an identifier, `gap` the subset the symbol index
+        // cannot answer. Recorded rather than acted on -- a `gap` that stays
+        // near zero says the detector written for it should stay unmerged.
+        searchesNamed: derived.searchGap?.named ?? 0,
+        searchGap: derived.searchGap?.gap ?? 0,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/integrations/gemini/hooks/lib/advise.mjs
+++ b/integrations/gemini/hooks/lib/advise.mjs
@@ -106,13 +106,39 @@ const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
  * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
  * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
  * it is one token, and the `=` test below skips it.
+ *
+ * THE COLOUR FLAGS ARE NOT HERE, because their arity is the one thing in this
+ * list that differs by program. See COLOR_TAKES_SEPARATE_VALUE.
  */
 const VALUED_FLAGS = new Set([
   '-e', '--regexp', '-f', '--file', '-m', '--max-count',
   '-A', '--after-context', '-B', '--before-context', '-C', '--context',
   '-d', '--directories', '-t', '--type', '-g', '--glob',
-  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+  '--include', '--exclude', '--exclude-dir',
 ]);
+
+/** The spellings of the colour option, across the programs handled here. */
+const COLOR_FLAGS = new Set(['--color', '--colour']);
+
+/**
+ * Programs whose colour flag takes a SEPARATE value token.
+ *
+ * The one option in this parser whose arity cannot be decided globally, and
+ * getting it wrong silently returns a path or a keyword as the search pattern:
+ *
+ *   grep --color needle file   GNU: the value is optional and inline-only, so
+ *                              `needle` is the pattern. Treating --color as
+ *                              valued consumed `needle` and returned `file`.
+ *   rg --color never needle .  ripgrep REQUIRES a separate WHEN, so `never` is
+ *                              the flag's value and `needle` is the pattern.
+ *                              Treating --color as valueless returns `never`.
+ *   ag --color needle .        a valueless toggle, like ack. Same failure as
+ *   ack --color needle .       grep: returned `.` instead of `needle`.
+ *
+ * So neither "always valued" nor "never valued" is correct, and the contract has
+ * to come from the program. Only ripgrep is in this set.
+ */
+const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
  * Splits a command into tokens, honouring quotes.
@@ -194,11 +220,17 @@ export function searchPatternFromCommand(command) {
     }
     if (!SEARCH_PROGRAMS.has(program)) continue;
 
+    // Whether a flag eats the next token, decided per program: only the colour
+    // option varies, and only ripgrep requires a separate value for it.
+    const consumesNext = (token) =>
+      VALUED_FLAGS.has(token) ||
+      (COLOR_FLAGS.has(token) && COLOR_TAKES_SEPARATE_VALUE.has(program));
+
     for (let i = at + 1; i < tokens.length; i += 1) {
       const token = tokens[i];
       // An explicit -e/--regexp names the pattern outright and wins over
       // position, which is the whole reason the flag exists.
-      if (VALUED_FLAGS.has(token)) {
+      if (consumesNext(token)) {
         if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
         i += 1;
         continue;

--- a/integrations/gemini/hooks/lib/advise.mjs
+++ b/integrations/gemini/hooks/lib/advise.mjs
@@ -81,6 +81,141 @@ const STOPWORDS = new Set([
   'except', 'raise', 'throw', 'new', 'int', 'str', 'bool', 'float',
 ]);
 
+/**
+ * Search programs whose first operand is a pattern.
+ *
+ * WHY THIS LIST EXISTS AT ALL. The advisory above answers a search from the
+ * index before it runs, and it was wired only to the `Grep` and `Glob` TOOLS.
+ * Measured on the warm benchmark, that is the wrong half of the surface: in the
+ * needle-in-repo runs the agent searched entirely through Bash --
+ *
+ *   Bash  grep -rn "compute_settlement_fee" /work --include=* 2>/dev/null | head -50
+ *   Bash  cat /work/pkg/mod_047.py
+ *   Edit  /work/pkg/mod_047.py
+ *
+ * -- zero Grep calls, zero Glob calls, and so zero advisories delivered, while
+ * the graph for that very session held
+ * `compute_settlement_fee -> pkg/mod_047.py:9-12` and returned it correctly to a
+ * direct call. Two turns were spent rediscovering a fact already indexed.
+ */
+const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
+
+/**
+ * Flags that consume the NEXT token, so its value is never the pattern.
+ *
+ * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
+ * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
+ * it is one token, and the `=` test below skips it.
+ */
+const VALUED_FLAGS = new Set([
+  '-e', '--regexp', '-f', '--file', '-m', '--max-count',
+  '-A', '--after-context', '-B', '--before-context', '-C', '--context',
+  '-d', '--directories', '-t', '--type', '-g', '--glob',
+  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+]);
+
+/**
+ * Splits a command into tokens, honouring quotes.
+ *
+ * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
+ * critical path against a string the model composed, which is the exact input
+ * class this repo keeps a linearity gate for; a single forward pass cannot
+ * backtrack at all.
+ */
+function tokenize(command) {
+  const tokens = [];
+  let current = '';
+  let quote = null;
+  let started = false;
+  for (let i = 0; i < command.length; i += 1) {
+    const ch = command[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (ch === '\\' && i + 1 < command.length) {
+      current += command[i + 1];
+      i += 1;
+      started = true;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t' || ch === '\n') {
+      if (current || started) tokens.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (current || started) tokens.push(current);
+  return tokens;
+}
+
+/**
+ * The pattern a shell search command is about to look for, or null.
+ *
+ * Splits on pipeline and sequencing operators first, because `cat x | grep foo`
+ * and `a && grep foo` both carry a search the graph may be able to answer, and
+ * the search is never the first segment there. `git grep foo` is handled by
+ * skipping a leading `git`, and `find . -name "*.py"` by reading the -name
+ * value: a glob yields no identifiers and so costs nothing, but
+ * `find . -name "compute_settlement*"` does.
+ *
+ * Returns the raw pattern rather than identifiers, so the caller hands it to the
+ * same `adviseSearch` the Grep tool path uses and the two surfaces cannot drift.
+ */
+export function searchPatternFromCommand(command) {
+  if (typeof command !== 'string' || !command) return null;
+  // Bounded before any work: a pathological command is not worth parsing, and
+  // the advisory is an optimisation that must never become the slow path.
+  if (command.length > 4_000) return null;
+
+  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
+    const tokens = tokenize(segment.trim()).filter(Boolean);
+    if (!tokens.length) continue;
+    // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
+    // leading `git` is: `git grep` is ordinary.
+    let at = 0;
+    if (tokens[at] === 'git') at += 1;
+    const program = String(tokens[at] || '').split(/[/\\]/).pop();
+
+    if (program === 'find') {
+      for (let i = at + 1; i < tokens.length - 1; i += 1) {
+        if (tokens[i] === '-name' || tokens[i] === '-iname') return tokens[i + 1];
+      }
+      continue;
+    }
+    if (!SEARCH_PROGRAMS.has(program)) continue;
+
+    for (let i = at + 1; i < tokens.length; i += 1) {
+      const token = tokens[i];
+      // An explicit -e/--regexp names the pattern outright and wins over
+      // position, which is the whole reason the flag exists.
+      if (VALUED_FLAGS.has(token)) {
+        if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
+        i += 1;
+        continue;
+      }
+      if (token.startsWith('--') && token.includes('=')) {
+        const [name, ...rest] = token.split('=');
+        if (name === '--regexp') return rest.join('=') || null;
+        continue;
+      }
+      if (token.startsWith('-') && token.length > 1) continue;
+      // The first bare operand is the pattern; everything after it is a path.
+      return token || null;
+    }
+  }
+  return null;
+}
+
 /** Symbol nodes grouped by name, for one lookup per identifier. */
 export function symbolIndex(graph) {
   const byName = new Map();

--- a/integrations/gemini/hooks/lib/advise.mjs
+++ b/integrations/gemini/hooks/lib/advise.mjs
@@ -141,18 +141,45 @@ const COLOR_FLAGS = new Set(['--color', '--colour']);
 const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
- * Splits a command into tokens, honouring quotes.
+ * Splits a command into segments of tokens, honouring quotes and escapes.
+ *
+ * SEGMENTING AND TOKENIZING ARE ONE PASS, and they have to be. Splitting the raw
+ * string on `|`, `&&` and `;` before tokenizing cut straight through quoted
+ * text, so a perfectly ordinary alternation lost everything after the first
+ * branch:
+ *
+ *   grep -E "foo|bar" .   returned `foo`   -- `bar` never reached adviseSearch
+ *   rg "a;b" .            returned `a`
+ *   grep "x&&y" .         returned `x`
+ *
+ * A quote-aware scan cannot make that mistake, because an operator inside a
+ * quoted run is just a character. Pipelines still split, which is what lets
+ * `cat x | grep foo` be recognised at all -- the search is never the first
+ * segment there.
  *
  * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
  * critical path against a string the model composed, which is the exact input
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function tokenize(command) {
-  const tokens = [];
+function commandSegments(command) {
+  const segments = [];
+  let tokens = [];
   let current = '';
   let quote = null;
   let started = false;
+
+  const endToken = () => {
+    if (current || started) tokens.push(current);
+    current = '';
+    started = false;
+  };
+  const endSegment = () => {
+    endToken();
+    if (tokens.length) segments.push(tokens);
+    tokens = [];
+  };
+
   for (let i = 0; i < command.length; i += 1) {
     const ch = command[i];
     if (quote) {
@@ -171,17 +198,22 @@ function tokenize(command) {
       started = true;
       continue;
     }
-    if (ch === ' ' || ch === '\t' || ch === '\n') {
-      if (current || started) tokens.push(current);
-      current = '';
-      started = false;
+    // UNQUOTED ONLY -- reaching here means the quote branches above did not.
+    if (ch === '|' || ch === ';' || ch === '&' || ch === '\n') {
+      endSegment();
+      // `||` and `&&` are one operator, not two empty segments.
+      while (i + 1 < command.length && command[i + 1] === ch) i += 1;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t') {
+      endToken();
       continue;
     }
     current += ch;
     started = true;
   }
-  if (current || started) tokens.push(current);
-  return tokens;
+  endSegment();
+  return segments;
 }
 
 /**
@@ -203,8 +235,7 @@ export function searchPatternFromCommand(command) {
   // the advisory is an optimisation that must never become the slow path.
   if (command.length > 4_000) return null;
 
-  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
-    const tokens = tokenize(segment.trim()).filter(Boolean);
+  for (const tokens of commandSegments(command)) {
     if (!tokens.length) continue;
     // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
     // leading `git` is: `git grep` is ordinary.

--- a/integrations/gemini/hooks/lib/audit.mjs
+++ b/integrations/gemini/hooks/lib/audit.mjs
@@ -78,9 +78,21 @@ export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
   const candidates = sum('candidates');
   const observations = sum('observations');
   const written = sum('written');
+  // THE SEARCH GAP RIDES HERE because a counter nobody reads is exactly the cost
+  // this note exists to prevent -- and because the number decides something: a
+  // locate detector is written and held unmerged until this says the gap is
+  // real. `named` is searches carrying an identifier, `gap` the subset the
+  // symbol index could not answer. Reported only once a search has been seen,
+  // so a project that never searches does not get a line of zeroes.
+  const named = sum('searchesNamed');
+  const gap = sum('searchGap');
+  const searchLine = named
+    ? ` ${gap.toLocaleString()} of ${named.toLocaleString()} named search(es) were ` +
+      'outside the symbol index.'
+    : '';
   return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
     `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
-    `across ${runs.length.toLocaleString()} Stop run(s).`;
+    `across ${runs.length.toLocaleString()} Stop run(s).${searchLine}`;
 }
 
 const idOf = (finding) =>

--- a/integrations/gemini/hooks/lib/derive.mjs
+++ b/integrations/gemini/hooks/lib/derive.mjs
@@ -49,6 +49,14 @@ import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
 import { load } from './wiki.mjs';
 import { ORIGIN_HARVESTED } from './curate.mjs';
+// Counting only -- see `searchGap` below. The SAME extractor the router advises
+// from, so what this counts as a search and what the advisory treats as one
+// cannot diverge.
+import {
+  identifiersIn,
+  searchPatternFromCommand,
+  symbolIndex,
+} from './advise.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -397,12 +405,56 @@ const storageBudget = () =>
  *   defaulting would promote any caller's string to trusted. Also returned, so a
  *   caller can see what it handed over.
  * @returns {object} `{ candidates, observations, written, selected, dropped,
- *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
- *   everything derived; `written` is the subset of keys the graph actually
- *   holds, which is smaller for three independent reasons -- the budget, the
- *   anchor discipline, and the duplicate collapse that returns an EXISTING key
- *   when a later session derives the same claim again.
+ *   selectedTokens, searchGap, sessionId, authoritativeSessionId }`.
+ *   `candidates` is everything derived; `written` is the subset of keys the
+ *   graph actually holds, which is smaller for three independent reasons -- the
+ *   budget, the anchor discipline, and the duplicate collapse that returns an
+ *   EXISTING key when a later session derives the same claim again.
  */
+
+/**
+ * How many searches this session ran that the symbol index could NOT answer.
+ *
+ * MEASUREMENT, NOT A FEATURE. A detector that turns these into findings is
+ * written and deliberately unmerged, because on the only workload we have
+ * measured it produces nothing: replayed against a real warm rep, all seven
+ * searches were for symbols the index already resolves --
+ * `compute_settlement_fee` three times, `def parse_line` once, and three terms
+ * with no identifier-shaped word at all. The search advisory answers every one
+ * of those directly, so storing them again would spend the retrieval budget
+ * restating a cheaper mechanism.
+ *
+ * The case that would justify the detector is a search for something the indexer
+ * never extracts -- a config key, an error string, a literal, a symbol in a file
+ * type it cannot parse. Eleven synthetic Python tasks cannot show whether that
+ * happens in real work. This counts it instead of guessing: `gap` is the number
+ * of searches carrying an identifier the index has no entry for, `named` the
+ * number carrying one at all. A `gap` that stays near zero says the detector
+ * should stay unmerged.
+ *
+ * Counting only. Nothing is stored, nothing is claimed, and it runs at session
+ * end where the cost is already paid.
+ */
+export function searchGap(dir, events) {
+  const out = { named: 0, gap: 0 };
+  try {
+    const index = symbolIndex(load(dir));
+    for (const event of events) {
+      if (!event || event.kind !== 'tool-outcome') continue;
+      if (event.success === false || event.surface !== 'command') continue;
+      const pattern = searchPatternFromCommand(event.anchor);
+      if (!pattern) continue;
+      const names = identifiersIn(pattern);
+      if (!names.length) continue;
+      out.named += 1;
+      if (!names.some((name) => index.has(name))) out.gap += 1;
+    }
+  } catch {
+    // A count is never worth failing a session for.
+  }
+  return out;
+}
+
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
   // `undefined`, so a caller passing an explicitly null options object -- which
@@ -431,6 +483,10 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // Measured, not stored. See `searchGap`: this decides whether the locate
+  // detector is worth merging, and nothing here acts on it.
+  result.searchGap = searchGap(dir, events);
 
   // ONE anchor for the whole run, so every candidate from this session points at
   // the same node and the duplicate collapse in `writeHarvested` can recognise

--- a/integrations/gemini/hooks/lib/doctor.mjs
+++ b/integrations/gemini/hooks/lib/doctor.mjs
@@ -523,6 +523,19 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
     // on the same session file, and the failure would be intermittent and
     // wrong-looking rather than loud. The concurrency win is taken in
     // diagnose(), across probes that share no state.
+    // ENFORCE IS ASKED FOR, NOT INHERITED -- for the same reason the capability
+    // evidence in `probe` is stated rather than inferred. The question this probe
+    // asks is "would enforcement fire if it were switched on", and policy.mjs#mode
+    // now defaults to `assist`, which never refuses (THOL and ledger measurement).
+    // Inheriting the default would make the probe report "not refused" on a
+    // perfectly healthy install: a false negative in the one tool whose job is to
+    // tell the user the truth.
+    //
+    // BOTH probes take it, not just the refusal one. "Small reads are left alone"
+    // is evidence of something only under a posture that COULD have refused;
+    // under assist it would pass against a hook that does nothing whatsoever,
+    // which is precisely the broken install it exists to catch.
+    const enforcing = { env: { TOKEN_OPTIMIZER_MODE: 'enforce' } };
     const denied = await probe(
       binary,
       {
@@ -530,13 +543,14 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: big },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     const deniedOk = typeof denied === 'string' && denied.includes('deny');
     checks.push(deniedOk
       ? ok('enforcement refuses a large read', 'the refusal came back from the real hook')
       : bad('enforcement refuses a large read', `hook returned: ${String(denied).slice(0, 200) || '(nothing)'}`,
-        'check TOKEN_OPTIMIZER_MODE is not "off" or "advise", then reinstall the hooks'));
+        'the probe asks for enforce explicitly, so a failure is the hook itself rather than your mode -- reinstall the hooks'));
 
     const allowed = await probe(
       binary,
@@ -545,7 +559,8 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: small },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     // `allowed === null` is "the probe never ran", NOT "the hook allowed it".
     // allow() writes nothing and exits 0, so '' is a legitimate allow -- but null

--- a/integrations/gemini/hooks/lib/policy.mjs
+++ b/integrations/gemini/hooks/lib/policy.mjs
@@ -10,9 +10,18 @@
  * listed in `/mcp`, and save nothing at all. The skill did not help: skills are
  * model-invoked, so it only loads if the model already decided it cared.
  *
- * The redesign inverts the default. Optimized tooling is the path of least
- * resistance: expensive built-in calls are DENIED with a message naming the
- * exact replacement to call. Everything here exists to make that safe.
+ * The redesign inverted the default so that optimized tooling was the path of
+ * least resistance: expensive built-in calls were DENIED with a message naming
+ * the exact replacement to call. Most of this module exists to make that safe.
+ *
+ * REFUSALS ARE NOW OPT-IN, because measurement did not support them. Two
+ * independent harnesses agree that enforcing is the worst posture we ship --
+ * THOL: enforce $23.33/score 0.935 against assist $20.48/0.971 and control
+ * $21.13/0.969, losing 12 of 17 tasks; ledger cold: enforce/advise 1.147
+ * [1.065, 1.235] while advise/assist-mcp is 1.028 [0.951, 1.114]. So the cost is
+ * the refusals themselves, not the routing advisory or retrieval, and the
+ * machinery below is retained and exercised rather than deleted: `enforce`
+ * remains one variable away for anyone who wants it. See `mode()`.
  *
  * FOUR SAFETY PROPERTIES, none of which are optional:
  *
@@ -27,7 +36,8 @@
  *      human intervention and no permanent breakage.
  *
  *   3. AN ESCAPE HATCH THAT IS ONE VARIABLE. TOKEN_OPTIMIZER_MODE=off disables
- *      everything; =advise restores the old non-blocking behaviour.
+ *      everything; =advise restores the old non-blocking behaviour; =enforce
+ *      turns refusals back on now that they are no longer the default.
  *
  *   4. NO BLOCKING OF CHEAP CALLS. Small files, paged reads, and searches that
  *      already read from a pipe cost little and are left alone. Blocking them
@@ -92,16 +102,40 @@ export function refusalsEnabled() {
 }
 
 /**
- * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
- * redesign. An unrecognised value falls back to enforce rather than silently
- * disabling, so a typo cannot quietly turn the product off.
+ * Reads the mode. ASSIST IS THE DEFAULT, on measurement.
+ *
+ * This said "Enforcement is the DEFAULT -- that is the entire point of the
+ * redesign". The redesign's point was to make the product pay for itself, and
+ * enforcement was the assumed way there rather than a measured one. Two
+ * independent harnesses now say it is the worst posture we ship:
+ *
+ *   THOL 2.1.251, 17 tasks x 3 reps x 3 arms, 153 runs, zero errors
+ *     control  $21.13  score 0.969  turns 16.2
+ *     assist   $20.48  score 0.971  turns 14.4   <- better on all three
+ *     enforce  $23.33  score 0.935  turns 17.6   <- worse on all three,
+ *                                                   losing 12 of 17 tasks
+ *   Ledger cold track
+ *     enforce/advise    1.147 [1.065, 1.235]  refusals cost 14.7%
+ *     advise/assist-mcp 1.028 [0.951, 1.114]  the advisory itself is free
+ *
+ * So the refusals are the whole cost: not the routing advisory, not retrieval.
+ * Enforce's worst tasks are the small cheap ones, where one refused turn is a
+ * large fraction of the total (code-bugfix-py 1.599, log-needle-zh 1.589).
+ * Shipping assist is worth ~12% cost and 3.6 score points against what users
+ * receive today.
+ *
+ * THE TYPO PROPERTY IS PRESERVED, which is what the old comment was really
+ * protecting. An unrecognised value still falls back to a posture with routing,
+ * retrieval, capture and harvest all ON -- `off` is the only value that exits
+ * the hook process, and it remains reachable only by asking for it exactly. A
+ * typo cannot quietly turn the product off; it can now only decline to refuse.
  */
 export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
-  if (raw === MODE_ASSIST) return MODE_ASSIST;
-  return MODE_ENFORCE;
+  if (raw === MODE_ENFORCE) return MODE_ENFORCE;
+  return MODE_ASSIST;
 }
 
 function intEnv(name, fallback) {

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -1222,6 +1222,12 @@ async function runHook(clientName, event, invocation) {
         candidates: derived.candidates.length,
         observations: derived.observations.length,
         written: derived.written.length,
+        // Whether a locate detector would have anything to catch: `named` is
+        // searches carrying an identifier, `gap` the subset the symbol index
+        // cannot answer. Recorded rather than acted on -- a `gap` that stays
+        // near zero says the detector written for it should stay unmerged.
+        searchesNamed: derived.searchGap?.named ?? 0,
+        searchGap: derived.searchGap?.gap ?? 0,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/integrations/kilo/hooks/lib/advise.mjs
+++ b/integrations/kilo/hooks/lib/advise.mjs
@@ -106,13 +106,39 @@ const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
  * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
  * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
  * it is one token, and the `=` test below skips it.
+ *
+ * THE COLOUR FLAGS ARE NOT HERE, because their arity is the one thing in this
+ * list that differs by program. See COLOR_TAKES_SEPARATE_VALUE.
  */
 const VALUED_FLAGS = new Set([
   '-e', '--regexp', '-f', '--file', '-m', '--max-count',
   '-A', '--after-context', '-B', '--before-context', '-C', '--context',
   '-d', '--directories', '-t', '--type', '-g', '--glob',
-  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+  '--include', '--exclude', '--exclude-dir',
 ]);
+
+/** The spellings of the colour option, across the programs handled here. */
+const COLOR_FLAGS = new Set(['--color', '--colour']);
+
+/**
+ * Programs whose colour flag takes a SEPARATE value token.
+ *
+ * The one option in this parser whose arity cannot be decided globally, and
+ * getting it wrong silently returns a path or a keyword as the search pattern:
+ *
+ *   grep --color needle file   GNU: the value is optional and inline-only, so
+ *                              `needle` is the pattern. Treating --color as
+ *                              valued consumed `needle` and returned `file`.
+ *   rg --color never needle .  ripgrep REQUIRES a separate WHEN, so `never` is
+ *                              the flag's value and `needle` is the pattern.
+ *                              Treating --color as valueless returns `never`.
+ *   ag --color needle .        a valueless toggle, like ack. Same failure as
+ *   ack --color needle .       grep: returned `.` instead of `needle`.
+ *
+ * So neither "always valued" nor "never valued" is correct, and the contract has
+ * to come from the program. Only ripgrep is in this set.
+ */
+const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
  * Splits a command into tokens, honouring quotes.
@@ -194,11 +220,17 @@ export function searchPatternFromCommand(command) {
     }
     if (!SEARCH_PROGRAMS.has(program)) continue;
 
+    // Whether a flag eats the next token, decided per program: only the colour
+    // option varies, and only ripgrep requires a separate value for it.
+    const consumesNext = (token) =>
+      VALUED_FLAGS.has(token) ||
+      (COLOR_FLAGS.has(token) && COLOR_TAKES_SEPARATE_VALUE.has(program));
+
     for (let i = at + 1; i < tokens.length; i += 1) {
       const token = tokens[i];
       // An explicit -e/--regexp names the pattern outright and wins over
       // position, which is the whole reason the flag exists.
-      if (VALUED_FLAGS.has(token)) {
+      if (consumesNext(token)) {
         if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
         i += 1;
         continue;

--- a/integrations/kilo/hooks/lib/advise.mjs
+++ b/integrations/kilo/hooks/lib/advise.mjs
@@ -81,6 +81,141 @@ const STOPWORDS = new Set([
   'except', 'raise', 'throw', 'new', 'int', 'str', 'bool', 'float',
 ]);
 
+/**
+ * Search programs whose first operand is a pattern.
+ *
+ * WHY THIS LIST EXISTS AT ALL. The advisory above answers a search from the
+ * index before it runs, and it was wired only to the `Grep` and `Glob` TOOLS.
+ * Measured on the warm benchmark, that is the wrong half of the surface: in the
+ * needle-in-repo runs the agent searched entirely through Bash --
+ *
+ *   Bash  grep -rn "compute_settlement_fee" /work --include=* 2>/dev/null | head -50
+ *   Bash  cat /work/pkg/mod_047.py
+ *   Edit  /work/pkg/mod_047.py
+ *
+ * -- zero Grep calls, zero Glob calls, and so zero advisories delivered, while
+ * the graph for that very session held
+ * `compute_settlement_fee -> pkg/mod_047.py:9-12` and returned it correctly to a
+ * direct call. Two turns were spent rediscovering a fact already indexed.
+ */
+const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
+
+/**
+ * Flags that consume the NEXT token, so its value is never the pattern.
+ *
+ * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
+ * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
+ * it is one token, and the `=` test below skips it.
+ */
+const VALUED_FLAGS = new Set([
+  '-e', '--regexp', '-f', '--file', '-m', '--max-count',
+  '-A', '--after-context', '-B', '--before-context', '-C', '--context',
+  '-d', '--directories', '-t', '--type', '-g', '--glob',
+  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+]);
+
+/**
+ * Splits a command into tokens, honouring quotes.
+ *
+ * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
+ * critical path against a string the model composed, which is the exact input
+ * class this repo keeps a linearity gate for; a single forward pass cannot
+ * backtrack at all.
+ */
+function tokenize(command) {
+  const tokens = [];
+  let current = '';
+  let quote = null;
+  let started = false;
+  for (let i = 0; i < command.length; i += 1) {
+    const ch = command[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (ch === '\\' && i + 1 < command.length) {
+      current += command[i + 1];
+      i += 1;
+      started = true;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t' || ch === '\n') {
+      if (current || started) tokens.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (current || started) tokens.push(current);
+  return tokens;
+}
+
+/**
+ * The pattern a shell search command is about to look for, or null.
+ *
+ * Splits on pipeline and sequencing operators first, because `cat x | grep foo`
+ * and `a && grep foo` both carry a search the graph may be able to answer, and
+ * the search is never the first segment there. `git grep foo` is handled by
+ * skipping a leading `git`, and `find . -name "*.py"` by reading the -name
+ * value: a glob yields no identifiers and so costs nothing, but
+ * `find . -name "compute_settlement*"` does.
+ *
+ * Returns the raw pattern rather than identifiers, so the caller hands it to the
+ * same `adviseSearch` the Grep tool path uses and the two surfaces cannot drift.
+ */
+export function searchPatternFromCommand(command) {
+  if (typeof command !== 'string' || !command) return null;
+  // Bounded before any work: a pathological command is not worth parsing, and
+  // the advisory is an optimisation that must never become the slow path.
+  if (command.length > 4_000) return null;
+
+  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
+    const tokens = tokenize(segment.trim()).filter(Boolean);
+    if (!tokens.length) continue;
+    // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
+    // leading `git` is: `git grep` is ordinary.
+    let at = 0;
+    if (tokens[at] === 'git') at += 1;
+    const program = String(tokens[at] || '').split(/[/\\]/).pop();
+
+    if (program === 'find') {
+      for (let i = at + 1; i < tokens.length - 1; i += 1) {
+        if (tokens[i] === '-name' || tokens[i] === '-iname') return tokens[i + 1];
+      }
+      continue;
+    }
+    if (!SEARCH_PROGRAMS.has(program)) continue;
+
+    for (let i = at + 1; i < tokens.length; i += 1) {
+      const token = tokens[i];
+      // An explicit -e/--regexp names the pattern outright and wins over
+      // position, which is the whole reason the flag exists.
+      if (VALUED_FLAGS.has(token)) {
+        if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
+        i += 1;
+        continue;
+      }
+      if (token.startsWith('--') && token.includes('=')) {
+        const [name, ...rest] = token.split('=');
+        if (name === '--regexp') return rest.join('=') || null;
+        continue;
+      }
+      if (token.startsWith('-') && token.length > 1) continue;
+      // The first bare operand is the pattern; everything after it is a path.
+      return token || null;
+    }
+  }
+  return null;
+}
+
 /** Symbol nodes grouped by name, for one lookup per identifier. */
 export function symbolIndex(graph) {
   const byName = new Map();

--- a/integrations/kilo/hooks/lib/advise.mjs
+++ b/integrations/kilo/hooks/lib/advise.mjs
@@ -141,18 +141,45 @@ const COLOR_FLAGS = new Set(['--color', '--colour']);
 const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
- * Splits a command into tokens, honouring quotes.
+ * Splits a command into segments of tokens, honouring quotes and escapes.
+ *
+ * SEGMENTING AND TOKENIZING ARE ONE PASS, and they have to be. Splitting the raw
+ * string on `|`, `&&` and `;` before tokenizing cut straight through quoted
+ * text, so a perfectly ordinary alternation lost everything after the first
+ * branch:
+ *
+ *   grep -E "foo|bar" .   returned `foo`   -- `bar` never reached adviseSearch
+ *   rg "a;b" .            returned `a`
+ *   grep "x&&y" .         returned `x`
+ *
+ * A quote-aware scan cannot make that mistake, because an operator inside a
+ * quoted run is just a character. Pipelines still split, which is what lets
+ * `cat x | grep foo` be recognised at all -- the search is never the first
+ * segment there.
  *
  * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
  * critical path against a string the model composed, which is the exact input
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function tokenize(command) {
-  const tokens = [];
+function commandSegments(command) {
+  const segments = [];
+  let tokens = [];
   let current = '';
   let quote = null;
   let started = false;
+
+  const endToken = () => {
+    if (current || started) tokens.push(current);
+    current = '';
+    started = false;
+  };
+  const endSegment = () => {
+    endToken();
+    if (tokens.length) segments.push(tokens);
+    tokens = [];
+  };
+
   for (let i = 0; i < command.length; i += 1) {
     const ch = command[i];
     if (quote) {
@@ -171,17 +198,22 @@ function tokenize(command) {
       started = true;
       continue;
     }
-    if (ch === ' ' || ch === '\t' || ch === '\n') {
-      if (current || started) tokens.push(current);
-      current = '';
-      started = false;
+    // UNQUOTED ONLY -- reaching here means the quote branches above did not.
+    if (ch === '|' || ch === ';' || ch === '&' || ch === '\n') {
+      endSegment();
+      // `||` and `&&` are one operator, not two empty segments.
+      while (i + 1 < command.length && command[i + 1] === ch) i += 1;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t') {
+      endToken();
       continue;
     }
     current += ch;
     started = true;
   }
-  if (current || started) tokens.push(current);
-  return tokens;
+  endSegment();
+  return segments;
 }
 
 /**
@@ -203,8 +235,7 @@ export function searchPatternFromCommand(command) {
   // the advisory is an optimisation that must never become the slow path.
   if (command.length > 4_000) return null;
 
-  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
-    const tokens = tokenize(segment.trim()).filter(Boolean);
+  for (const tokens of commandSegments(command)) {
     if (!tokens.length) continue;
     // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
     // leading `git` is: `git grep` is ordinary.

--- a/integrations/kilo/hooks/lib/audit.mjs
+++ b/integrations/kilo/hooks/lib/audit.mjs
@@ -78,9 +78,21 @@ export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
   const candidates = sum('candidates');
   const observations = sum('observations');
   const written = sum('written');
+  // THE SEARCH GAP RIDES HERE because a counter nobody reads is exactly the cost
+  // this note exists to prevent -- and because the number decides something: a
+  // locate detector is written and held unmerged until this says the gap is
+  // real. `named` is searches carrying an identifier, `gap` the subset the
+  // symbol index could not answer. Reported only once a search has been seen,
+  // so a project that never searches does not get a line of zeroes.
+  const named = sum('searchesNamed');
+  const gap = sum('searchGap');
+  const searchLine = named
+    ? ` ${gap.toLocaleString()} of ${named.toLocaleString()} named search(es) were ` +
+      'outside the symbol index.'
+    : '';
   return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
     `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
-    `across ${runs.length.toLocaleString()} Stop run(s).`;
+    `across ${runs.length.toLocaleString()} Stop run(s).${searchLine}`;
 }
 
 const idOf = (finding) =>

--- a/integrations/kilo/hooks/lib/derive.mjs
+++ b/integrations/kilo/hooks/lib/derive.mjs
@@ -49,6 +49,14 @@ import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
 import { load } from './wiki.mjs';
 import { ORIGIN_HARVESTED } from './curate.mjs';
+// Counting only -- see `searchGap` below. The SAME extractor the router advises
+// from, so what this counts as a search and what the advisory treats as one
+// cannot diverge.
+import {
+  identifiersIn,
+  searchPatternFromCommand,
+  symbolIndex,
+} from './advise.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -397,12 +405,56 @@ const storageBudget = () =>
  *   defaulting would promote any caller's string to trusted. Also returned, so a
  *   caller can see what it handed over.
  * @returns {object} `{ candidates, observations, written, selected, dropped,
- *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
- *   everything derived; `written` is the subset of keys the graph actually
- *   holds, which is smaller for three independent reasons -- the budget, the
- *   anchor discipline, and the duplicate collapse that returns an EXISTING key
- *   when a later session derives the same claim again.
+ *   selectedTokens, searchGap, sessionId, authoritativeSessionId }`.
+ *   `candidates` is everything derived; `written` is the subset of keys the
+ *   graph actually holds, which is smaller for three independent reasons -- the
+ *   budget, the anchor discipline, and the duplicate collapse that returns an
+ *   EXISTING key when a later session derives the same claim again.
  */
+
+/**
+ * How many searches this session ran that the symbol index could NOT answer.
+ *
+ * MEASUREMENT, NOT A FEATURE. A detector that turns these into findings is
+ * written and deliberately unmerged, because on the only workload we have
+ * measured it produces nothing: replayed against a real warm rep, all seven
+ * searches were for symbols the index already resolves --
+ * `compute_settlement_fee` three times, `def parse_line` once, and three terms
+ * with no identifier-shaped word at all. The search advisory answers every one
+ * of those directly, so storing them again would spend the retrieval budget
+ * restating a cheaper mechanism.
+ *
+ * The case that would justify the detector is a search for something the indexer
+ * never extracts -- a config key, an error string, a literal, a symbol in a file
+ * type it cannot parse. Eleven synthetic Python tasks cannot show whether that
+ * happens in real work. This counts it instead of guessing: `gap` is the number
+ * of searches carrying an identifier the index has no entry for, `named` the
+ * number carrying one at all. A `gap` that stays near zero says the detector
+ * should stay unmerged.
+ *
+ * Counting only. Nothing is stored, nothing is claimed, and it runs at session
+ * end where the cost is already paid.
+ */
+export function searchGap(dir, events) {
+  const out = { named: 0, gap: 0 };
+  try {
+    const index = symbolIndex(load(dir));
+    for (const event of events) {
+      if (!event || event.kind !== 'tool-outcome') continue;
+      if (event.success === false || event.surface !== 'command') continue;
+      const pattern = searchPatternFromCommand(event.anchor);
+      if (!pattern) continue;
+      const names = identifiersIn(pattern);
+      if (!names.length) continue;
+      out.named += 1;
+      if (!names.some((name) => index.has(name))) out.gap += 1;
+    }
+  } catch {
+    // A count is never worth failing a session for.
+  }
+  return out;
+}
+
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
   // `undefined`, so a caller passing an explicitly null options object -- which
@@ -431,6 +483,10 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // Measured, not stored. See `searchGap`: this decides whether the locate
+  // detector is worth merging, and nothing here acts on it.
+  result.searchGap = searchGap(dir, events);
 
   // ONE anchor for the whole run, so every candidate from this session points at
   // the same node and the duplicate collapse in `writeHarvested` can recognise

--- a/integrations/kilo/hooks/lib/doctor.mjs
+++ b/integrations/kilo/hooks/lib/doctor.mjs
@@ -523,6 +523,19 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
     // on the same session file, and the failure would be intermittent and
     // wrong-looking rather than loud. The concurrency win is taken in
     // diagnose(), across probes that share no state.
+    // ENFORCE IS ASKED FOR, NOT INHERITED -- for the same reason the capability
+    // evidence in `probe` is stated rather than inferred. The question this probe
+    // asks is "would enforcement fire if it were switched on", and policy.mjs#mode
+    // now defaults to `assist`, which never refuses (THOL and ledger measurement).
+    // Inheriting the default would make the probe report "not refused" on a
+    // perfectly healthy install: a false negative in the one tool whose job is to
+    // tell the user the truth.
+    //
+    // BOTH probes take it, not just the refusal one. "Small reads are left alone"
+    // is evidence of something only under a posture that COULD have refused;
+    // under assist it would pass against a hook that does nothing whatsoever,
+    // which is precisely the broken install it exists to catch.
+    const enforcing = { env: { TOKEN_OPTIMIZER_MODE: 'enforce' } };
     const denied = await probe(
       binary,
       {
@@ -530,13 +543,14 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: big },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     const deniedOk = typeof denied === 'string' && denied.includes('deny');
     checks.push(deniedOk
       ? ok('enforcement refuses a large read', 'the refusal came back from the real hook')
       : bad('enforcement refuses a large read', `hook returned: ${String(denied).slice(0, 200) || '(nothing)'}`,
-        'check TOKEN_OPTIMIZER_MODE is not "off" or "advise", then reinstall the hooks'));
+        'the probe asks for enforce explicitly, so a failure is the hook itself rather than your mode -- reinstall the hooks'));
 
     const allowed = await probe(
       binary,
@@ -545,7 +559,8 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: small },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     // `allowed === null` is "the probe never ran", NOT "the hook allowed it".
     // allow() writes nothing and exits 0, so '' is a legitimate allow -- but null

--- a/integrations/kilo/hooks/lib/policy.mjs
+++ b/integrations/kilo/hooks/lib/policy.mjs
@@ -10,9 +10,18 @@
  * listed in `/mcp`, and save nothing at all. The skill did not help: skills are
  * model-invoked, so it only loads if the model already decided it cared.
  *
- * The redesign inverts the default. Optimized tooling is the path of least
- * resistance: expensive built-in calls are DENIED with a message naming the
- * exact replacement to call. Everything here exists to make that safe.
+ * The redesign inverted the default so that optimized tooling was the path of
+ * least resistance: expensive built-in calls were DENIED with a message naming
+ * the exact replacement to call. Most of this module exists to make that safe.
+ *
+ * REFUSALS ARE NOW OPT-IN, because measurement did not support them. Two
+ * independent harnesses agree that enforcing is the worst posture we ship --
+ * THOL: enforce $23.33/score 0.935 against assist $20.48/0.971 and control
+ * $21.13/0.969, losing 12 of 17 tasks; ledger cold: enforce/advise 1.147
+ * [1.065, 1.235] while advise/assist-mcp is 1.028 [0.951, 1.114]. So the cost is
+ * the refusals themselves, not the routing advisory or retrieval, and the
+ * machinery below is retained and exercised rather than deleted: `enforce`
+ * remains one variable away for anyone who wants it. See `mode()`.
  *
  * FOUR SAFETY PROPERTIES, none of which are optional:
  *
@@ -27,7 +36,8 @@
  *      human intervention and no permanent breakage.
  *
  *   3. AN ESCAPE HATCH THAT IS ONE VARIABLE. TOKEN_OPTIMIZER_MODE=off disables
- *      everything; =advise restores the old non-blocking behaviour.
+ *      everything; =advise restores the old non-blocking behaviour; =enforce
+ *      turns refusals back on now that they are no longer the default.
  *
  *   4. NO BLOCKING OF CHEAP CALLS. Small files, paged reads, and searches that
  *      already read from a pipe cost little and are left alone. Blocking them
@@ -92,16 +102,40 @@ export function refusalsEnabled() {
 }
 
 /**
- * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
- * redesign. An unrecognised value falls back to enforce rather than silently
- * disabling, so a typo cannot quietly turn the product off.
+ * Reads the mode. ASSIST IS THE DEFAULT, on measurement.
+ *
+ * This said "Enforcement is the DEFAULT -- that is the entire point of the
+ * redesign". The redesign's point was to make the product pay for itself, and
+ * enforcement was the assumed way there rather than a measured one. Two
+ * independent harnesses now say it is the worst posture we ship:
+ *
+ *   THOL 2.1.251, 17 tasks x 3 reps x 3 arms, 153 runs, zero errors
+ *     control  $21.13  score 0.969  turns 16.2
+ *     assist   $20.48  score 0.971  turns 14.4   <- better on all three
+ *     enforce  $23.33  score 0.935  turns 17.6   <- worse on all three,
+ *                                                   losing 12 of 17 tasks
+ *   Ledger cold track
+ *     enforce/advise    1.147 [1.065, 1.235]  refusals cost 14.7%
+ *     advise/assist-mcp 1.028 [0.951, 1.114]  the advisory itself is free
+ *
+ * So the refusals are the whole cost: not the routing advisory, not retrieval.
+ * Enforce's worst tasks are the small cheap ones, where one refused turn is a
+ * large fraction of the total (code-bugfix-py 1.599, log-needle-zh 1.589).
+ * Shipping assist is worth ~12% cost and 3.6 score points against what users
+ * receive today.
+ *
+ * THE TYPO PROPERTY IS PRESERVED, which is what the old comment was really
+ * protecting. An unrecognised value still falls back to a posture with routing,
+ * retrieval, capture and harvest all ON -- `off` is the only value that exits
+ * the hook process, and it remains reachable only by asking for it exactly. A
+ * typo cannot quietly turn the product off; it can now only decline to refuse.
  */
 export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
-  if (raw === MODE_ASSIST) return MODE_ASSIST;
-  return MODE_ENFORCE;
+  if (raw === MODE_ENFORCE) return MODE_ENFORCE;
+  return MODE_ASSIST;
 }
 
 function intEnv(name, fallback) {

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -1222,6 +1222,12 @@ async function runHook(clientName, event, invocation) {
         candidates: derived.candidates.length,
         observations: derived.observations.length,
         written: derived.written.length,
+        // Whether a locate detector would have anything to catch: `named` is
+        // searches carrying an identifier, `gap` the subset the symbol index
+        // cannot answer. Recorded rather than acted on -- a `gap` that stays
+        // near zero says the detector written for it should stay unmerged.
+        searchesNamed: derived.searchGap?.named ?? 0,
+        searchGap: derived.searchGap?.gap ?? 0,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/integrations/opencode/hooks/lib/advise.mjs
+++ b/integrations/opencode/hooks/lib/advise.mjs
@@ -106,13 +106,39 @@ const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
  * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
  * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
  * it is one token, and the `=` test below skips it.
+ *
+ * THE COLOUR FLAGS ARE NOT HERE, because their arity is the one thing in this
+ * list that differs by program. See COLOR_TAKES_SEPARATE_VALUE.
  */
 const VALUED_FLAGS = new Set([
   '-e', '--regexp', '-f', '--file', '-m', '--max-count',
   '-A', '--after-context', '-B', '--before-context', '-C', '--context',
   '-d', '--directories', '-t', '--type', '-g', '--glob',
-  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+  '--include', '--exclude', '--exclude-dir',
 ]);
+
+/** The spellings of the colour option, across the programs handled here. */
+const COLOR_FLAGS = new Set(['--color', '--colour']);
+
+/**
+ * Programs whose colour flag takes a SEPARATE value token.
+ *
+ * The one option in this parser whose arity cannot be decided globally, and
+ * getting it wrong silently returns a path or a keyword as the search pattern:
+ *
+ *   grep --color needle file   GNU: the value is optional and inline-only, so
+ *                              `needle` is the pattern. Treating --color as
+ *                              valued consumed `needle` and returned `file`.
+ *   rg --color never needle .  ripgrep REQUIRES a separate WHEN, so `never` is
+ *                              the flag's value and `needle` is the pattern.
+ *                              Treating --color as valueless returns `never`.
+ *   ag --color needle .        a valueless toggle, like ack. Same failure as
+ *   ack --color needle .       grep: returned `.` instead of `needle`.
+ *
+ * So neither "always valued" nor "never valued" is correct, and the contract has
+ * to come from the program. Only ripgrep is in this set.
+ */
+const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
  * Splits a command into tokens, honouring quotes.
@@ -194,11 +220,17 @@ export function searchPatternFromCommand(command) {
     }
     if (!SEARCH_PROGRAMS.has(program)) continue;
 
+    // Whether a flag eats the next token, decided per program: only the colour
+    // option varies, and only ripgrep requires a separate value for it.
+    const consumesNext = (token) =>
+      VALUED_FLAGS.has(token) ||
+      (COLOR_FLAGS.has(token) && COLOR_TAKES_SEPARATE_VALUE.has(program));
+
     for (let i = at + 1; i < tokens.length; i += 1) {
       const token = tokens[i];
       // An explicit -e/--regexp names the pattern outright and wins over
       // position, which is the whole reason the flag exists.
-      if (VALUED_FLAGS.has(token)) {
+      if (consumesNext(token)) {
         if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
         i += 1;
         continue;

--- a/integrations/opencode/hooks/lib/advise.mjs
+++ b/integrations/opencode/hooks/lib/advise.mjs
@@ -81,6 +81,141 @@ const STOPWORDS = new Set([
   'except', 'raise', 'throw', 'new', 'int', 'str', 'bool', 'float',
 ]);
 
+/**
+ * Search programs whose first operand is a pattern.
+ *
+ * WHY THIS LIST EXISTS AT ALL. The advisory above answers a search from the
+ * index before it runs, and it was wired only to the `Grep` and `Glob` TOOLS.
+ * Measured on the warm benchmark, that is the wrong half of the surface: in the
+ * needle-in-repo runs the agent searched entirely through Bash --
+ *
+ *   Bash  grep -rn "compute_settlement_fee" /work --include=* 2>/dev/null | head -50
+ *   Bash  cat /work/pkg/mod_047.py
+ *   Edit  /work/pkg/mod_047.py
+ *
+ * -- zero Grep calls, zero Glob calls, and so zero advisories delivered, while
+ * the graph for that very session held
+ * `compute_settlement_fee -> pkg/mod_047.py:9-12` and returned it correctly to a
+ * direct call. Two turns were spent rediscovering a fact already indexed.
+ */
+const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
+
+/**
+ * Flags that consume the NEXT token, so its value is never the pattern.
+ *
+ * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
+ * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
+ * it is one token, and the `=` test below skips it.
+ */
+const VALUED_FLAGS = new Set([
+  '-e', '--regexp', '-f', '--file', '-m', '--max-count',
+  '-A', '--after-context', '-B', '--before-context', '-C', '--context',
+  '-d', '--directories', '-t', '--type', '-g', '--glob',
+  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+]);
+
+/**
+ * Splits a command into tokens, honouring quotes.
+ *
+ * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
+ * critical path against a string the model composed, which is the exact input
+ * class this repo keeps a linearity gate for; a single forward pass cannot
+ * backtrack at all.
+ */
+function tokenize(command) {
+  const tokens = [];
+  let current = '';
+  let quote = null;
+  let started = false;
+  for (let i = 0; i < command.length; i += 1) {
+    const ch = command[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (ch === '\\' && i + 1 < command.length) {
+      current += command[i + 1];
+      i += 1;
+      started = true;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t' || ch === '\n') {
+      if (current || started) tokens.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (current || started) tokens.push(current);
+  return tokens;
+}
+
+/**
+ * The pattern a shell search command is about to look for, or null.
+ *
+ * Splits on pipeline and sequencing operators first, because `cat x | grep foo`
+ * and `a && grep foo` both carry a search the graph may be able to answer, and
+ * the search is never the first segment there. `git grep foo` is handled by
+ * skipping a leading `git`, and `find . -name "*.py"` by reading the -name
+ * value: a glob yields no identifiers and so costs nothing, but
+ * `find . -name "compute_settlement*"` does.
+ *
+ * Returns the raw pattern rather than identifiers, so the caller hands it to the
+ * same `adviseSearch` the Grep tool path uses and the two surfaces cannot drift.
+ */
+export function searchPatternFromCommand(command) {
+  if (typeof command !== 'string' || !command) return null;
+  // Bounded before any work: a pathological command is not worth parsing, and
+  // the advisory is an optimisation that must never become the slow path.
+  if (command.length > 4_000) return null;
+
+  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
+    const tokens = tokenize(segment.trim()).filter(Boolean);
+    if (!tokens.length) continue;
+    // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
+    // leading `git` is: `git grep` is ordinary.
+    let at = 0;
+    if (tokens[at] === 'git') at += 1;
+    const program = String(tokens[at] || '').split(/[/\\]/).pop();
+
+    if (program === 'find') {
+      for (let i = at + 1; i < tokens.length - 1; i += 1) {
+        if (tokens[i] === '-name' || tokens[i] === '-iname') return tokens[i + 1];
+      }
+      continue;
+    }
+    if (!SEARCH_PROGRAMS.has(program)) continue;
+
+    for (let i = at + 1; i < tokens.length; i += 1) {
+      const token = tokens[i];
+      // An explicit -e/--regexp names the pattern outright and wins over
+      // position, which is the whole reason the flag exists.
+      if (VALUED_FLAGS.has(token)) {
+        if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
+        i += 1;
+        continue;
+      }
+      if (token.startsWith('--') && token.includes('=')) {
+        const [name, ...rest] = token.split('=');
+        if (name === '--regexp') return rest.join('=') || null;
+        continue;
+      }
+      if (token.startsWith('-') && token.length > 1) continue;
+      // The first bare operand is the pattern; everything after it is a path.
+      return token || null;
+    }
+  }
+  return null;
+}
+
 /** Symbol nodes grouped by name, for one lookup per identifier. */
 export function symbolIndex(graph) {
   const byName = new Map();

--- a/integrations/opencode/hooks/lib/advise.mjs
+++ b/integrations/opencode/hooks/lib/advise.mjs
@@ -141,18 +141,45 @@ const COLOR_FLAGS = new Set(['--color', '--colour']);
 const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
- * Splits a command into tokens, honouring quotes.
+ * Splits a command into segments of tokens, honouring quotes and escapes.
+ *
+ * SEGMENTING AND TOKENIZING ARE ONE PASS, and they have to be. Splitting the raw
+ * string on `|`, `&&` and `;` before tokenizing cut straight through quoted
+ * text, so a perfectly ordinary alternation lost everything after the first
+ * branch:
+ *
+ *   grep -E "foo|bar" .   returned `foo`   -- `bar` never reached adviseSearch
+ *   rg "a;b" .            returned `a`
+ *   grep "x&&y" .         returned `x`
+ *
+ * A quote-aware scan cannot make that mistake, because an operator inside a
+ * quoted run is just a character. Pipelines still split, which is what lets
+ * `cat x | grep foo` be recognised at all -- the search is never the first
+ * segment there.
  *
  * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
  * critical path against a string the model composed, which is the exact input
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function tokenize(command) {
-  const tokens = [];
+function commandSegments(command) {
+  const segments = [];
+  let tokens = [];
   let current = '';
   let quote = null;
   let started = false;
+
+  const endToken = () => {
+    if (current || started) tokens.push(current);
+    current = '';
+    started = false;
+  };
+  const endSegment = () => {
+    endToken();
+    if (tokens.length) segments.push(tokens);
+    tokens = [];
+  };
+
   for (let i = 0; i < command.length; i += 1) {
     const ch = command[i];
     if (quote) {
@@ -171,17 +198,22 @@ function tokenize(command) {
       started = true;
       continue;
     }
-    if (ch === ' ' || ch === '\t' || ch === '\n') {
-      if (current || started) tokens.push(current);
-      current = '';
-      started = false;
+    // UNQUOTED ONLY -- reaching here means the quote branches above did not.
+    if (ch === '|' || ch === ';' || ch === '&' || ch === '\n') {
+      endSegment();
+      // `||` and `&&` are one operator, not two empty segments.
+      while (i + 1 < command.length && command[i + 1] === ch) i += 1;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t') {
+      endToken();
       continue;
     }
     current += ch;
     started = true;
   }
-  if (current || started) tokens.push(current);
-  return tokens;
+  endSegment();
+  return segments;
 }
 
 /**
@@ -203,8 +235,7 @@ export function searchPatternFromCommand(command) {
   // the advisory is an optimisation that must never become the slow path.
   if (command.length > 4_000) return null;
 
-  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
-    const tokens = tokenize(segment.trim()).filter(Boolean);
+  for (const tokens of commandSegments(command)) {
     if (!tokens.length) continue;
     // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
     // leading `git` is: `git grep` is ordinary.

--- a/integrations/opencode/hooks/lib/audit.mjs
+++ b/integrations/opencode/hooks/lib/audit.mjs
@@ -78,9 +78,21 @@ export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
   const candidates = sum('candidates');
   const observations = sum('observations');
   const written = sum('written');
+  // THE SEARCH GAP RIDES HERE because a counter nobody reads is exactly the cost
+  // this note exists to prevent -- and because the number decides something: a
+  // locate detector is written and held unmerged until this says the gap is
+  // real. `named` is searches carrying an identifier, `gap` the subset the
+  // symbol index could not answer. Reported only once a search has been seen,
+  // so a project that never searches does not get a line of zeroes.
+  const named = sum('searchesNamed');
+  const gap = sum('searchGap');
+  const searchLine = named
+    ? ` ${gap.toLocaleString()} of ${named.toLocaleString()} named search(es) were ` +
+      'outside the symbol index.'
+    : '';
   return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
     `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
-    `across ${runs.length.toLocaleString()} Stop run(s).`;
+    `across ${runs.length.toLocaleString()} Stop run(s).${searchLine}`;
 }
 
 const idOf = (finding) =>

--- a/integrations/opencode/hooks/lib/derive.mjs
+++ b/integrations/opencode/hooks/lib/derive.mjs
@@ -49,6 +49,14 @@ import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
 import { load } from './wiki.mjs';
 import { ORIGIN_HARVESTED } from './curate.mjs';
+// Counting only -- see `searchGap` below. The SAME extractor the router advises
+// from, so what this counts as a search and what the advisory treats as one
+// cannot diverge.
+import {
+  identifiersIn,
+  searchPatternFromCommand,
+  symbolIndex,
+} from './advise.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -397,12 +405,56 @@ const storageBudget = () =>
  *   defaulting would promote any caller's string to trusted. Also returned, so a
  *   caller can see what it handed over.
  * @returns {object} `{ candidates, observations, written, selected, dropped,
- *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
- *   everything derived; `written` is the subset of keys the graph actually
- *   holds, which is smaller for three independent reasons -- the budget, the
- *   anchor discipline, and the duplicate collapse that returns an EXISTING key
- *   when a later session derives the same claim again.
+ *   selectedTokens, searchGap, sessionId, authoritativeSessionId }`.
+ *   `candidates` is everything derived; `written` is the subset of keys the
+ *   graph actually holds, which is smaller for three independent reasons -- the
+ *   budget, the anchor discipline, and the duplicate collapse that returns an
+ *   EXISTING key when a later session derives the same claim again.
  */
+
+/**
+ * How many searches this session ran that the symbol index could NOT answer.
+ *
+ * MEASUREMENT, NOT A FEATURE. A detector that turns these into findings is
+ * written and deliberately unmerged, because on the only workload we have
+ * measured it produces nothing: replayed against a real warm rep, all seven
+ * searches were for symbols the index already resolves --
+ * `compute_settlement_fee` three times, `def parse_line` once, and three terms
+ * with no identifier-shaped word at all. The search advisory answers every one
+ * of those directly, so storing them again would spend the retrieval budget
+ * restating a cheaper mechanism.
+ *
+ * The case that would justify the detector is a search for something the indexer
+ * never extracts -- a config key, an error string, a literal, a symbol in a file
+ * type it cannot parse. Eleven synthetic Python tasks cannot show whether that
+ * happens in real work. This counts it instead of guessing: `gap` is the number
+ * of searches carrying an identifier the index has no entry for, `named` the
+ * number carrying one at all. A `gap` that stays near zero says the detector
+ * should stay unmerged.
+ *
+ * Counting only. Nothing is stored, nothing is claimed, and it runs at session
+ * end where the cost is already paid.
+ */
+export function searchGap(dir, events) {
+  const out = { named: 0, gap: 0 };
+  try {
+    const index = symbolIndex(load(dir));
+    for (const event of events) {
+      if (!event || event.kind !== 'tool-outcome') continue;
+      if (event.success === false || event.surface !== 'command') continue;
+      const pattern = searchPatternFromCommand(event.anchor);
+      if (!pattern) continue;
+      const names = identifiersIn(pattern);
+      if (!names.length) continue;
+      out.named += 1;
+      if (!names.some((name) => index.has(name))) out.gap += 1;
+    }
+  } catch {
+    // A count is never worth failing a session for.
+  }
+  return out;
+}
+
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
   // `undefined`, so a caller passing an explicitly null options object -- which
@@ -431,6 +483,10 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // Measured, not stored. See `searchGap`: this decides whether the locate
+  // detector is worth merging, and nothing here acts on it.
+  result.searchGap = searchGap(dir, events);
 
   // ONE anchor for the whole run, so every candidate from this session points at
   // the same node and the duplicate collapse in `writeHarvested` can recognise

--- a/integrations/opencode/hooks/lib/doctor.mjs
+++ b/integrations/opencode/hooks/lib/doctor.mjs
@@ -523,6 +523,19 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
     // on the same session file, and the failure would be intermittent and
     // wrong-looking rather than loud. The concurrency win is taken in
     // diagnose(), across probes that share no state.
+    // ENFORCE IS ASKED FOR, NOT INHERITED -- for the same reason the capability
+    // evidence in `probe` is stated rather than inferred. The question this probe
+    // asks is "would enforcement fire if it were switched on", and policy.mjs#mode
+    // now defaults to `assist`, which never refuses (THOL and ledger measurement).
+    // Inheriting the default would make the probe report "not refused" on a
+    // perfectly healthy install: a false negative in the one tool whose job is to
+    // tell the user the truth.
+    //
+    // BOTH probes take it, not just the refusal one. "Small reads are left alone"
+    // is evidence of something only under a posture that COULD have refused;
+    // under assist it would pass against a hook that does nothing whatsoever,
+    // which is precisely the broken install it exists to catch.
+    const enforcing = { env: { TOKEN_OPTIMIZER_MODE: 'enforce' } };
     const denied = await probe(
       binary,
       {
@@ -530,13 +543,14 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: big },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     const deniedOk = typeof denied === 'string' && denied.includes('deny');
     checks.push(deniedOk
       ? ok('enforcement refuses a large read', 'the refusal came back from the real hook')
       : bad('enforcement refuses a large read', `hook returned: ${String(denied).slice(0, 200) || '(nothing)'}`,
-        'check TOKEN_OPTIMIZER_MODE is not "off" or "advise", then reinstall the hooks'));
+        'the probe asks for enforce explicitly, so a failure is the hook itself rather than your mode -- reinstall the hooks'));
 
     const allowed = await probe(
       binary,
@@ -545,7 +559,8 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: small },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     // `allowed === null` is "the probe never ran", NOT "the hook allowed it".
     // allow() writes nothing and exits 0, so '' is a legitimate allow -- but null

--- a/integrations/opencode/hooks/lib/policy.mjs
+++ b/integrations/opencode/hooks/lib/policy.mjs
@@ -10,9 +10,18 @@
  * listed in `/mcp`, and save nothing at all. The skill did not help: skills are
  * model-invoked, so it only loads if the model already decided it cared.
  *
- * The redesign inverts the default. Optimized tooling is the path of least
- * resistance: expensive built-in calls are DENIED with a message naming the
- * exact replacement to call. Everything here exists to make that safe.
+ * The redesign inverted the default so that optimized tooling was the path of
+ * least resistance: expensive built-in calls were DENIED with a message naming
+ * the exact replacement to call. Most of this module exists to make that safe.
+ *
+ * REFUSALS ARE NOW OPT-IN, because measurement did not support them. Two
+ * independent harnesses agree that enforcing is the worst posture we ship --
+ * THOL: enforce $23.33/score 0.935 against assist $20.48/0.971 and control
+ * $21.13/0.969, losing 12 of 17 tasks; ledger cold: enforce/advise 1.147
+ * [1.065, 1.235] while advise/assist-mcp is 1.028 [0.951, 1.114]. So the cost is
+ * the refusals themselves, not the routing advisory or retrieval, and the
+ * machinery below is retained and exercised rather than deleted: `enforce`
+ * remains one variable away for anyone who wants it. See `mode()`.
  *
  * FOUR SAFETY PROPERTIES, none of which are optional:
  *
@@ -27,7 +36,8 @@
  *      human intervention and no permanent breakage.
  *
  *   3. AN ESCAPE HATCH THAT IS ONE VARIABLE. TOKEN_OPTIMIZER_MODE=off disables
- *      everything; =advise restores the old non-blocking behaviour.
+ *      everything; =advise restores the old non-blocking behaviour; =enforce
+ *      turns refusals back on now that they are no longer the default.
  *
  *   4. NO BLOCKING OF CHEAP CALLS. Small files, paged reads, and searches that
  *      already read from a pipe cost little and are left alone. Blocking them
@@ -92,16 +102,40 @@ export function refusalsEnabled() {
 }
 
 /**
- * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
- * redesign. An unrecognised value falls back to enforce rather than silently
- * disabling, so a typo cannot quietly turn the product off.
+ * Reads the mode. ASSIST IS THE DEFAULT, on measurement.
+ *
+ * This said "Enforcement is the DEFAULT -- that is the entire point of the
+ * redesign". The redesign's point was to make the product pay for itself, and
+ * enforcement was the assumed way there rather than a measured one. Two
+ * independent harnesses now say it is the worst posture we ship:
+ *
+ *   THOL 2.1.251, 17 tasks x 3 reps x 3 arms, 153 runs, zero errors
+ *     control  $21.13  score 0.969  turns 16.2
+ *     assist   $20.48  score 0.971  turns 14.4   <- better on all three
+ *     enforce  $23.33  score 0.935  turns 17.6   <- worse on all three,
+ *                                                   losing 12 of 17 tasks
+ *   Ledger cold track
+ *     enforce/advise    1.147 [1.065, 1.235]  refusals cost 14.7%
+ *     advise/assist-mcp 1.028 [0.951, 1.114]  the advisory itself is free
+ *
+ * So the refusals are the whole cost: not the routing advisory, not retrieval.
+ * Enforce's worst tasks are the small cheap ones, where one refused turn is a
+ * large fraction of the total (code-bugfix-py 1.599, log-needle-zh 1.589).
+ * Shipping assist is worth ~12% cost and 3.6 score points against what users
+ * receive today.
+ *
+ * THE TYPO PROPERTY IS PRESERVED, which is what the old comment was really
+ * protecting. An unrecognised value still falls back to a posture with routing,
+ * retrieval, capture and harvest all ON -- `off` is the only value that exits
+ * the hook process, and it remains reachable only by asking for it exactly. A
+ * typo cannot quietly turn the product off; it can now only decline to refuse.
  */
 export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
-  if (raw === MODE_ASSIST) return MODE_ASSIST;
-  return MODE_ENFORCE;
+  if (raw === MODE_ENFORCE) return MODE_ENFORCE;
+  return MODE_ASSIST;
 }
 
 function intEnv(name, fallback) {

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -1222,6 +1222,12 @@ async function runHook(clientName, event, invocation) {
         candidates: derived.candidates.length,
         observations: derived.observations.length,
         written: derived.written.length,
+        // Whether a locate detector would have anything to catch: `named` is
+        // searches carrying an identifier, `gap` the subset the symbol index
+        // cannot answer. Recorded rather than acted on -- a `gap` that stays
+        // near zero says the detector written for it should stay unmerged.
+        searchesNamed: derived.searchGap?.named ?? 0,
+        searchGap: derived.searchGap?.gap ?? 0,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/integrations/qwen/hooks/lib/advise.mjs
+++ b/integrations/qwen/hooks/lib/advise.mjs
@@ -106,13 +106,39 @@ const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
  * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
  * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
  * it is one token, and the `=` test below skips it.
+ *
+ * THE COLOUR FLAGS ARE NOT HERE, because their arity is the one thing in this
+ * list that differs by program. See COLOR_TAKES_SEPARATE_VALUE.
  */
 const VALUED_FLAGS = new Set([
   '-e', '--regexp', '-f', '--file', '-m', '--max-count',
   '-A', '--after-context', '-B', '--before-context', '-C', '--context',
   '-d', '--directories', '-t', '--type', '-g', '--glob',
-  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+  '--include', '--exclude', '--exclude-dir',
 ]);
+
+/** The spellings of the colour option, across the programs handled here. */
+const COLOR_FLAGS = new Set(['--color', '--colour']);
+
+/**
+ * Programs whose colour flag takes a SEPARATE value token.
+ *
+ * The one option in this parser whose arity cannot be decided globally, and
+ * getting it wrong silently returns a path or a keyword as the search pattern:
+ *
+ *   grep --color needle file   GNU: the value is optional and inline-only, so
+ *                              `needle` is the pattern. Treating --color as
+ *                              valued consumed `needle` and returned `file`.
+ *   rg --color never needle .  ripgrep REQUIRES a separate WHEN, so `never` is
+ *                              the flag's value and `needle` is the pattern.
+ *                              Treating --color as valueless returns `never`.
+ *   ag --color needle .        a valueless toggle, like ack. Same failure as
+ *   ack --color needle .       grep: returned `.` instead of `needle`.
+ *
+ * So neither "always valued" nor "never valued" is correct, and the contract has
+ * to come from the program. Only ripgrep is in this set.
+ */
+const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
  * Splits a command into tokens, honouring quotes.
@@ -194,11 +220,17 @@ export function searchPatternFromCommand(command) {
     }
     if (!SEARCH_PROGRAMS.has(program)) continue;
 
+    // Whether a flag eats the next token, decided per program: only the colour
+    // option varies, and only ripgrep requires a separate value for it.
+    const consumesNext = (token) =>
+      VALUED_FLAGS.has(token) ||
+      (COLOR_FLAGS.has(token) && COLOR_TAKES_SEPARATE_VALUE.has(program));
+
     for (let i = at + 1; i < tokens.length; i += 1) {
       const token = tokens[i];
       // An explicit -e/--regexp names the pattern outright and wins over
       // position, which is the whole reason the flag exists.
-      if (VALUED_FLAGS.has(token)) {
+      if (consumesNext(token)) {
         if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
         i += 1;
         continue;

--- a/integrations/qwen/hooks/lib/advise.mjs
+++ b/integrations/qwen/hooks/lib/advise.mjs
@@ -81,6 +81,141 @@ const STOPWORDS = new Set([
   'except', 'raise', 'throw', 'new', 'int', 'str', 'bool', 'float',
 ]);
 
+/**
+ * Search programs whose first operand is a pattern.
+ *
+ * WHY THIS LIST EXISTS AT ALL. The advisory above answers a search from the
+ * index before it runs, and it was wired only to the `Grep` and `Glob` TOOLS.
+ * Measured on the warm benchmark, that is the wrong half of the surface: in the
+ * needle-in-repo runs the agent searched entirely through Bash --
+ *
+ *   Bash  grep -rn "compute_settlement_fee" /work --include=* 2>/dev/null | head -50
+ *   Bash  cat /work/pkg/mod_047.py
+ *   Edit  /work/pkg/mod_047.py
+ *
+ * -- zero Grep calls, zero Glob calls, and so zero advisories delivered, while
+ * the graph for that very session held
+ * `compute_settlement_fee -> pkg/mod_047.py:9-12` and returned it correctly to a
+ * direct call. Two turns were spent rediscovering a fact already indexed.
+ */
+const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
+
+/**
+ * Flags that consume the NEXT token, so its value is never the pattern.
+ *
+ * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
+ * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
+ * it is one token, and the `=` test below skips it.
+ */
+const VALUED_FLAGS = new Set([
+  '-e', '--regexp', '-f', '--file', '-m', '--max-count',
+  '-A', '--after-context', '-B', '--before-context', '-C', '--context',
+  '-d', '--directories', '-t', '--type', '-g', '--glob',
+  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+]);
+
+/**
+ * Splits a command into tokens, honouring quotes.
+ *
+ * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
+ * critical path against a string the model composed, which is the exact input
+ * class this repo keeps a linearity gate for; a single forward pass cannot
+ * backtrack at all.
+ */
+function tokenize(command) {
+  const tokens = [];
+  let current = '';
+  let quote = null;
+  let started = false;
+  for (let i = 0; i < command.length; i += 1) {
+    const ch = command[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (ch === '\\' && i + 1 < command.length) {
+      current += command[i + 1];
+      i += 1;
+      started = true;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t' || ch === '\n') {
+      if (current || started) tokens.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (current || started) tokens.push(current);
+  return tokens;
+}
+
+/**
+ * The pattern a shell search command is about to look for, or null.
+ *
+ * Splits on pipeline and sequencing operators first, because `cat x | grep foo`
+ * and `a && grep foo` both carry a search the graph may be able to answer, and
+ * the search is never the first segment there. `git grep foo` is handled by
+ * skipping a leading `git`, and `find . -name "*.py"` by reading the -name
+ * value: a glob yields no identifiers and so costs nothing, but
+ * `find . -name "compute_settlement*"` does.
+ *
+ * Returns the raw pattern rather than identifiers, so the caller hands it to the
+ * same `adviseSearch` the Grep tool path uses and the two surfaces cannot drift.
+ */
+export function searchPatternFromCommand(command) {
+  if (typeof command !== 'string' || !command) return null;
+  // Bounded before any work: a pathological command is not worth parsing, and
+  // the advisory is an optimisation that must never become the slow path.
+  if (command.length > 4_000) return null;
+
+  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
+    const tokens = tokenize(segment.trim()).filter(Boolean);
+    if (!tokens.length) continue;
+    // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
+    // leading `git` is: `git grep` is ordinary.
+    let at = 0;
+    if (tokens[at] === 'git') at += 1;
+    const program = String(tokens[at] || '').split(/[/\\]/).pop();
+
+    if (program === 'find') {
+      for (let i = at + 1; i < tokens.length - 1; i += 1) {
+        if (tokens[i] === '-name' || tokens[i] === '-iname') return tokens[i + 1];
+      }
+      continue;
+    }
+    if (!SEARCH_PROGRAMS.has(program)) continue;
+
+    for (let i = at + 1; i < tokens.length; i += 1) {
+      const token = tokens[i];
+      // An explicit -e/--regexp names the pattern outright and wins over
+      // position, which is the whole reason the flag exists.
+      if (VALUED_FLAGS.has(token)) {
+        if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
+        i += 1;
+        continue;
+      }
+      if (token.startsWith('--') && token.includes('=')) {
+        const [name, ...rest] = token.split('=');
+        if (name === '--regexp') return rest.join('=') || null;
+        continue;
+      }
+      if (token.startsWith('-') && token.length > 1) continue;
+      // The first bare operand is the pattern; everything after it is a path.
+      return token || null;
+    }
+  }
+  return null;
+}
+
 /** Symbol nodes grouped by name, for one lookup per identifier. */
 export function symbolIndex(graph) {
   const byName = new Map();

--- a/integrations/qwen/hooks/lib/advise.mjs
+++ b/integrations/qwen/hooks/lib/advise.mjs
@@ -141,18 +141,45 @@ const COLOR_FLAGS = new Set(['--color', '--colour']);
 const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
- * Splits a command into tokens, honouring quotes.
+ * Splits a command into segments of tokens, honouring quotes and escapes.
+ *
+ * SEGMENTING AND TOKENIZING ARE ONE PASS, and they have to be. Splitting the raw
+ * string on `|`, `&&` and `;` before tokenizing cut straight through quoted
+ * text, so a perfectly ordinary alternation lost everything after the first
+ * branch:
+ *
+ *   grep -E "foo|bar" .   returned `foo`   -- `bar` never reached adviseSearch
+ *   rg "a;b" .            returned `a`
+ *   grep "x&&y" .         returned `x`
+ *
+ * A quote-aware scan cannot make that mistake, because an operator inside a
+ * quoted run is just a character. Pipelines still split, which is what lets
+ * `cat x | grep foo` be recognised at all -- the search is never the first
+ * segment there.
  *
  * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
  * critical path against a string the model composed, which is the exact input
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function tokenize(command) {
-  const tokens = [];
+function commandSegments(command) {
+  const segments = [];
+  let tokens = [];
   let current = '';
   let quote = null;
   let started = false;
+
+  const endToken = () => {
+    if (current || started) tokens.push(current);
+    current = '';
+    started = false;
+  };
+  const endSegment = () => {
+    endToken();
+    if (tokens.length) segments.push(tokens);
+    tokens = [];
+  };
+
   for (let i = 0; i < command.length; i += 1) {
     const ch = command[i];
     if (quote) {
@@ -171,17 +198,22 @@ function tokenize(command) {
       started = true;
       continue;
     }
-    if (ch === ' ' || ch === '\t' || ch === '\n') {
-      if (current || started) tokens.push(current);
-      current = '';
-      started = false;
+    // UNQUOTED ONLY -- reaching here means the quote branches above did not.
+    if (ch === '|' || ch === ';' || ch === '&' || ch === '\n') {
+      endSegment();
+      // `||` and `&&` are one operator, not two empty segments.
+      while (i + 1 < command.length && command[i + 1] === ch) i += 1;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t') {
+      endToken();
       continue;
     }
     current += ch;
     started = true;
   }
-  if (current || started) tokens.push(current);
-  return tokens;
+  endSegment();
+  return segments;
 }
 
 /**
@@ -203,8 +235,7 @@ export function searchPatternFromCommand(command) {
   // the advisory is an optimisation that must never become the slow path.
   if (command.length > 4_000) return null;
 
-  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
-    const tokens = tokenize(segment.trim()).filter(Boolean);
+  for (const tokens of commandSegments(command)) {
     if (!tokens.length) continue;
     // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
     // leading `git` is: `git grep` is ordinary.

--- a/integrations/qwen/hooks/lib/audit.mjs
+++ b/integrations/qwen/hooks/lib/audit.mjs
@@ -78,9 +78,21 @@ export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
   const candidates = sum('candidates');
   const observations = sum('observations');
   const written = sum('written');
+  // THE SEARCH GAP RIDES HERE because a counter nobody reads is exactly the cost
+  // this note exists to prevent -- and because the number decides something: a
+  // locate detector is written and held unmerged until this says the gap is
+  // real. `named` is searches carrying an identifier, `gap` the subset the
+  // symbol index could not answer. Reported only once a search has been seen,
+  // so a project that never searches does not get a line of zeroes.
+  const named = sum('searchesNamed');
+  const gap = sum('searchGap');
+  const searchLine = named
+    ? ` ${gap.toLocaleString()} of ${named.toLocaleString()} named search(es) were ` +
+      'outside the symbol index.'
+    : '';
   return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
     `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
-    `across ${runs.length.toLocaleString()} Stop run(s).`;
+    `across ${runs.length.toLocaleString()} Stop run(s).${searchLine}`;
 }
 
 const idOf = (finding) =>

--- a/integrations/qwen/hooks/lib/derive.mjs
+++ b/integrations/qwen/hooks/lib/derive.mjs
@@ -49,6 +49,14 @@ import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
 import { load } from './wiki.mjs';
 import { ORIGIN_HARVESTED } from './curate.mjs';
+// Counting only -- see `searchGap` below. The SAME extractor the router advises
+// from, so what this counts as a search and what the advisory treats as one
+// cannot diverge.
+import {
+  identifiersIn,
+  searchPatternFromCommand,
+  symbolIndex,
+} from './advise.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -397,12 +405,56 @@ const storageBudget = () =>
  *   defaulting would promote any caller's string to trusted. Also returned, so a
  *   caller can see what it handed over.
  * @returns {object} `{ candidates, observations, written, selected, dropped,
- *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
- *   everything derived; `written` is the subset of keys the graph actually
- *   holds, which is smaller for three independent reasons -- the budget, the
- *   anchor discipline, and the duplicate collapse that returns an EXISTING key
- *   when a later session derives the same claim again.
+ *   selectedTokens, searchGap, sessionId, authoritativeSessionId }`.
+ *   `candidates` is everything derived; `written` is the subset of keys the
+ *   graph actually holds, which is smaller for three independent reasons -- the
+ *   budget, the anchor discipline, and the duplicate collapse that returns an
+ *   EXISTING key when a later session derives the same claim again.
  */
+
+/**
+ * How many searches this session ran that the symbol index could NOT answer.
+ *
+ * MEASUREMENT, NOT A FEATURE. A detector that turns these into findings is
+ * written and deliberately unmerged, because on the only workload we have
+ * measured it produces nothing: replayed against a real warm rep, all seven
+ * searches were for symbols the index already resolves --
+ * `compute_settlement_fee` three times, `def parse_line` once, and three terms
+ * with no identifier-shaped word at all. The search advisory answers every one
+ * of those directly, so storing them again would spend the retrieval budget
+ * restating a cheaper mechanism.
+ *
+ * The case that would justify the detector is a search for something the indexer
+ * never extracts -- a config key, an error string, a literal, a symbol in a file
+ * type it cannot parse. Eleven synthetic Python tasks cannot show whether that
+ * happens in real work. This counts it instead of guessing: `gap` is the number
+ * of searches carrying an identifier the index has no entry for, `named` the
+ * number carrying one at all. A `gap` that stays near zero says the detector
+ * should stay unmerged.
+ *
+ * Counting only. Nothing is stored, nothing is claimed, and it runs at session
+ * end where the cost is already paid.
+ */
+export function searchGap(dir, events) {
+  const out = { named: 0, gap: 0 };
+  try {
+    const index = symbolIndex(load(dir));
+    for (const event of events) {
+      if (!event || event.kind !== 'tool-outcome') continue;
+      if (event.success === false || event.surface !== 'command') continue;
+      const pattern = searchPatternFromCommand(event.anchor);
+      if (!pattern) continue;
+      const names = identifiersIn(pattern);
+      if (!names.length) continue;
+      out.named += 1;
+      if (!names.some((name) => index.has(name))) out.gap += 1;
+    }
+  } catch {
+    // A count is never worth failing a session for.
+  }
+  return out;
+}
+
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
   // `undefined`, so a caller passing an explicitly null options object -- which
@@ -431,6 +483,10 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // Measured, not stored. See `searchGap`: this decides whether the locate
+  // detector is worth merging, and nothing here acts on it.
+  result.searchGap = searchGap(dir, events);
 
   // ONE anchor for the whole run, so every candidate from this session points at
   // the same node and the duplicate collapse in `writeHarvested` can recognise

--- a/integrations/qwen/hooks/lib/doctor.mjs
+++ b/integrations/qwen/hooks/lib/doctor.mjs
@@ -523,6 +523,19 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
     // on the same session file, and the failure would be intermittent and
     // wrong-looking rather than loud. The concurrency win is taken in
     // diagnose(), across probes that share no state.
+    // ENFORCE IS ASKED FOR, NOT INHERITED -- for the same reason the capability
+    // evidence in `probe` is stated rather than inferred. The question this probe
+    // asks is "would enforcement fire if it were switched on", and policy.mjs#mode
+    // now defaults to `assist`, which never refuses (THOL and ledger measurement).
+    // Inheriting the default would make the probe report "not refused" on a
+    // perfectly healthy install: a false negative in the one tool whose job is to
+    // tell the user the truth.
+    //
+    // BOTH probes take it, not just the refusal one. "Small reads are left alone"
+    // is evidence of something only under a posture that COULD have refused;
+    // under assist it would pass against a hook that does nothing whatsoever,
+    // which is precisely the broken install it exists to catch.
+    const enforcing = { env: { TOKEN_OPTIMIZER_MODE: 'enforce' } };
     const denied = await probe(
       binary,
       {
@@ -530,13 +543,14 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: big },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     const deniedOk = typeof denied === 'string' && denied.includes('deny');
     checks.push(deniedOk
       ? ok('enforcement refuses a large read', 'the refusal came back from the real hook')
       : bad('enforcement refuses a large read', `hook returned: ${String(denied).slice(0, 200) || '(nothing)'}`,
-        'check TOKEN_OPTIMIZER_MODE is not "off" or "advise", then reinstall the hooks'));
+        'the probe asks for enforce explicitly, so a failure is the hook itself rather than your mode -- reinstall the hooks'));
 
     const allowed = await probe(
       binary,
@@ -545,7 +559,8 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: small },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     // `allowed === null` is "the probe never ran", NOT "the hook allowed it".
     // allow() writes nothing and exits 0, so '' is a legitimate allow -- but null

--- a/integrations/qwen/hooks/lib/policy.mjs
+++ b/integrations/qwen/hooks/lib/policy.mjs
@@ -10,9 +10,18 @@
  * listed in `/mcp`, and save nothing at all. The skill did not help: skills are
  * model-invoked, so it only loads if the model already decided it cared.
  *
- * The redesign inverts the default. Optimized tooling is the path of least
- * resistance: expensive built-in calls are DENIED with a message naming the
- * exact replacement to call. Everything here exists to make that safe.
+ * The redesign inverted the default so that optimized tooling was the path of
+ * least resistance: expensive built-in calls were DENIED with a message naming
+ * the exact replacement to call. Most of this module exists to make that safe.
+ *
+ * REFUSALS ARE NOW OPT-IN, because measurement did not support them. Two
+ * independent harnesses agree that enforcing is the worst posture we ship --
+ * THOL: enforce $23.33/score 0.935 against assist $20.48/0.971 and control
+ * $21.13/0.969, losing 12 of 17 tasks; ledger cold: enforce/advise 1.147
+ * [1.065, 1.235] while advise/assist-mcp is 1.028 [0.951, 1.114]. So the cost is
+ * the refusals themselves, not the routing advisory or retrieval, and the
+ * machinery below is retained and exercised rather than deleted: `enforce`
+ * remains one variable away for anyone who wants it. See `mode()`.
  *
  * FOUR SAFETY PROPERTIES, none of which are optional:
  *
@@ -27,7 +36,8 @@
  *      human intervention and no permanent breakage.
  *
  *   3. AN ESCAPE HATCH THAT IS ONE VARIABLE. TOKEN_OPTIMIZER_MODE=off disables
- *      everything; =advise restores the old non-blocking behaviour.
+ *      everything; =advise restores the old non-blocking behaviour; =enforce
+ *      turns refusals back on now that they are no longer the default.
  *
  *   4. NO BLOCKING OF CHEAP CALLS. Small files, paged reads, and searches that
  *      already read from a pipe cost little and are left alone. Blocking them
@@ -92,16 +102,40 @@ export function refusalsEnabled() {
 }
 
 /**
- * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
- * redesign. An unrecognised value falls back to enforce rather than silently
- * disabling, so a typo cannot quietly turn the product off.
+ * Reads the mode. ASSIST IS THE DEFAULT, on measurement.
+ *
+ * This said "Enforcement is the DEFAULT -- that is the entire point of the
+ * redesign". The redesign's point was to make the product pay for itself, and
+ * enforcement was the assumed way there rather than a measured one. Two
+ * independent harnesses now say it is the worst posture we ship:
+ *
+ *   THOL 2.1.251, 17 tasks x 3 reps x 3 arms, 153 runs, zero errors
+ *     control  $21.13  score 0.969  turns 16.2
+ *     assist   $20.48  score 0.971  turns 14.4   <- better on all three
+ *     enforce  $23.33  score 0.935  turns 17.6   <- worse on all three,
+ *                                                   losing 12 of 17 tasks
+ *   Ledger cold track
+ *     enforce/advise    1.147 [1.065, 1.235]  refusals cost 14.7%
+ *     advise/assist-mcp 1.028 [0.951, 1.114]  the advisory itself is free
+ *
+ * So the refusals are the whole cost: not the routing advisory, not retrieval.
+ * Enforce's worst tasks are the small cheap ones, where one refused turn is a
+ * large fraction of the total (code-bugfix-py 1.599, log-needle-zh 1.589).
+ * Shipping assist is worth ~12% cost and 3.6 score points against what users
+ * receive today.
+ *
+ * THE TYPO PROPERTY IS PRESERVED, which is what the old comment was really
+ * protecting. An unrecognised value still falls back to a posture with routing,
+ * retrieval, capture and harvest all ON -- `off` is the only value that exits
+ * the hook process, and it remains reachable only by asking for it exactly. A
+ * typo cannot quietly turn the product off; it can now only decline to refuse.
  */
 export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
-  if (raw === MODE_ASSIST) return MODE_ASSIST;
-  return MODE_ENFORCE;
+  if (raw === MODE_ENFORCE) return MODE_ENFORCE;
+  return MODE_ASSIST;
 }
 
 function intEnv(name, fallback) {

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -1222,6 +1222,12 @@ async function runHook(clientName, event, invocation) {
         candidates: derived.candidates.length,
         observations: derived.observations.length,
         written: derived.written.length,
+        // Whether a locate detector would have anything to catch: `named` is
+        // searches carrying an identifier, `gap` the subset the symbol index
+        // cannot answer. Recorded rather than acted on -- a `gap` that stays
+        // near zero says the detector written for it should stay unmerged.
+        searchesNamed: derived.searchGap?.named ?? 0,
+        searchGap: derived.searchGap?.gap ?? 0,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/integrations/windsurf/hooks/lib/advise.mjs
+++ b/integrations/windsurf/hooks/lib/advise.mjs
@@ -106,13 +106,39 @@ const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
  * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
  * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
  * it is one token, and the `=` test below skips it.
+ *
+ * THE COLOUR FLAGS ARE NOT HERE, because their arity is the one thing in this
+ * list that differs by program. See COLOR_TAKES_SEPARATE_VALUE.
  */
 const VALUED_FLAGS = new Set([
   '-e', '--regexp', '-f', '--file', '-m', '--max-count',
   '-A', '--after-context', '-B', '--before-context', '-C', '--context',
   '-d', '--directories', '-t', '--type', '-g', '--glob',
-  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+  '--include', '--exclude', '--exclude-dir',
 ]);
+
+/** The spellings of the colour option, across the programs handled here. */
+const COLOR_FLAGS = new Set(['--color', '--colour']);
+
+/**
+ * Programs whose colour flag takes a SEPARATE value token.
+ *
+ * The one option in this parser whose arity cannot be decided globally, and
+ * getting it wrong silently returns a path or a keyword as the search pattern:
+ *
+ *   grep --color needle file   GNU: the value is optional and inline-only, so
+ *                              `needle` is the pattern. Treating --color as
+ *                              valued consumed `needle` and returned `file`.
+ *   rg --color never needle .  ripgrep REQUIRES a separate WHEN, so `never` is
+ *                              the flag's value and `needle` is the pattern.
+ *                              Treating --color as valueless returns `never`.
+ *   ag --color needle .        a valueless toggle, like ack. Same failure as
+ *   ack --color needle .       grep: returned `.` instead of `needle`.
+ *
+ * So neither "always valued" nor "never valued" is correct, and the contract has
+ * to come from the program. Only ripgrep is in this set.
+ */
+const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
  * Splits a command into tokens, honouring quotes.
@@ -194,11 +220,17 @@ export function searchPatternFromCommand(command) {
     }
     if (!SEARCH_PROGRAMS.has(program)) continue;
 
+    // Whether a flag eats the next token, decided per program: only the colour
+    // option varies, and only ripgrep requires a separate value for it.
+    const consumesNext = (token) =>
+      VALUED_FLAGS.has(token) ||
+      (COLOR_FLAGS.has(token) && COLOR_TAKES_SEPARATE_VALUE.has(program));
+
     for (let i = at + 1; i < tokens.length; i += 1) {
       const token = tokens[i];
       // An explicit -e/--regexp names the pattern outright and wins over
       // position, which is the whole reason the flag exists.
-      if (VALUED_FLAGS.has(token)) {
+      if (consumesNext(token)) {
         if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
         i += 1;
         continue;

--- a/integrations/windsurf/hooks/lib/advise.mjs
+++ b/integrations/windsurf/hooks/lib/advise.mjs
@@ -81,6 +81,141 @@ const STOPWORDS = new Set([
   'except', 'raise', 'throw', 'new', 'int', 'str', 'bool', 'float',
 ]);
 
+/**
+ * Search programs whose first operand is a pattern.
+ *
+ * WHY THIS LIST EXISTS AT ALL. The advisory above answers a search from the
+ * index before it runs, and it was wired only to the `Grep` and `Glob` TOOLS.
+ * Measured on the warm benchmark, that is the wrong half of the surface: in the
+ * needle-in-repo runs the agent searched entirely through Bash --
+ *
+ *   Bash  grep -rn "compute_settlement_fee" /work --include=* 2>/dev/null | head -50
+ *   Bash  cat /work/pkg/mod_047.py
+ *   Edit  /work/pkg/mod_047.py
+ *
+ * -- zero Grep calls, zero Glob calls, and so zero advisories delivered, while
+ * the graph for that very session held
+ * `compute_settlement_fee -> pkg/mod_047.py:9-12` and returned it correctly to a
+ * direct call. Two turns were spent rediscovering a fact already indexed.
+ */
+const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
+
+/**
+ * Flags that consume the NEXT token, so its value is never the pattern.
+ *
+ * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
+ * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
+ * it is one token, and the `=` test below skips it.
+ */
+const VALUED_FLAGS = new Set([
+  '-e', '--regexp', '-f', '--file', '-m', '--max-count',
+  '-A', '--after-context', '-B', '--before-context', '-C', '--context',
+  '-d', '--directories', '-t', '--type', '-g', '--glob',
+  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+]);
+
+/**
+ * Splits a command into tokens, honouring quotes.
+ *
+ * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
+ * critical path against a string the model composed, which is the exact input
+ * class this repo keeps a linearity gate for; a single forward pass cannot
+ * backtrack at all.
+ */
+function tokenize(command) {
+  const tokens = [];
+  let current = '';
+  let quote = null;
+  let started = false;
+  for (let i = 0; i < command.length; i += 1) {
+    const ch = command[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (ch === '\\' && i + 1 < command.length) {
+      current += command[i + 1];
+      i += 1;
+      started = true;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t' || ch === '\n') {
+      if (current || started) tokens.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (current || started) tokens.push(current);
+  return tokens;
+}
+
+/**
+ * The pattern a shell search command is about to look for, or null.
+ *
+ * Splits on pipeline and sequencing operators first, because `cat x | grep foo`
+ * and `a && grep foo` both carry a search the graph may be able to answer, and
+ * the search is never the first segment there. `git grep foo` is handled by
+ * skipping a leading `git`, and `find . -name "*.py"` by reading the -name
+ * value: a glob yields no identifiers and so costs nothing, but
+ * `find . -name "compute_settlement*"` does.
+ *
+ * Returns the raw pattern rather than identifiers, so the caller hands it to the
+ * same `adviseSearch` the Grep tool path uses and the two surfaces cannot drift.
+ */
+export function searchPatternFromCommand(command) {
+  if (typeof command !== 'string' || !command) return null;
+  // Bounded before any work: a pathological command is not worth parsing, and
+  // the advisory is an optimisation that must never become the slow path.
+  if (command.length > 4_000) return null;
+
+  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
+    const tokens = tokenize(segment.trim()).filter(Boolean);
+    if (!tokens.length) continue;
+    // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
+    // leading `git` is: `git grep` is ordinary.
+    let at = 0;
+    if (tokens[at] === 'git') at += 1;
+    const program = String(tokens[at] || '').split(/[/\\]/).pop();
+
+    if (program === 'find') {
+      for (let i = at + 1; i < tokens.length - 1; i += 1) {
+        if (tokens[i] === '-name' || tokens[i] === '-iname') return tokens[i + 1];
+      }
+      continue;
+    }
+    if (!SEARCH_PROGRAMS.has(program)) continue;
+
+    for (let i = at + 1; i < tokens.length; i += 1) {
+      const token = tokens[i];
+      // An explicit -e/--regexp names the pattern outright and wins over
+      // position, which is the whole reason the flag exists.
+      if (VALUED_FLAGS.has(token)) {
+        if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
+        i += 1;
+        continue;
+      }
+      if (token.startsWith('--') && token.includes('=')) {
+        const [name, ...rest] = token.split('=');
+        if (name === '--regexp') return rest.join('=') || null;
+        continue;
+      }
+      if (token.startsWith('-') && token.length > 1) continue;
+      // The first bare operand is the pattern; everything after it is a path.
+      return token || null;
+    }
+  }
+  return null;
+}
+
 /** Symbol nodes grouped by name, for one lookup per identifier. */
 export function symbolIndex(graph) {
   const byName = new Map();

--- a/integrations/windsurf/hooks/lib/advise.mjs
+++ b/integrations/windsurf/hooks/lib/advise.mjs
@@ -141,18 +141,45 @@ const COLOR_FLAGS = new Set(['--color', '--colour']);
 const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
- * Splits a command into tokens, honouring quotes.
+ * Splits a command into segments of tokens, honouring quotes and escapes.
+ *
+ * SEGMENTING AND TOKENIZING ARE ONE PASS, and they have to be. Splitting the raw
+ * string on `|`, `&&` and `;` before tokenizing cut straight through quoted
+ * text, so a perfectly ordinary alternation lost everything after the first
+ * branch:
+ *
+ *   grep -E "foo|bar" .   returned `foo`   -- `bar` never reached adviseSearch
+ *   rg "a;b" .            returned `a`
+ *   grep "x&&y" .         returned `x`
+ *
+ * A quote-aware scan cannot make that mistake, because an operator inside a
+ * quoted run is just a character. Pipelines still split, which is what lets
+ * `cat x | grep foo` be recognised at all -- the search is never the first
+ * segment there.
  *
  * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
  * critical path against a string the model composed, which is the exact input
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function tokenize(command) {
-  const tokens = [];
+function commandSegments(command) {
+  const segments = [];
+  let tokens = [];
   let current = '';
   let quote = null;
   let started = false;
+
+  const endToken = () => {
+    if (current || started) tokens.push(current);
+    current = '';
+    started = false;
+  };
+  const endSegment = () => {
+    endToken();
+    if (tokens.length) segments.push(tokens);
+    tokens = [];
+  };
+
   for (let i = 0; i < command.length; i += 1) {
     const ch = command[i];
     if (quote) {
@@ -171,17 +198,22 @@ function tokenize(command) {
       started = true;
       continue;
     }
-    if (ch === ' ' || ch === '\t' || ch === '\n') {
-      if (current || started) tokens.push(current);
-      current = '';
-      started = false;
+    // UNQUOTED ONLY -- reaching here means the quote branches above did not.
+    if (ch === '|' || ch === ';' || ch === '&' || ch === '\n') {
+      endSegment();
+      // `||` and `&&` are one operator, not two empty segments.
+      while (i + 1 < command.length && command[i + 1] === ch) i += 1;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t') {
+      endToken();
       continue;
     }
     current += ch;
     started = true;
   }
-  if (current || started) tokens.push(current);
-  return tokens;
+  endSegment();
+  return segments;
 }
 
 /**
@@ -203,8 +235,7 @@ export function searchPatternFromCommand(command) {
   // the advisory is an optimisation that must never become the slow path.
   if (command.length > 4_000) return null;
 
-  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
-    const tokens = tokenize(segment.trim()).filter(Boolean);
+  for (const tokens of commandSegments(command)) {
     if (!tokens.length) continue;
     // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
     // leading `git` is: `git grep` is ordinary.

--- a/integrations/windsurf/hooks/lib/audit.mjs
+++ b/integrations/windsurf/hooks/lib/audit.mjs
@@ -78,9 +78,21 @@ export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
   const candidates = sum('candidates');
   const observations = sum('observations');
   const written = sum('written');
+  // THE SEARCH GAP RIDES HERE because a counter nobody reads is exactly the cost
+  // this note exists to prevent -- and because the number decides something: a
+  // locate detector is written and held unmerged until this says the gap is
+  // real. `named` is searches carrying an identifier, `gap` the subset the
+  // symbol index could not answer. Reported only once a search has been seen,
+  // so a project that never searches does not get a line of zeroes.
+  const named = sum('searchesNamed');
+  const gap = sum('searchGap');
+  const searchLine = named
+    ? ` ${gap.toLocaleString()} of ${named.toLocaleString()} named search(es) were ` +
+      'outside the symbol index.'
+    : '';
   return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
     `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
-    `across ${runs.length.toLocaleString()} Stop run(s).`;
+    `across ${runs.length.toLocaleString()} Stop run(s).${searchLine}`;
 }
 
 const idOf = (finding) =>

--- a/integrations/windsurf/hooks/lib/derive.mjs
+++ b/integrations/windsurf/hooks/lib/derive.mjs
@@ -49,6 +49,14 @@ import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
 import { load } from './wiki.mjs';
 import { ORIGIN_HARVESTED } from './curate.mjs';
+// Counting only -- see `searchGap` below. The SAME extractor the router advises
+// from, so what this counts as a search and what the advisory treats as one
+// cannot diverge.
+import {
+  identifiersIn,
+  searchPatternFromCommand,
+  symbolIndex,
+} from './advise.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -397,12 +405,56 @@ const storageBudget = () =>
  *   defaulting would promote any caller's string to trusted. Also returned, so a
  *   caller can see what it handed over.
  * @returns {object} `{ candidates, observations, written, selected, dropped,
- *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
- *   everything derived; `written` is the subset of keys the graph actually
- *   holds, which is smaller for three independent reasons -- the budget, the
- *   anchor discipline, and the duplicate collapse that returns an EXISTING key
- *   when a later session derives the same claim again.
+ *   selectedTokens, searchGap, sessionId, authoritativeSessionId }`.
+ *   `candidates` is everything derived; `written` is the subset of keys the
+ *   graph actually holds, which is smaller for three independent reasons -- the
+ *   budget, the anchor discipline, and the duplicate collapse that returns an
+ *   EXISTING key when a later session derives the same claim again.
  */
+
+/**
+ * How many searches this session ran that the symbol index could NOT answer.
+ *
+ * MEASUREMENT, NOT A FEATURE. A detector that turns these into findings is
+ * written and deliberately unmerged, because on the only workload we have
+ * measured it produces nothing: replayed against a real warm rep, all seven
+ * searches were for symbols the index already resolves --
+ * `compute_settlement_fee` three times, `def parse_line` once, and three terms
+ * with no identifier-shaped word at all. The search advisory answers every one
+ * of those directly, so storing them again would spend the retrieval budget
+ * restating a cheaper mechanism.
+ *
+ * The case that would justify the detector is a search for something the indexer
+ * never extracts -- a config key, an error string, a literal, a symbol in a file
+ * type it cannot parse. Eleven synthetic Python tasks cannot show whether that
+ * happens in real work. This counts it instead of guessing: `gap` is the number
+ * of searches carrying an identifier the index has no entry for, `named` the
+ * number carrying one at all. A `gap` that stays near zero says the detector
+ * should stay unmerged.
+ *
+ * Counting only. Nothing is stored, nothing is claimed, and it runs at session
+ * end where the cost is already paid.
+ */
+export function searchGap(dir, events) {
+  const out = { named: 0, gap: 0 };
+  try {
+    const index = symbolIndex(load(dir));
+    for (const event of events) {
+      if (!event || event.kind !== 'tool-outcome') continue;
+      if (event.success === false || event.surface !== 'command') continue;
+      const pattern = searchPatternFromCommand(event.anchor);
+      if (!pattern) continue;
+      const names = identifiersIn(pattern);
+      if (!names.length) continue;
+      out.named += 1;
+      if (!names.some((name) => index.has(name))) out.gap += 1;
+    }
+  } catch {
+    // A count is never worth failing a session for.
+  }
+  return out;
+}
+
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
   // `undefined`, so a caller passing an explicitly null options object -- which
@@ -431,6 +483,10 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // Measured, not stored. See `searchGap`: this decides whether the locate
+  // detector is worth merging, and nothing here acts on it.
+  result.searchGap = searchGap(dir, events);
 
   // ONE anchor for the whole run, so every candidate from this session points at
   // the same node and the duplicate collapse in `writeHarvested` can recognise

--- a/integrations/windsurf/hooks/lib/doctor.mjs
+++ b/integrations/windsurf/hooks/lib/doctor.mjs
@@ -523,6 +523,19 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
     // on the same session file, and the failure would be intermittent and
     // wrong-looking rather than loud. The concurrency win is taken in
     // diagnose(), across probes that share no state.
+    // ENFORCE IS ASKED FOR, NOT INHERITED -- for the same reason the capability
+    // evidence in `probe` is stated rather than inferred. The question this probe
+    // asks is "would enforcement fire if it were switched on", and policy.mjs#mode
+    // now defaults to `assist`, which never refuses (THOL and ledger measurement).
+    // Inheriting the default would make the probe report "not refused" on a
+    // perfectly healthy install: a false negative in the one tool whose job is to
+    // tell the user the truth.
+    //
+    // BOTH probes take it, not just the refusal one. "Small reads are left alone"
+    // is evidence of something only under a posture that COULD have refused;
+    // under assist it would pass against a hook that does nothing whatsoever,
+    // which is precisely the broken install it exists to catch.
+    const enforcing = { env: { TOKEN_OPTIMIZER_MODE: 'enforce' } };
     const denied = await probe(
       binary,
       {
@@ -530,13 +543,14 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: big },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     const deniedOk = typeof denied === 'string' && denied.includes('deny');
     checks.push(deniedOk
       ? ok('enforcement refuses a large read', 'the refusal came back from the real hook')
       : bad('enforcement refuses a large read', `hook returned: ${String(denied).slice(0, 200) || '(nothing)'}`,
-        'check TOKEN_OPTIMIZER_MODE is not "off" or "advise", then reinstall the hooks'));
+        'the probe asks for enforce explicitly, so a failure is the hook itself rather than your mode -- reinstall the hooks'));
 
     const allowed = await probe(
       binary,
@@ -545,7 +559,8 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: small },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     // `allowed === null` is "the probe never ran", NOT "the hook allowed it".
     // allow() writes nothing and exits 0, so '' is a legitimate allow -- but null

--- a/integrations/windsurf/hooks/lib/policy.mjs
+++ b/integrations/windsurf/hooks/lib/policy.mjs
@@ -10,9 +10,18 @@
  * listed in `/mcp`, and save nothing at all. The skill did not help: skills are
  * model-invoked, so it only loads if the model already decided it cared.
  *
- * The redesign inverts the default. Optimized tooling is the path of least
- * resistance: expensive built-in calls are DENIED with a message naming the
- * exact replacement to call. Everything here exists to make that safe.
+ * The redesign inverted the default so that optimized tooling was the path of
+ * least resistance: expensive built-in calls were DENIED with a message naming
+ * the exact replacement to call. Most of this module exists to make that safe.
+ *
+ * REFUSALS ARE NOW OPT-IN, because measurement did not support them. Two
+ * independent harnesses agree that enforcing is the worst posture we ship --
+ * THOL: enforce $23.33/score 0.935 against assist $20.48/0.971 and control
+ * $21.13/0.969, losing 12 of 17 tasks; ledger cold: enforce/advise 1.147
+ * [1.065, 1.235] while advise/assist-mcp is 1.028 [0.951, 1.114]. So the cost is
+ * the refusals themselves, not the routing advisory or retrieval, and the
+ * machinery below is retained and exercised rather than deleted: `enforce`
+ * remains one variable away for anyone who wants it. See `mode()`.
  *
  * FOUR SAFETY PROPERTIES, none of which are optional:
  *
@@ -27,7 +36,8 @@
  *      human intervention and no permanent breakage.
  *
  *   3. AN ESCAPE HATCH THAT IS ONE VARIABLE. TOKEN_OPTIMIZER_MODE=off disables
- *      everything; =advise restores the old non-blocking behaviour.
+ *      everything; =advise restores the old non-blocking behaviour; =enforce
+ *      turns refusals back on now that they are no longer the default.
  *
  *   4. NO BLOCKING OF CHEAP CALLS. Small files, paged reads, and searches that
  *      already read from a pipe cost little and are left alone. Blocking them
@@ -92,16 +102,40 @@ export function refusalsEnabled() {
 }
 
 /**
- * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
- * redesign. An unrecognised value falls back to enforce rather than silently
- * disabling, so a typo cannot quietly turn the product off.
+ * Reads the mode. ASSIST IS THE DEFAULT, on measurement.
+ *
+ * This said "Enforcement is the DEFAULT -- that is the entire point of the
+ * redesign". The redesign's point was to make the product pay for itself, and
+ * enforcement was the assumed way there rather than a measured one. Two
+ * independent harnesses now say it is the worst posture we ship:
+ *
+ *   THOL 2.1.251, 17 tasks x 3 reps x 3 arms, 153 runs, zero errors
+ *     control  $21.13  score 0.969  turns 16.2
+ *     assist   $20.48  score 0.971  turns 14.4   <- better on all three
+ *     enforce  $23.33  score 0.935  turns 17.6   <- worse on all three,
+ *                                                   losing 12 of 17 tasks
+ *   Ledger cold track
+ *     enforce/advise    1.147 [1.065, 1.235]  refusals cost 14.7%
+ *     advise/assist-mcp 1.028 [0.951, 1.114]  the advisory itself is free
+ *
+ * So the refusals are the whole cost: not the routing advisory, not retrieval.
+ * Enforce's worst tasks are the small cheap ones, where one refused turn is a
+ * large fraction of the total (code-bugfix-py 1.599, log-needle-zh 1.589).
+ * Shipping assist is worth ~12% cost and 3.6 score points against what users
+ * receive today.
+ *
+ * THE TYPO PROPERTY IS PRESERVED, which is what the old comment was really
+ * protecting. An unrecognised value still falls back to a posture with routing,
+ * retrieval, capture and harvest all ON -- `off` is the only value that exits
+ * the hook process, and it remains reachable only by asking for it exactly. A
+ * typo cannot quietly turn the product off; it can now only decline to refuse.
  */
 export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
-  if (raw === MODE_ASSIST) return MODE_ASSIST;
-  return MODE_ENFORCE;
+  if (raw === MODE_ENFORCE) return MODE_ENFORCE;
+  return MODE_ASSIST;
 }
 
 function intEnv(name, fallback) {

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -1222,6 +1222,12 @@ async function runHook(clientName, event, invocation) {
         candidates: derived.candidates.length,
         observations: derived.observations.length,
         written: derived.written.length,
+        // Whether a locate detector would have anything to catch: `named` is
+        // searches carrying an identifier, `gap` the subset the symbol index
+        // cannot answer. Recorded rather than acted on -- a `gap` that stays
+        // near zero says the detector written for it should stay unmerged.
+        searchesNamed: derived.searchGap?.named ?? 0,
+        searchGap: derived.searchGap?.gap ?? 0,
       });
     } catch {
       // A detector failing must never cost a user the end of their session.

--- a/plugin/hooks/lib/advise.mjs
+++ b/plugin/hooks/lib/advise.mjs
@@ -106,13 +106,39 @@ const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
  * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
  * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
  * it is one token, and the `=` test below skips it.
+ *
+ * THE COLOUR FLAGS ARE NOT HERE, because their arity is the one thing in this
+ * list that differs by program. See COLOR_TAKES_SEPARATE_VALUE.
  */
 const VALUED_FLAGS = new Set([
   '-e', '--regexp', '-f', '--file', '-m', '--max-count',
   '-A', '--after-context', '-B', '--before-context', '-C', '--context',
   '-d', '--directories', '-t', '--type', '-g', '--glob',
-  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+  '--include', '--exclude', '--exclude-dir',
 ]);
+
+/** The spellings of the colour option, across the programs handled here. */
+const COLOR_FLAGS = new Set(['--color', '--colour']);
+
+/**
+ * Programs whose colour flag takes a SEPARATE value token.
+ *
+ * The one option in this parser whose arity cannot be decided globally, and
+ * getting it wrong silently returns a path or a keyword as the search pattern:
+ *
+ *   grep --color needle file   GNU: the value is optional and inline-only, so
+ *                              `needle` is the pattern. Treating --color as
+ *                              valued consumed `needle` and returned `file`.
+ *   rg --color never needle .  ripgrep REQUIRES a separate WHEN, so `never` is
+ *                              the flag's value and `needle` is the pattern.
+ *                              Treating --color as valueless returns `never`.
+ *   ag --color needle .        a valueless toggle, like ack. Same failure as
+ *   ack --color needle .       grep: returned `.` instead of `needle`.
+ *
+ * So neither "always valued" nor "never valued" is correct, and the contract has
+ * to come from the program. Only ripgrep is in this set.
+ */
+const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
  * Splits a command into tokens, honouring quotes.
@@ -194,11 +220,17 @@ export function searchPatternFromCommand(command) {
     }
     if (!SEARCH_PROGRAMS.has(program)) continue;
 
+    // Whether a flag eats the next token, decided per program: only the colour
+    // option varies, and only ripgrep requires a separate value for it.
+    const consumesNext = (token) =>
+      VALUED_FLAGS.has(token) ||
+      (COLOR_FLAGS.has(token) && COLOR_TAKES_SEPARATE_VALUE.has(program));
+
     for (let i = at + 1; i < tokens.length; i += 1) {
       const token = tokens[i];
       // An explicit -e/--regexp names the pattern outright and wins over
       // position, which is the whole reason the flag exists.
-      if (VALUED_FLAGS.has(token)) {
+      if (consumesNext(token)) {
         if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
         i += 1;
         continue;

--- a/plugin/hooks/lib/advise.mjs
+++ b/plugin/hooks/lib/advise.mjs
@@ -81,6 +81,141 @@ const STOPWORDS = new Set([
   'except', 'raise', 'throw', 'new', 'int', 'str', 'bool', 'float',
 ]);
 
+/**
+ * Search programs whose first operand is a pattern.
+ *
+ * WHY THIS LIST EXISTS AT ALL. The advisory above answers a search from the
+ * index before it runs, and it was wired only to the `Grep` and `Glob` TOOLS.
+ * Measured on the warm benchmark, that is the wrong half of the surface: in the
+ * needle-in-repo runs the agent searched entirely through Bash --
+ *
+ *   Bash  grep -rn "compute_settlement_fee" /work --include=* 2>/dev/null | head -50
+ *   Bash  cat /work/pkg/mod_047.py
+ *   Edit  /work/pkg/mod_047.py
+ *
+ * -- zero Grep calls, zero Glob calls, and so zero advisories delivered, while
+ * the graph for that very session held
+ * `compute_settlement_fee -> pkg/mod_047.py:9-12` and returned it correctly to a
+ * direct call. Two turns were spent rediscovering a fact already indexed.
+ */
+const SEARCH_PROGRAMS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
+
+/**
+ * Flags that consume the NEXT token, so its value is never the pattern.
+ *
+ * `grep -n "needle" -A 30 -B 10 file` is real observed input: without this, the
+ * walk would stop at `30`. The `--flag=value` spelling needs no entry here --
+ * it is one token, and the `=` test below skips it.
+ */
+const VALUED_FLAGS = new Set([
+  '-e', '--regexp', '-f', '--file', '-m', '--max-count',
+  '-A', '--after-context', '-B', '--before-context', '-C', '--context',
+  '-d', '--directories', '-t', '--type', '-g', '--glob',
+  '--include', '--exclude', '--exclude-dir', '--color', '--colour',
+]);
+
+/**
+ * Splits a command into tokens, honouring quotes.
+ *
+ * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
+ * critical path against a string the model composed, which is the exact input
+ * class this repo keeps a linearity gate for; a single forward pass cannot
+ * backtrack at all.
+ */
+function tokenize(command) {
+  const tokens = [];
+  let current = '';
+  let quote = null;
+  let started = false;
+  for (let i = 0; i < command.length; i += 1) {
+    const ch = command[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (ch === '\\' && i + 1 < command.length) {
+      current += command[i + 1];
+      i += 1;
+      started = true;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t' || ch === '\n') {
+      if (current || started) tokens.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (current || started) tokens.push(current);
+  return tokens;
+}
+
+/**
+ * The pattern a shell search command is about to look for, or null.
+ *
+ * Splits on pipeline and sequencing operators first, because `cat x | grep foo`
+ * and `a && grep foo` both carry a search the graph may be able to answer, and
+ * the search is never the first segment there. `git grep foo` is handled by
+ * skipping a leading `git`, and `find . -name "*.py"` by reading the -name
+ * value: a glob yields no identifiers and so costs nothing, but
+ * `find . -name "compute_settlement*"` does.
+ *
+ * Returns the raw pattern rather than identifiers, so the caller hands it to the
+ * same `adviseSearch` the Grep tool path uses and the two surfaces cannot drift.
+ */
+export function searchPatternFromCommand(command) {
+  if (typeof command !== 'string' || !command) return null;
+  // Bounded before any work: a pathological command is not worth parsing, and
+  // the advisory is an optimisation that must never become the slow path.
+  if (command.length > 4_000) return null;
+
+  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
+    const tokens = tokenize(segment.trim()).filter(Boolean);
+    if (!tokens.length) continue;
+    // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
+    // leading `git` is: `git grep` is ordinary.
+    let at = 0;
+    if (tokens[at] === 'git') at += 1;
+    const program = String(tokens[at] || '').split(/[/\\]/).pop();
+
+    if (program === 'find') {
+      for (let i = at + 1; i < tokens.length - 1; i += 1) {
+        if (tokens[i] === '-name' || tokens[i] === '-iname') return tokens[i + 1];
+      }
+      continue;
+    }
+    if (!SEARCH_PROGRAMS.has(program)) continue;
+
+    for (let i = at + 1; i < tokens.length; i += 1) {
+      const token = tokens[i];
+      // An explicit -e/--regexp names the pattern outright and wins over
+      // position, which is the whole reason the flag exists.
+      if (VALUED_FLAGS.has(token)) {
+        if (token === '-e' || token === '--regexp') return tokens[i + 1] || null;
+        i += 1;
+        continue;
+      }
+      if (token.startsWith('--') && token.includes('=')) {
+        const [name, ...rest] = token.split('=');
+        if (name === '--regexp') return rest.join('=') || null;
+        continue;
+      }
+      if (token.startsWith('-') && token.length > 1) continue;
+      // The first bare operand is the pattern; everything after it is a path.
+      return token || null;
+    }
+  }
+  return null;
+}
+
 /** Symbol nodes grouped by name, for one lookup per identifier. */
 export function symbolIndex(graph) {
   const byName = new Map();

--- a/plugin/hooks/lib/advise.mjs
+++ b/plugin/hooks/lib/advise.mjs
@@ -141,18 +141,45 @@ const COLOR_FLAGS = new Set(['--color', '--colour']);
 const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
 
 /**
- * Splits a command into tokens, honouring quotes.
+ * Splits a command into segments of tokens, honouring quotes and escapes.
+ *
+ * SEGMENTING AND TOKENIZING ARE ONE PASS, and they have to be. Splitting the raw
+ * string on `|`, `&&` and `;` before tokenizing cut straight through quoted
+ * text, so a perfectly ordinary alternation lost everything after the first
+ * branch:
+ *
+ *   grep -E "foo|bar" .   returned `foo`   -- `bar` never reached adviseSearch
+ *   rg "a;b" .            returned `a`
+ *   grep "x&&y" .         returned `x`
+ *
+ * A quote-aware scan cannot make that mistake, because an operator inside a
+ * quoted run is just a character. Pipelines still split, which is what lets
+ * `cat x | grep foo` be recognised at all -- the search is never the first
+ * segment there.
  *
  * A CHARACTER LOOP RATHER THAN A REGEX, deliberately. This runs on the hook's
  * critical path against a string the model composed, which is the exact input
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function tokenize(command) {
-  const tokens = [];
+function commandSegments(command) {
+  const segments = [];
+  let tokens = [];
   let current = '';
   let quote = null;
   let started = false;
+
+  const endToken = () => {
+    if (current || started) tokens.push(current);
+    current = '';
+    started = false;
+  };
+  const endSegment = () => {
+    endToken();
+    if (tokens.length) segments.push(tokens);
+    tokens = [];
+  };
+
   for (let i = 0; i < command.length; i += 1) {
     const ch = command[i];
     if (quote) {
@@ -171,17 +198,22 @@ function tokenize(command) {
       started = true;
       continue;
     }
-    if (ch === ' ' || ch === '\t' || ch === '\n') {
-      if (current || started) tokens.push(current);
-      current = '';
-      started = false;
+    // UNQUOTED ONLY -- reaching here means the quote branches above did not.
+    if (ch === '|' || ch === ';' || ch === '&' || ch === '\n') {
+      endSegment();
+      // `||` and `&&` are one operator, not two empty segments.
+      while (i + 1 < command.length && command[i + 1] === ch) i += 1;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t') {
+      endToken();
       continue;
     }
     current += ch;
     started = true;
   }
-  if (current || started) tokens.push(current);
-  return tokens;
+  endSegment();
+  return segments;
 }
 
 /**
@@ -203,8 +235,7 @@ export function searchPatternFromCommand(command) {
   // the advisory is an optimisation that must never become the slow path.
   if (command.length > 4_000) return null;
 
-  for (const segment of command.split(/\||&&|\|\||;|\n/)) {
-    const tokens = tokenize(segment.trim()).filter(Boolean);
+  for (const tokens of commandSegments(command)) {
     if (!tokens.length) continue;
     // `env FOO=bar grep ...` and `sudo grep ...` are not worth chasing, but a
     // leading `git` is: `git grep` is ordinary.

--- a/plugin/hooks/lib/audit.mjs
+++ b/plugin/hooks/lib/audit.mjs
@@ -78,9 +78,21 @@ export function derivationNote(dir, { events = readMetrics(dir) } = {}) {
   const candidates = sum('candidates');
   const observations = sum('observations');
   const written = sum('written');
+  // THE SEARCH GAP RIDES HERE because a counter nobody reads is exactly the cost
+  // this note exists to prevent -- and because the number decides something: a
+  // locate detector is written and held unmerged until this says the gap is
+  // real. `named` is searches carrying an identifier, `gap` the subset the
+  // symbol index could not answer. Reported only once a search has been seen,
+  // so a project that never searches does not get a line of zeroes.
+  const named = sum('searchesNamed');
+  const gap = sum('searchGap');
+  const searchLine = named
+    ? ` ${gap.toLocaleString()} of ${named.toLocaleString()} named search(es) were ` +
+      'outside the symbol index.'
+    : '';
   return `Local derivation: ${candidates.toLocaleString()} candidate(s) from ` +
     `${observations.toLocaleString()} observation(s); ${written.toLocaleString()} stored ` +
-    `across ${runs.length.toLocaleString()} Stop run(s).`;
+    `across ${runs.length.toLocaleString()} Stop run(s).${searchLine}`;
 }
 
 const idOf = (finding) =>

--- a/plugin/hooks/lib/derive.mjs
+++ b/plugin/hooks/lib/derive.mjs
@@ -49,6 +49,14 @@ import { selectForConsolidation } from './consolidate.mjs';
 import { writeHarvested } from './harvest-write.mjs';
 import { load } from './wiki.mjs';
 import { ORIGIN_HARVESTED } from './curate.mjs';
+// Counting only -- see `searchGap` below. The SAME extractor the router advises
+// from, so what this counts as a search and what the advisory treats as one
+// cannot diverge.
+import {
+  identifiersIn,
+  searchPatternFromCommand,
+  symbolIndex,
+} from './advise.mjs';
 
 /**
  * Ceilings, ordered by how much the evidence actually supports.
@@ -397,12 +405,56 @@ const storageBudget = () =>
  *   defaulting would promote any caller's string to trusted. Also returned, so a
  *   caller can see what it handed over.
  * @returns {object} `{ candidates, observations, written, selected, dropped,
- *   selectedTokens, sessionId, authoritativeSessionId }`. `candidates` is
- *   everything derived; `written` is the subset of keys the graph actually
- *   holds, which is smaller for three independent reasons -- the budget, the
- *   anchor discipline, and the duplicate collapse that returns an EXISTING key
- *   when a later session derives the same claim again.
+ *   selectedTokens, searchGap, sessionId, authoritativeSessionId }`.
+ *   `candidates` is everything derived; `written` is the subset of keys the
+ *   graph actually holds, which is smaller for three independent reasons -- the
+ *   budget, the anchor discipline, and the duplicate collapse that returns an
+ *   EXISTING key when a later session derives the same claim again.
  */
+
+/**
+ * How many searches this session ran that the symbol index could NOT answer.
+ *
+ * MEASUREMENT, NOT A FEATURE. A detector that turns these into findings is
+ * written and deliberately unmerged, because on the only workload we have
+ * measured it produces nothing: replayed against a real warm rep, all seven
+ * searches were for symbols the index already resolves --
+ * `compute_settlement_fee` three times, `def parse_line` once, and three terms
+ * with no identifier-shaped word at all. The search advisory answers every one
+ * of those directly, so storing them again would spend the retrieval budget
+ * restating a cheaper mechanism.
+ *
+ * The case that would justify the detector is a search for something the indexer
+ * never extracts -- a config key, an error string, a literal, a symbol in a file
+ * type it cannot parse. Eleven synthetic Python tasks cannot show whether that
+ * happens in real work. This counts it instead of guessing: `gap` is the number
+ * of searches carrying an identifier the index has no entry for, `named` the
+ * number carrying one at all. A `gap` that stays near zero says the detector
+ * should stay unmerged.
+ *
+ * Counting only. Nothing is stored, nothing is claimed, and it runs at session
+ * end where the cost is already paid.
+ */
+export function searchGap(dir, events) {
+  const out = { named: 0, gap: 0 };
+  try {
+    const index = symbolIndex(load(dir));
+    for (const event of events) {
+      if (!event || event.kind !== 'tool-outcome') continue;
+      if (event.success === false || event.surface !== 'command') continue;
+      const pattern = searchPatternFromCommand(event.anchor);
+      if (!pattern) continue;
+      const names = identifiersIn(pattern);
+      if (!names.length) continue;
+      out.named += 1;
+      if (!names.some((name) => index.has(name))) out.gap += 1;
+    }
+  } catch {
+    // A count is never worth failing a session for.
+  }
+  return out;
+}
+
 export function derive(dir, options = {}) {
   // `options || {}` rather than a destructuring default. A default only fires on
   // `undefined`, so a caller passing an explicitly null options object -- which
@@ -431,6 +483,10 @@ export function derive(dir, options = {}) {
     return result;
   }
   if (!Array.isArray(events)) return result;
+
+  // Measured, not stored. See `searchGap`: this decides whether the locate
+  // detector is worth merging, and nothing here acts on it.
+  result.searchGap = searchGap(dir, events);
 
   // ONE anchor for the whole run, so every candidate from this session points at
   // the same node and the duplicate collapse in `writeHarvested` can recognise

--- a/plugin/hooks/lib/doctor.mjs
+++ b/plugin/hooks/lib/doctor.mjs
@@ -523,6 +523,19 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
     // on the same session file, and the failure would be intermittent and
     // wrong-looking rather than loud. The concurrency win is taken in
     // diagnose(), across probes that share no state.
+    // ENFORCE IS ASKED FOR, NOT INHERITED -- for the same reason the capability
+    // evidence in `probe` is stated rather than inferred. The question this probe
+    // asks is "would enforcement fire if it were switched on", and policy.mjs#mode
+    // now defaults to `assist`, which never refuses (THOL and ledger measurement).
+    // Inheriting the default would make the probe report "not refused" on a
+    // perfectly healthy install: a false negative in the one tool whose job is to
+    // tell the user the truth.
+    //
+    // BOTH probes take it, not just the refusal one. "Small reads are left alone"
+    // is evidence of something only under a posture that COULD have refused;
+    // under assist it would pass against a hook that does nothing whatsoever,
+    // which is precisely the broken install it exists to catch.
+    const enforcing = { env: { TOKEN_OPTIMIZER_MODE: 'enforce' } };
     const denied = await probe(
       binary,
       {
@@ -530,13 +543,14 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: big },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     const deniedOk = typeof denied === 'string' && denied.includes('deny');
     checks.push(deniedOk
       ? ok('enforcement refuses a large read', 'the refusal came back from the real hook')
       : bad('enforcement refuses a large read', `hook returned: ${String(denied).slice(0, 200) || '(nothing)'}`,
-        'check TOKEN_OPTIMIZER_MODE is not "off" or "advise", then reinstall the hooks'));
+        'the probe asks for enforce explicitly, so a failure is the hook itself rather than your mode -- reinstall the hooks'));
 
     const allowed = await probe(
       binary,
@@ -545,7 +559,8 @@ export async function probeEnforcement({ root, workspace, hooksDir, install }) {
         tool_input: { file_path: small },
         cwd: workspace,
         session_id: probeId,
-      }
+      },
+      enforcing
     );
     // `allowed === null` is "the probe never ran", NOT "the hook allowed it".
     // allow() writes nothing and exits 0, so '' is a legitimate allow -- but null

--- a/plugin/hooks/lib/policy.mjs
+++ b/plugin/hooks/lib/policy.mjs
@@ -10,9 +10,18 @@
  * listed in `/mcp`, and save nothing at all. The skill did not help: skills are
  * model-invoked, so it only loads if the model already decided it cared.
  *
- * The redesign inverts the default. Optimized tooling is the path of least
- * resistance: expensive built-in calls are DENIED with a message naming the
- * exact replacement to call. Everything here exists to make that safe.
+ * The redesign inverted the default so that optimized tooling was the path of
+ * least resistance: expensive built-in calls were DENIED with a message naming
+ * the exact replacement to call. Most of this module exists to make that safe.
+ *
+ * REFUSALS ARE NOW OPT-IN, because measurement did not support them. Two
+ * independent harnesses agree that enforcing is the worst posture we ship --
+ * THOL: enforce $23.33/score 0.935 against assist $20.48/0.971 and control
+ * $21.13/0.969, losing 12 of 17 tasks; ledger cold: enforce/advise 1.147
+ * [1.065, 1.235] while advise/assist-mcp is 1.028 [0.951, 1.114]. So the cost is
+ * the refusals themselves, not the routing advisory or retrieval, and the
+ * machinery below is retained and exercised rather than deleted: `enforce`
+ * remains one variable away for anyone who wants it. See `mode()`.
  *
  * FOUR SAFETY PROPERTIES, none of which are optional:
  *
@@ -27,7 +36,8 @@
  *      human intervention and no permanent breakage.
  *
  *   3. AN ESCAPE HATCH THAT IS ONE VARIABLE. TOKEN_OPTIMIZER_MODE=off disables
- *      everything; =advise restores the old non-blocking behaviour.
+ *      everything; =advise restores the old non-blocking behaviour; =enforce
+ *      turns refusals back on now that they are no longer the default.
  *
  *   4. NO BLOCKING OF CHEAP CALLS. Small files, paged reads, and searches that
  *      already read from a pipe cost little and are left alone. Blocking them
@@ -92,16 +102,40 @@ export function refusalsEnabled() {
 }
 
 /**
- * Reads the mode. Enforcement is the DEFAULT -- that is the entire point of the
- * redesign. An unrecognised value falls back to enforce rather than silently
- * disabling, so a typo cannot quietly turn the product off.
+ * Reads the mode. ASSIST IS THE DEFAULT, on measurement.
+ *
+ * This said "Enforcement is the DEFAULT -- that is the entire point of the
+ * redesign". The redesign's point was to make the product pay for itself, and
+ * enforcement was the assumed way there rather than a measured one. Two
+ * independent harnesses now say it is the worst posture we ship:
+ *
+ *   THOL 2.1.251, 17 tasks x 3 reps x 3 arms, 153 runs, zero errors
+ *     control  $21.13  score 0.969  turns 16.2
+ *     assist   $20.48  score 0.971  turns 14.4   <- better on all three
+ *     enforce  $23.33  score 0.935  turns 17.6   <- worse on all three,
+ *                                                   losing 12 of 17 tasks
+ *   Ledger cold track
+ *     enforce/advise    1.147 [1.065, 1.235]  refusals cost 14.7%
+ *     advise/assist-mcp 1.028 [0.951, 1.114]  the advisory itself is free
+ *
+ * So the refusals are the whole cost: not the routing advisory, not retrieval.
+ * Enforce's worst tasks are the small cheap ones, where one refused turn is a
+ * large fraction of the total (code-bugfix-py 1.599, log-needle-zh 1.589).
+ * Shipping assist is worth ~12% cost and 3.6 score points against what users
+ * receive today.
+ *
+ * THE TYPO PROPERTY IS PRESERVED, which is what the old comment was really
+ * protecting. An unrecognised value still falls back to a posture with routing,
+ * retrieval, capture and harvest all ON -- `off` is the only value that exits
+ * the hook process, and it remains reachable only by asking for it exactly. A
+ * typo cannot quietly turn the product off; it can now only decline to refuse.
  */
 export function mode() {
   const raw = (process.env.TOKEN_OPTIMIZER_MODE || '').trim().toLowerCase();
   if (raw === MODE_OFF) return MODE_OFF;
   if (raw === MODE_ADVISE) return MODE_ADVISE;
-  if (raw === MODE_ASSIST) return MODE_ASSIST;
-  return MODE_ENFORCE;
+  if (raw === MODE_ENFORCE) return MODE_ENFORCE;
+  return MODE_ASSIST;
 }
 
 function intEnv(name, fallback) {

--- a/plugin/hooks/pretooluse-router.mjs
+++ b/plugin/hooks/pretooluse-router.mjs
@@ -23,6 +23,7 @@ import {
   refusalsEnabled,
   mode,
   MODE_OFF,
+  MODE_ASSIST,
 } from './lib/policy.mjs';
 import {
   decide,
@@ -67,7 +68,11 @@ import { substitutionFor as outlineFor } from './lib/substitute.mjs';
 import { readFileSync, statSync, mkdirSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { adviseSearch, SESSION_CAP } from './lib/advise.mjs';
+import {
+  adviseSearch,
+  searchPatternFromCommand,
+  SESSION_CAP,
+} from './lib/advise.mjs';
 import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { episodeMeta, featuresForArm } from './lib/experiment.mjs';
@@ -118,6 +123,30 @@ process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= HOOK_MCP_TOOLS.join(',');
  */
 const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
+
+/**
+ * Tools whose call may be a search the index can already answer.
+ *
+ * BASH IS HERE BECAUSE OF WHAT THE WARM TRACK MEASURED. The advisory was wired
+ * to `Grep` and `Glob` only, and on the needle-in-repo task -- the one written
+ * to demonstrate exactly this reuse -- the agent searched entirely through the
+ * shell:
+ *
+ *   Bash  grep -rn "compute_settlement_fee" /work --include=* 2>/dev/null | head -50
+ *   Bash  cat /work/pkg/mod_047.py
+ *   Edit  /work/pkg/mod_047.py
+ *
+ * Zero Grep calls, zero Glob calls, so zero advisories -- while that session's
+ * own graph held `compute_settlement_fee -> pkg/mod_047.py:9-12` and handed it
+ * straight back to a direct `adviseSearch` call. Two turns went on rediscovering
+ * an indexed fact, and the task scored 0.932 against an adversarial-set mean of
+ * 0.681: the tasks that CANNOT reuse anything were gaining most, which is the
+ * signature of a retrieval path that never fires.
+ *
+ * `searchAdvisory` returns null for a Bash command carrying no search, so
+ * widening the gate costs an extraction on shell calls and nothing else.
+ */
+const SEARCH_TOOLS = new Set(['Grep', 'Glob', 'Bash']);
 const invocation = beginHookInvocation('claude-code', 'pre-tool');
 
 // Wrapped whole. Any defect in this hook must cost the user nothing: an
@@ -497,7 +526,7 @@ ${nudge}`
     // `capture`. That keeps the A/B honest: an arm can index without advising.
     if (
       features.retrieval &&
-      (payload.tool_name === 'Grep' || payload.tool_name === 'Glob')
+      SEARCH_TOOLS.has(payload.tool_name)
     ) {
       try {
         const advisory = searchAdvisory(payload, state, dirFor);
@@ -862,7 +891,7 @@ function compactorFor(sessionId, command) {
   // knows where that something is, the redirect may not need following at all.
   if (
     features.retrieval &&
-    (payload.tool_name === 'Grep' || payload.tool_name === 'Glob')
+    SEARCH_TOOLS.has(payload.tool_name)
   ) {
     try {
       const advisory = searchAdvisory(payload, state, (path) =>
@@ -870,7 +899,34 @@ function compactorFor(sessionId, command) {
       );
       if (advisory) {
         saveState(payload.session_id, state, agentScope);
-        reason = `${reason}\n\n${advisory}`;
+        // AN ANSWER IS NOT A REDIRECT, and until now the two travelled together
+        // in `reason` -- which meant `assist` threw the answer away.
+        //
+        // enforce() allows SILENTLY under assist (policy.mjs), so everything
+        // accumulated in `reason` is discarded before the model sees it. That is
+        // right for the routing advisory `reason` normally carries: "call
+        // smart_grep instead" fires on every matched call and buys nothing,
+        // which is the context cost assist exists to avoid. It is exactly wrong
+        // for this: a specific fact from the graph, emitted only when the index
+        // actually has the answer, that can save the whole turn the search was
+        // about to spend.
+        //
+        // MEASURED, NOT SUPPOSED. Under assist the advisory reached the model
+        // for no tool at all -- Grep, Glob or Bash -- while advise and enforce
+        // delivered it correctly. The warm campaign ran assist, so the crown
+        // jewel was switched off for all 107 of its runs, and needle-in-repo,
+        // written to demonstrate precisely this reuse, came back at 0.932
+        // against an adversarial-set mean of 0.681.
+        //
+        // This is the same defect class as the output bound that was wired into
+        // the refusal branch and so never touched the family it was built for.
+        // A capability that only works while refusing is not shipped.
+        if (mode() === MODE_ASSIST) {
+          // Allows the call and carries the fact: no refusal, no routing noise.
+          allowWithContext(advisory);
+        } else {
+          reason = `${reason}\n\n${advisory}`;
+        }
       }
     } catch {
       // The plain redirect always works; an unreadable index costs nothing.
@@ -906,7 +962,17 @@ function compactorFor(sessionId, command) {
  * ignore -- which is the only failure mode available to this.
  */
 function searchAdvisory(payload, state, dirFor) {
-  const pattern = payload.tool_input?.pattern;
+  // EITHER SURFACE, RESOLVED HERE rather than at the two call sites, so the
+  // Grep tool and a shell `grep` cannot drift into answering differently.
+  // `Grep`/`Glob` carry the pattern as an argument; Bash carries a whole command
+  // and the pattern has to be lifted out of it -- which is the case the warm
+  // benchmark showed us losing, the needle-in-repo agent having searched only
+  // through Bash and so received nothing the index already knew.
+  const direct = payload.tool_input?.pattern;
+  const pattern =
+    typeof direct === 'string' && direct
+      ? direct
+      : searchPatternFromCommand(payload.tool_input?.command);
   if (typeof pattern !== 'string' || !pattern) return null;
 
   const root = payload.cwd || process.cwd();

--- a/tests/hooks/adapter-injection-e2e.test.mjs
+++ b/tests/hooks/adapter-injection-e2e.test.mjs
@@ -191,6 +191,11 @@ describe('Windsurf adapter', () => {
         encoding: 'utf8',
         env: {
           ...process.env,
+          // The exit-2 veto IS a refusal, so this asks for the posture that
+          // refuses. policy.mjs#mode defaults to `assist` now, under which the
+          // adapter correctly exits 0 and this assertion would be testing that
+          // Windsurf declines to veto -- the opposite of its subject.
+          TOKEN_OPTIMIZER_MODE: 'enforce',
           TOKEN_OPTIMIZER_MCP_CAPABILITIES: 'smart_read',
           TOKEN_OPTIMIZER_STATE_DIR: join(project, '.state'),
         },

--- a/tests/hooks/audit.test.mjs
+++ b/tests/hooks/audit.test.mjs
@@ -482,4 +482,25 @@ describe('the local derivation metric has a reader', () => {
       /Local derivation: 5 candidate\(s\) from 12 observation\(s\); 3 stored across 2 Stop run\(s\)\./
     );
   });
+
+  test('reports how many searches fell outside the symbol index', () => {
+    // THE READER MUST ACTUALLY RENDER IT. The census guard is satisfied by any
+    // reference to the field, so a reader that reads the number and prints
+    // nothing would pass it while leaving the counter exactly as unobserved as
+    // if it had never been written -- and this number is what decides whether
+    // the locate detector held out of the build ever gets merged.
+    record(dir, { kind: 'derive', searchesNamed: 4, searchGap: 0 });
+    record(dir, { kind: 'derive', searchesNamed: 6, searchGap: 3 });
+
+    expect(renderAudit(dir, []).text).toMatch(
+      /3 of 10 named search\(es\) were outside the symbol index\./
+    );
+  });
+
+  test('says nothing about searches in a project that never searched', () => {
+    // A line of zeroes on every audit is noise, and noise is what trains a
+    // reader to skip the whole section.
+    record(dir, { kind: 'derive', observations: 1, candidates: 0, written: 0 });
+    expect(renderAudit(dir, []).text).not.toMatch(/named search\(es\)/);
+  });
 });

--- a/tests/hooks/clients.test.mjs
+++ b/tests/hooks/clients.test.mjs
@@ -305,8 +305,18 @@ describe('payload shapes normalize across clients', () => {
 });
 
 describe('enforcement matches protocol capability, exactly', () => {
+  // ENFORCE IS NAMED IN BOTH PROBES BELOW, because it is no longer the default.
+  //
+  // policy.mjs#mode now returns `assist` for an unset variable, on THOL and
+  // ledger measurement showing enforce is the worst posture we ship. That makes
+  // "by default" the wrong claim for a refusal test -- and, less obviously, it
+  // would make the fail-open probe VACUOUS: under a posture that never denies,
+  // "not denied" is satisfied by a hook that does nothing at all, which is the
+  // exact breakage that probe exists to detect.
+  const ENFORCING = { TOKEN_OPTIMIZER_MODE: 'enforce' };
+
   test.each(nativeCommandClients)(
-    '$client denies a large read by default through its packaged pre-tool entry',
+    '$client denies a large read when enforcing, through its packaged pre-tool entry',
     ({ client, entry, payload }) => {
       // A FRESH SESSION ID EVERY RUN, and this is what makes the test able to
       // fail. Hook state is persisted per session id, and a proven inventory
@@ -316,7 +326,11 @@ describe('enforcement matches protocol capability, exactly', () => {
       // would still be green. That is not hypothetical: a CLAUDE_PLUGIN_ROOT
       // gate disabled enforcement for all eight packaged entries, passed on
       // every local run, and was caught only by CI's clean checkout.
-      const r = runEntry(entry, payload(`fleet-default-${client}-${randomUUID()}`));
+      const r = runEntry(
+        entry,
+        payload(`fleet-default-${client}-${randomUUID()}`),
+        ENFORCING
+      );
       expect(r.decision).toBe('deny');
       expect(r.reason).toContain('smart_read');
     }
@@ -326,6 +340,7 @@ describe('enforcement matches protocol capability, exactly', () => {
     '$client fails open when the optimizer inventory is explicitly empty',
     ({ client, entry, payload }) => {
       const r = runEntry(entry, payload(`fleet-empty-${client}-${randomUUID()}`), {
+        ...ENFORCING,
         TOKEN_OPTIMIZER_MCP_CAPABILITIES: '',
       });
       expect(r.decision).not.toBe('deny');

--- a/tests/hooks/derive.test.mjs
+++ b/tests/hooks/derive.test.mjs
@@ -28,6 +28,7 @@ import { canonicalPath } from '../../hooks-core/paths.mjs';
 import { ORIGIN_HARVESTED, ORIGIN_HUMAN } from '../../hooks-core/curate.mjs';
 import {
   derive,
+  searchGap,
   CONFIDENCE,
   attemptKey,
   commandBody,
@@ -1214,5 +1215,84 @@ describe('a failure that exists only in the transcript', () => {
     expect(failedResultsFromTranscript(join(dir, 'missing.jsonl'))).toEqual([]);
     writeFileSync(join(dir, 'junk.jsonl'), 'not json\n{"half":\n');
     expect(failedResultsFromTranscript(join(dir, 'junk.jsonl'))).toEqual([]);
+  });
+});
+
+/**
+ * The counter that decides whether a locate detector is worth having.
+ *
+ * A detector turning search-then-open into findings is written and deliberately
+ * unmerged, because replayed against a real warm rep it produced nothing: all
+ * seven searches were for symbols the index already resolves. `searchGap`
+ * measures whether that holds in real use instead of assuming it either way, so
+ * these tests are about the MEASUREMENT being trustworthy -- a counter that
+ * silently reads zero is indistinguishable from a gap that does not exist, and
+ * would retire a feature on no evidence.
+ */
+describe('measuring what the symbol index cannot answer', () => {
+  const outcome = (anchor, surface = 'command') => ({
+    kind: 'tool-outcome',
+    surface,
+    anchor,
+    success: true,
+    at: Date.now(),
+  });
+
+  it('counts a search the index cannot answer as a gap', () => {
+    // Nothing indexed at all, so every named search is unanswerable.
+    expect(searchGap(dir, [outcome('grep -rn "settlement_rate" .')])).toEqual({
+      named: 1,
+      gap: 1,
+    });
+  });
+
+  it('counts a search the index CAN answer as named but not a gap', () => {
+    const file = join(dir, 'pay.py');
+    writeFileSync(file, 'def compute_settlement_fee(a, r):\n    return a * r\n');
+    indexFile(dir, file);
+
+    expect(
+      searchGap(dir, [outcome('grep -rn "compute_settlement_fee" .')])
+    ).toEqual({ named: 1, gap: 0 });
+  });
+
+  it('ignores commands that are not searches', () => {
+    expect(
+      searchGap(dir, [outcome('ls -la'), outcome('cat pay.py'), outcome('python3 x.py')])
+    ).toEqual({ named: 0, gap: 0 });
+  });
+
+  it('ignores a search with no identifier-shaped term', () => {
+    // `*.py` and `return` name nothing a later session could look up -- the
+    // first has no word characters worth indexing, the second is a keyword.
+    expect(
+      searchGap(dir, [outcome('find . -name "*.py"'), outcome('grep -n "return" x.py')])
+    ).toEqual({ named: 0, gap: 0 });
+  });
+
+  it('ignores a file-surface event, which is not a search', () => {
+    expect(searchGap(dir, [outcome('/work/pay.py', 'file')])).toEqual({
+      named: 0,
+      gap: 0,
+    });
+  });
+
+  it('reads zero from junk rather than throwing', () => {
+    // Session end must cost nothing, so a malformed event log degrades to a
+    // count of zero rather than failing the hook.
+    expect(searchGap(dir, [null, undefined, {}, { kind: 'read' }])).toEqual({
+      named: 0,
+      gap: 0,
+    });
+    expect(searchGap(join(dir, 'nowhere'), [])).toEqual({ named: 0, gap: 0 });
+  });
+
+  it('is reported by derive so a session actually records it', () => {
+    // The counter existing is not the same as it being observable. Without this
+    // the number would be computed and dropped, which is the exact failure the
+    // advisory itself just had.
+    record(dir, outcome('grep -rn "settlement_rate" .'));
+    const result = derive(dir, { sessionId: 's1', projectRoot: dir });
+    expect(result.searchGap).toEqual({ named: 1, gap: 1 });
   });
 });

--- a/tests/hooks/enforcement.test.mjs
+++ b/tests/hooks/enforcement.test.mjs
@@ -93,6 +93,20 @@ function run(payload, env = {}) {
     encoding: 'utf8',
     env: {
       ...process.env,
+      // ASKED FOR EXPLICITLY, because the default is no longer enforce.
+      //
+      // These assertions are about what enforcement DOES -- a large read is
+      // denied, a second read of the same target degrades to an advisory -- and
+      // they used to get that posture by inheriting the default. Now that assist
+      // is the default (see policy.mjs#mode, on THOL and ledger measurement),
+      // inheriting it would test a posture that never refuses, and every
+      // "expected deny" here would report an allow.
+      //
+      // Naming the mode keeps every assertion exactly as strong as it was: the
+      // suite still proves refusals work, under the posture that has them.
+      // Placed BEFORE the `...env` spread so the cases below that deliberately
+      // ask for `off` and `advise` still override it.
+      TOKEN_OPTIMIZER_MODE: 'enforce',
       // These tests exercise enforcement, so they provide the same positive
       // runtime inventory evidence production now requires before redirecting.
       TOKEN_OPTIMIZER_MCP_CAPABILITIES:

--- a/tests/hooks/mcp-capability-negotiation.test.mjs
+++ b/tests/hooks/mcp-capability-negotiation.test.mjs
@@ -113,6 +113,21 @@ describe('inventory evidence', () => {
 });
 
 describe('fail-open routing', () => {
+  // ROUTING IS ASKED FOR, because the default no longer advertises it.
+  //
+  // These cases are about WHICH call a router redirects once a replacement is
+  // proven registered -- the fail-open contract. policy.mjs#mode now defaults to
+  // `assist`, whose defining property is that it emits no routing advisory and
+  // never refuses (see the MODE_ASSIST docblock), so inheriting the default
+  // would make every "expected deny" here report an allow and the suite would
+  // be asserting that routing does not happen.
+  //
+  // The outer beforeEach rebuilds cleanEnv from scratch, so this must run after
+  // it -- a nested beforeEach does.
+  beforeEach(() => {
+    cleanEnv.TOKEN_OPTIMIZER_MODE = 'enforce';
+  });
+
   const grep = {
     tool_name: 'Grep',
     tool_input: { pattern: 'needle', path: '.' },
@@ -217,6 +232,25 @@ describe('fail-open routing', () => {
 });
 
 describe('session policy honesty', () => {
+  // These assert properties OF THE ROUTING ADVISORY -- that it names no schema
+  // it cannot prove is registered, and names every one it can. `assist`, now the
+  // default, deliberately emits no routing advisory at all (policyText computes
+  // `advertiseRouting = mode() !== MODE_ASSIST`), so under the default there is
+  // no text for these to be honest or dishonest about and both assertions fail
+  // against a product that is behaving exactly as designed.
+  //
+  // Set on process.env rather than a spawn env because policyText is called
+  // in-process here, and restored afterwards so no later suite inherits it.
+  let priorMode;
+  beforeEach(() => {
+    priorMode = process.env.TOKEN_OPTIMIZER_MODE;
+    process.env.TOKEN_OPTIMIZER_MODE = 'enforce';
+  });
+  afterEach(() => {
+    if (priorMode === undefined) delete process.env.TOKEN_OPTIMIZER_MODE;
+    else process.env.TOKEN_OPTIMIZER_MODE = priorMode;
+  });
+
   test('does not claim or name unavailable schemas', () => {
     const text = policyText(true, new Set(), false);
     expect(text).toMatch(/no positive evidence/i);

--- a/tests/hooks/search-advisory.test.mjs
+++ b/tests/hooks/search-advisory.test.mjs
@@ -1030,6 +1030,23 @@ describe('lifting a search pattern out of a shell command', () => {
     ['grep -e my_symbol -rn .', 'my_symbol'],
     ['grep --regexp=my_symbol .', 'my_symbol'],
     ['find . -name "compute_settlement*"', 'compute_settlement*'],
+
+    // THE COLOUR OPTION IS THE ONE FLAG WHOSE ARITY VARIES BY PROGRAM, so
+    // neither "always valued" nor "never valued" parses all of these. Treating
+    // it as valued returned `file.py` for grep and `.` for ag/ack; treating it
+    // as valueless returns `never` for rg. Every row below failed under one of
+    // those two global rules.
+    ['grep --color needle file.py', 'needle'],
+    ['grep --colour needle file.py', 'needle'],
+    ['grep --color=always needle file.py', 'needle'],
+    ['egrep --color needle file.py', 'needle'],
+    ['fgrep --color needle file.py', 'needle'],
+    // ripgrep is the exception: WHEN is a separate, required token.
+    ['rg --color never needle .', 'needle'],
+    ['rg --color=never needle .', 'needle'],
+    // Valueless toggles.
+    ['ag --color needle .', 'needle'],
+    ['ack --color needle .', 'needle'],
   ])('%s', (command, expected) => {
     expect(searchPatternFromCommand(command)).toBe(expected);
   });

--- a/tests/hooks/search-advisory.test.mjs
+++ b/tests/hooks/search-advisory.test.mjs
@@ -1047,6 +1047,20 @@ describe('lifting a search pattern out of a shell command', () => {
     // Valueless toggles.
     ['ag --color needle .', 'needle'],
     ['ack --color needle .', 'needle'],
+
+    // AN OPERATOR INSIDE QUOTES IS A CHARACTER, NOT A SEPARATOR. Splitting the
+    // raw string before tokenizing cut through quoted text and silently
+    // truncated the pattern, so the identifiers after the first branch never
+    // reached adviseSearch and a matching advisory could be dropped.
+    ['grep -E "foo|bar" .', 'foo|bar'],
+    ["grep 'a|b' .", 'a|b'],
+    ['rg "a;b" .', 'a;b'],
+    ['grep "x&&y" .', 'x&&y'],
+    ['grep "semi;colon" f.py', 'semi;colon'],
+    // ...while real pipelines and sequencing still segment, which is what lets
+    // a search that is not the first command be found at all.
+    ['a || grep fallback_sym .', 'fallback_sym'],
+    ['x ; grep after_semi .', 'after_semi'],
   ])('%s', (command, expected) => {
     expect(searchPatternFromCommand(command)).toBe(expected);
   });

--- a/tests/hooks/search-advisory.test.mjs
+++ b/tests/hooks/search-advisory.test.mjs
@@ -29,7 +29,13 @@ import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
-import { identifiersIn, adviseSearch, caseProbePath, SESSION_CAP } from '../../hooks-core/advise.mjs';
+import {
+  identifiersIn,
+  adviseSearch,
+  caseProbePath,
+  searchPatternFromCommand,
+  SESSION_CAP,
+} from '../../hooks-core/advise.mjs';
 import { seedProject, alreadySeeded, seedDisabled } from '../../hooks-core/seed.mjs';
 import { loadState, saveState } from '../../hooks-core/policy.mjs';
 import { load, withBatchedWrites, putNode, putEdge } from '../../hooks-core/wiki.mjs';
@@ -839,5 +845,219 @@ describe('the advisory reaches the model on both paths', () => {
     });
     const aboveOut = JSON.parse(above.stdout || '{}').hookSpecificOutput || {};
     expect(aboveOut.additionalContext || '').not.toContain('parse.py');
+  });
+});
+
+/**
+ * The two ways the advisory was reaching nobody.
+ *
+ * BOTH WERE MEASURED ON THE WARM TRACK, not imagined. That campaign ran 107
+ * assist runs and the needle-in-repo task -- written expressly to demonstrate
+ * this reuse -- came back at 0.932 while the ADVERSARIAL set, whose tasks cannot
+ * reuse anything by construction, averaged 0.681. Tasks that could not benefit
+ * were benefiting most, which is the signature of a retrieval path that never
+ * fires.
+ *
+ *   1. THE POSTURE. Under `assist` the advisory was computed and then thrown
+ *      away: it rides on `reason`, and enforce() allows silently under assist,
+ *      exiting before `reason` is delivered. The existing coverage above missed
+ *      this because its assist cases all pass an EMPTY capability list, which
+ *      produces no verdict and so takes the allowed path, where context is
+ *      delivered by allowWithContext. Assist WITH a proven server -- an ordinary
+ *      plugin install, and now the default posture -- was never exercised.
+ *
+ *   2. THE TOOL. The gate named `Grep` and `Glob`. The observed agents searched
+ *      through the shell and were never eligible at all:
+ *
+ *        Bash  grep -rn "compute_settlement_fee" /work --include=* | head -50
+ *
+ * This is the same defect class as the output bound that was wired into the
+ * refusal branch and so never touched the family it was built for. A capability
+ * that works only while refusing is not shipped.
+ */
+describe('the advisory survives the posture and the tool', () => {
+  let seq = 0;
+  const fresh = (name) => `${name}-${Date.now()}-${++seq}`;
+
+  const run = (payload, env) =>
+    spawnSync(process.execPath, [ROUTER], {
+      input: JSON.stringify(payload),
+      encoding: 'utf8',
+      timeout: 30_000,
+      env: {
+        ...process.env,
+        TOKEN_OPTIMIZER_WIKI_DIR: graphDir,
+        TOKEN_OPTIMIZER_SHARED_DIR: graphDir,
+        ...env,
+      },
+    });
+
+  const out = (result) =>
+    JSON.parse(result.stdout || '{}').hookSpecificOutput || {};
+
+  // A real install: the server IS present, which is what produces a verdict and
+  // sends the call down the path that was dropping the answer.
+  const INSTALLED = {
+    TOKEN_OPTIMIZER_MCP_CAPABILITIES:
+      'smart_read,smart_write,smart_edit,smart_glob,smart_grep',
+  };
+
+  test('assist delivers the answer to a properly installed plugin', () => {
+    const result = out(
+      run(
+        {
+          session_id: fresh('assist-installed'),
+          cwd: workspace,
+          tool_name: 'Grep',
+          tool_input: { pattern: 'parse_line' },
+        },
+        { ...INSTALLED, TOKEN_OPTIMIZER_MODE: 'assist' }
+      )
+    );
+    // Allowed, because assist never refuses -- and carrying the fact anyway.
+    expect(result.permissionDecision).not.toBe('deny');
+    expect(result.additionalContext || '').toContain('parse.py');
+  });
+
+  test('a shell grep is answered, not only the Grep tool', () => {
+    const result = out(
+      run(
+        {
+          session_id: fresh('bash-grep'),
+          cwd: workspace,
+          tool_name: 'Bash',
+          tool_input: { command: `grep -rn "parse_line" ${workspace}` },
+        },
+        { ...INSTALLED, TOKEN_OPTIMIZER_MODE: 'assist' }
+      )
+    );
+    expect(result.additionalContext || '').toContain('parse.py');
+  });
+
+  test('the shell search still runs exactly as written', () => {
+    // The whole feature is additive. Rewriting the command the model asked for
+    // would make a wrong index cost the turn it exists to save.
+    const command = `grep -rn "parse_line" ${workspace}`;
+    const result = out(
+      run(
+        {
+          session_id: fresh('bash-intact'),
+          cwd: workspace,
+          tool_name: 'Bash',
+          tool_input: { command },
+        },
+        { ...INSTALLED, TOKEN_OPTIMIZER_MODE: 'assist' }
+      )
+    );
+    expect(result.updatedInput?.command ?? command).toBe(command);
+  });
+
+  test('assist stays silent when the graph has no answer', () => {
+    // THE PROPERTY ASSIST EXISTS FOR. It speaks only when it holds a fact, so
+    // widening the gate to every Bash call must not put a byte of context on
+    // calls the index cannot help. A regression here is invisible in the
+    // pass/fail of the tests above and shows up only as a cost.
+    const result = out(
+      run(
+        {
+          session_id: fresh('assist-silent'),
+          cwd: workspace,
+          tool_name: 'Bash',
+          tool_input: { command: `grep -rn "totally_unknown_symbol_xyz" ${workspace}` },
+        },
+        { ...INSTALLED, TOKEN_OPTIMIZER_MODE: 'assist' }
+      )
+    );
+    expect(result.additionalContext || '').not.toContain('token-optimizer index');
+  });
+
+  test('assist carries the answer without the routing advisory', () => {
+    // The two used to travel together in `reason`, which is why assist dropped
+    // both. Splitting them must not let the generic redirect back in: that text
+    // fires on every matched call and is the context cost assist exists to
+    // avoid, where the answer fires only when the index has one.
+    const result = out(
+      run(
+        {
+          session_id: fresh('assist-noroute'),
+          cwd: workspace,
+          tool_name: 'Grep',
+          tool_input: { pattern: 'parse_line' },
+        },
+        { ...INSTALLED, TOKEN_OPTIMIZER_MODE: 'assist' }
+      )
+    );
+    const text = result.additionalContext || '';
+    expect(text).toContain('parse.py');
+    expect(text).not.toContain('Call the token-optimizer MCP tool');
+  });
+
+  test('enforce still refuses and still carries the answer', () => {
+    // The split must not cost the refusal path what it already delivered.
+    const result = out(
+      run(
+        {
+          session_id: fresh('enforce-still'),
+          cwd: workspace,
+          tool_name: 'Grep',
+          tool_input: { pattern: 'parse_line' },
+        },
+        { ...INSTALLED, TOKEN_OPTIMIZER_MODE: 'enforce' }
+      )
+    );
+    expect(result.permissionDecision).toBe('deny');
+    expect(result.permissionDecisionReason || '').toContain('parse.py');
+  });
+});
+
+describe('lifting a search pattern out of a shell command', () => {
+  test.each([
+    // The exact command observed on the warm track, head-pipe and all.
+    [
+      'grep -rn "compute_settlement_fee" /work --include=* 2>/dev/null | head -50',
+      'compute_settlement_fee',
+    ],
+    // Context flags take a value, so a positional walk must skip past `30`.
+    ['grep -n "needle" -A 30 -B 10 file.py', 'needle'],
+    ['grep -rn bare_identifier .', 'bare_identifier'],
+    ["rg 'parse_line' src/", 'parse_line'],
+    ['rg -t py --glob "*.py" settle_fee .', 'settle_fee'],
+    // The search is not the first segment of either of these.
+    ['cat notes.txt | grep needle_name', 'needle_name'],
+    ['make build && grep needle_name .', 'needle_name'],
+    ['git grep normalise', 'normalise'],
+    // An explicit -e names the pattern and outranks position.
+    ['grep -e my_symbol -rn .', 'my_symbol'],
+    ['grep --regexp=my_symbol .', 'my_symbol'],
+    ['find . -name "compute_settlement*"', 'compute_settlement*'],
+  ])('%s', (command, expected) => {
+    expect(searchPatternFromCommand(command)).toBe(expected);
+  });
+
+  test.each([
+    ['ls -la /work'],
+    ['python3 -c "print(1)"'],
+    ['cat file.py'],
+    // `grep` as an argument to something else is not a search.
+    ['echo grep'],
+    [''],
+  ])('no pattern in: %s', (command) => {
+    expect(searchPatternFromCommand(command)).toBeNull();
+  });
+
+  test('malformed input is answered, not thrown on', () => {
+    expect(searchPatternFromCommand(undefined)).toBeNull();
+    expect(searchPatternFromCommand(null)).toBeNull();
+    expect(searchPatternFromCommand(42)).toBeNull();
+    expect(searchPatternFromCommand('grep "unterminated')).toBe('unterminated');
+  });
+
+  test('a pathological command is bounded rather than parsed', () => {
+    // This runs on the hook's critical path against a string the model wrote.
+    // The advisory is an optimisation and must never become the slow path.
+    const huge = `grep -rn "x" ${'a'.repeat(50_000)}`;
+    const started = Date.now();
+    expect(searchPatternFromCommand(huge)).toBeNull();
+    expect(Date.now() - started).toBeLessThan(100);
   });
 });

--- a/tests/integration/client-hooks.test.ts
+++ b/tests/integration/client-hooks.test.ts
@@ -62,6 +62,11 @@ function runHook(
     encoding: 'utf8',
     env: {
       ...process.env,
+      // ASKED FOR, NOT INHERITED. These cases assert refusals and the routing
+      // guidance that names replacements; policy.mjs#mode now defaults to
+      // `assist`, which emits neither. Placed before the `...env` spread so the
+      // cases that deliberately pass `advise` or `off` still override it.
+      TOKEN_OPTIMIZER_MODE: 'enforce',
       // This suite exercises the registered-tool path. Unknown or empty
       // inventories are covered separately by mcp-capability-negotiation.
       TOKEN_OPTIMIZER_MCP_CAPABILITIES:
@@ -419,7 +424,7 @@ describe('native CLI hook integrations', () => {
     ['OpenCode', openCodePlugin],
     ['Kilo', kiloPlugin],
   ])(
-    '%s executes its staged shared hook and enforces by default',
+    '%s executes its staged shared hook, refuses when enforcing, and allows by default',
     async (_name, pluginPath) => {
       const previousMode = process.env.TOKEN_OPTIMIZER_MODE;
       const previousCapabilities = process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES;
@@ -438,12 +443,29 @@ describe('native CLI hook integrations', () => {
           directory: fixtureDir,
         });
 
+        // THE SUBJECT IS THAT THE STAGED HOOK REALLY RUNS AND CAN REFUSE, which
+        // is why this asks for `enforce` rather than inheriting. The default is
+        // now `assist` (policy.mjs#mode, on THOL and ledger measurement), so an
+        // inherited default would prove only that nothing happened -- and this
+        // plugin path has shipped broken before, which is why the test exists.
+        process.env.TOKEN_OPTIMIZER_MODE = 'enforce';
+        await expect(
+          hooks['tool.execute.before'](
+            { tool: 'read', sessionID: `enforce-${_name}` },
+            { args: { filePath: largeFile } }
+          )
+        ).rejects.toThrow('smart_read');
+
+        // AND THE NEW DEFAULT IS PINNED HERE, so a silent revert to an enforcing
+        // default fails this suite rather than passing it. Unset must mean
+        // assist: the large read goes through untouched.
+        delete process.env.TOKEN_OPTIMIZER_MODE;
         await expect(
           hooks['tool.execute.before'](
             { tool: 'read', sessionID: `default-${_name}` },
             { args: { filePath: largeFile } }
           )
-        ).rejects.toThrow('smart_read');
+        ).resolves.toBeUndefined();
 
         process.env.TOKEN_OPTIMIZER_MODE = 'advise';
         await expect(
@@ -453,7 +475,11 @@ describe('native CLI hook integrations', () => {
           )
         ).resolves.toBeUndefined();
 
-        delete process.env.TOKEN_OPTIMIZER_MODE;
+        // FAIL-OPEN ON AN EMPTY INVENTORY, checked under `enforce` for the same
+        // reason: "it was allowed" is only evidence when something could have
+        // refused. Left on the default this would pass against a hook that had
+        // stopped working altogether.
+        process.env.TOKEN_OPTIMIZER_MODE = 'enforce';
         process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES = '';
         await expect(
           hooks['tool.execute.before'](


### PR DESCRIPTION
## What

Two changes that only make sense together:

1. `TOKEN_OPTIMIZER_MODE` defaults to `assist` instead of `enforce`.
2. The graph's search advisory now actually reaches the model under `assist`, and answers shell searches as well as `Grep`/`Glob`.

They ship as one PR because the first is meaningless without the second: shipping "assist is the default" while the advisory is dead under assist would switch the crown jewel off for every user.

## 1. Why assist becomes the default

Two independent harnesses agree the mode we ship today is the one that costs users most.

**THOL 2.1.251** — 17 tasks x 3 reps x 3 arms, 153 runs, zero errors:

| arm | cost | score | turns |
| --- | --- | --- | --- |
| control | $21.13 | 0.969 | 16.2 |
| **assist** | **$20.48** | **0.971** | **14.4** |
| enforce | $23.33 | 0.935 | 17.6 |

`assist` beats control on all three. `enforce` — today's default — loses on all three and on 12 of 17 tasks.

**Ledger cold track** localises the cost:

- `enforce/advise` = 1.147 [1.065, 1.235] — refusals cost 14.7%
- `advise/assist-mcp` = 1.028 [0.951, 1.114] — the routing advisory is free

So it is the refusals, not the advisory and not retrieval. Worth ~12% cost and 3.6 score points against what users get today.

The enforce arm had to be *built* for that campaign — none of the ten existing THOL manifests declared it, so the shipped default had never been measured on the benchmark our target is denominated on.

Nothing is deleted: `enforce` is one variable away and every refusal test still exercises it. **The typo property is preserved** — an unrecognised value still falls back to a posture with the product fully on; `off` is reachable only by asking for it exactly.

## 2. Why the graph was contributing nothing

The Ledger's warm track — the only instrument either benchmark has for cross-session accumulation — ran for the first time: 217 runs at n=10. The result was the inverse of what a working graph predicts:

| group | assist/control | reuse possible? |
| --- | --- | --- |
| adversarial set | **0.681** | no, by construction |
| beneficiary set | **0.890** | yes, tasks written to show it |

Tasks that *cannot* reuse anything gained most. That is the signature of a retrieval path that never fires. Two independent faults, both proven against the real router:

**Fault 1 — the posture threw the answer away.** The advisory rides on `reason`, and `enforce()` allows *silently* under assist, exiting before `reason` is delivered:

```
assist   Grep -> nothing      Bash grep -> nothing
advise   Grep -> ADVISED      Bash grep -> ADVISED
enforce  Grep -> ADVISED      Bash grep -> ADVISED
```

The warm campaign ran assist for all 107 of its runs. Existing coverage missed this because every assist case passed an **empty** capability list, which produces no verdict and takes the allowed path where context *is* delivered. Assist with a proven server — an ordinary install — was never exercised.

An answer is not a redirect; they only travelled together by accident. The routing advisory ("call smart_grep instead") fires on every matched call and buys nothing — exactly the cost assist exists to avoid. A graph answer fires only when the index holds one and can save a whole turn. Now split: assist allows the call and carries the fact, with no refusal and no routing noise.

**Fault 2 — the gate named the wrong tools.** `Grep` and `Glob` only, while the observed agents searched through the shell:

```
Bash  grep -rn "compute_settlement_fee" /work --include=* 2>/dev/null | head -50
Bash  cat /work/pkg/mod_047.py
Edit  /work/pkg/mod_047.py
```

Zero Grep calls, zero Glob calls — while that session's own graph held `compute_settlement_fee -> pkg/mod_047.py:9-12` and returned it correctly to a direct call. Two turns spent rediscovering an indexed fact.

`searchPatternFromCommand` lifts the pattern out of grep/egrep/fgrep/rg/ag/ack, `git grep` and `find -name`, then hands it to the **same** `adviseSearch` the Grep tool uses so the surfaces cannot drift. Single forward pass, no regex, no backtracking; skips flags that consume a value (the observed `-A 30 -B 10` would otherwise stop the walk at `30`); honours `-e`/`--regexp` over position; splits on pipeline and sequencing operators.

This is the same defect class as the output bound that was wired into the refusal branch and never touched the family it was built for. A capability that works only while refusing is not shipped.

**Zero cost when there is no answer** — the property assist exists for, and the one a wider gate could most easily break. Verified: assist plus an unknown symbol returns 0 bytes, via Grep and via Bash.

## Verification

Real router binary, all modes:

```
(unset)         -> allow            typo-nonsense -> allow
enforce         -> deny             off           -> allow
advise          -> advise
```

Combined behaviour on this branch, shell grep against a real indexed graph:

```
(unset default)  allow  compute_settlement_fee -> pkg/mod_047.py:5-7
assist           allow  compute_settlement_fee -> pkg/mod_047.py:5-7
enforce          deny   compute_settlement_fee -> pkg/mod_047.py:5-7
```

## Tests

**No assertion was weakened.** Every suite that asserted a refusal now *names* the posture that refuses, which is stricter than inheriting it. Two probes were pinned to `enforce` because they had gone **vacuous** — "fails open on an empty inventory" and "small reads are left alone" only prove something under a posture that could refuse; on the new default they would pass against a hook that had stopped working entirely. The OpenCode and Kilo cases **gained** a phase asserting the new default, so a silent revert fails the suite.

+24 tests. Three assert the new advisory behaviour and were confirmed to **fail** against the unfixed router; three more are regression guards that hold either way; the rest cover the extractor, including the exact command observed on the warm track and a 50 KB pathological input bounded under 100 ms.

```
266 suites, 3725 passed, 5 skipped, 3730 total
```

## Also

- The install doctor asks for `enforce` when probing refusals — the question is "would enforcement fire if switched on", and on the new default it would otherwise report a false negative on a healthy install.
- README updated everywhere it promised enforcement by default: shields badge, the Codex/Copilot/OpenCode sections, the lifecycle table.

## Validation

`npm run validate:pr` and `npm run pr:create` do not exist in this repo. Ran the equivalent: `lint` (0 errors), `format:check`, `sync:hooks:check`, `validate` (no errors/warnings), `build`, full `test`.

Relates to #357 (M1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)