### PR TITLE
feat(derive): pair a fix to its failure by target, so findings actually form

### DIFF
--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -44,8 +44,9 @@ import {
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
+  readMetrics,
 } from './metrics.mjs';
-import { derive } from './derive.mjs';
+import { derive, projectRootFromActivity } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -1205,7 +1206,32 @@ async function runHook(clientName, event, invocation) {
       // one figure alone cannot distinguish "nothing to derive" from "derived
       // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
-      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      // WHERE THE WORK HAPPENED, NOT WHERE THE CLIENT WAS LAUNCHED.
+      //
+      // `projectRootFor` on a cwd with no VCS marker -- a home directory, which
+      // is how this client is commonly started -- returns the synthetic fallback
+      // `~/.token-optimizer/unrooted`. That is not null, so every `if
+      // (projectRoot)` gate downstream passes, and `projectAnchor` then hands
+      // back the directory itself because the fallback holds no project marker.
+      // `writeHarvested` resolves anchors through `indexFile`, which returns
+      // null for a directory, and the finding is refused as unanchorable.
+      //
+      // Measured consequence on this machine: 937 derive runs, 8 candidates,
+      // ZERO findings written, beside 2,965 symbol nodes in the same graph. The
+      // router already keys capture on where the FILE lives rather than on the
+      // session's cwd; this applies that rule to derivation too, and falls back
+      // to the cwd answer when the session touched nothing resolvable.
+      const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      let projectRoot = cwdRoot;
+      try {
+        projectRoot =
+          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+            resolve: (anchor) => projectRootFor(anchor, cwd),
+            cwd,
+          }) || cwdRoot;
+      } catch {
+        // Inferring the project is an improvement, never a precondition.
+      }
       const dir = wikiDir(projectRoot);
       const derived = derive(dir, {
         sessionId,

--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -53,6 +53,7 @@ import {
   load,
   wikiDir,
   projectRootFor,
+  unrootedRoot,
 } from './wiki.mjs';
 import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
@@ -76,7 +77,7 @@ import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
-import { isFsSafePath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
   recordingNudge,
@@ -92,7 +93,7 @@ import {
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
-import { registerProject } from './projects.mjs';
+import { registerProject, registeredProjects } from './projects.mjs';
 import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
@@ -107,6 +108,62 @@ export const CLIENTS = nativeClientProfiles();
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
+
+/**
+ * How many registered project graphs a session-end sweep may open.
+ *
+ * The registry is append-only and unbounded over time -- 4,033 records on this
+ * machine -- and each graph read is a tail of up to 2 MB. Bounded to the most
+ * recently seen handful, which is the only part of the registry a single
+ * session can plausibly have written to.
+ */
+const CROSS_PROJECT_SCAN_LIMIT =
+  Number(process.env.TOKEN_OPTIMIZER_CROSS_PROJECT_SCAN) || 12;
+
+/** A project the current session cannot have touched is not worth opening. */
+const CROSS_PROJECT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The activity this session recorded, gathered from every graph that could hold
+ * it.
+ *
+ * Capture is keyed on where the FILE lives (`recordToolOutcome(wikiDir(root))`,
+ * post-tool), not on the session's cwd. So when the client is started outside a
+ * repository -- a home directory, the common case -- the session's own file
+ * activity is written into each touched project's graph, and the unrooted graph
+ * that `cwd` resolves to holds none of it. Reading only that graph is why the
+ * inference below returned null in exactly the case it exists for: measured on
+ * this machine, the unrooted store holds 12,376 file anchors and ZERO of them
+ * under a repository.
+ *
+ * The sweep is confined to that case. A cwd that IS a repository already owns
+ * the graph its own files were captured into, so it pays nothing.
+ */
+export function sessionActivity(cwdRoot) {
+  let events = [];
+  try {
+    events = readMetrics(wikiDir(cwdRoot));
+  } catch {
+    events = [];
+  }
+  if (canonicalPath(cwdRoot) !== canonicalPath(unrootedRoot())) return events;
+  const cutoff = Date.now() - CROSS_PROJECT_MAX_AGE_MS;
+  let projects = [];
+  try {
+    // Sorted most-recently-seen first by `registeredProjects`.
+    projects = registeredProjects().filter((p) => (p.lastSeenAt || 0) >= cutoff);
+  } catch {
+    return events;
+  }
+  for (const project of projects.slice(0, CROSS_PROJECT_SCAN_LIMIT)) {
+    try {
+      events = events.concat(readMetrics(project.graphDir));
+    } catch {
+      // One unreadable store must not cost the session its inference.
+    }
+  }
+  return events;
+}
 
 /**
  * The response envelopes a completed tool call can arrive in.
@@ -1221,13 +1278,21 @@ async function runHook(clientName, event, invocation) {
       // router already keys capture on where the FILE lives rather than on the
       // session's cwd; this applies that rule to derivation too, and falls back
       // to the cwd answer when the session touched nothing resolvable.
+      //
+      // The evidence is gathered by `sessionActivity`, NOT from the cwd graph
+      // alone: capture keyed on the file's project means an unrooted session's
+      // own activity was written into the graphs of the projects it touched.
+      // Reading only the unrooted graph found 12,376 file anchors and not one
+      // under a repository, so the inference was inert in precisely the case it
+      // was written for.
       const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
       let projectRoot = cwdRoot;
       try {
         projectRoot =
-          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+          projectRootFromActivity(sessionActivity(cwdRoot), {
             resolve: (anchor) => projectRootFor(anchor, cwd),
             cwd,
+            sessionId,
           }) || cwdRoot;
       } catch {
         // Inferring the project is an improvement, never a precondition.

--- a/hooks-core/advise.mjs
+++ b/hooks-core/advise.mjs
@@ -160,7 +160,7 @@ const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function commandSegments(command) {
+export function commandSegments(command) {
   const segments = [];
   let tokens = [];
   let current = '';

--- a/hooks-core/derive.mjs
+++ b/hooks-core/derive.mjs
@@ -737,6 +737,27 @@ export function derive(dir, options = {}) {
   let outcomes = [];
   try {
     if (projectRoot) {
+      // SCOPED TO THE SESSION THE CLAIM WILL NAME.
+      //
+      // Every claim these detectors build opens `observed in one session:`,
+      // and the store holds every session's outcomes -- so nothing but the
+      // ten-minute window stopped a failure from one session pairing with a
+      // success from another and asserting a provenance that never happened.
+      //
+      // NEVER OBSERVED, SAID PLAINLY. Across both live stores on this machine
+      // -- 7,173 command outcomes over 3 sessions here, 543 over 9 sessions in
+      // the unrooted one -- 5,155 and 298 adjacent in-window pairs respectively
+      // and ZERO of them crossed a session. Sessions are long and rarely
+      // interleave inside ten minutes. This is a correctness fix against a
+      // false claim, not a fix for observed damage, and it is not offered as
+      // one. Concurrent sessions do occur -- one was recorded on this machine
+      // while this was being written -- and they share the unrooted store.
+      //
+      // The merged transcript failures below are deliberately NOT filtered:
+      // `failedResultsFromTranscript` carries no sessionId, and the transcript
+      // it read is this session's, so they are already scoped by construction.
+      // Filtering them here would drop the only source of command failures
+      // that exists -- Claude Code never fires PostToolUse on a non-zero exit.
       outcomes = events
         .filter(
           (e) =>
@@ -744,7 +765,10 @@ export function derive(dir, options = {}) {
             e.kind === 'tool-outcome' &&
             e.surface === 'command' &&
             typeof e.anchor === 'string' &&
-            e.anchor.trim()
+            e.anchor.trim() &&
+            // An event predating the field still counts; a DIFFERENT session
+            // never does.
+            (!sessionId || !e.sessionId || e.sessionId === sessionId)
         )
         .map((e) => ({
           command: e.anchor.trim(),

--- a/hooks-core/derive.mjs
+++ b/hooks-core/derive.mjs
@@ -51,6 +51,7 @@ import { ORIGIN_HARVESTED } from './curate.mjs';
 // from, so what this counts as a search and what the advisory treats as one
 // cannot diverge.
 import {
+  commandSegments,
   identifiersIn,
   searchPatternFromCommand,
   symbolIndex,
@@ -180,11 +181,38 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
-const hasAttemptIdentity = (command) =>
-  attemptKey(command)
+/**
+ * THE WHOLE BODY, NOT THE FIRST THREE TOKENS.
+ *
+ * This used to read the separator set off `attemptKey`, which keeps only the
+ * first three non-flag tokens -- so it caught a separator only when one landed
+ * early by luck of position. Verified against the real functions:
+ *
+ *   git fetch && npx jest tests/foo   key `git fetch &&`        -> rejected
+ *   npx jest tests/foo && node x.mjs  key `npx jest tests/foo`  -> ACCEPTED
+ *   grep -rn foo src | head -20       key `grep foo src`        -> ACCEPTED
+ *
+ * The last two are exactly the claims this guard exists to stop: the key names
+ * `npx`, so a pair would blame `npx` for a failure `node` may have caused.
+ * Every existing test placed the separator in the first three tokens, so none
+ * of them could see it.
+ *
+ * `commandSegments` is reused rather than a fresh scan because it is already
+ * the quote-aware one: splitting the raw string would cut through `grep -E
+ * "foo|bar"` and reject an ordinary alternation as a pipeline.
+ *
+ * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
+ * before this sees it -- that case is one command spelled two ways.
+ */
+const hasAttemptIdentity = (command) => {
+  const body = commandBody(command);
+  if (!body.trim()) return false;
+  if (commandSegments(body).length > 1) return false;
+  return attemptKey(command)
     .split(' ')
     .filter(Boolean)
     .every((token) => !COMMAND_SEPARATORS.has(token));
+};
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -433,11 +461,20 @@ export function projectRootFromActivity(events, { resolve, cwd, sessionId = null
   const counts = new Map();
   for (const event of events) {
     // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
-    // session that wrote it, so counting every event ever recorded lets a busy
-    // session from last week outvote the one now ending -- and the question
-    // being asked is "where did THIS session work", not "where is this graph
-    // busiest". Callers that pass no id keep the whole-graph count.
-    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
+    // session that wrote it, and the caller concatenates several graphs, so
+    // counting every event ever recorded lets a busy session from last week
+    // outvote the one now ending -- and the question being asked is "where did
+    // THIS session work", not "where is this graph busiest". Callers that pass
+    // no id keep the whole-graph count.
+    //
+    // AN EVENT THAT CANNOT NAME ITS SESSION IS EXCLUDED, not exempted. Exempting
+    // it was a deliberate concession to older records, and measurement says the
+    // concession buys nothing: across the three live stores on this machine, 2
+    // of 22,321 file/read events lack the field -- 0.01%. Set against that, an
+    // unstamped event sitting in ANOTHER project's graph would vote for that
+    // project on the strength of no evidence at all, which is precisely the
+    // failure this filter exists to prevent.
+    if (sessionId && event?.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.

--- a/hooks-core/derive.mjs
+++ b/hooks-core/derive.mjs
@@ -913,6 +913,20 @@ export function derive(dir, options = {}) {
           const failed = lastFailure;
           lastFailure = null;
 
+          // BOTH SIDES MUST NAME A SINGLE COMMAND, the same rule detector 1
+          // applies. `commandBody` strips only a LEADING directory change, and
+          // `commandProgram` reads the first token, so a chained command
+          // attributes the failure to the wrong program entirely:
+          //
+          //   git fetch && npx jest tests/foo.test.mjs   -> program "git"
+          //   cat x | npx jest tests/foo.test.mjs        -> program "cat"
+          //
+          // Paired against `npm test -- tests/foo.test.mjs` those would ship
+          // "npm test succeeded where git fetch failed" and tell a later session
+          // to avoid `git`. Checked per side rather than once, because unlike
+          // detector 1 these two do NOT share a key by construction.
+          if (!hasAttemptIdentity(failed.command)) continue;
+          if (!hasAttemptIdentity(outcome.command)) continue;
           // Same program is detector 1's case, whether it pairs there or not.
           if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
           // A fix follows its failure closely. Hours apart is two unrelated

--- a/hooks-core/derive.mjs
+++ b/hooks-core/derive.mjs
@@ -401,6 +401,66 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * against a fabricated anchor. That is the fail-open direction: no finding
  * beats a finding anchored to something that is not what the claim is about.
  */
+
+/**
+ * The project a session actually worked in, read off what it touched.
+ *
+ * WHY THE SESSION'S CWD IS THE WRONG ANSWER. `adapter.mjs` resolves the root
+ * with `projectRootFor(join(cwd, '__session__'), cwd)`, and when Claude Code is
+ * launched from a directory with no VCS marker -- a home directory, which is how
+ * this machine runs it -- that returns the synthetic fallback
+ * `~/.token-optimizer/unrooted`. It is NOT null, so every `if (projectRoot)`
+ * gate passes, and then `projectAnchor` hands back the directory itself because
+ * the fallback contains no project marker. `writeHarvested` resolves anchors
+ * through `indexFile`, `indexFile` on a directory returns null, and the finding
+ * is refused as unanchorable.
+ *
+ * That is the whole reason this machine's graph holds 2,965 symbols and ONE
+ * finding: 937 derive runs produced candidates and stored none of them, while
+ * every layer reported success.
+ *
+ * The router already solved this for capture -- "THE GRAPH IS PER PROJECT, so it
+ * is keyed on where the FILE lives, not on where the client happens to be
+ * running" -- and derivation simply never adopted it. This applies the same
+ * rule at Stop time: take the file anchors the session recorded, resolve each to
+ * its own project, and pick the one that holds the most of them.
+ *
+ * Returns null when nothing resolves, which leaves the caller's original root
+ * untouched -- a wrong project is worse than the status quo.
+ */
+export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+  if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
+  const counts = new Map();
+  for (const event of events) {
+    const anchor = event?.anchor;
+    // File surfaces only. A command anchor is the command text, and resolving
+    // `npm test -- x` as a path would invent a project out of a sentence.
+    if (!anchor || typeof anchor !== 'string') continue;
+    if (event.kind !== 'read' && !(event.kind === 'tool-outcome' && event.surface === 'file')) {
+      continue;
+    }
+    let root;
+    try {
+      root = resolve(anchor, cwd);
+    } catch {
+      continue;
+    }
+    // The fallback resolves to a path inside the optimizer's own store, which is
+    // never a project someone is working in.
+    if (!root || String(root).includes('.token-optimizer')) continue;
+    counts.set(root, (counts.get(root) || 0) + 1);
+  }
+  let best = null;
+  let most = 0;
+  for (const [root, n] of counts) {
+    if (n > most) {
+      most = n;
+      best = root;
+    }
+  }
+  return best;
+}
+
 export function projectAnchor(projectRoot) {
   if (!projectRoot) return null;
   let entries;

--- a/hooks-core/derive.mjs
+++ b/hooks-core/derive.mjs
@@ -65,7 +65,16 @@ import {
  * command. A correction is a lexical guess about what a human meant. Churn
  * describes our own reading behaviour and says nothing about the code at all.
  */
-export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+export const CONFIDENCE = {
+  command: 0.9,
+  test: 0.85,
+  // Below `command` because the inference is weaker: two commands sharing a
+  // target is good evidence of one intent, but not the same evidence as the
+  // identical invocation being retried. Labelled speculative, deliberately.
+  retarget: 0.6,
+  correction: 0.6,
+  churn: 0.4,
+};
 
 /** Claim text cap. A finding is one sentence; a paragraph is evidence. */
 const CLAIM_MAX = 300;
@@ -73,6 +82,17 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * How close a fix must follow its failure to count as the same attempt.
+ *
+ * Detector 5 pairs across DIFFERENT programs, so it cannot lean on command
+ * identity to know the two are related -- proximity is doing that work instead.
+ * Ten minutes is long enough for a real correction, including reading an error
+ * and looking something up, and short enough that two unrelated pieces of work
+ * touching one file in an afternoon are not reported as one story.
+ */
+const RETARGET_WINDOW_MS = 10 * 60 * 1000;
 
 /**
  * The anchor cap a command surface is stored under, restated here as a TEST.
@@ -285,6 +305,50 @@ export function attemptKey(command) {
     .join(' ')
     .toLowerCase();
 }
+/**
+ * The thing a command ACTS ON -- a path, a test file, a target.
+ *
+ * WHY `attemptKey` IS NOT ENOUGH, measured rather than supposed. That key is
+ * program-plus-operands, so the single most valuable lesson a session can teach
+ * cannot pair by construction:
+ *
+ *   npx jest tests/foo      -> key "npx jest tests/foo"
+ *   npm test -- tests/foo   -> key "npm test tests/foo"
+ *
+ * Different keys, no pair, no finding -- yet that is exactly the correction
+ * worth recording, because the fix was to run a DIFFERENT program against the
+ * same target. The existing detector can only catch the same command re-run and
+ * succeeding, which its own guard then discards as incoherent.
+ *
+ * The measured cost of that: across 937 real derive runs on this machine, 8
+ * candidates were produced and ZERO were stored.
+ *
+ * So this returns the shared operand -- `tests/foo` above -- which is what the
+ * two attempts genuinely have in common. Only operands that NAME something are
+ * admitted: a path separator or a file extension. A bare word like `build` is
+ * refused, because `npm run build` and `make build` sharing the token `build`
+ * is a coincidence of vocabulary, not evidence of one intent.
+ */
+export function commandOperand(command) {
+  const tokens = commandBody(command)
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'));
+  // Skipping the first token: the PROGRAM is what differs between the two
+  // attempts, so including it would reproduce attemptKey's blind spot.
+  for (const token of tokens.slice(1)) {
+    const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
+    if (named && token.length >= 4) return token.toLowerCase();
+  }
+  return null;
+}
+
+/** The program a command invokes, for deciding whether two attempts differ. */
+export function commandProgram(command) {
+  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  return first.split(/[/\\]/).pop().toLowerCase();
+}
+
 
 /** Normalised claim text, so the same lesson derived twice is one candidate. */
 const claimKey = (type, claim) =>
@@ -517,9 +581,15 @@ export function derive(dir, options = {}) {
   // a transcript failure that pairs with nothing stays unclaimed, which is also
   // what keeps a failure from ANOTHER project's directory out of this project's
   // graph -- a candidate cannot be emitted without a success recorded HERE.
+  // HOISTED so detector 5 can pair over the SAME merged list -- events plus the
+  // transcript failures folded in below. Rebuilding it there would duplicate the
+  // de-duplication logic and let the two detectors drift; leaving it block-scoped
+  // gave detector 5 a ReferenceError that its own try/catch swallowed, which is
+  // silent nothing rather than a visible failure.
+  let outcomes = [];
   try {
     if (projectRoot) {
-      const outcomes = events
+      outcomes = events
         .filter(
           (e) =>
             e &&
@@ -800,6 +870,92 @@ export function derive(dir, options = {}) {
   } catch {
     // One detector, never the session.
   }
+  // ---- 5: a DIFFERENT command against the same target succeeded -----------
+  //
+  // THE LESSON DETECTOR 1 CANNOT REACH. Its `attemptKey` is program-plus-
+  // operands, so the correction worth recording -- reaching for a different
+  // tool against the same target -- lands in two groups that never meet:
+  //
+  //   npx jest tests/foo.test.mjs     key "npx jest tests/foo.test.mjs"
+  //   npm test -- tests/foo.test.mjs  key "npm test tests/foo.test.mjs"
+  //
+  // What detector 1 CAN pair is the identical command re-run, and its own guard
+  // then correctly discards that as incoherent -- "`npm run build` works where
+  // `npm run build` failed" claims nothing. So between the key and the guard,
+  // the command family had almost no reachable evidence: measured across 937
+  // real derive runs on this machine, 8 candidates and ZERO stored findings.
+  //
+  // This pairs on the shared OPERAND instead, and only when the PROGRAM differs
+  // -- same-program pairs are detector 1's business and are left to it. The
+  // conservatism the original key was protecting is kept in three other places:
+  // the operand must NAME something (a path or an extension, never a bare word
+  // like `build`), the two attempts must be close in time, and the ceiling is
+  // 0.6 rather than 0.9 because sharing a target is weaker evidence than
+  // repeating an invocation.
+  try {
+    if (projectRoot && outcomes?.length) {
+      const byTarget = new Map();
+      for (const outcome of outcomes) {
+        const target = commandOperand(outcome.command);
+        if (!target) continue;
+        if (!byTarget.has(target)) byTarget.set(target, []);
+        byTarget.get(target).push(outcome);
+      }
+
+      for (const [target, run] of byTarget) {
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          lastFailure = null;
+
+          // Same program is detector 1's case, whether it pairs there or not.
+          if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
+          // A fix follows its failure closely. Hours apart is two unrelated
+          // pieces of work that happened to touch one file.
+          const apart = Math.abs((outcome.at || 0) - (failed.at || 0));
+          if (!apart || apart > RETARGET_WINDOW_MS) continue;
+          // Same rule as detector 1: nothing quotable, nothing claimed.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          const confidence = CONFIDENCE.retarget;
+          add({
+            type: 'command',
+            claim: redact(
+              `In this project \`${commandBody(outcome.command)}\` succeeded on ${target} where ` +
+                `\`${commandBody(failed.command)}\` had failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded against the same target \`${target}\` ` +
+                `${Math.round(apart / 1000)}s later. Different programs, one target: ordered ` +
+                'and close, but not proven causal -- an intervening edit explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: `when about to run \`${commandProgram(failed.command)}\` against ${target} in this project`,
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: [`\`${commandBody(failed.command)}\` later succeeds unchanged`],
+            trigger: triggerFor(failed.command),
+            anchors: [anchorPath],
+            derivedBy: 'retarget',
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
 
   // ---- storage, under a budget -------------------------------------------
   //

--- a/hooks-core/derive.mjs
+++ b/hooks-core/derive.mjs
@@ -203,11 +203,26 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  *
  * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
  * before this sees it -- that case is one command spelled two ways.
+ *
+ * A TRAILING SEPARATOR LEAVES NOTHING TO COUNT, which is the hole in reading
+ * the segment count alone. `commandSegments` pushes only non-empty token
+ * lists, so `npx jest tests/foo &&` is ONE segment, and `attemptKey` -- the
+ * first three non-flag tokens -- never sees the `&&` either. The command is
+ * still half of something, and `cmd &` on its own is a background job whose
+ * exit code belongs to the shell rather than to the program named. Appending a
+ * sentinel token makes the missing segment materialise, which reuses the one
+ * scanner that already understands quotes instead of adding a second,
+ * differently-wrong one: `grep -E "foo|bar" src/x.mjs` stays a single segment
+ * with the sentinel attached, exactly as it does without it.
  */
+// Not a plausible argument to anything, so it can only ever be the token this
+// function appended.
+const SEGMENT_SENTINEL = '__token_optimizer_segment_probe__';
+
 const hasAttemptIdentity = (command) => {
   const body = commandBody(command);
   if (!body.trim()) return false;
-  if (commandSegments(body).length > 1) return false;
+  if (commandSegments(`${body} ${SEGMENT_SENTINEL}`).length > 1) return false;
   return attemptKey(command)
     .split(' ')
     .filter(Boolean)
@@ -366,7 +381,13 @@ export function commandOperand(command) {
   // attempts, so including it would reproduce attemptKey's blind spot.
   for (const token of tokens.slice(1)) {
     const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
-    if (named && token.length >= 4) return token.toLowerCase();
+    // AS WRITTEN, not folded. This value is the grouping key AND the text of
+    // the stored claim, and folding it made the claim name a path that does
+    // not exist on a case-sensitive filesystem: `src/Foo.test.mjs` was
+    // recorded, and served to a later session, as `src/foo.test.mjs`. The
+    // caller folds a copy for the key instead, so matching stays
+    // case-insensitive without the claim paying for it.
+    if (named && token.length >= 4) return token;
   }
   return null;
 }
@@ -1066,15 +1087,23 @@ export function derive(dir, options = {}) {
   // repeating an invocation.
   try {
     if (projectRoot && outcomes?.length) {
+      // KEYED FOLDED, DISPLAYED AS WRITTEN. Two invocations naming the same
+      // file with different capitalisation are the same target on Windows and
+      // macOS, so the key folds; the text stored in the finding must not,
+      // because a claim naming `src/foo.test.mjs` for a file called
+      // `src/Foo.test.mjs` is a path that does not resolve on Linux -- and
+      // that text is what a later session reads. The first spelling seen wins,
+      // which is the one the failing attempt actually used.
       const byTarget = new Map();
       for (const outcome of outcomes) {
-        const target = commandOperand(outcome.command);
-        if (!target) continue;
-        if (!byTarget.has(target)) byTarget.set(target, []);
-        byTarget.get(target).push(outcome);
+        const operand = commandOperand(outcome.command);
+        if (!operand) continue;
+        const key = operand.toLowerCase();
+        if (!byTarget.has(key)) byTarget.set(key, { target: operand, run: [] });
+        byTarget.get(key).run.push(outcome);
       }
 
-      for (const [target, run] of byTarget) {
+      for (const { target, run } of byTarget.values()) {
         let lastFailure = null;
         for (const outcome of run) {
           if (outcome.failed) {

--- a/hooks-core/derive.mjs
+++ b/hooks-core/derive.mjs
@@ -371,9 +371,45 @@ export function commandOperand(command) {
   return null;
 }
 
-/** The program a command invokes, for deciding whether two attempts differ. */
+/**
+ * A leading `VAR=value` prefix, which a shell applies to the environment of
+ * the command that follows rather than running as the command itself.
+ */
+const ENV_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+/**
+ * The program a command invokes, for deciding whether two attempts differ.
+ *
+ * ENVIRONMENT PREFIXES ARE NOT THE PROGRAM. Taking the first token verbatim
+ * reported `SP=/tmp/x` as the program for `SP=/tmp/x node run.mjs`, and that
+ * is not a cosmetic slip: measured over this machine's real history, 816 of
+ * 7,165 recorded command outcomes -- 11.4% -- named an assignment.
+ *
+ * IT FAILS IN THE DANGEROUS DIRECTION. This function exists to decide that two
+ * attempts used DIFFERENT programs, so two runs of the same tool under
+ * different variables --
+ *
+ *   SP=/a node run.mjs    (failed)
+ *   SPW=/b node run.mjs   (succeeded)
+ *
+ * -- compared as `sp=/a` against `spw=/b`, differed, and were eligible to
+ * pair. The claim that pairing produces is `node run.mjs` succeeded where
+ * `node run.mjs` failed: exactly the incoherent statement detector 1's own
+ * guard exists to refuse, arriving through the door detector 5 opened.
+ *
+ * Skipping the prefixes is what a shell does, and it cannot invent a pair --
+ * two commands that were already the same program now compare equal, which
+ * only ever removes a candidate.
+ *
+ * NO MEASURED CHANGE TODAY, stated plainly: replaying both versions over the
+ * same real history gives an identical pairing outcome (20 pairs considered,
+ * 0 firing), because every affected command is also chained and rejected
+ * earlier. This is a correctness fix against a latent false claim, not a
+ * recall improvement, and it is not offered as one.
+ */
 export function commandProgram(command) {
-  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  const tokens = commandBody(command).trim().split(/\s+/).filter(Boolean);
+  const first = tokens.find((token) => !ENV_ASSIGNMENT.test(token)) || '';
   return first.split(/[/\\]/).pop().toLowerCase();
 }
 

--- a/hooks-core/derive.mjs
+++ b/hooks-core/derive.mjs
@@ -428,10 +428,16 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * Returns null when nothing resolves, which leaves the caller's original root
  * untouched -- a wrong project is worse than the status quo.
  */
-export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+export function projectRootFromActivity(events, { resolve, cwd, sessionId = null } = {}) {
   if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
   const counts = new Map();
   for (const event of events) {
+    // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
+    // session that wrote it, so counting every event ever recorded lets a busy
+    // session from last week outvote the one now ending -- and the question
+    // being asked is "where did THIS session work", not "where is this graph
+    // busiest". Callers that pass no id keep the whole-graph count.
+    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.
@@ -452,13 +458,22 @@ export function projectRootFromActivity(events, { resolve, cwd } = {}) {
   }
   let best = null;
   let most = 0;
+  let tied = false;
   for (const [root, n] of counts) {
     if (n > most) {
       most = n;
       best = root;
+      tied = false;
+    } else if (n === most) {
+      // A Map iterates in insertion order, so a tie would otherwise be broken by
+      // whichever file the session happened to touch first -- deterministic, but
+      // arbitrary, and wrong half the time. Findings would then be stored against
+      // a project the evidence does not single out. Decline instead; the caller
+      // keeps cwdRoot, which is at least a root the user chose.
+      tied = true;
     }
   }
-  return best;
+  return tied ? null : best;
 }
 
 export function projectAnchor(projectRoot) {

--- a/hooks-core/transcript.mjs
+++ b/hooks-core/transcript.mjs
@@ -287,6 +287,23 @@ const ANCHOR_MAX = 120;
  */
 const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
 
+/**
+ * A run the HARNESS stopped, which is not the command failing.
+ *
+ * The allowlist above admits anything shaped `Exit code N`, and a killed
+ * command reports `Exit code 143` with `Command timed out after 2m 0s` -- so
+ * it walks straight in. Nothing about it is a lesson about the command: it did
+ * not fail, it was not allowed to finish, and the same command run with a
+ * longer budget may well pass. Pairing one with a later success would claim a
+ * red-to-green transition that never happened.
+ *
+ * MEASURED, on a 237 MB transcript of ordinary feature work: of 130 admitted
+ * failures, 25 were timeouts -- 19%. At the 64 MB scan it was 11 of 23, 48%.
+ * User declines are NOT in this class and need no rule; the positive allowlist
+ * already excludes them, verified at every scan size on the same transcript.
+ */
+const HARNESS_TIMEOUT = /^\s*Command timed out after\b/m;
+
 /** Reads at most `bytes` from the END of a file, without loading the rest. */
 function readTail(path, bytes) {
   let fd;
@@ -388,6 +405,8 @@ export function failedResultsFromTranscript(transcriptPath, options = {}) {
       if (typeof block.content !== 'string') continue;
       const match = EXIT_CODE_RESULT.exec(block.content);
       if (!match) continue;
+      // The command ran, but the harness ended it. See HARNESS_TIMEOUT.
+      if (HARNESS_TIMEOUT.test(block.content)) continue;
       const command = commands.get(String(block.tool_use_id || ''));
       // No command means no claim. The result says something failed; without
       // the text of what failed there is nothing to say about it, and nothing

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -55,6 +55,7 @@ import {
   load,
   wikiDir,
   projectRootFor,
+  unrootedRoot,
 } from './wiki.mjs';
 import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
@@ -78,7 +79,7 @@ import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
-import { isFsSafePath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
   recordingNudge,
@@ -94,7 +95,7 @@ import {
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
-import { registerProject } from './projects.mjs';
+import { registerProject, registeredProjects } from './projects.mjs';
 import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
@@ -109,6 +110,62 @@ export const CLIENTS = nativeClientProfiles();
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
+
+/**
+ * How many registered project graphs a session-end sweep may open.
+ *
+ * The registry is append-only and unbounded over time -- 4,033 records on this
+ * machine -- and each graph read is a tail of up to 2 MB. Bounded to the most
+ * recently seen handful, which is the only part of the registry a single
+ * session can plausibly have written to.
+ */
+const CROSS_PROJECT_SCAN_LIMIT =
+  Number(process.env.TOKEN_OPTIMIZER_CROSS_PROJECT_SCAN) || 12;
+
+/** A project the current session cannot have touched is not worth opening. */
+const CROSS_PROJECT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The activity this session recorded, gathered from every graph that could hold
+ * it.
+ *
+ * Capture is keyed on where the FILE lives (`recordToolOutcome(wikiDir(root))`,
+ * post-tool), not on the session's cwd. So when the client is started outside a
+ * repository -- a home directory, the common case -- the session's own file
+ * activity is written into each touched project's graph, and the unrooted graph
+ * that `cwd` resolves to holds none of it. Reading only that graph is why the
+ * inference below returned null in exactly the case it exists for: measured on
+ * this machine, the unrooted store holds 12,376 file anchors and ZERO of them
+ * under a repository.
+ *
+ * The sweep is confined to that case. A cwd that IS a repository already owns
+ * the graph its own files were captured into, so it pays nothing.
+ */
+export function sessionActivity(cwdRoot) {
+  let events = [];
+  try {
+    events = readMetrics(wikiDir(cwdRoot));
+  } catch {
+    events = [];
+  }
+  if (canonicalPath(cwdRoot) !== canonicalPath(unrootedRoot())) return events;
+  const cutoff = Date.now() - CROSS_PROJECT_MAX_AGE_MS;
+  let projects = [];
+  try {
+    // Sorted most-recently-seen first by `registeredProjects`.
+    projects = registeredProjects().filter((p) => (p.lastSeenAt || 0) >= cutoff);
+  } catch {
+    return events;
+  }
+  for (const project of projects.slice(0, CROSS_PROJECT_SCAN_LIMIT)) {
+    try {
+      events = events.concat(readMetrics(project.graphDir));
+    } catch {
+      // One unreadable store must not cost the session its inference.
+    }
+  }
+  return events;
+}
 
 /**
  * The response envelopes a completed tool call can arrive in.
@@ -1223,13 +1280,21 @@ async function runHook(clientName, event, invocation) {
       // router already keys capture on where the FILE lives rather than on the
       // session's cwd; this applies that rule to derivation too, and falls back
       // to the cwd answer when the session touched nothing resolvable.
+      //
+      // The evidence is gathered by `sessionActivity`, NOT from the cwd graph
+      // alone: capture keyed on the file's project means an unrooted session's
+      // own activity was written into the graphs of the projects it touched.
+      // Reading only the unrooted graph found 12,376 file anchors and not one
+      // under a repository, so the inference was inert in precisely the case it
+      // was written for.
       const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
       let projectRoot = cwdRoot;
       try {
         projectRoot =
-          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+          projectRootFromActivity(sessionActivity(cwdRoot), {
             resolve: (anchor) => projectRootFor(anchor, cwd),
             cwd,
+            sessionId,
           }) || cwdRoot;
       } catch {
         // Inferring the project is an improvement, never a precondition.

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -46,8 +46,9 @@ import {
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
+  readMetrics,
 } from './metrics.mjs';
-import { derive } from './derive.mjs';
+import { derive, projectRootFromActivity } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -1207,7 +1208,32 @@ async function runHook(clientName, event, invocation) {
       // one figure alone cannot distinguish "nothing to derive" from "derived
       // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
-      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      // WHERE THE WORK HAPPENED, NOT WHERE THE CLIENT WAS LAUNCHED.
+      //
+      // `projectRootFor` on a cwd with no VCS marker -- a home directory, which
+      // is how this client is commonly started -- returns the synthetic fallback
+      // `~/.token-optimizer/unrooted`. That is not null, so every `if
+      // (projectRoot)` gate downstream passes, and `projectAnchor` then hands
+      // back the directory itself because the fallback holds no project marker.
+      // `writeHarvested` resolves anchors through `indexFile`, which returns
+      // null for a directory, and the finding is refused as unanchorable.
+      //
+      // Measured consequence on this machine: 937 derive runs, 8 candidates,
+      // ZERO findings written, beside 2,965 symbol nodes in the same graph. The
+      // router already keys capture on where the FILE lives rather than on the
+      // session's cwd; this applies that rule to derivation too, and falls back
+      // to the cwd answer when the session touched nothing resolvable.
+      const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      let projectRoot = cwdRoot;
+      try {
+        projectRoot =
+          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+            resolve: (anchor) => projectRootFor(anchor, cwd),
+            cwd,
+          }) || cwdRoot;
+      } catch {
+        // Inferring the project is an improvement, never a precondition.
+      }
       const dir = wikiDir(projectRoot);
       const derived = derive(dir, {
         sessionId,

--- a/integrations/cline/hooks/token-optimizer/lib/advise.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/advise.mjs
@@ -162,7 +162,7 @@ const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function commandSegments(command) {
+export function commandSegments(command) {
   const segments = [];
   let tokens = [];
   let current = '';

--- a/integrations/cline/hooks/token-optimizer/lib/derive.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/derive.mjs
@@ -205,11 +205,26 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  *
  * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
  * before this sees it -- that case is one command spelled two ways.
+ *
+ * A TRAILING SEPARATOR LEAVES NOTHING TO COUNT, which is the hole in reading
+ * the segment count alone. `commandSegments` pushes only non-empty token
+ * lists, so `npx jest tests/foo &&` is ONE segment, and `attemptKey` -- the
+ * first three non-flag tokens -- never sees the `&&` either. The command is
+ * still half of something, and `cmd &` on its own is a background job whose
+ * exit code belongs to the shell rather than to the program named. Appending a
+ * sentinel token makes the missing segment materialise, which reuses the one
+ * scanner that already understands quotes instead of adding a second,
+ * differently-wrong one: `grep -E "foo|bar" src/x.mjs` stays a single segment
+ * with the sentinel attached, exactly as it does without it.
  */
+// Not a plausible argument to anything, so it can only ever be the token this
+// function appended.
+const SEGMENT_SENTINEL = '__token_optimizer_segment_probe__';
+
 const hasAttemptIdentity = (command) => {
   const body = commandBody(command);
   if (!body.trim()) return false;
-  if (commandSegments(body).length > 1) return false;
+  if (commandSegments(`${body} ${SEGMENT_SENTINEL}`).length > 1) return false;
   return attemptKey(command)
     .split(' ')
     .filter(Boolean)
@@ -368,7 +383,13 @@ export function commandOperand(command) {
   // attempts, so including it would reproduce attemptKey's blind spot.
   for (const token of tokens.slice(1)) {
     const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
-    if (named && token.length >= 4) return token.toLowerCase();
+    // AS WRITTEN, not folded. This value is the grouping key AND the text of
+    // the stored claim, and folding it made the claim name a path that does
+    // not exist on a case-sensitive filesystem: `src/Foo.test.mjs` was
+    // recorded, and served to a later session, as `src/foo.test.mjs`. The
+    // caller folds a copy for the key instead, so matching stays
+    // case-insensitive without the claim paying for it.
+    if (named && token.length >= 4) return token;
   }
   return null;
 }
@@ -1068,15 +1089,23 @@ export function derive(dir, options = {}) {
   // repeating an invocation.
   try {
     if (projectRoot && outcomes?.length) {
+      // KEYED FOLDED, DISPLAYED AS WRITTEN. Two invocations naming the same
+      // file with different capitalisation are the same target on Windows and
+      // macOS, so the key folds; the text stored in the finding must not,
+      // because a claim naming `src/foo.test.mjs` for a file called
+      // `src/Foo.test.mjs` is a path that does not resolve on Linux -- and
+      // that text is what a later session reads. The first spelling seen wins,
+      // which is the one the failing attempt actually used.
       const byTarget = new Map();
       for (const outcome of outcomes) {
-        const target = commandOperand(outcome.command);
-        if (!target) continue;
-        if (!byTarget.has(target)) byTarget.set(target, []);
-        byTarget.get(target).push(outcome);
+        const operand = commandOperand(outcome.command);
+        if (!operand) continue;
+        const key = operand.toLowerCase();
+        if (!byTarget.has(key)) byTarget.set(key, { target: operand, run: [] });
+        byTarget.get(key).run.push(outcome);
       }
 
-      for (const [target, run] of byTarget) {
+      for (const { target, run } of byTarget.values()) {
         let lastFailure = null;
         for (const outcome of run) {
           if (outcome.failed) {

--- a/integrations/cline/hooks/token-optimizer/lib/derive.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/derive.mjs
@@ -67,7 +67,16 @@ import {
  * command. A correction is a lexical guess about what a human meant. Churn
  * describes our own reading behaviour and says nothing about the code at all.
  */
-export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+export const CONFIDENCE = {
+  command: 0.9,
+  test: 0.85,
+  // Below `command` because the inference is weaker: two commands sharing a
+  // target is good evidence of one intent, but not the same evidence as the
+  // identical invocation being retried. Labelled speculative, deliberately.
+  retarget: 0.6,
+  correction: 0.6,
+  churn: 0.4,
+};
 
 /** Claim text cap. A finding is one sentence; a paragraph is evidence. */
 const CLAIM_MAX = 300;
@@ -75,6 +84,17 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * How close a fix must follow its failure to count as the same attempt.
+ *
+ * Detector 5 pairs across DIFFERENT programs, so it cannot lean on command
+ * identity to know the two are related -- proximity is doing that work instead.
+ * Ten minutes is long enough for a real correction, including reading an error
+ * and looking something up, and short enough that two unrelated pieces of work
+ * touching one file in an afternoon are not reported as one story.
+ */
+const RETARGET_WINDOW_MS = 10 * 60 * 1000;
 
 /**
  * The anchor cap a command surface is stored under, restated here as a TEST.
@@ -287,6 +307,50 @@ export function attemptKey(command) {
     .join(' ')
     .toLowerCase();
 }
+/**
+ * The thing a command ACTS ON -- a path, a test file, a target.
+ *
+ * WHY `attemptKey` IS NOT ENOUGH, measured rather than supposed. That key is
+ * program-plus-operands, so the single most valuable lesson a session can teach
+ * cannot pair by construction:
+ *
+ *   npx jest tests/foo      -> key "npx jest tests/foo"
+ *   npm test -- tests/foo   -> key "npm test tests/foo"
+ *
+ * Different keys, no pair, no finding -- yet that is exactly the correction
+ * worth recording, because the fix was to run a DIFFERENT program against the
+ * same target. The existing detector can only catch the same command re-run and
+ * succeeding, which its own guard then discards as incoherent.
+ *
+ * The measured cost of that: across 937 real derive runs on this machine, 8
+ * candidates were produced and ZERO were stored.
+ *
+ * So this returns the shared operand -- `tests/foo` above -- which is what the
+ * two attempts genuinely have in common. Only operands that NAME something are
+ * admitted: a path separator or a file extension. A bare word like `build` is
+ * refused, because `npm run build` and `make build` sharing the token `build`
+ * is a coincidence of vocabulary, not evidence of one intent.
+ */
+export function commandOperand(command) {
+  const tokens = commandBody(command)
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'));
+  // Skipping the first token: the PROGRAM is what differs between the two
+  // attempts, so including it would reproduce attemptKey's blind spot.
+  for (const token of tokens.slice(1)) {
+    const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
+    if (named && token.length >= 4) return token.toLowerCase();
+  }
+  return null;
+}
+
+/** The program a command invokes, for deciding whether two attempts differ. */
+export function commandProgram(command) {
+  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  return first.split(/[/\\]/).pop().toLowerCase();
+}
+
 
 /** Normalised claim text, so the same lesson derived twice is one candidate. */
 const claimKey = (type, claim) =>
@@ -519,9 +583,15 @@ export function derive(dir, options = {}) {
   // a transcript failure that pairs with nothing stays unclaimed, which is also
   // what keeps a failure from ANOTHER project's directory out of this project's
   // graph -- a candidate cannot be emitted without a success recorded HERE.
+  // HOISTED so detector 5 can pair over the SAME merged list -- events plus the
+  // transcript failures folded in below. Rebuilding it there would duplicate the
+  // de-duplication logic and let the two detectors drift; leaving it block-scoped
+  // gave detector 5 a ReferenceError that its own try/catch swallowed, which is
+  // silent nothing rather than a visible failure.
+  let outcomes = [];
   try {
     if (projectRoot) {
-      const outcomes = events
+      outcomes = events
         .filter(
           (e) =>
             e &&
@@ -802,6 +872,92 @@ export function derive(dir, options = {}) {
   } catch {
     // One detector, never the session.
   }
+  // ---- 5: a DIFFERENT command against the same target succeeded -----------
+  //
+  // THE LESSON DETECTOR 1 CANNOT REACH. Its `attemptKey` is program-plus-
+  // operands, so the correction worth recording -- reaching for a different
+  // tool against the same target -- lands in two groups that never meet:
+  //
+  //   npx jest tests/foo.test.mjs     key "npx jest tests/foo.test.mjs"
+  //   npm test -- tests/foo.test.mjs  key "npm test tests/foo.test.mjs"
+  //
+  // What detector 1 CAN pair is the identical command re-run, and its own guard
+  // then correctly discards that as incoherent -- "`npm run build` works where
+  // `npm run build` failed" claims nothing. So between the key and the guard,
+  // the command family had almost no reachable evidence: measured across 937
+  // real derive runs on this machine, 8 candidates and ZERO stored findings.
+  //
+  // This pairs on the shared OPERAND instead, and only when the PROGRAM differs
+  // -- same-program pairs are detector 1's business and are left to it. The
+  // conservatism the original key was protecting is kept in three other places:
+  // the operand must NAME something (a path or an extension, never a bare word
+  // like `build`), the two attempts must be close in time, and the ceiling is
+  // 0.6 rather than 0.9 because sharing a target is weaker evidence than
+  // repeating an invocation.
+  try {
+    if (projectRoot && outcomes?.length) {
+      const byTarget = new Map();
+      for (const outcome of outcomes) {
+        const target = commandOperand(outcome.command);
+        if (!target) continue;
+        if (!byTarget.has(target)) byTarget.set(target, []);
+        byTarget.get(target).push(outcome);
+      }
+
+      for (const [target, run] of byTarget) {
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          lastFailure = null;
+
+          // Same program is detector 1's case, whether it pairs there or not.
+          if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
+          // A fix follows its failure closely. Hours apart is two unrelated
+          // pieces of work that happened to touch one file.
+          const apart = Math.abs((outcome.at || 0) - (failed.at || 0));
+          if (!apart || apart > RETARGET_WINDOW_MS) continue;
+          // Same rule as detector 1: nothing quotable, nothing claimed.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          const confidence = CONFIDENCE.retarget;
+          add({
+            type: 'command',
+            claim: redact(
+              `In this project \`${commandBody(outcome.command)}\` succeeded on ${target} where ` +
+                `\`${commandBody(failed.command)}\` had failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded against the same target \`${target}\` ` +
+                `${Math.round(apart / 1000)}s later. Different programs, one target: ordered ` +
+                'and close, but not proven causal -- an intervening edit explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: `when about to run \`${commandProgram(failed.command)}\` against ${target} in this project`,
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: [`\`${commandBody(failed.command)}\` later succeeds unchanged`],
+            trigger: triggerFor(failed.command),
+            anchors: [anchorPath],
+            derivedBy: 'retarget',
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
 
   // ---- storage, under a budget -------------------------------------------
   //

--- a/integrations/cline/hooks/token-optimizer/lib/derive.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/derive.mjs
@@ -739,6 +739,27 @@ export function derive(dir, options = {}) {
   let outcomes = [];
   try {
     if (projectRoot) {
+      // SCOPED TO THE SESSION THE CLAIM WILL NAME.
+      //
+      // Every claim these detectors build opens `observed in one session:`,
+      // and the store holds every session's outcomes -- so nothing but the
+      // ten-minute window stopped a failure from one session pairing with a
+      // success from another and asserting a provenance that never happened.
+      //
+      // NEVER OBSERVED, SAID PLAINLY. Across both live stores on this machine
+      // -- 7,173 command outcomes over 3 sessions here, 543 over 9 sessions in
+      // the unrooted one -- 5,155 and 298 adjacent in-window pairs respectively
+      // and ZERO of them crossed a session. Sessions are long and rarely
+      // interleave inside ten minutes. This is a correctness fix against a
+      // false claim, not a fix for observed damage, and it is not offered as
+      // one. Concurrent sessions do occur -- one was recorded on this machine
+      // while this was being written -- and they share the unrooted store.
+      //
+      // The merged transcript failures below are deliberately NOT filtered:
+      // `failedResultsFromTranscript` carries no sessionId, and the transcript
+      // it read is this session's, so they are already scoped by construction.
+      // Filtering them here would drop the only source of command failures
+      // that exists -- Claude Code never fires PostToolUse on a non-zero exit.
       outcomes = events
         .filter(
           (e) =>
@@ -746,7 +767,10 @@ export function derive(dir, options = {}) {
             e.kind === 'tool-outcome' &&
             e.surface === 'command' &&
             typeof e.anchor === 'string' &&
-            e.anchor.trim()
+            e.anchor.trim() &&
+            // An event predating the field still counts; a DIFFERENT session
+            // never does.
+            (!sessionId || !e.sessionId || e.sessionId === sessionId)
         )
         .map((e) => ({
           command: e.anchor.trim(),

--- a/integrations/cline/hooks/token-optimizer/lib/derive.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/derive.mjs
@@ -915,6 +915,20 @@ export function derive(dir, options = {}) {
           const failed = lastFailure;
           lastFailure = null;
 
+          // BOTH SIDES MUST NAME A SINGLE COMMAND, the same rule detector 1
+          // applies. `commandBody` strips only a LEADING directory change, and
+          // `commandProgram` reads the first token, so a chained command
+          // attributes the failure to the wrong program entirely:
+          //
+          //   git fetch && npx jest tests/foo.test.mjs   -> program "git"
+          //   cat x | npx jest tests/foo.test.mjs        -> program "cat"
+          //
+          // Paired against `npm test -- tests/foo.test.mjs` those would ship
+          // "npm test succeeded where git fetch failed" and tell a later session
+          // to avoid `git`. Checked per side rather than once, because unlike
+          // detector 1 these two do NOT share a key by construction.
+          if (!hasAttemptIdentity(failed.command)) continue;
+          if (!hasAttemptIdentity(outcome.command)) continue;
           // Same program is detector 1's case, whether it pairs there or not.
           if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
           // A fix follows its failure closely. Hours apart is two unrelated

--- a/integrations/cline/hooks/token-optimizer/lib/derive.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/derive.mjs
@@ -430,10 +430,16 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * Returns null when nothing resolves, which leaves the caller's original root
  * untouched -- a wrong project is worse than the status quo.
  */
-export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+export function projectRootFromActivity(events, { resolve, cwd, sessionId = null } = {}) {
   if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
   const counts = new Map();
   for (const event of events) {
+    // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
+    // session that wrote it, so counting every event ever recorded lets a busy
+    // session from last week outvote the one now ending -- and the question
+    // being asked is "where did THIS session work", not "where is this graph
+    // busiest". Callers that pass no id keep the whole-graph count.
+    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.
@@ -454,13 +460,22 @@ export function projectRootFromActivity(events, { resolve, cwd } = {}) {
   }
   let best = null;
   let most = 0;
+  let tied = false;
   for (const [root, n] of counts) {
     if (n > most) {
       most = n;
       best = root;
+      tied = false;
+    } else if (n === most) {
+      // A Map iterates in insertion order, so a tie would otherwise be broken by
+      // whichever file the session happened to touch first -- deterministic, but
+      // arbitrary, and wrong half the time. Findings would then be stored against
+      // a project the evidence does not single out. Decline instead; the caller
+      // keeps cwdRoot, which is at least a root the user chose.
+      tied = true;
     }
   }
-  return best;
+  return tied ? null : best;
 }
 
 export function projectAnchor(projectRoot) {

--- a/integrations/cline/hooks/token-optimizer/lib/derive.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/derive.mjs
@@ -373,9 +373,45 @@ export function commandOperand(command) {
   return null;
 }
 
-/** The program a command invokes, for deciding whether two attempts differ. */
+/**
+ * A leading `VAR=value` prefix, which a shell applies to the environment of
+ * the command that follows rather than running as the command itself.
+ */
+const ENV_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+/**
+ * The program a command invokes, for deciding whether two attempts differ.
+ *
+ * ENVIRONMENT PREFIXES ARE NOT THE PROGRAM. Taking the first token verbatim
+ * reported `SP=/tmp/x` as the program for `SP=/tmp/x node run.mjs`, and that
+ * is not a cosmetic slip: measured over this machine's real history, 816 of
+ * 7,165 recorded command outcomes -- 11.4% -- named an assignment.
+ *
+ * IT FAILS IN THE DANGEROUS DIRECTION. This function exists to decide that two
+ * attempts used DIFFERENT programs, so two runs of the same tool under
+ * different variables --
+ *
+ *   SP=/a node run.mjs    (failed)
+ *   SPW=/b node run.mjs   (succeeded)
+ *
+ * -- compared as `sp=/a` against `spw=/b`, differed, and were eligible to
+ * pair. The claim that pairing produces is `node run.mjs` succeeded where
+ * `node run.mjs` failed: exactly the incoherent statement detector 1's own
+ * guard exists to refuse, arriving through the door detector 5 opened.
+ *
+ * Skipping the prefixes is what a shell does, and it cannot invent a pair --
+ * two commands that were already the same program now compare equal, which
+ * only ever removes a candidate.
+ *
+ * NO MEASURED CHANGE TODAY, stated plainly: replaying both versions over the
+ * same real history gives an identical pairing outcome (20 pairs considered,
+ * 0 firing), because every affected command is also chained and rejected
+ * earlier. This is a correctness fix against a latent false claim, not a
+ * recall improvement, and it is not offered as one.
+ */
 export function commandProgram(command) {
-  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  const tokens = commandBody(command).trim().split(/\s+/).filter(Boolean);
+  const first = tokens.find((token) => !ENV_ASSIGNMENT.test(token)) || '';
   return first.split(/[/\\]/).pop().toLowerCase();
 }
 

--- a/integrations/cline/hooks/token-optimizer/lib/derive.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/derive.mjs
@@ -53,6 +53,7 @@ import { ORIGIN_HARVESTED } from './curate.mjs';
 // from, so what this counts as a search and what the advisory treats as one
 // cannot diverge.
 import {
+  commandSegments,
   identifiersIn,
   searchPatternFromCommand,
   symbolIndex,
@@ -182,11 +183,38 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
-const hasAttemptIdentity = (command) =>
-  attemptKey(command)
+/**
+ * THE WHOLE BODY, NOT THE FIRST THREE TOKENS.
+ *
+ * This used to read the separator set off `attemptKey`, which keeps only the
+ * first three non-flag tokens -- so it caught a separator only when one landed
+ * early by luck of position. Verified against the real functions:
+ *
+ *   git fetch && npx jest tests/foo   key `git fetch &&`        -> rejected
+ *   npx jest tests/foo && node x.mjs  key `npx jest tests/foo`  -> ACCEPTED
+ *   grep -rn foo src | head -20       key `grep foo src`        -> ACCEPTED
+ *
+ * The last two are exactly the claims this guard exists to stop: the key names
+ * `npx`, so a pair would blame `npx` for a failure `node` may have caused.
+ * Every existing test placed the separator in the first three tokens, so none
+ * of them could see it.
+ *
+ * `commandSegments` is reused rather than a fresh scan because it is already
+ * the quote-aware one: splitting the raw string would cut through `grep -E
+ * "foo|bar"` and reject an ordinary alternation as a pipeline.
+ *
+ * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
+ * before this sees it -- that case is one command spelled two ways.
+ */
+const hasAttemptIdentity = (command) => {
+  const body = commandBody(command);
+  if (!body.trim()) return false;
+  if (commandSegments(body).length > 1) return false;
+  return attemptKey(command)
     .split(' ')
     .filter(Boolean)
     .every((token) => !COMMAND_SEPARATORS.has(token));
+};
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -435,11 +463,20 @@ export function projectRootFromActivity(events, { resolve, cwd, sessionId = null
   const counts = new Map();
   for (const event of events) {
     // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
-    // session that wrote it, so counting every event ever recorded lets a busy
-    // session from last week outvote the one now ending -- and the question
-    // being asked is "where did THIS session work", not "where is this graph
-    // busiest". Callers that pass no id keep the whole-graph count.
-    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
+    // session that wrote it, and the caller concatenates several graphs, so
+    // counting every event ever recorded lets a busy session from last week
+    // outvote the one now ending -- and the question being asked is "where did
+    // THIS session work", not "where is this graph busiest". Callers that pass
+    // no id keep the whole-graph count.
+    //
+    // AN EVENT THAT CANNOT NAME ITS SESSION IS EXCLUDED, not exempted. Exempting
+    // it was a deliberate concession to older records, and measurement says the
+    // concession buys nothing: across the three live stores on this machine, 2
+    // of 22,321 file/read events lack the field -- 0.01%. Set against that, an
+    // unstamped event sitting in ANOTHER project's graph would vote for that
+    // project on the strength of no evidence at all, which is precisely the
+    // failure this filter exists to prevent.
+    if (sessionId && event?.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.

--- a/integrations/cline/hooks/token-optimizer/lib/derive.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/derive.mjs
@@ -403,6 +403,66 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * against a fabricated anchor. That is the fail-open direction: no finding
  * beats a finding anchored to something that is not what the claim is about.
  */
+
+/**
+ * The project a session actually worked in, read off what it touched.
+ *
+ * WHY THE SESSION'S CWD IS THE WRONG ANSWER. `adapter.mjs` resolves the root
+ * with `projectRootFor(join(cwd, '__session__'), cwd)`, and when Claude Code is
+ * launched from a directory with no VCS marker -- a home directory, which is how
+ * this machine runs it -- that returns the synthetic fallback
+ * `~/.token-optimizer/unrooted`. It is NOT null, so every `if (projectRoot)`
+ * gate passes, and then `projectAnchor` hands back the directory itself because
+ * the fallback contains no project marker. `writeHarvested` resolves anchors
+ * through `indexFile`, `indexFile` on a directory returns null, and the finding
+ * is refused as unanchorable.
+ *
+ * That is the whole reason this machine's graph holds 2,965 symbols and ONE
+ * finding: 937 derive runs produced candidates and stored none of them, while
+ * every layer reported success.
+ *
+ * The router already solved this for capture -- "THE GRAPH IS PER PROJECT, so it
+ * is keyed on where the FILE lives, not on where the client happens to be
+ * running" -- and derivation simply never adopted it. This applies the same
+ * rule at Stop time: take the file anchors the session recorded, resolve each to
+ * its own project, and pick the one that holds the most of them.
+ *
+ * Returns null when nothing resolves, which leaves the caller's original root
+ * untouched -- a wrong project is worse than the status quo.
+ */
+export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+  if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
+  const counts = new Map();
+  for (const event of events) {
+    const anchor = event?.anchor;
+    // File surfaces only. A command anchor is the command text, and resolving
+    // `npm test -- x` as a path would invent a project out of a sentence.
+    if (!anchor || typeof anchor !== 'string') continue;
+    if (event.kind !== 'read' && !(event.kind === 'tool-outcome' && event.surface === 'file')) {
+      continue;
+    }
+    let root;
+    try {
+      root = resolve(anchor, cwd);
+    } catch {
+      continue;
+    }
+    // The fallback resolves to a path inside the optimizer's own store, which is
+    // never a project someone is working in.
+    if (!root || String(root).includes('.token-optimizer')) continue;
+    counts.set(root, (counts.get(root) || 0) + 1);
+  }
+  let best = null;
+  let most = 0;
+  for (const [root, n] of counts) {
+    if (n > most) {
+      most = n;
+      best = root;
+    }
+  }
+  return best;
+}
+
 export function projectAnchor(projectRoot) {
   if (!projectRoot) return null;
   let entries;

--- a/integrations/cline/hooks/token-optimizer/lib/transcript.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/transcript.mjs
@@ -289,6 +289,23 @@ const ANCHOR_MAX = 120;
  */
 const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
 
+/**
+ * A run the HARNESS stopped, which is not the command failing.
+ *
+ * The allowlist above admits anything shaped `Exit code N`, and a killed
+ * command reports `Exit code 143` with `Command timed out after 2m 0s` -- so
+ * it walks straight in. Nothing about it is a lesson about the command: it did
+ * not fail, it was not allowed to finish, and the same command run with a
+ * longer budget may well pass. Pairing one with a later success would claim a
+ * red-to-green transition that never happened.
+ *
+ * MEASURED, on a 237 MB transcript of ordinary feature work: of 130 admitted
+ * failures, 25 were timeouts -- 19%. At the 64 MB scan it was 11 of 23, 48%.
+ * User declines are NOT in this class and need no rule; the positive allowlist
+ * already excludes them, verified at every scan size on the same transcript.
+ */
+const HARNESS_TIMEOUT = /^\s*Command timed out after\b/m;
+
 /** Reads at most `bytes` from the END of a file, without loading the rest. */
 function readTail(path, bytes) {
   let fd;
@@ -390,6 +407,8 @@ export function failedResultsFromTranscript(transcriptPath, options = {}) {
       if (typeof block.content !== 'string') continue;
       const match = EXIT_CODE_RESULT.exec(block.content);
       if (!match) continue;
+      // The command ran, but the harness ended it. See HARNESS_TIMEOUT.
+      if (HARNESS_TIMEOUT.test(block.content)) continue;
       const command = commands.get(String(block.tool_use_id || ''));
       // No command means no claim. The result says something failed; without
       // the text of what failed there is nothing to say about it, and nothing

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -55,6 +55,7 @@ import {
   load,
   wikiDir,
   projectRootFor,
+  unrootedRoot,
 } from './wiki.mjs';
 import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
@@ -78,7 +79,7 @@ import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
-import { isFsSafePath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
   recordingNudge,
@@ -94,7 +95,7 @@ import {
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
-import { registerProject } from './projects.mjs';
+import { registerProject, registeredProjects } from './projects.mjs';
 import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
@@ -109,6 +110,62 @@ export const CLIENTS = nativeClientProfiles();
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
+
+/**
+ * How many registered project graphs a session-end sweep may open.
+ *
+ * The registry is append-only and unbounded over time -- 4,033 records on this
+ * machine -- and each graph read is a tail of up to 2 MB. Bounded to the most
+ * recently seen handful, which is the only part of the registry a single
+ * session can plausibly have written to.
+ */
+const CROSS_PROJECT_SCAN_LIMIT =
+  Number(process.env.TOKEN_OPTIMIZER_CROSS_PROJECT_SCAN) || 12;
+
+/** A project the current session cannot have touched is not worth opening. */
+const CROSS_PROJECT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The activity this session recorded, gathered from every graph that could hold
+ * it.
+ *
+ * Capture is keyed on where the FILE lives (`recordToolOutcome(wikiDir(root))`,
+ * post-tool), not on the session's cwd. So when the client is started outside a
+ * repository -- a home directory, the common case -- the session's own file
+ * activity is written into each touched project's graph, and the unrooted graph
+ * that `cwd` resolves to holds none of it. Reading only that graph is why the
+ * inference below returned null in exactly the case it exists for: measured on
+ * this machine, the unrooted store holds 12,376 file anchors and ZERO of them
+ * under a repository.
+ *
+ * The sweep is confined to that case. A cwd that IS a repository already owns
+ * the graph its own files were captured into, so it pays nothing.
+ */
+export function sessionActivity(cwdRoot) {
+  let events = [];
+  try {
+    events = readMetrics(wikiDir(cwdRoot));
+  } catch {
+    events = [];
+  }
+  if (canonicalPath(cwdRoot) !== canonicalPath(unrootedRoot())) return events;
+  const cutoff = Date.now() - CROSS_PROJECT_MAX_AGE_MS;
+  let projects = [];
+  try {
+    // Sorted most-recently-seen first by `registeredProjects`.
+    projects = registeredProjects().filter((p) => (p.lastSeenAt || 0) >= cutoff);
+  } catch {
+    return events;
+  }
+  for (const project of projects.slice(0, CROSS_PROJECT_SCAN_LIMIT)) {
+    try {
+      events = events.concat(readMetrics(project.graphDir));
+    } catch {
+      // One unreadable store must not cost the session its inference.
+    }
+  }
+  return events;
+}
 
 /**
  * The response envelopes a completed tool call can arrive in.
@@ -1223,13 +1280,21 @@ async function runHook(clientName, event, invocation) {
       // router already keys capture on where the FILE lives rather than on the
       // session's cwd; this applies that rule to derivation too, and falls back
       // to the cwd answer when the session touched nothing resolvable.
+      //
+      // The evidence is gathered by `sessionActivity`, NOT from the cwd graph
+      // alone: capture keyed on the file's project means an unrooted session's
+      // own activity was written into the graphs of the projects it touched.
+      // Reading only the unrooted graph found 12,376 file anchors and not one
+      // under a repository, so the inference was inert in precisely the case it
+      // was written for.
       const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
       let projectRoot = cwdRoot;
       try {
         projectRoot =
-          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+          projectRootFromActivity(sessionActivity(cwdRoot), {
             resolve: (anchor) => projectRootFor(anchor, cwd),
             cwd,
+            sessionId,
           }) || cwdRoot;
       } catch {
         // Inferring the project is an improvement, never a precondition.

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -46,8 +46,9 @@ import {
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
+  readMetrics,
 } from './metrics.mjs';
-import { derive } from './derive.mjs';
+import { derive, projectRootFromActivity } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -1207,7 +1208,32 @@ async function runHook(clientName, event, invocation) {
       // one figure alone cannot distinguish "nothing to derive" from "derived
       // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
-      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      // WHERE THE WORK HAPPENED, NOT WHERE THE CLIENT WAS LAUNCHED.
+      //
+      // `projectRootFor` on a cwd with no VCS marker -- a home directory, which
+      // is how this client is commonly started -- returns the synthetic fallback
+      // `~/.token-optimizer/unrooted`. That is not null, so every `if
+      // (projectRoot)` gate downstream passes, and `projectAnchor` then hands
+      // back the directory itself because the fallback holds no project marker.
+      // `writeHarvested` resolves anchors through `indexFile`, which returns
+      // null for a directory, and the finding is refused as unanchorable.
+      //
+      // Measured consequence on this machine: 937 derive runs, 8 candidates,
+      // ZERO findings written, beside 2,965 symbol nodes in the same graph. The
+      // router already keys capture on where the FILE lives rather than on the
+      // session's cwd; this applies that rule to derivation too, and falls back
+      // to the cwd answer when the session touched nothing resolvable.
+      const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      let projectRoot = cwdRoot;
+      try {
+        projectRoot =
+          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+            resolve: (anchor) => projectRootFor(anchor, cwd),
+            cwd,
+          }) || cwdRoot;
+      } catch {
+        // Inferring the project is an improvement, never a precondition.
+      }
       const dir = wikiDir(projectRoot);
       const derived = derive(dir, {
         sessionId,

--- a/integrations/codex/hooks/lib/advise.mjs
+++ b/integrations/codex/hooks/lib/advise.mjs
@@ -162,7 +162,7 @@ const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function commandSegments(command) {
+export function commandSegments(command) {
   const segments = [];
   let tokens = [];
   let current = '';

--- a/integrations/codex/hooks/lib/derive.mjs
+++ b/integrations/codex/hooks/lib/derive.mjs
@@ -205,11 +205,26 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  *
  * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
  * before this sees it -- that case is one command spelled two ways.
+ *
+ * A TRAILING SEPARATOR LEAVES NOTHING TO COUNT, which is the hole in reading
+ * the segment count alone. `commandSegments` pushes only non-empty token
+ * lists, so `npx jest tests/foo &&` is ONE segment, and `attemptKey` -- the
+ * first three non-flag tokens -- never sees the `&&` either. The command is
+ * still half of something, and `cmd &` on its own is a background job whose
+ * exit code belongs to the shell rather than to the program named. Appending a
+ * sentinel token makes the missing segment materialise, which reuses the one
+ * scanner that already understands quotes instead of adding a second,
+ * differently-wrong one: `grep -E "foo|bar" src/x.mjs` stays a single segment
+ * with the sentinel attached, exactly as it does without it.
  */
+// Not a plausible argument to anything, so it can only ever be the token this
+// function appended.
+const SEGMENT_SENTINEL = '__token_optimizer_segment_probe__';
+
 const hasAttemptIdentity = (command) => {
   const body = commandBody(command);
   if (!body.trim()) return false;
-  if (commandSegments(body).length > 1) return false;
+  if (commandSegments(`${body} ${SEGMENT_SENTINEL}`).length > 1) return false;
   return attemptKey(command)
     .split(' ')
     .filter(Boolean)
@@ -368,7 +383,13 @@ export function commandOperand(command) {
   // attempts, so including it would reproduce attemptKey's blind spot.
   for (const token of tokens.slice(1)) {
     const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
-    if (named && token.length >= 4) return token.toLowerCase();
+    // AS WRITTEN, not folded. This value is the grouping key AND the text of
+    // the stored claim, and folding it made the claim name a path that does
+    // not exist on a case-sensitive filesystem: `src/Foo.test.mjs` was
+    // recorded, and served to a later session, as `src/foo.test.mjs`. The
+    // caller folds a copy for the key instead, so matching stays
+    // case-insensitive without the claim paying for it.
+    if (named && token.length >= 4) return token;
   }
   return null;
 }
@@ -1068,15 +1089,23 @@ export function derive(dir, options = {}) {
   // repeating an invocation.
   try {
     if (projectRoot && outcomes?.length) {
+      // KEYED FOLDED, DISPLAYED AS WRITTEN. Two invocations naming the same
+      // file with different capitalisation are the same target on Windows and
+      // macOS, so the key folds; the text stored in the finding must not,
+      // because a claim naming `src/foo.test.mjs` for a file called
+      // `src/Foo.test.mjs` is a path that does not resolve on Linux -- and
+      // that text is what a later session reads. The first spelling seen wins,
+      // which is the one the failing attempt actually used.
       const byTarget = new Map();
       for (const outcome of outcomes) {
-        const target = commandOperand(outcome.command);
-        if (!target) continue;
-        if (!byTarget.has(target)) byTarget.set(target, []);
-        byTarget.get(target).push(outcome);
+        const operand = commandOperand(outcome.command);
+        if (!operand) continue;
+        const key = operand.toLowerCase();
+        if (!byTarget.has(key)) byTarget.set(key, { target: operand, run: [] });
+        byTarget.get(key).run.push(outcome);
       }
 
-      for (const [target, run] of byTarget) {
+      for (const { target, run } of byTarget.values()) {
         let lastFailure = null;
         for (const outcome of run) {
           if (outcome.failed) {

--- a/integrations/codex/hooks/lib/derive.mjs
+++ b/integrations/codex/hooks/lib/derive.mjs
@@ -67,7 +67,16 @@ import {
  * command. A correction is a lexical guess about what a human meant. Churn
  * describes our own reading behaviour and says nothing about the code at all.
  */
-export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+export const CONFIDENCE = {
+  command: 0.9,
+  test: 0.85,
+  // Below `command` because the inference is weaker: two commands sharing a
+  // target is good evidence of one intent, but not the same evidence as the
+  // identical invocation being retried. Labelled speculative, deliberately.
+  retarget: 0.6,
+  correction: 0.6,
+  churn: 0.4,
+};
 
 /** Claim text cap. A finding is one sentence; a paragraph is evidence. */
 const CLAIM_MAX = 300;
@@ -75,6 +84,17 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * How close a fix must follow its failure to count as the same attempt.
+ *
+ * Detector 5 pairs across DIFFERENT programs, so it cannot lean on command
+ * identity to know the two are related -- proximity is doing that work instead.
+ * Ten minutes is long enough for a real correction, including reading an error
+ * and looking something up, and short enough that two unrelated pieces of work
+ * touching one file in an afternoon are not reported as one story.
+ */
+const RETARGET_WINDOW_MS = 10 * 60 * 1000;
 
 /**
  * The anchor cap a command surface is stored under, restated here as a TEST.
@@ -287,6 +307,50 @@ export function attemptKey(command) {
     .join(' ')
     .toLowerCase();
 }
+/**
+ * The thing a command ACTS ON -- a path, a test file, a target.
+ *
+ * WHY `attemptKey` IS NOT ENOUGH, measured rather than supposed. That key is
+ * program-plus-operands, so the single most valuable lesson a session can teach
+ * cannot pair by construction:
+ *
+ *   npx jest tests/foo      -> key "npx jest tests/foo"
+ *   npm test -- tests/foo   -> key "npm test tests/foo"
+ *
+ * Different keys, no pair, no finding -- yet that is exactly the correction
+ * worth recording, because the fix was to run a DIFFERENT program against the
+ * same target. The existing detector can only catch the same command re-run and
+ * succeeding, which its own guard then discards as incoherent.
+ *
+ * The measured cost of that: across 937 real derive runs on this machine, 8
+ * candidates were produced and ZERO were stored.
+ *
+ * So this returns the shared operand -- `tests/foo` above -- which is what the
+ * two attempts genuinely have in common. Only operands that NAME something are
+ * admitted: a path separator or a file extension. A bare word like `build` is
+ * refused, because `npm run build` and `make build` sharing the token `build`
+ * is a coincidence of vocabulary, not evidence of one intent.
+ */
+export function commandOperand(command) {
+  const tokens = commandBody(command)
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'));
+  // Skipping the first token: the PROGRAM is what differs between the two
+  // attempts, so including it would reproduce attemptKey's blind spot.
+  for (const token of tokens.slice(1)) {
+    const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
+    if (named && token.length >= 4) return token.toLowerCase();
+  }
+  return null;
+}
+
+/** The program a command invokes, for deciding whether two attempts differ. */
+export function commandProgram(command) {
+  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  return first.split(/[/\\]/).pop().toLowerCase();
+}
+
 
 /** Normalised claim text, so the same lesson derived twice is one candidate. */
 const claimKey = (type, claim) =>
@@ -519,9 +583,15 @@ export function derive(dir, options = {}) {
   // a transcript failure that pairs with nothing stays unclaimed, which is also
   // what keeps a failure from ANOTHER project's directory out of this project's
   // graph -- a candidate cannot be emitted without a success recorded HERE.
+  // HOISTED so detector 5 can pair over the SAME merged list -- events plus the
+  // transcript failures folded in below. Rebuilding it there would duplicate the
+  // de-duplication logic and let the two detectors drift; leaving it block-scoped
+  // gave detector 5 a ReferenceError that its own try/catch swallowed, which is
+  // silent nothing rather than a visible failure.
+  let outcomes = [];
   try {
     if (projectRoot) {
-      const outcomes = events
+      outcomes = events
         .filter(
           (e) =>
             e &&
@@ -802,6 +872,92 @@ export function derive(dir, options = {}) {
   } catch {
     // One detector, never the session.
   }
+  // ---- 5: a DIFFERENT command against the same target succeeded -----------
+  //
+  // THE LESSON DETECTOR 1 CANNOT REACH. Its `attemptKey` is program-plus-
+  // operands, so the correction worth recording -- reaching for a different
+  // tool against the same target -- lands in two groups that never meet:
+  //
+  //   npx jest tests/foo.test.mjs     key "npx jest tests/foo.test.mjs"
+  //   npm test -- tests/foo.test.mjs  key "npm test tests/foo.test.mjs"
+  //
+  // What detector 1 CAN pair is the identical command re-run, and its own guard
+  // then correctly discards that as incoherent -- "`npm run build` works where
+  // `npm run build` failed" claims nothing. So between the key and the guard,
+  // the command family had almost no reachable evidence: measured across 937
+  // real derive runs on this machine, 8 candidates and ZERO stored findings.
+  //
+  // This pairs on the shared OPERAND instead, and only when the PROGRAM differs
+  // -- same-program pairs are detector 1's business and are left to it. The
+  // conservatism the original key was protecting is kept in three other places:
+  // the operand must NAME something (a path or an extension, never a bare word
+  // like `build`), the two attempts must be close in time, and the ceiling is
+  // 0.6 rather than 0.9 because sharing a target is weaker evidence than
+  // repeating an invocation.
+  try {
+    if (projectRoot && outcomes?.length) {
+      const byTarget = new Map();
+      for (const outcome of outcomes) {
+        const target = commandOperand(outcome.command);
+        if (!target) continue;
+        if (!byTarget.has(target)) byTarget.set(target, []);
+        byTarget.get(target).push(outcome);
+      }
+
+      for (const [target, run] of byTarget) {
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          lastFailure = null;
+
+          // Same program is detector 1's case, whether it pairs there or not.
+          if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
+          // A fix follows its failure closely. Hours apart is two unrelated
+          // pieces of work that happened to touch one file.
+          const apart = Math.abs((outcome.at || 0) - (failed.at || 0));
+          if (!apart || apart > RETARGET_WINDOW_MS) continue;
+          // Same rule as detector 1: nothing quotable, nothing claimed.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          const confidence = CONFIDENCE.retarget;
+          add({
+            type: 'command',
+            claim: redact(
+              `In this project \`${commandBody(outcome.command)}\` succeeded on ${target} where ` +
+                `\`${commandBody(failed.command)}\` had failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded against the same target \`${target}\` ` +
+                `${Math.round(apart / 1000)}s later. Different programs, one target: ordered ` +
+                'and close, but not proven causal -- an intervening edit explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: `when about to run \`${commandProgram(failed.command)}\` against ${target} in this project`,
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: [`\`${commandBody(failed.command)}\` later succeeds unchanged`],
+            trigger: triggerFor(failed.command),
+            anchors: [anchorPath],
+            derivedBy: 'retarget',
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
 
   // ---- storage, under a budget -------------------------------------------
   //

--- a/integrations/codex/hooks/lib/derive.mjs
+++ b/integrations/codex/hooks/lib/derive.mjs
@@ -739,6 +739,27 @@ export function derive(dir, options = {}) {
   let outcomes = [];
   try {
     if (projectRoot) {
+      // SCOPED TO THE SESSION THE CLAIM WILL NAME.
+      //
+      // Every claim these detectors build opens `observed in one session:`,
+      // and the store holds every session's outcomes -- so nothing but the
+      // ten-minute window stopped a failure from one session pairing with a
+      // success from another and asserting a provenance that never happened.
+      //
+      // NEVER OBSERVED, SAID PLAINLY. Across both live stores on this machine
+      // -- 7,173 command outcomes over 3 sessions here, 543 over 9 sessions in
+      // the unrooted one -- 5,155 and 298 adjacent in-window pairs respectively
+      // and ZERO of them crossed a session. Sessions are long and rarely
+      // interleave inside ten minutes. This is a correctness fix against a
+      // false claim, not a fix for observed damage, and it is not offered as
+      // one. Concurrent sessions do occur -- one was recorded on this machine
+      // while this was being written -- and they share the unrooted store.
+      //
+      // The merged transcript failures below are deliberately NOT filtered:
+      // `failedResultsFromTranscript` carries no sessionId, and the transcript
+      // it read is this session's, so they are already scoped by construction.
+      // Filtering them here would drop the only source of command failures
+      // that exists -- Claude Code never fires PostToolUse on a non-zero exit.
       outcomes = events
         .filter(
           (e) =>
@@ -746,7 +767,10 @@ export function derive(dir, options = {}) {
             e.kind === 'tool-outcome' &&
             e.surface === 'command' &&
             typeof e.anchor === 'string' &&
-            e.anchor.trim()
+            e.anchor.trim() &&
+            // An event predating the field still counts; a DIFFERENT session
+            // never does.
+            (!sessionId || !e.sessionId || e.sessionId === sessionId)
         )
         .map((e) => ({
           command: e.anchor.trim(),

--- a/integrations/codex/hooks/lib/derive.mjs
+++ b/integrations/codex/hooks/lib/derive.mjs
@@ -915,6 +915,20 @@ export function derive(dir, options = {}) {
           const failed = lastFailure;
           lastFailure = null;
 
+          // BOTH SIDES MUST NAME A SINGLE COMMAND, the same rule detector 1
+          // applies. `commandBody` strips only a LEADING directory change, and
+          // `commandProgram` reads the first token, so a chained command
+          // attributes the failure to the wrong program entirely:
+          //
+          //   git fetch && npx jest tests/foo.test.mjs   -> program "git"
+          //   cat x | npx jest tests/foo.test.mjs        -> program "cat"
+          //
+          // Paired against `npm test -- tests/foo.test.mjs` those would ship
+          // "npm test succeeded where git fetch failed" and tell a later session
+          // to avoid `git`. Checked per side rather than once, because unlike
+          // detector 1 these two do NOT share a key by construction.
+          if (!hasAttemptIdentity(failed.command)) continue;
+          if (!hasAttemptIdentity(outcome.command)) continue;
           // Same program is detector 1's case, whether it pairs there or not.
           if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
           // A fix follows its failure closely. Hours apart is two unrelated

--- a/integrations/codex/hooks/lib/derive.mjs
+++ b/integrations/codex/hooks/lib/derive.mjs
@@ -430,10 +430,16 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * Returns null when nothing resolves, which leaves the caller's original root
  * untouched -- a wrong project is worse than the status quo.
  */
-export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+export function projectRootFromActivity(events, { resolve, cwd, sessionId = null } = {}) {
   if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
   const counts = new Map();
   for (const event of events) {
+    // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
+    // session that wrote it, so counting every event ever recorded lets a busy
+    // session from last week outvote the one now ending -- and the question
+    // being asked is "where did THIS session work", not "where is this graph
+    // busiest". Callers that pass no id keep the whole-graph count.
+    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.
@@ -454,13 +460,22 @@ export function projectRootFromActivity(events, { resolve, cwd } = {}) {
   }
   let best = null;
   let most = 0;
+  let tied = false;
   for (const [root, n] of counts) {
     if (n > most) {
       most = n;
       best = root;
+      tied = false;
+    } else if (n === most) {
+      // A Map iterates in insertion order, so a tie would otherwise be broken by
+      // whichever file the session happened to touch first -- deterministic, but
+      // arbitrary, and wrong half the time. Findings would then be stored against
+      // a project the evidence does not single out. Decline instead; the caller
+      // keeps cwdRoot, which is at least a root the user chose.
+      tied = true;
     }
   }
-  return best;
+  return tied ? null : best;
 }
 
 export function projectAnchor(projectRoot) {

--- a/integrations/codex/hooks/lib/derive.mjs
+++ b/integrations/codex/hooks/lib/derive.mjs
@@ -373,9 +373,45 @@ export function commandOperand(command) {
   return null;
 }
 
-/** The program a command invokes, for deciding whether two attempts differ. */
+/**
+ * A leading `VAR=value` prefix, which a shell applies to the environment of
+ * the command that follows rather than running as the command itself.
+ */
+const ENV_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+/**
+ * The program a command invokes, for deciding whether two attempts differ.
+ *
+ * ENVIRONMENT PREFIXES ARE NOT THE PROGRAM. Taking the first token verbatim
+ * reported `SP=/tmp/x` as the program for `SP=/tmp/x node run.mjs`, and that
+ * is not a cosmetic slip: measured over this machine's real history, 816 of
+ * 7,165 recorded command outcomes -- 11.4% -- named an assignment.
+ *
+ * IT FAILS IN THE DANGEROUS DIRECTION. This function exists to decide that two
+ * attempts used DIFFERENT programs, so two runs of the same tool under
+ * different variables --
+ *
+ *   SP=/a node run.mjs    (failed)
+ *   SPW=/b node run.mjs   (succeeded)
+ *
+ * -- compared as `sp=/a` against `spw=/b`, differed, and were eligible to
+ * pair. The claim that pairing produces is `node run.mjs` succeeded where
+ * `node run.mjs` failed: exactly the incoherent statement detector 1's own
+ * guard exists to refuse, arriving through the door detector 5 opened.
+ *
+ * Skipping the prefixes is what a shell does, and it cannot invent a pair --
+ * two commands that were already the same program now compare equal, which
+ * only ever removes a candidate.
+ *
+ * NO MEASURED CHANGE TODAY, stated plainly: replaying both versions over the
+ * same real history gives an identical pairing outcome (20 pairs considered,
+ * 0 firing), because every affected command is also chained and rejected
+ * earlier. This is a correctness fix against a latent false claim, not a
+ * recall improvement, and it is not offered as one.
+ */
 export function commandProgram(command) {
-  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  const tokens = commandBody(command).trim().split(/\s+/).filter(Boolean);
+  const first = tokens.find((token) => !ENV_ASSIGNMENT.test(token)) || '';
   return first.split(/[/\\]/).pop().toLowerCase();
 }
 

--- a/integrations/codex/hooks/lib/derive.mjs
+++ b/integrations/codex/hooks/lib/derive.mjs
@@ -53,6 +53,7 @@ import { ORIGIN_HARVESTED } from './curate.mjs';
 // from, so what this counts as a search and what the advisory treats as one
 // cannot diverge.
 import {
+  commandSegments,
   identifiersIn,
   searchPatternFromCommand,
   symbolIndex,
@@ -182,11 +183,38 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
-const hasAttemptIdentity = (command) =>
-  attemptKey(command)
+/**
+ * THE WHOLE BODY, NOT THE FIRST THREE TOKENS.
+ *
+ * This used to read the separator set off `attemptKey`, which keeps only the
+ * first three non-flag tokens -- so it caught a separator only when one landed
+ * early by luck of position. Verified against the real functions:
+ *
+ *   git fetch && npx jest tests/foo   key `git fetch &&`        -> rejected
+ *   npx jest tests/foo && node x.mjs  key `npx jest tests/foo`  -> ACCEPTED
+ *   grep -rn foo src | head -20       key `grep foo src`        -> ACCEPTED
+ *
+ * The last two are exactly the claims this guard exists to stop: the key names
+ * `npx`, so a pair would blame `npx` for a failure `node` may have caused.
+ * Every existing test placed the separator in the first three tokens, so none
+ * of them could see it.
+ *
+ * `commandSegments` is reused rather than a fresh scan because it is already
+ * the quote-aware one: splitting the raw string would cut through `grep -E
+ * "foo|bar"` and reject an ordinary alternation as a pipeline.
+ *
+ * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
+ * before this sees it -- that case is one command spelled two ways.
+ */
+const hasAttemptIdentity = (command) => {
+  const body = commandBody(command);
+  if (!body.trim()) return false;
+  if (commandSegments(body).length > 1) return false;
+  return attemptKey(command)
     .split(' ')
     .filter(Boolean)
     .every((token) => !COMMAND_SEPARATORS.has(token));
+};
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -435,11 +463,20 @@ export function projectRootFromActivity(events, { resolve, cwd, sessionId = null
   const counts = new Map();
   for (const event of events) {
     // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
-    // session that wrote it, so counting every event ever recorded lets a busy
-    // session from last week outvote the one now ending -- and the question
-    // being asked is "where did THIS session work", not "where is this graph
-    // busiest". Callers that pass no id keep the whole-graph count.
-    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
+    // session that wrote it, and the caller concatenates several graphs, so
+    // counting every event ever recorded lets a busy session from last week
+    // outvote the one now ending -- and the question being asked is "where did
+    // THIS session work", not "where is this graph busiest". Callers that pass
+    // no id keep the whole-graph count.
+    //
+    // AN EVENT THAT CANNOT NAME ITS SESSION IS EXCLUDED, not exempted. Exempting
+    // it was a deliberate concession to older records, and measurement says the
+    // concession buys nothing: across the three live stores on this machine, 2
+    // of 22,321 file/read events lack the field -- 0.01%. Set against that, an
+    // unstamped event sitting in ANOTHER project's graph would vote for that
+    // project on the strength of no evidence at all, which is precisely the
+    // failure this filter exists to prevent.
+    if (sessionId && event?.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.

--- a/integrations/codex/hooks/lib/derive.mjs
+++ b/integrations/codex/hooks/lib/derive.mjs
@@ -403,6 +403,66 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * against a fabricated anchor. That is the fail-open direction: no finding
  * beats a finding anchored to something that is not what the claim is about.
  */
+
+/**
+ * The project a session actually worked in, read off what it touched.
+ *
+ * WHY THE SESSION'S CWD IS THE WRONG ANSWER. `adapter.mjs` resolves the root
+ * with `projectRootFor(join(cwd, '__session__'), cwd)`, and when Claude Code is
+ * launched from a directory with no VCS marker -- a home directory, which is how
+ * this machine runs it -- that returns the synthetic fallback
+ * `~/.token-optimizer/unrooted`. It is NOT null, so every `if (projectRoot)`
+ * gate passes, and then `projectAnchor` hands back the directory itself because
+ * the fallback contains no project marker. `writeHarvested` resolves anchors
+ * through `indexFile`, `indexFile` on a directory returns null, and the finding
+ * is refused as unanchorable.
+ *
+ * That is the whole reason this machine's graph holds 2,965 symbols and ONE
+ * finding: 937 derive runs produced candidates and stored none of them, while
+ * every layer reported success.
+ *
+ * The router already solved this for capture -- "THE GRAPH IS PER PROJECT, so it
+ * is keyed on where the FILE lives, not on where the client happens to be
+ * running" -- and derivation simply never adopted it. This applies the same
+ * rule at Stop time: take the file anchors the session recorded, resolve each to
+ * its own project, and pick the one that holds the most of them.
+ *
+ * Returns null when nothing resolves, which leaves the caller's original root
+ * untouched -- a wrong project is worse than the status quo.
+ */
+export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+  if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
+  const counts = new Map();
+  for (const event of events) {
+    const anchor = event?.anchor;
+    // File surfaces only. A command anchor is the command text, and resolving
+    // `npm test -- x` as a path would invent a project out of a sentence.
+    if (!anchor || typeof anchor !== 'string') continue;
+    if (event.kind !== 'read' && !(event.kind === 'tool-outcome' && event.surface === 'file')) {
+      continue;
+    }
+    let root;
+    try {
+      root = resolve(anchor, cwd);
+    } catch {
+      continue;
+    }
+    // The fallback resolves to a path inside the optimizer's own store, which is
+    // never a project someone is working in.
+    if (!root || String(root).includes('.token-optimizer')) continue;
+    counts.set(root, (counts.get(root) || 0) + 1);
+  }
+  let best = null;
+  let most = 0;
+  for (const [root, n] of counts) {
+    if (n > most) {
+      most = n;
+      best = root;
+    }
+  }
+  return best;
+}
+
 export function projectAnchor(projectRoot) {
   if (!projectRoot) return null;
   let entries;

--- a/integrations/codex/hooks/lib/transcript.mjs
+++ b/integrations/codex/hooks/lib/transcript.mjs
@@ -289,6 +289,23 @@ const ANCHOR_MAX = 120;
  */
 const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
 
+/**
+ * A run the HARNESS stopped, which is not the command failing.
+ *
+ * The allowlist above admits anything shaped `Exit code N`, and a killed
+ * command reports `Exit code 143` with `Command timed out after 2m 0s` -- so
+ * it walks straight in. Nothing about it is a lesson about the command: it did
+ * not fail, it was not allowed to finish, and the same command run with a
+ * longer budget may well pass. Pairing one with a later success would claim a
+ * red-to-green transition that never happened.
+ *
+ * MEASURED, on a 237 MB transcript of ordinary feature work: of 130 admitted
+ * failures, 25 were timeouts -- 19%. At the 64 MB scan it was 11 of 23, 48%.
+ * User declines are NOT in this class and need no rule; the positive allowlist
+ * already excludes them, verified at every scan size on the same transcript.
+ */
+const HARNESS_TIMEOUT = /^\s*Command timed out after\b/m;
+
 /** Reads at most `bytes` from the END of a file, without loading the rest. */
 function readTail(path, bytes) {
   let fd;
@@ -390,6 +407,8 @@ export function failedResultsFromTranscript(transcriptPath, options = {}) {
       if (typeof block.content !== 'string') continue;
       const match = EXIT_CODE_RESULT.exec(block.content);
       if (!match) continue;
+      // The command ran, but the harness ended it. See HARNESS_TIMEOUT.
+      if (HARNESS_TIMEOUT.test(block.content)) continue;
       const command = commands.get(String(block.tool_use_id || ''));
       // No command means no claim. The result says something failed; without
       // the text of what failed there is nothing to say about it, and nothing

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -55,6 +55,7 @@ import {
   load,
   wikiDir,
   projectRootFor,
+  unrootedRoot,
 } from './wiki.mjs';
 import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
@@ -78,7 +79,7 @@ import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
-import { isFsSafePath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
   recordingNudge,
@@ -94,7 +95,7 @@ import {
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
-import { registerProject } from './projects.mjs';
+import { registerProject, registeredProjects } from './projects.mjs';
 import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
@@ -109,6 +110,62 @@ export const CLIENTS = nativeClientProfiles();
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
+
+/**
+ * How many registered project graphs a session-end sweep may open.
+ *
+ * The registry is append-only and unbounded over time -- 4,033 records on this
+ * machine -- and each graph read is a tail of up to 2 MB. Bounded to the most
+ * recently seen handful, which is the only part of the registry a single
+ * session can plausibly have written to.
+ */
+const CROSS_PROJECT_SCAN_LIMIT =
+  Number(process.env.TOKEN_OPTIMIZER_CROSS_PROJECT_SCAN) || 12;
+
+/** A project the current session cannot have touched is not worth opening. */
+const CROSS_PROJECT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The activity this session recorded, gathered from every graph that could hold
+ * it.
+ *
+ * Capture is keyed on where the FILE lives (`recordToolOutcome(wikiDir(root))`,
+ * post-tool), not on the session's cwd. So when the client is started outside a
+ * repository -- a home directory, the common case -- the session's own file
+ * activity is written into each touched project's graph, and the unrooted graph
+ * that `cwd` resolves to holds none of it. Reading only that graph is why the
+ * inference below returned null in exactly the case it exists for: measured on
+ * this machine, the unrooted store holds 12,376 file anchors and ZERO of them
+ * under a repository.
+ *
+ * The sweep is confined to that case. A cwd that IS a repository already owns
+ * the graph its own files were captured into, so it pays nothing.
+ */
+export function sessionActivity(cwdRoot) {
+  let events = [];
+  try {
+    events = readMetrics(wikiDir(cwdRoot));
+  } catch {
+    events = [];
+  }
+  if (canonicalPath(cwdRoot) !== canonicalPath(unrootedRoot())) return events;
+  const cutoff = Date.now() - CROSS_PROJECT_MAX_AGE_MS;
+  let projects = [];
+  try {
+    // Sorted most-recently-seen first by `registeredProjects`.
+    projects = registeredProjects().filter((p) => (p.lastSeenAt || 0) >= cutoff);
+  } catch {
+    return events;
+  }
+  for (const project of projects.slice(0, CROSS_PROJECT_SCAN_LIMIT)) {
+    try {
+      events = events.concat(readMetrics(project.graphDir));
+    } catch {
+      // One unreadable store must not cost the session its inference.
+    }
+  }
+  return events;
+}
 
 /**
  * The response envelopes a completed tool call can arrive in.
@@ -1223,13 +1280,21 @@ async function runHook(clientName, event, invocation) {
       // router already keys capture on where the FILE lives rather than on the
       // session's cwd; this applies that rule to derivation too, and falls back
       // to the cwd answer when the session touched nothing resolvable.
+      //
+      // The evidence is gathered by `sessionActivity`, NOT from the cwd graph
+      // alone: capture keyed on the file's project means an unrooted session's
+      // own activity was written into the graphs of the projects it touched.
+      // Reading only the unrooted graph found 12,376 file anchors and not one
+      // under a repository, so the inference was inert in precisely the case it
+      // was written for.
       const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
       let projectRoot = cwdRoot;
       try {
         projectRoot =
-          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+          projectRootFromActivity(sessionActivity(cwdRoot), {
             resolve: (anchor) => projectRootFor(anchor, cwd),
             cwd,
+            sessionId,
           }) || cwdRoot;
       } catch {
         // Inferring the project is an improvement, never a precondition.

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -46,8 +46,9 @@ import {
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
+  readMetrics,
 } from './metrics.mjs';
-import { derive } from './derive.mjs';
+import { derive, projectRootFromActivity } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -1207,7 +1208,32 @@ async function runHook(clientName, event, invocation) {
       // one figure alone cannot distinguish "nothing to derive" from "derived
       // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
-      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      // WHERE THE WORK HAPPENED, NOT WHERE THE CLIENT WAS LAUNCHED.
+      //
+      // `projectRootFor` on a cwd with no VCS marker -- a home directory, which
+      // is how this client is commonly started -- returns the synthetic fallback
+      // `~/.token-optimizer/unrooted`. That is not null, so every `if
+      // (projectRoot)` gate downstream passes, and `projectAnchor` then hands
+      // back the directory itself because the fallback holds no project marker.
+      // `writeHarvested` resolves anchors through `indexFile`, which returns
+      // null for a directory, and the finding is refused as unanchorable.
+      //
+      // Measured consequence on this machine: 937 derive runs, 8 candidates,
+      // ZERO findings written, beside 2,965 symbol nodes in the same graph. The
+      // router already keys capture on where the FILE lives rather than on the
+      // session's cwd; this applies that rule to derivation too, and falls back
+      // to the cwd answer when the session touched nothing resolvable.
+      const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      let projectRoot = cwdRoot;
+      try {
+        projectRoot =
+          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+            resolve: (anchor) => projectRootFor(anchor, cwd),
+            cwd,
+          }) || cwdRoot;
+      } catch {
+        // Inferring the project is an improvement, never a precondition.
+      }
       const dir = wikiDir(projectRoot);
       const derived = derive(dir, {
         sessionId,

--- a/integrations/codex/plugin/hooks/lib/advise.mjs
+++ b/integrations/codex/plugin/hooks/lib/advise.mjs
@@ -162,7 +162,7 @@ const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function commandSegments(command) {
+export function commandSegments(command) {
   const segments = [];
   let tokens = [];
   let current = '';

--- a/integrations/codex/plugin/hooks/lib/derive.mjs
+++ b/integrations/codex/plugin/hooks/lib/derive.mjs
@@ -205,11 +205,26 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  *
  * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
  * before this sees it -- that case is one command spelled two ways.
+ *
+ * A TRAILING SEPARATOR LEAVES NOTHING TO COUNT, which is the hole in reading
+ * the segment count alone. `commandSegments` pushes only non-empty token
+ * lists, so `npx jest tests/foo &&` is ONE segment, and `attemptKey` -- the
+ * first three non-flag tokens -- never sees the `&&` either. The command is
+ * still half of something, and `cmd &` on its own is a background job whose
+ * exit code belongs to the shell rather than to the program named. Appending a
+ * sentinel token makes the missing segment materialise, which reuses the one
+ * scanner that already understands quotes instead of adding a second,
+ * differently-wrong one: `grep -E "foo|bar" src/x.mjs` stays a single segment
+ * with the sentinel attached, exactly as it does without it.
  */
+// Not a plausible argument to anything, so it can only ever be the token this
+// function appended.
+const SEGMENT_SENTINEL = '__token_optimizer_segment_probe__';
+
 const hasAttemptIdentity = (command) => {
   const body = commandBody(command);
   if (!body.trim()) return false;
-  if (commandSegments(body).length > 1) return false;
+  if (commandSegments(`${body} ${SEGMENT_SENTINEL}`).length > 1) return false;
   return attemptKey(command)
     .split(' ')
     .filter(Boolean)
@@ -368,7 +383,13 @@ export function commandOperand(command) {
   // attempts, so including it would reproduce attemptKey's blind spot.
   for (const token of tokens.slice(1)) {
     const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
-    if (named && token.length >= 4) return token.toLowerCase();
+    // AS WRITTEN, not folded. This value is the grouping key AND the text of
+    // the stored claim, and folding it made the claim name a path that does
+    // not exist on a case-sensitive filesystem: `src/Foo.test.mjs` was
+    // recorded, and served to a later session, as `src/foo.test.mjs`. The
+    // caller folds a copy for the key instead, so matching stays
+    // case-insensitive without the claim paying for it.
+    if (named && token.length >= 4) return token;
   }
   return null;
 }
@@ -1068,15 +1089,23 @@ export function derive(dir, options = {}) {
   // repeating an invocation.
   try {
     if (projectRoot && outcomes?.length) {
+      // KEYED FOLDED, DISPLAYED AS WRITTEN. Two invocations naming the same
+      // file with different capitalisation are the same target on Windows and
+      // macOS, so the key folds; the text stored in the finding must not,
+      // because a claim naming `src/foo.test.mjs` for a file called
+      // `src/Foo.test.mjs` is a path that does not resolve on Linux -- and
+      // that text is what a later session reads. The first spelling seen wins,
+      // which is the one the failing attempt actually used.
       const byTarget = new Map();
       for (const outcome of outcomes) {
-        const target = commandOperand(outcome.command);
-        if (!target) continue;
-        if (!byTarget.has(target)) byTarget.set(target, []);
-        byTarget.get(target).push(outcome);
+        const operand = commandOperand(outcome.command);
+        if (!operand) continue;
+        const key = operand.toLowerCase();
+        if (!byTarget.has(key)) byTarget.set(key, { target: operand, run: [] });
+        byTarget.get(key).run.push(outcome);
       }
 
-      for (const [target, run] of byTarget) {
+      for (const { target, run } of byTarget.values()) {
         let lastFailure = null;
         for (const outcome of run) {
           if (outcome.failed) {

--- a/integrations/codex/plugin/hooks/lib/derive.mjs
+++ b/integrations/codex/plugin/hooks/lib/derive.mjs
@@ -67,7 +67,16 @@ import {
  * command. A correction is a lexical guess about what a human meant. Churn
  * describes our own reading behaviour and says nothing about the code at all.
  */
-export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+export const CONFIDENCE = {
+  command: 0.9,
+  test: 0.85,
+  // Below `command` because the inference is weaker: two commands sharing a
+  // target is good evidence of one intent, but not the same evidence as the
+  // identical invocation being retried. Labelled speculative, deliberately.
+  retarget: 0.6,
+  correction: 0.6,
+  churn: 0.4,
+};
 
 /** Claim text cap. A finding is one sentence; a paragraph is evidence. */
 const CLAIM_MAX = 300;
@@ -75,6 +84,17 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * How close a fix must follow its failure to count as the same attempt.
+ *
+ * Detector 5 pairs across DIFFERENT programs, so it cannot lean on command
+ * identity to know the two are related -- proximity is doing that work instead.
+ * Ten minutes is long enough for a real correction, including reading an error
+ * and looking something up, and short enough that two unrelated pieces of work
+ * touching one file in an afternoon are not reported as one story.
+ */
+const RETARGET_WINDOW_MS = 10 * 60 * 1000;
 
 /**
  * The anchor cap a command surface is stored under, restated here as a TEST.
@@ -287,6 +307,50 @@ export function attemptKey(command) {
     .join(' ')
     .toLowerCase();
 }
+/**
+ * The thing a command ACTS ON -- a path, a test file, a target.
+ *
+ * WHY `attemptKey` IS NOT ENOUGH, measured rather than supposed. That key is
+ * program-plus-operands, so the single most valuable lesson a session can teach
+ * cannot pair by construction:
+ *
+ *   npx jest tests/foo      -> key "npx jest tests/foo"
+ *   npm test -- tests/foo   -> key "npm test tests/foo"
+ *
+ * Different keys, no pair, no finding -- yet that is exactly the correction
+ * worth recording, because the fix was to run a DIFFERENT program against the
+ * same target. The existing detector can only catch the same command re-run and
+ * succeeding, which its own guard then discards as incoherent.
+ *
+ * The measured cost of that: across 937 real derive runs on this machine, 8
+ * candidates were produced and ZERO were stored.
+ *
+ * So this returns the shared operand -- `tests/foo` above -- which is what the
+ * two attempts genuinely have in common. Only operands that NAME something are
+ * admitted: a path separator or a file extension. A bare word like `build` is
+ * refused, because `npm run build` and `make build` sharing the token `build`
+ * is a coincidence of vocabulary, not evidence of one intent.
+ */
+export function commandOperand(command) {
+  const tokens = commandBody(command)
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'));
+  // Skipping the first token: the PROGRAM is what differs between the two
+  // attempts, so including it would reproduce attemptKey's blind spot.
+  for (const token of tokens.slice(1)) {
+    const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
+    if (named && token.length >= 4) return token.toLowerCase();
+  }
+  return null;
+}
+
+/** The program a command invokes, for deciding whether two attempts differ. */
+export function commandProgram(command) {
+  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  return first.split(/[/\\]/).pop().toLowerCase();
+}
+
 
 /** Normalised claim text, so the same lesson derived twice is one candidate. */
 const claimKey = (type, claim) =>
@@ -519,9 +583,15 @@ export function derive(dir, options = {}) {
   // a transcript failure that pairs with nothing stays unclaimed, which is also
   // what keeps a failure from ANOTHER project's directory out of this project's
   // graph -- a candidate cannot be emitted without a success recorded HERE.
+  // HOISTED so detector 5 can pair over the SAME merged list -- events plus the
+  // transcript failures folded in below. Rebuilding it there would duplicate the
+  // de-duplication logic and let the two detectors drift; leaving it block-scoped
+  // gave detector 5 a ReferenceError that its own try/catch swallowed, which is
+  // silent nothing rather than a visible failure.
+  let outcomes = [];
   try {
     if (projectRoot) {
-      const outcomes = events
+      outcomes = events
         .filter(
           (e) =>
             e &&
@@ -802,6 +872,92 @@ export function derive(dir, options = {}) {
   } catch {
     // One detector, never the session.
   }
+  // ---- 5: a DIFFERENT command against the same target succeeded -----------
+  //
+  // THE LESSON DETECTOR 1 CANNOT REACH. Its `attemptKey` is program-plus-
+  // operands, so the correction worth recording -- reaching for a different
+  // tool against the same target -- lands in two groups that never meet:
+  //
+  //   npx jest tests/foo.test.mjs     key "npx jest tests/foo.test.mjs"
+  //   npm test -- tests/foo.test.mjs  key "npm test tests/foo.test.mjs"
+  //
+  // What detector 1 CAN pair is the identical command re-run, and its own guard
+  // then correctly discards that as incoherent -- "`npm run build` works where
+  // `npm run build` failed" claims nothing. So between the key and the guard,
+  // the command family had almost no reachable evidence: measured across 937
+  // real derive runs on this machine, 8 candidates and ZERO stored findings.
+  //
+  // This pairs on the shared OPERAND instead, and only when the PROGRAM differs
+  // -- same-program pairs are detector 1's business and are left to it. The
+  // conservatism the original key was protecting is kept in three other places:
+  // the operand must NAME something (a path or an extension, never a bare word
+  // like `build`), the two attempts must be close in time, and the ceiling is
+  // 0.6 rather than 0.9 because sharing a target is weaker evidence than
+  // repeating an invocation.
+  try {
+    if (projectRoot && outcomes?.length) {
+      const byTarget = new Map();
+      for (const outcome of outcomes) {
+        const target = commandOperand(outcome.command);
+        if (!target) continue;
+        if (!byTarget.has(target)) byTarget.set(target, []);
+        byTarget.get(target).push(outcome);
+      }
+
+      for (const [target, run] of byTarget) {
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          lastFailure = null;
+
+          // Same program is detector 1's case, whether it pairs there or not.
+          if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
+          // A fix follows its failure closely. Hours apart is two unrelated
+          // pieces of work that happened to touch one file.
+          const apart = Math.abs((outcome.at || 0) - (failed.at || 0));
+          if (!apart || apart > RETARGET_WINDOW_MS) continue;
+          // Same rule as detector 1: nothing quotable, nothing claimed.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          const confidence = CONFIDENCE.retarget;
+          add({
+            type: 'command',
+            claim: redact(
+              `In this project \`${commandBody(outcome.command)}\` succeeded on ${target} where ` +
+                `\`${commandBody(failed.command)}\` had failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded against the same target \`${target}\` ` +
+                `${Math.round(apart / 1000)}s later. Different programs, one target: ordered ` +
+                'and close, but not proven causal -- an intervening edit explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: `when about to run \`${commandProgram(failed.command)}\` against ${target} in this project`,
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: [`\`${commandBody(failed.command)}\` later succeeds unchanged`],
+            trigger: triggerFor(failed.command),
+            anchors: [anchorPath],
+            derivedBy: 'retarget',
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
 
   // ---- storage, under a budget -------------------------------------------
   //

--- a/integrations/codex/plugin/hooks/lib/derive.mjs
+++ b/integrations/codex/plugin/hooks/lib/derive.mjs
@@ -739,6 +739,27 @@ export function derive(dir, options = {}) {
   let outcomes = [];
   try {
     if (projectRoot) {
+      // SCOPED TO THE SESSION THE CLAIM WILL NAME.
+      //
+      // Every claim these detectors build opens `observed in one session:`,
+      // and the store holds every session's outcomes -- so nothing but the
+      // ten-minute window stopped a failure from one session pairing with a
+      // success from another and asserting a provenance that never happened.
+      //
+      // NEVER OBSERVED, SAID PLAINLY. Across both live stores on this machine
+      // -- 7,173 command outcomes over 3 sessions here, 543 over 9 sessions in
+      // the unrooted one -- 5,155 and 298 adjacent in-window pairs respectively
+      // and ZERO of them crossed a session. Sessions are long and rarely
+      // interleave inside ten minutes. This is a correctness fix against a
+      // false claim, not a fix for observed damage, and it is not offered as
+      // one. Concurrent sessions do occur -- one was recorded on this machine
+      // while this was being written -- and they share the unrooted store.
+      //
+      // The merged transcript failures below are deliberately NOT filtered:
+      // `failedResultsFromTranscript` carries no sessionId, and the transcript
+      // it read is this session's, so they are already scoped by construction.
+      // Filtering them here would drop the only source of command failures
+      // that exists -- Claude Code never fires PostToolUse on a non-zero exit.
       outcomes = events
         .filter(
           (e) =>
@@ -746,7 +767,10 @@ export function derive(dir, options = {}) {
             e.kind === 'tool-outcome' &&
             e.surface === 'command' &&
             typeof e.anchor === 'string' &&
-            e.anchor.trim()
+            e.anchor.trim() &&
+            // An event predating the field still counts; a DIFFERENT session
+            // never does.
+            (!sessionId || !e.sessionId || e.sessionId === sessionId)
         )
         .map((e) => ({
           command: e.anchor.trim(),

--- a/integrations/codex/plugin/hooks/lib/derive.mjs
+++ b/integrations/codex/plugin/hooks/lib/derive.mjs
@@ -915,6 +915,20 @@ export function derive(dir, options = {}) {
           const failed = lastFailure;
           lastFailure = null;
 
+          // BOTH SIDES MUST NAME A SINGLE COMMAND, the same rule detector 1
+          // applies. `commandBody` strips only a LEADING directory change, and
+          // `commandProgram` reads the first token, so a chained command
+          // attributes the failure to the wrong program entirely:
+          //
+          //   git fetch && npx jest tests/foo.test.mjs   -> program "git"
+          //   cat x | npx jest tests/foo.test.mjs        -> program "cat"
+          //
+          // Paired against `npm test -- tests/foo.test.mjs` those would ship
+          // "npm test succeeded where git fetch failed" and tell a later session
+          // to avoid `git`. Checked per side rather than once, because unlike
+          // detector 1 these two do NOT share a key by construction.
+          if (!hasAttemptIdentity(failed.command)) continue;
+          if (!hasAttemptIdentity(outcome.command)) continue;
           // Same program is detector 1's case, whether it pairs there or not.
           if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
           // A fix follows its failure closely. Hours apart is two unrelated

--- a/integrations/codex/plugin/hooks/lib/derive.mjs
+++ b/integrations/codex/plugin/hooks/lib/derive.mjs
@@ -430,10 +430,16 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * Returns null when nothing resolves, which leaves the caller's original root
  * untouched -- a wrong project is worse than the status quo.
  */
-export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+export function projectRootFromActivity(events, { resolve, cwd, sessionId = null } = {}) {
   if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
   const counts = new Map();
   for (const event of events) {
+    // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
+    // session that wrote it, so counting every event ever recorded lets a busy
+    // session from last week outvote the one now ending -- and the question
+    // being asked is "where did THIS session work", not "where is this graph
+    // busiest". Callers that pass no id keep the whole-graph count.
+    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.
@@ -454,13 +460,22 @@ export function projectRootFromActivity(events, { resolve, cwd } = {}) {
   }
   let best = null;
   let most = 0;
+  let tied = false;
   for (const [root, n] of counts) {
     if (n > most) {
       most = n;
       best = root;
+      tied = false;
+    } else if (n === most) {
+      // A Map iterates in insertion order, so a tie would otherwise be broken by
+      // whichever file the session happened to touch first -- deterministic, but
+      // arbitrary, and wrong half the time. Findings would then be stored against
+      // a project the evidence does not single out. Decline instead; the caller
+      // keeps cwdRoot, which is at least a root the user chose.
+      tied = true;
     }
   }
-  return best;
+  return tied ? null : best;
 }
 
 export function projectAnchor(projectRoot) {

--- a/integrations/codex/plugin/hooks/lib/derive.mjs
+++ b/integrations/codex/plugin/hooks/lib/derive.mjs
@@ -373,9 +373,45 @@ export function commandOperand(command) {
   return null;
 }
 
-/** The program a command invokes, for deciding whether two attempts differ. */
+/**
+ * A leading `VAR=value` prefix, which a shell applies to the environment of
+ * the command that follows rather than running as the command itself.
+ */
+const ENV_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+/**
+ * The program a command invokes, for deciding whether two attempts differ.
+ *
+ * ENVIRONMENT PREFIXES ARE NOT THE PROGRAM. Taking the first token verbatim
+ * reported `SP=/tmp/x` as the program for `SP=/tmp/x node run.mjs`, and that
+ * is not a cosmetic slip: measured over this machine's real history, 816 of
+ * 7,165 recorded command outcomes -- 11.4% -- named an assignment.
+ *
+ * IT FAILS IN THE DANGEROUS DIRECTION. This function exists to decide that two
+ * attempts used DIFFERENT programs, so two runs of the same tool under
+ * different variables --
+ *
+ *   SP=/a node run.mjs    (failed)
+ *   SPW=/b node run.mjs   (succeeded)
+ *
+ * -- compared as `sp=/a` against `spw=/b`, differed, and were eligible to
+ * pair. The claim that pairing produces is `node run.mjs` succeeded where
+ * `node run.mjs` failed: exactly the incoherent statement detector 1's own
+ * guard exists to refuse, arriving through the door detector 5 opened.
+ *
+ * Skipping the prefixes is what a shell does, and it cannot invent a pair --
+ * two commands that were already the same program now compare equal, which
+ * only ever removes a candidate.
+ *
+ * NO MEASURED CHANGE TODAY, stated plainly: replaying both versions over the
+ * same real history gives an identical pairing outcome (20 pairs considered,
+ * 0 firing), because every affected command is also chained and rejected
+ * earlier. This is a correctness fix against a latent false claim, not a
+ * recall improvement, and it is not offered as one.
+ */
 export function commandProgram(command) {
-  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  const tokens = commandBody(command).trim().split(/\s+/).filter(Boolean);
+  const first = tokens.find((token) => !ENV_ASSIGNMENT.test(token)) || '';
   return first.split(/[/\\]/).pop().toLowerCase();
 }
 

--- a/integrations/codex/plugin/hooks/lib/derive.mjs
+++ b/integrations/codex/plugin/hooks/lib/derive.mjs
@@ -53,6 +53,7 @@ import { ORIGIN_HARVESTED } from './curate.mjs';
 // from, so what this counts as a search and what the advisory treats as one
 // cannot diverge.
 import {
+  commandSegments,
   identifiersIn,
   searchPatternFromCommand,
   symbolIndex,
@@ -182,11 +183,38 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
-const hasAttemptIdentity = (command) =>
-  attemptKey(command)
+/**
+ * THE WHOLE BODY, NOT THE FIRST THREE TOKENS.
+ *
+ * This used to read the separator set off `attemptKey`, which keeps only the
+ * first three non-flag tokens -- so it caught a separator only when one landed
+ * early by luck of position. Verified against the real functions:
+ *
+ *   git fetch && npx jest tests/foo   key `git fetch &&`        -> rejected
+ *   npx jest tests/foo && node x.mjs  key `npx jest tests/foo`  -> ACCEPTED
+ *   grep -rn foo src | head -20       key `grep foo src`        -> ACCEPTED
+ *
+ * The last two are exactly the claims this guard exists to stop: the key names
+ * `npx`, so a pair would blame `npx` for a failure `node` may have caused.
+ * Every existing test placed the separator in the first three tokens, so none
+ * of them could see it.
+ *
+ * `commandSegments` is reused rather than a fresh scan because it is already
+ * the quote-aware one: splitting the raw string would cut through `grep -E
+ * "foo|bar"` and reject an ordinary alternation as a pipeline.
+ *
+ * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
+ * before this sees it -- that case is one command spelled two ways.
+ */
+const hasAttemptIdentity = (command) => {
+  const body = commandBody(command);
+  if (!body.trim()) return false;
+  if (commandSegments(body).length > 1) return false;
+  return attemptKey(command)
     .split(' ')
     .filter(Boolean)
     .every((token) => !COMMAND_SEPARATORS.has(token));
+};
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -435,11 +463,20 @@ export function projectRootFromActivity(events, { resolve, cwd, sessionId = null
   const counts = new Map();
   for (const event of events) {
     // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
-    // session that wrote it, so counting every event ever recorded lets a busy
-    // session from last week outvote the one now ending -- and the question
-    // being asked is "where did THIS session work", not "where is this graph
-    // busiest". Callers that pass no id keep the whole-graph count.
-    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
+    // session that wrote it, and the caller concatenates several graphs, so
+    // counting every event ever recorded lets a busy session from last week
+    // outvote the one now ending -- and the question being asked is "where did
+    // THIS session work", not "where is this graph busiest". Callers that pass
+    // no id keep the whole-graph count.
+    //
+    // AN EVENT THAT CANNOT NAME ITS SESSION IS EXCLUDED, not exempted. Exempting
+    // it was a deliberate concession to older records, and measurement says the
+    // concession buys nothing: across the three live stores on this machine, 2
+    // of 22,321 file/read events lack the field -- 0.01%. Set against that, an
+    // unstamped event sitting in ANOTHER project's graph would vote for that
+    // project on the strength of no evidence at all, which is precisely the
+    // failure this filter exists to prevent.
+    if (sessionId && event?.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.

--- a/integrations/codex/plugin/hooks/lib/derive.mjs
+++ b/integrations/codex/plugin/hooks/lib/derive.mjs
@@ -403,6 +403,66 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * against a fabricated anchor. That is the fail-open direction: no finding
  * beats a finding anchored to something that is not what the claim is about.
  */
+
+/**
+ * The project a session actually worked in, read off what it touched.
+ *
+ * WHY THE SESSION'S CWD IS THE WRONG ANSWER. `adapter.mjs` resolves the root
+ * with `projectRootFor(join(cwd, '__session__'), cwd)`, and when Claude Code is
+ * launched from a directory with no VCS marker -- a home directory, which is how
+ * this machine runs it -- that returns the synthetic fallback
+ * `~/.token-optimizer/unrooted`. It is NOT null, so every `if (projectRoot)`
+ * gate passes, and then `projectAnchor` hands back the directory itself because
+ * the fallback contains no project marker. `writeHarvested` resolves anchors
+ * through `indexFile`, `indexFile` on a directory returns null, and the finding
+ * is refused as unanchorable.
+ *
+ * That is the whole reason this machine's graph holds 2,965 symbols and ONE
+ * finding: 937 derive runs produced candidates and stored none of them, while
+ * every layer reported success.
+ *
+ * The router already solved this for capture -- "THE GRAPH IS PER PROJECT, so it
+ * is keyed on where the FILE lives, not on where the client happens to be
+ * running" -- and derivation simply never adopted it. This applies the same
+ * rule at Stop time: take the file anchors the session recorded, resolve each to
+ * its own project, and pick the one that holds the most of them.
+ *
+ * Returns null when nothing resolves, which leaves the caller's original root
+ * untouched -- a wrong project is worse than the status quo.
+ */
+export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+  if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
+  const counts = new Map();
+  for (const event of events) {
+    const anchor = event?.anchor;
+    // File surfaces only. A command anchor is the command text, and resolving
+    // `npm test -- x` as a path would invent a project out of a sentence.
+    if (!anchor || typeof anchor !== 'string') continue;
+    if (event.kind !== 'read' && !(event.kind === 'tool-outcome' && event.surface === 'file')) {
+      continue;
+    }
+    let root;
+    try {
+      root = resolve(anchor, cwd);
+    } catch {
+      continue;
+    }
+    // The fallback resolves to a path inside the optimizer's own store, which is
+    // never a project someone is working in.
+    if (!root || String(root).includes('.token-optimizer')) continue;
+    counts.set(root, (counts.get(root) || 0) + 1);
+  }
+  let best = null;
+  let most = 0;
+  for (const [root, n] of counts) {
+    if (n > most) {
+      most = n;
+      best = root;
+    }
+  }
+  return best;
+}
+
 export function projectAnchor(projectRoot) {
   if (!projectRoot) return null;
   let entries;

--- a/integrations/codex/plugin/hooks/lib/transcript.mjs
+++ b/integrations/codex/plugin/hooks/lib/transcript.mjs
@@ -289,6 +289,23 @@ const ANCHOR_MAX = 120;
  */
 const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
 
+/**
+ * A run the HARNESS stopped, which is not the command failing.
+ *
+ * The allowlist above admits anything shaped `Exit code N`, and a killed
+ * command reports `Exit code 143` with `Command timed out after 2m 0s` -- so
+ * it walks straight in. Nothing about it is a lesson about the command: it did
+ * not fail, it was not allowed to finish, and the same command run with a
+ * longer budget may well pass. Pairing one with a later success would claim a
+ * red-to-green transition that never happened.
+ *
+ * MEASURED, on a 237 MB transcript of ordinary feature work: of 130 admitted
+ * failures, 25 were timeouts -- 19%. At the 64 MB scan it was 11 of 23, 48%.
+ * User declines are NOT in this class and need no rule; the positive allowlist
+ * already excludes them, verified at every scan size on the same transcript.
+ */
+const HARNESS_TIMEOUT = /^\s*Command timed out after\b/m;
+
 /** Reads at most `bytes` from the END of a file, without loading the rest. */
 function readTail(path, bytes) {
   let fd;
@@ -390,6 +407,8 @@ export function failedResultsFromTranscript(transcriptPath, options = {}) {
       if (typeof block.content !== 'string') continue;
       const match = EXIT_CODE_RESULT.exec(block.content);
       if (!match) continue;
+      // The command ran, but the harness ended it. See HARNESS_TIMEOUT.
+      if (HARNESS_TIMEOUT.test(block.content)) continue;
       const command = commands.get(String(block.tool_use_id || ''));
       // No command means no claim. The result says something failed; without
       // the text of what failed there is nothing to say about it, and nothing

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -55,6 +55,7 @@ import {
   load,
   wikiDir,
   projectRootFor,
+  unrootedRoot,
 } from './wiki.mjs';
 import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
@@ -78,7 +79,7 @@ import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
-import { isFsSafePath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
   recordingNudge,
@@ -94,7 +95,7 @@ import {
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
-import { registerProject } from './projects.mjs';
+import { registerProject, registeredProjects } from './projects.mjs';
 import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
@@ -109,6 +110,62 @@ export const CLIENTS = nativeClientProfiles();
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
+
+/**
+ * How many registered project graphs a session-end sweep may open.
+ *
+ * The registry is append-only and unbounded over time -- 4,033 records on this
+ * machine -- and each graph read is a tail of up to 2 MB. Bounded to the most
+ * recently seen handful, which is the only part of the registry a single
+ * session can plausibly have written to.
+ */
+const CROSS_PROJECT_SCAN_LIMIT =
+  Number(process.env.TOKEN_OPTIMIZER_CROSS_PROJECT_SCAN) || 12;
+
+/** A project the current session cannot have touched is not worth opening. */
+const CROSS_PROJECT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The activity this session recorded, gathered from every graph that could hold
+ * it.
+ *
+ * Capture is keyed on where the FILE lives (`recordToolOutcome(wikiDir(root))`,
+ * post-tool), not on the session's cwd. So when the client is started outside a
+ * repository -- a home directory, the common case -- the session's own file
+ * activity is written into each touched project's graph, and the unrooted graph
+ * that `cwd` resolves to holds none of it. Reading only that graph is why the
+ * inference below returned null in exactly the case it exists for: measured on
+ * this machine, the unrooted store holds 12,376 file anchors and ZERO of them
+ * under a repository.
+ *
+ * The sweep is confined to that case. A cwd that IS a repository already owns
+ * the graph its own files were captured into, so it pays nothing.
+ */
+export function sessionActivity(cwdRoot) {
+  let events = [];
+  try {
+    events = readMetrics(wikiDir(cwdRoot));
+  } catch {
+    events = [];
+  }
+  if (canonicalPath(cwdRoot) !== canonicalPath(unrootedRoot())) return events;
+  const cutoff = Date.now() - CROSS_PROJECT_MAX_AGE_MS;
+  let projects = [];
+  try {
+    // Sorted most-recently-seen first by `registeredProjects`.
+    projects = registeredProjects().filter((p) => (p.lastSeenAt || 0) >= cutoff);
+  } catch {
+    return events;
+  }
+  for (const project of projects.slice(0, CROSS_PROJECT_SCAN_LIMIT)) {
+    try {
+      events = events.concat(readMetrics(project.graphDir));
+    } catch {
+      // One unreadable store must not cost the session its inference.
+    }
+  }
+  return events;
+}
 
 /**
  * The response envelopes a completed tool call can arrive in.
@@ -1223,13 +1280,21 @@ async function runHook(clientName, event, invocation) {
       // router already keys capture on where the FILE lives rather than on the
       // session's cwd; this applies that rule to derivation too, and falls back
       // to the cwd answer when the session touched nothing resolvable.
+      //
+      // The evidence is gathered by `sessionActivity`, NOT from the cwd graph
+      // alone: capture keyed on the file's project means an unrooted session's
+      // own activity was written into the graphs of the projects it touched.
+      // Reading only the unrooted graph found 12,376 file anchors and not one
+      // under a repository, so the inference was inert in precisely the case it
+      // was written for.
       const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
       let projectRoot = cwdRoot;
       try {
         projectRoot =
-          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+          projectRootFromActivity(sessionActivity(cwdRoot), {
             resolve: (anchor) => projectRootFor(anchor, cwd),
             cwd,
+            sessionId,
           }) || cwdRoot;
       } catch {
         // Inferring the project is an improvement, never a precondition.

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -46,8 +46,9 @@ import {
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
+  readMetrics,
 } from './metrics.mjs';
-import { derive } from './derive.mjs';
+import { derive, projectRootFromActivity } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -1207,7 +1208,32 @@ async function runHook(clientName, event, invocation) {
       // one figure alone cannot distinguish "nothing to derive" from "derived
       // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
-      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      // WHERE THE WORK HAPPENED, NOT WHERE THE CLIENT WAS LAUNCHED.
+      //
+      // `projectRootFor` on a cwd with no VCS marker -- a home directory, which
+      // is how this client is commonly started -- returns the synthetic fallback
+      // `~/.token-optimizer/unrooted`. That is not null, so every `if
+      // (projectRoot)` gate downstream passes, and `projectAnchor` then hands
+      // back the directory itself because the fallback holds no project marker.
+      // `writeHarvested` resolves anchors through `indexFile`, which returns
+      // null for a directory, and the finding is refused as unanchorable.
+      //
+      // Measured consequence on this machine: 937 derive runs, 8 candidates,
+      // ZERO findings written, beside 2,965 symbol nodes in the same graph. The
+      // router already keys capture on where the FILE lives rather than on the
+      // session's cwd; this applies that rule to derivation too, and falls back
+      // to the cwd answer when the session touched nothing resolvable.
+      const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      let projectRoot = cwdRoot;
+      try {
+        projectRoot =
+          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+            resolve: (anchor) => projectRootFor(anchor, cwd),
+            cwd,
+          }) || cwdRoot;
+      } catch {
+        // Inferring the project is an improvement, never a precondition.
+      }
       const dir = wikiDir(projectRoot);
       const derived = derive(dir, {
         sessionId,

--- a/integrations/copilot/.github/hooks/lib/advise.mjs
+++ b/integrations/copilot/.github/hooks/lib/advise.mjs
@@ -162,7 +162,7 @@ const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function commandSegments(command) {
+export function commandSegments(command) {
   const segments = [];
   let tokens = [];
   let current = '';

--- a/integrations/copilot/.github/hooks/lib/derive.mjs
+++ b/integrations/copilot/.github/hooks/lib/derive.mjs
@@ -205,11 +205,26 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  *
  * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
  * before this sees it -- that case is one command spelled two ways.
+ *
+ * A TRAILING SEPARATOR LEAVES NOTHING TO COUNT, which is the hole in reading
+ * the segment count alone. `commandSegments` pushes only non-empty token
+ * lists, so `npx jest tests/foo &&` is ONE segment, and `attemptKey` -- the
+ * first three non-flag tokens -- never sees the `&&` either. The command is
+ * still half of something, and `cmd &` on its own is a background job whose
+ * exit code belongs to the shell rather than to the program named. Appending a
+ * sentinel token makes the missing segment materialise, which reuses the one
+ * scanner that already understands quotes instead of adding a second,
+ * differently-wrong one: `grep -E "foo|bar" src/x.mjs` stays a single segment
+ * with the sentinel attached, exactly as it does without it.
  */
+// Not a plausible argument to anything, so it can only ever be the token this
+// function appended.
+const SEGMENT_SENTINEL = '__token_optimizer_segment_probe__';
+
 const hasAttemptIdentity = (command) => {
   const body = commandBody(command);
   if (!body.trim()) return false;
-  if (commandSegments(body).length > 1) return false;
+  if (commandSegments(`${body} ${SEGMENT_SENTINEL}`).length > 1) return false;
   return attemptKey(command)
     .split(' ')
     .filter(Boolean)
@@ -368,7 +383,13 @@ export function commandOperand(command) {
   // attempts, so including it would reproduce attemptKey's blind spot.
   for (const token of tokens.slice(1)) {
     const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
-    if (named && token.length >= 4) return token.toLowerCase();
+    // AS WRITTEN, not folded. This value is the grouping key AND the text of
+    // the stored claim, and folding it made the claim name a path that does
+    // not exist on a case-sensitive filesystem: `src/Foo.test.mjs` was
+    // recorded, and served to a later session, as `src/foo.test.mjs`. The
+    // caller folds a copy for the key instead, so matching stays
+    // case-insensitive without the claim paying for it.
+    if (named && token.length >= 4) return token;
   }
   return null;
 }
@@ -1068,15 +1089,23 @@ export function derive(dir, options = {}) {
   // repeating an invocation.
   try {
     if (projectRoot && outcomes?.length) {
+      // KEYED FOLDED, DISPLAYED AS WRITTEN. Two invocations naming the same
+      // file with different capitalisation are the same target on Windows and
+      // macOS, so the key folds; the text stored in the finding must not,
+      // because a claim naming `src/foo.test.mjs` for a file called
+      // `src/Foo.test.mjs` is a path that does not resolve on Linux -- and
+      // that text is what a later session reads. The first spelling seen wins,
+      // which is the one the failing attempt actually used.
       const byTarget = new Map();
       for (const outcome of outcomes) {
-        const target = commandOperand(outcome.command);
-        if (!target) continue;
-        if (!byTarget.has(target)) byTarget.set(target, []);
-        byTarget.get(target).push(outcome);
+        const operand = commandOperand(outcome.command);
+        if (!operand) continue;
+        const key = operand.toLowerCase();
+        if (!byTarget.has(key)) byTarget.set(key, { target: operand, run: [] });
+        byTarget.get(key).run.push(outcome);
       }
 
-      for (const [target, run] of byTarget) {
+      for (const { target, run } of byTarget.values()) {
         let lastFailure = null;
         for (const outcome of run) {
           if (outcome.failed) {

--- a/integrations/copilot/.github/hooks/lib/derive.mjs
+++ b/integrations/copilot/.github/hooks/lib/derive.mjs
@@ -67,7 +67,16 @@ import {
  * command. A correction is a lexical guess about what a human meant. Churn
  * describes our own reading behaviour and says nothing about the code at all.
  */
-export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+export const CONFIDENCE = {
+  command: 0.9,
+  test: 0.85,
+  // Below `command` because the inference is weaker: two commands sharing a
+  // target is good evidence of one intent, but not the same evidence as the
+  // identical invocation being retried. Labelled speculative, deliberately.
+  retarget: 0.6,
+  correction: 0.6,
+  churn: 0.4,
+};
 
 /** Claim text cap. A finding is one sentence; a paragraph is evidence. */
 const CLAIM_MAX = 300;
@@ -75,6 +84,17 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * How close a fix must follow its failure to count as the same attempt.
+ *
+ * Detector 5 pairs across DIFFERENT programs, so it cannot lean on command
+ * identity to know the two are related -- proximity is doing that work instead.
+ * Ten minutes is long enough for a real correction, including reading an error
+ * and looking something up, and short enough that two unrelated pieces of work
+ * touching one file in an afternoon are not reported as one story.
+ */
+const RETARGET_WINDOW_MS = 10 * 60 * 1000;
 
 /**
  * The anchor cap a command surface is stored under, restated here as a TEST.
@@ -287,6 +307,50 @@ export function attemptKey(command) {
     .join(' ')
     .toLowerCase();
 }
+/**
+ * The thing a command ACTS ON -- a path, a test file, a target.
+ *
+ * WHY `attemptKey` IS NOT ENOUGH, measured rather than supposed. That key is
+ * program-plus-operands, so the single most valuable lesson a session can teach
+ * cannot pair by construction:
+ *
+ *   npx jest tests/foo      -> key "npx jest tests/foo"
+ *   npm test -- tests/foo   -> key "npm test tests/foo"
+ *
+ * Different keys, no pair, no finding -- yet that is exactly the correction
+ * worth recording, because the fix was to run a DIFFERENT program against the
+ * same target. The existing detector can only catch the same command re-run and
+ * succeeding, which its own guard then discards as incoherent.
+ *
+ * The measured cost of that: across 937 real derive runs on this machine, 8
+ * candidates were produced and ZERO were stored.
+ *
+ * So this returns the shared operand -- `tests/foo` above -- which is what the
+ * two attempts genuinely have in common. Only operands that NAME something are
+ * admitted: a path separator or a file extension. A bare word like `build` is
+ * refused, because `npm run build` and `make build` sharing the token `build`
+ * is a coincidence of vocabulary, not evidence of one intent.
+ */
+export function commandOperand(command) {
+  const tokens = commandBody(command)
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'));
+  // Skipping the first token: the PROGRAM is what differs between the two
+  // attempts, so including it would reproduce attemptKey's blind spot.
+  for (const token of tokens.slice(1)) {
+    const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
+    if (named && token.length >= 4) return token.toLowerCase();
+  }
+  return null;
+}
+
+/** The program a command invokes, for deciding whether two attempts differ. */
+export function commandProgram(command) {
+  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  return first.split(/[/\\]/).pop().toLowerCase();
+}
+
 
 /** Normalised claim text, so the same lesson derived twice is one candidate. */
 const claimKey = (type, claim) =>
@@ -519,9 +583,15 @@ export function derive(dir, options = {}) {
   // a transcript failure that pairs with nothing stays unclaimed, which is also
   // what keeps a failure from ANOTHER project's directory out of this project's
   // graph -- a candidate cannot be emitted without a success recorded HERE.
+  // HOISTED so detector 5 can pair over the SAME merged list -- events plus the
+  // transcript failures folded in below. Rebuilding it there would duplicate the
+  // de-duplication logic and let the two detectors drift; leaving it block-scoped
+  // gave detector 5 a ReferenceError that its own try/catch swallowed, which is
+  // silent nothing rather than a visible failure.
+  let outcomes = [];
   try {
     if (projectRoot) {
-      const outcomes = events
+      outcomes = events
         .filter(
           (e) =>
             e &&
@@ -802,6 +872,92 @@ export function derive(dir, options = {}) {
   } catch {
     // One detector, never the session.
   }
+  // ---- 5: a DIFFERENT command against the same target succeeded -----------
+  //
+  // THE LESSON DETECTOR 1 CANNOT REACH. Its `attemptKey` is program-plus-
+  // operands, so the correction worth recording -- reaching for a different
+  // tool against the same target -- lands in two groups that never meet:
+  //
+  //   npx jest tests/foo.test.mjs     key "npx jest tests/foo.test.mjs"
+  //   npm test -- tests/foo.test.mjs  key "npm test tests/foo.test.mjs"
+  //
+  // What detector 1 CAN pair is the identical command re-run, and its own guard
+  // then correctly discards that as incoherent -- "`npm run build` works where
+  // `npm run build` failed" claims nothing. So between the key and the guard,
+  // the command family had almost no reachable evidence: measured across 937
+  // real derive runs on this machine, 8 candidates and ZERO stored findings.
+  //
+  // This pairs on the shared OPERAND instead, and only when the PROGRAM differs
+  // -- same-program pairs are detector 1's business and are left to it. The
+  // conservatism the original key was protecting is kept in three other places:
+  // the operand must NAME something (a path or an extension, never a bare word
+  // like `build`), the two attempts must be close in time, and the ceiling is
+  // 0.6 rather than 0.9 because sharing a target is weaker evidence than
+  // repeating an invocation.
+  try {
+    if (projectRoot && outcomes?.length) {
+      const byTarget = new Map();
+      for (const outcome of outcomes) {
+        const target = commandOperand(outcome.command);
+        if (!target) continue;
+        if (!byTarget.has(target)) byTarget.set(target, []);
+        byTarget.get(target).push(outcome);
+      }
+
+      for (const [target, run] of byTarget) {
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          lastFailure = null;
+
+          // Same program is detector 1's case, whether it pairs there or not.
+          if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
+          // A fix follows its failure closely. Hours apart is two unrelated
+          // pieces of work that happened to touch one file.
+          const apart = Math.abs((outcome.at || 0) - (failed.at || 0));
+          if (!apart || apart > RETARGET_WINDOW_MS) continue;
+          // Same rule as detector 1: nothing quotable, nothing claimed.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          const confidence = CONFIDENCE.retarget;
+          add({
+            type: 'command',
+            claim: redact(
+              `In this project \`${commandBody(outcome.command)}\` succeeded on ${target} where ` +
+                `\`${commandBody(failed.command)}\` had failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded against the same target \`${target}\` ` +
+                `${Math.round(apart / 1000)}s later. Different programs, one target: ordered ` +
+                'and close, but not proven causal -- an intervening edit explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: `when about to run \`${commandProgram(failed.command)}\` against ${target} in this project`,
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: [`\`${commandBody(failed.command)}\` later succeeds unchanged`],
+            trigger: triggerFor(failed.command),
+            anchors: [anchorPath],
+            derivedBy: 'retarget',
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
 
   // ---- storage, under a budget -------------------------------------------
   //

--- a/integrations/copilot/.github/hooks/lib/derive.mjs
+++ b/integrations/copilot/.github/hooks/lib/derive.mjs
@@ -739,6 +739,27 @@ export function derive(dir, options = {}) {
   let outcomes = [];
   try {
     if (projectRoot) {
+      // SCOPED TO THE SESSION THE CLAIM WILL NAME.
+      //
+      // Every claim these detectors build opens `observed in one session:`,
+      // and the store holds every session's outcomes -- so nothing but the
+      // ten-minute window stopped a failure from one session pairing with a
+      // success from another and asserting a provenance that never happened.
+      //
+      // NEVER OBSERVED, SAID PLAINLY. Across both live stores on this machine
+      // -- 7,173 command outcomes over 3 sessions here, 543 over 9 sessions in
+      // the unrooted one -- 5,155 and 298 adjacent in-window pairs respectively
+      // and ZERO of them crossed a session. Sessions are long and rarely
+      // interleave inside ten minutes. This is a correctness fix against a
+      // false claim, not a fix for observed damage, and it is not offered as
+      // one. Concurrent sessions do occur -- one was recorded on this machine
+      // while this was being written -- and they share the unrooted store.
+      //
+      // The merged transcript failures below are deliberately NOT filtered:
+      // `failedResultsFromTranscript` carries no sessionId, and the transcript
+      // it read is this session's, so they are already scoped by construction.
+      // Filtering them here would drop the only source of command failures
+      // that exists -- Claude Code never fires PostToolUse on a non-zero exit.
       outcomes = events
         .filter(
           (e) =>
@@ -746,7 +767,10 @@ export function derive(dir, options = {}) {
             e.kind === 'tool-outcome' &&
             e.surface === 'command' &&
             typeof e.anchor === 'string' &&
-            e.anchor.trim()
+            e.anchor.trim() &&
+            // An event predating the field still counts; a DIFFERENT session
+            // never does.
+            (!sessionId || !e.sessionId || e.sessionId === sessionId)
         )
         .map((e) => ({
           command: e.anchor.trim(),

--- a/integrations/copilot/.github/hooks/lib/derive.mjs
+++ b/integrations/copilot/.github/hooks/lib/derive.mjs
@@ -915,6 +915,20 @@ export function derive(dir, options = {}) {
           const failed = lastFailure;
           lastFailure = null;
 
+          // BOTH SIDES MUST NAME A SINGLE COMMAND, the same rule detector 1
+          // applies. `commandBody` strips only a LEADING directory change, and
+          // `commandProgram` reads the first token, so a chained command
+          // attributes the failure to the wrong program entirely:
+          //
+          //   git fetch && npx jest tests/foo.test.mjs   -> program "git"
+          //   cat x | npx jest tests/foo.test.mjs        -> program "cat"
+          //
+          // Paired against `npm test -- tests/foo.test.mjs` those would ship
+          // "npm test succeeded where git fetch failed" and tell a later session
+          // to avoid `git`. Checked per side rather than once, because unlike
+          // detector 1 these two do NOT share a key by construction.
+          if (!hasAttemptIdentity(failed.command)) continue;
+          if (!hasAttemptIdentity(outcome.command)) continue;
           // Same program is detector 1's case, whether it pairs there or not.
           if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
           // A fix follows its failure closely. Hours apart is two unrelated

--- a/integrations/copilot/.github/hooks/lib/derive.mjs
+++ b/integrations/copilot/.github/hooks/lib/derive.mjs
@@ -430,10 +430,16 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * Returns null when nothing resolves, which leaves the caller's original root
  * untouched -- a wrong project is worse than the status quo.
  */
-export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+export function projectRootFromActivity(events, { resolve, cwd, sessionId = null } = {}) {
   if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
   const counts = new Map();
   for (const event of events) {
+    // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
+    // session that wrote it, so counting every event ever recorded lets a busy
+    // session from last week outvote the one now ending -- and the question
+    // being asked is "where did THIS session work", not "where is this graph
+    // busiest". Callers that pass no id keep the whole-graph count.
+    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.
@@ -454,13 +460,22 @@ export function projectRootFromActivity(events, { resolve, cwd } = {}) {
   }
   let best = null;
   let most = 0;
+  let tied = false;
   for (const [root, n] of counts) {
     if (n > most) {
       most = n;
       best = root;
+      tied = false;
+    } else if (n === most) {
+      // A Map iterates in insertion order, so a tie would otherwise be broken by
+      // whichever file the session happened to touch first -- deterministic, but
+      // arbitrary, and wrong half the time. Findings would then be stored against
+      // a project the evidence does not single out. Decline instead; the caller
+      // keeps cwdRoot, which is at least a root the user chose.
+      tied = true;
     }
   }
-  return best;
+  return tied ? null : best;
 }
 
 export function projectAnchor(projectRoot) {

--- a/integrations/copilot/.github/hooks/lib/derive.mjs
+++ b/integrations/copilot/.github/hooks/lib/derive.mjs
@@ -373,9 +373,45 @@ export function commandOperand(command) {
   return null;
 }
 
-/** The program a command invokes, for deciding whether two attempts differ. */
+/**
+ * A leading `VAR=value` prefix, which a shell applies to the environment of
+ * the command that follows rather than running as the command itself.
+ */
+const ENV_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+/**
+ * The program a command invokes, for deciding whether two attempts differ.
+ *
+ * ENVIRONMENT PREFIXES ARE NOT THE PROGRAM. Taking the first token verbatim
+ * reported `SP=/tmp/x` as the program for `SP=/tmp/x node run.mjs`, and that
+ * is not a cosmetic slip: measured over this machine's real history, 816 of
+ * 7,165 recorded command outcomes -- 11.4% -- named an assignment.
+ *
+ * IT FAILS IN THE DANGEROUS DIRECTION. This function exists to decide that two
+ * attempts used DIFFERENT programs, so two runs of the same tool under
+ * different variables --
+ *
+ *   SP=/a node run.mjs    (failed)
+ *   SPW=/b node run.mjs   (succeeded)
+ *
+ * -- compared as `sp=/a` against `spw=/b`, differed, and were eligible to
+ * pair. The claim that pairing produces is `node run.mjs` succeeded where
+ * `node run.mjs` failed: exactly the incoherent statement detector 1's own
+ * guard exists to refuse, arriving through the door detector 5 opened.
+ *
+ * Skipping the prefixes is what a shell does, and it cannot invent a pair --
+ * two commands that were already the same program now compare equal, which
+ * only ever removes a candidate.
+ *
+ * NO MEASURED CHANGE TODAY, stated plainly: replaying both versions over the
+ * same real history gives an identical pairing outcome (20 pairs considered,
+ * 0 firing), because every affected command is also chained and rejected
+ * earlier. This is a correctness fix against a latent false claim, not a
+ * recall improvement, and it is not offered as one.
+ */
 export function commandProgram(command) {
-  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  const tokens = commandBody(command).trim().split(/\s+/).filter(Boolean);
+  const first = tokens.find((token) => !ENV_ASSIGNMENT.test(token)) || '';
   return first.split(/[/\\]/).pop().toLowerCase();
 }
 

--- a/integrations/copilot/.github/hooks/lib/derive.mjs
+++ b/integrations/copilot/.github/hooks/lib/derive.mjs
@@ -53,6 +53,7 @@ import { ORIGIN_HARVESTED } from './curate.mjs';
 // from, so what this counts as a search and what the advisory treats as one
 // cannot diverge.
 import {
+  commandSegments,
   identifiersIn,
   searchPatternFromCommand,
   symbolIndex,
@@ -182,11 +183,38 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
-const hasAttemptIdentity = (command) =>
-  attemptKey(command)
+/**
+ * THE WHOLE BODY, NOT THE FIRST THREE TOKENS.
+ *
+ * This used to read the separator set off `attemptKey`, which keeps only the
+ * first three non-flag tokens -- so it caught a separator only when one landed
+ * early by luck of position. Verified against the real functions:
+ *
+ *   git fetch && npx jest tests/foo   key `git fetch &&`        -> rejected
+ *   npx jest tests/foo && node x.mjs  key `npx jest tests/foo`  -> ACCEPTED
+ *   grep -rn foo src | head -20       key `grep foo src`        -> ACCEPTED
+ *
+ * The last two are exactly the claims this guard exists to stop: the key names
+ * `npx`, so a pair would blame `npx` for a failure `node` may have caused.
+ * Every existing test placed the separator in the first three tokens, so none
+ * of them could see it.
+ *
+ * `commandSegments` is reused rather than a fresh scan because it is already
+ * the quote-aware one: splitting the raw string would cut through `grep -E
+ * "foo|bar"` and reject an ordinary alternation as a pipeline.
+ *
+ * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
+ * before this sees it -- that case is one command spelled two ways.
+ */
+const hasAttemptIdentity = (command) => {
+  const body = commandBody(command);
+  if (!body.trim()) return false;
+  if (commandSegments(body).length > 1) return false;
+  return attemptKey(command)
     .split(' ')
     .filter(Boolean)
     .every((token) => !COMMAND_SEPARATORS.has(token));
+};
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -435,11 +463,20 @@ export function projectRootFromActivity(events, { resolve, cwd, sessionId = null
   const counts = new Map();
   for (const event of events) {
     // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
-    // session that wrote it, so counting every event ever recorded lets a busy
-    // session from last week outvote the one now ending -- and the question
-    // being asked is "where did THIS session work", not "where is this graph
-    // busiest". Callers that pass no id keep the whole-graph count.
-    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
+    // session that wrote it, and the caller concatenates several graphs, so
+    // counting every event ever recorded lets a busy session from last week
+    // outvote the one now ending -- and the question being asked is "where did
+    // THIS session work", not "where is this graph busiest". Callers that pass
+    // no id keep the whole-graph count.
+    //
+    // AN EVENT THAT CANNOT NAME ITS SESSION IS EXCLUDED, not exempted. Exempting
+    // it was a deliberate concession to older records, and measurement says the
+    // concession buys nothing: across the three live stores on this machine, 2
+    // of 22,321 file/read events lack the field -- 0.01%. Set against that, an
+    // unstamped event sitting in ANOTHER project's graph would vote for that
+    // project on the strength of no evidence at all, which is precisely the
+    // failure this filter exists to prevent.
+    if (sessionId && event?.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.

--- a/integrations/copilot/.github/hooks/lib/derive.mjs
+++ b/integrations/copilot/.github/hooks/lib/derive.mjs
@@ -403,6 +403,66 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * against a fabricated anchor. That is the fail-open direction: no finding
  * beats a finding anchored to something that is not what the claim is about.
  */
+
+/**
+ * The project a session actually worked in, read off what it touched.
+ *
+ * WHY THE SESSION'S CWD IS THE WRONG ANSWER. `adapter.mjs` resolves the root
+ * with `projectRootFor(join(cwd, '__session__'), cwd)`, and when Claude Code is
+ * launched from a directory with no VCS marker -- a home directory, which is how
+ * this machine runs it -- that returns the synthetic fallback
+ * `~/.token-optimizer/unrooted`. It is NOT null, so every `if (projectRoot)`
+ * gate passes, and then `projectAnchor` hands back the directory itself because
+ * the fallback contains no project marker. `writeHarvested` resolves anchors
+ * through `indexFile`, `indexFile` on a directory returns null, and the finding
+ * is refused as unanchorable.
+ *
+ * That is the whole reason this machine's graph holds 2,965 symbols and ONE
+ * finding: 937 derive runs produced candidates and stored none of them, while
+ * every layer reported success.
+ *
+ * The router already solved this for capture -- "THE GRAPH IS PER PROJECT, so it
+ * is keyed on where the FILE lives, not on where the client happens to be
+ * running" -- and derivation simply never adopted it. This applies the same
+ * rule at Stop time: take the file anchors the session recorded, resolve each to
+ * its own project, and pick the one that holds the most of them.
+ *
+ * Returns null when nothing resolves, which leaves the caller's original root
+ * untouched -- a wrong project is worse than the status quo.
+ */
+export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+  if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
+  const counts = new Map();
+  for (const event of events) {
+    const anchor = event?.anchor;
+    // File surfaces only. A command anchor is the command text, and resolving
+    // `npm test -- x` as a path would invent a project out of a sentence.
+    if (!anchor || typeof anchor !== 'string') continue;
+    if (event.kind !== 'read' && !(event.kind === 'tool-outcome' && event.surface === 'file')) {
+      continue;
+    }
+    let root;
+    try {
+      root = resolve(anchor, cwd);
+    } catch {
+      continue;
+    }
+    // The fallback resolves to a path inside the optimizer's own store, which is
+    // never a project someone is working in.
+    if (!root || String(root).includes('.token-optimizer')) continue;
+    counts.set(root, (counts.get(root) || 0) + 1);
+  }
+  let best = null;
+  let most = 0;
+  for (const [root, n] of counts) {
+    if (n > most) {
+      most = n;
+      best = root;
+    }
+  }
+  return best;
+}
+
 export function projectAnchor(projectRoot) {
   if (!projectRoot) return null;
   let entries;

--- a/integrations/copilot/.github/hooks/lib/transcript.mjs
+++ b/integrations/copilot/.github/hooks/lib/transcript.mjs
@@ -289,6 +289,23 @@ const ANCHOR_MAX = 120;
  */
 const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
 
+/**
+ * A run the HARNESS stopped, which is not the command failing.
+ *
+ * The allowlist above admits anything shaped `Exit code N`, and a killed
+ * command reports `Exit code 143` with `Command timed out after 2m 0s` -- so
+ * it walks straight in. Nothing about it is a lesson about the command: it did
+ * not fail, it was not allowed to finish, and the same command run with a
+ * longer budget may well pass. Pairing one with a later success would claim a
+ * red-to-green transition that never happened.
+ *
+ * MEASURED, on a 237 MB transcript of ordinary feature work: of 130 admitted
+ * failures, 25 were timeouts -- 19%. At the 64 MB scan it was 11 of 23, 48%.
+ * User declines are NOT in this class and need no rule; the positive allowlist
+ * already excludes them, verified at every scan size on the same transcript.
+ */
+const HARNESS_TIMEOUT = /^\s*Command timed out after\b/m;
+
 /** Reads at most `bytes` from the END of a file, without loading the rest. */
 function readTail(path, bytes) {
   let fd;
@@ -390,6 +407,8 @@ export function failedResultsFromTranscript(transcriptPath, options = {}) {
       if (typeof block.content !== 'string') continue;
       const match = EXIT_CODE_RESULT.exec(block.content);
       if (!match) continue;
+      // The command ran, but the harness ended it. See HARNESS_TIMEOUT.
+      if (HARNESS_TIMEOUT.test(block.content)) continue;
       const command = commands.get(String(block.tool_use_id || ''));
       // No command means no claim. The result says something failed; without
       // the text of what failed there is nothing to say about it, and nothing

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -55,6 +55,7 @@ import {
   load,
   wikiDir,
   projectRootFor,
+  unrootedRoot,
 } from './wiki.mjs';
 import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
@@ -78,7 +79,7 @@ import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
-import { isFsSafePath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
   recordingNudge,
@@ -94,7 +95,7 @@ import {
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
-import { registerProject } from './projects.mjs';
+import { registerProject, registeredProjects } from './projects.mjs';
 import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
@@ -109,6 +110,62 @@ export const CLIENTS = nativeClientProfiles();
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
+
+/**
+ * How many registered project graphs a session-end sweep may open.
+ *
+ * The registry is append-only and unbounded over time -- 4,033 records on this
+ * machine -- and each graph read is a tail of up to 2 MB. Bounded to the most
+ * recently seen handful, which is the only part of the registry a single
+ * session can plausibly have written to.
+ */
+const CROSS_PROJECT_SCAN_LIMIT =
+  Number(process.env.TOKEN_OPTIMIZER_CROSS_PROJECT_SCAN) || 12;
+
+/** A project the current session cannot have touched is not worth opening. */
+const CROSS_PROJECT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The activity this session recorded, gathered from every graph that could hold
+ * it.
+ *
+ * Capture is keyed on where the FILE lives (`recordToolOutcome(wikiDir(root))`,
+ * post-tool), not on the session's cwd. So when the client is started outside a
+ * repository -- a home directory, the common case -- the session's own file
+ * activity is written into each touched project's graph, and the unrooted graph
+ * that `cwd` resolves to holds none of it. Reading only that graph is why the
+ * inference below returned null in exactly the case it exists for: measured on
+ * this machine, the unrooted store holds 12,376 file anchors and ZERO of them
+ * under a repository.
+ *
+ * The sweep is confined to that case. A cwd that IS a repository already owns
+ * the graph its own files were captured into, so it pays nothing.
+ */
+export function sessionActivity(cwdRoot) {
+  let events = [];
+  try {
+    events = readMetrics(wikiDir(cwdRoot));
+  } catch {
+    events = [];
+  }
+  if (canonicalPath(cwdRoot) !== canonicalPath(unrootedRoot())) return events;
+  const cutoff = Date.now() - CROSS_PROJECT_MAX_AGE_MS;
+  let projects = [];
+  try {
+    // Sorted most-recently-seen first by `registeredProjects`.
+    projects = registeredProjects().filter((p) => (p.lastSeenAt || 0) >= cutoff);
+  } catch {
+    return events;
+  }
+  for (const project of projects.slice(0, CROSS_PROJECT_SCAN_LIMIT)) {
+    try {
+      events = events.concat(readMetrics(project.graphDir));
+    } catch {
+      // One unreadable store must not cost the session its inference.
+    }
+  }
+  return events;
+}
 
 /**
  * The response envelopes a completed tool call can arrive in.
@@ -1223,13 +1280,21 @@ async function runHook(clientName, event, invocation) {
       // router already keys capture on where the FILE lives rather than on the
       // session's cwd; this applies that rule to derivation too, and falls back
       // to the cwd answer when the session touched nothing resolvable.
+      //
+      // The evidence is gathered by `sessionActivity`, NOT from the cwd graph
+      // alone: capture keyed on the file's project means an unrooted session's
+      // own activity was written into the graphs of the projects it touched.
+      // Reading only the unrooted graph found 12,376 file anchors and not one
+      // under a repository, so the inference was inert in precisely the case it
+      // was written for.
       const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
       let projectRoot = cwdRoot;
       try {
         projectRoot =
-          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+          projectRootFromActivity(sessionActivity(cwdRoot), {
             resolve: (anchor) => projectRootFor(anchor, cwd),
             cwd,
+            sessionId,
           }) || cwdRoot;
       } catch {
         // Inferring the project is an improvement, never a precondition.

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -46,8 +46,9 @@ import {
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
+  readMetrics,
 } from './metrics.mjs';
-import { derive } from './derive.mjs';
+import { derive, projectRootFromActivity } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -1207,7 +1208,32 @@ async function runHook(clientName, event, invocation) {
       // one figure alone cannot distinguish "nothing to derive" from "derived
       // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
-      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      // WHERE THE WORK HAPPENED, NOT WHERE THE CLIENT WAS LAUNCHED.
+      //
+      // `projectRootFor` on a cwd with no VCS marker -- a home directory, which
+      // is how this client is commonly started -- returns the synthetic fallback
+      // `~/.token-optimizer/unrooted`. That is not null, so every `if
+      // (projectRoot)` gate downstream passes, and `projectAnchor` then hands
+      // back the directory itself because the fallback holds no project marker.
+      // `writeHarvested` resolves anchors through `indexFile`, which returns
+      // null for a directory, and the finding is refused as unanchorable.
+      //
+      // Measured consequence on this machine: 937 derive runs, 8 candidates,
+      // ZERO findings written, beside 2,965 symbol nodes in the same graph. The
+      // router already keys capture on where the FILE lives rather than on the
+      // session's cwd; this applies that rule to derivation too, and falls back
+      // to the cwd answer when the session touched nothing resolvable.
+      const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      let projectRoot = cwdRoot;
+      try {
+        projectRoot =
+          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+            resolve: (anchor) => projectRootFor(anchor, cwd),
+            cwd,
+          }) || cwdRoot;
+      } catch {
+        // Inferring the project is an improvement, never a precondition.
+      }
       const dir = wikiDir(projectRoot);
       const derived = derive(dir, {
         sessionId,

--- a/integrations/cursor/hooks/lib/advise.mjs
+++ b/integrations/cursor/hooks/lib/advise.mjs
@@ -162,7 +162,7 @@ const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function commandSegments(command) {
+export function commandSegments(command) {
   const segments = [];
   let tokens = [];
   let current = '';

--- a/integrations/cursor/hooks/lib/derive.mjs
+++ b/integrations/cursor/hooks/lib/derive.mjs
@@ -205,11 +205,26 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  *
  * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
  * before this sees it -- that case is one command spelled two ways.
+ *
+ * A TRAILING SEPARATOR LEAVES NOTHING TO COUNT, which is the hole in reading
+ * the segment count alone. `commandSegments` pushes only non-empty token
+ * lists, so `npx jest tests/foo &&` is ONE segment, and `attemptKey` -- the
+ * first three non-flag tokens -- never sees the `&&` either. The command is
+ * still half of something, and `cmd &` on its own is a background job whose
+ * exit code belongs to the shell rather than to the program named. Appending a
+ * sentinel token makes the missing segment materialise, which reuses the one
+ * scanner that already understands quotes instead of adding a second,
+ * differently-wrong one: `grep -E "foo|bar" src/x.mjs` stays a single segment
+ * with the sentinel attached, exactly as it does without it.
  */
+// Not a plausible argument to anything, so it can only ever be the token this
+// function appended.
+const SEGMENT_SENTINEL = '__token_optimizer_segment_probe__';
+
 const hasAttemptIdentity = (command) => {
   const body = commandBody(command);
   if (!body.trim()) return false;
-  if (commandSegments(body).length > 1) return false;
+  if (commandSegments(`${body} ${SEGMENT_SENTINEL}`).length > 1) return false;
   return attemptKey(command)
     .split(' ')
     .filter(Boolean)
@@ -368,7 +383,13 @@ export function commandOperand(command) {
   // attempts, so including it would reproduce attemptKey's blind spot.
   for (const token of tokens.slice(1)) {
     const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
-    if (named && token.length >= 4) return token.toLowerCase();
+    // AS WRITTEN, not folded. This value is the grouping key AND the text of
+    // the stored claim, and folding it made the claim name a path that does
+    // not exist on a case-sensitive filesystem: `src/Foo.test.mjs` was
+    // recorded, and served to a later session, as `src/foo.test.mjs`. The
+    // caller folds a copy for the key instead, so matching stays
+    // case-insensitive without the claim paying for it.
+    if (named && token.length >= 4) return token;
   }
   return null;
 }
@@ -1068,15 +1089,23 @@ export function derive(dir, options = {}) {
   // repeating an invocation.
   try {
     if (projectRoot && outcomes?.length) {
+      // KEYED FOLDED, DISPLAYED AS WRITTEN. Two invocations naming the same
+      // file with different capitalisation are the same target on Windows and
+      // macOS, so the key folds; the text stored in the finding must not,
+      // because a claim naming `src/foo.test.mjs` for a file called
+      // `src/Foo.test.mjs` is a path that does not resolve on Linux -- and
+      // that text is what a later session reads. The first spelling seen wins,
+      // which is the one the failing attempt actually used.
       const byTarget = new Map();
       for (const outcome of outcomes) {
-        const target = commandOperand(outcome.command);
-        if (!target) continue;
-        if (!byTarget.has(target)) byTarget.set(target, []);
-        byTarget.get(target).push(outcome);
+        const operand = commandOperand(outcome.command);
+        if (!operand) continue;
+        const key = operand.toLowerCase();
+        if (!byTarget.has(key)) byTarget.set(key, { target: operand, run: [] });
+        byTarget.get(key).run.push(outcome);
       }
 
-      for (const [target, run] of byTarget) {
+      for (const { target, run } of byTarget.values()) {
         let lastFailure = null;
         for (const outcome of run) {
           if (outcome.failed) {

--- a/integrations/cursor/hooks/lib/derive.mjs
+++ b/integrations/cursor/hooks/lib/derive.mjs
@@ -67,7 +67,16 @@ import {
  * command. A correction is a lexical guess about what a human meant. Churn
  * describes our own reading behaviour and says nothing about the code at all.
  */
-export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+export const CONFIDENCE = {
+  command: 0.9,
+  test: 0.85,
+  // Below `command` because the inference is weaker: two commands sharing a
+  // target is good evidence of one intent, but not the same evidence as the
+  // identical invocation being retried. Labelled speculative, deliberately.
+  retarget: 0.6,
+  correction: 0.6,
+  churn: 0.4,
+};
 
 /** Claim text cap. A finding is one sentence; a paragraph is evidence. */
 const CLAIM_MAX = 300;
@@ -75,6 +84,17 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * How close a fix must follow its failure to count as the same attempt.
+ *
+ * Detector 5 pairs across DIFFERENT programs, so it cannot lean on command
+ * identity to know the two are related -- proximity is doing that work instead.
+ * Ten minutes is long enough for a real correction, including reading an error
+ * and looking something up, and short enough that two unrelated pieces of work
+ * touching one file in an afternoon are not reported as one story.
+ */
+const RETARGET_WINDOW_MS = 10 * 60 * 1000;
 
 /**
  * The anchor cap a command surface is stored under, restated here as a TEST.
@@ -287,6 +307,50 @@ export function attemptKey(command) {
     .join(' ')
     .toLowerCase();
 }
+/**
+ * The thing a command ACTS ON -- a path, a test file, a target.
+ *
+ * WHY `attemptKey` IS NOT ENOUGH, measured rather than supposed. That key is
+ * program-plus-operands, so the single most valuable lesson a session can teach
+ * cannot pair by construction:
+ *
+ *   npx jest tests/foo      -> key "npx jest tests/foo"
+ *   npm test -- tests/foo   -> key "npm test tests/foo"
+ *
+ * Different keys, no pair, no finding -- yet that is exactly the correction
+ * worth recording, because the fix was to run a DIFFERENT program against the
+ * same target. The existing detector can only catch the same command re-run and
+ * succeeding, which its own guard then discards as incoherent.
+ *
+ * The measured cost of that: across 937 real derive runs on this machine, 8
+ * candidates were produced and ZERO were stored.
+ *
+ * So this returns the shared operand -- `tests/foo` above -- which is what the
+ * two attempts genuinely have in common. Only operands that NAME something are
+ * admitted: a path separator or a file extension. A bare word like `build` is
+ * refused, because `npm run build` and `make build` sharing the token `build`
+ * is a coincidence of vocabulary, not evidence of one intent.
+ */
+export function commandOperand(command) {
+  const tokens = commandBody(command)
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'));
+  // Skipping the first token: the PROGRAM is what differs between the two
+  // attempts, so including it would reproduce attemptKey's blind spot.
+  for (const token of tokens.slice(1)) {
+    const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
+    if (named && token.length >= 4) return token.toLowerCase();
+  }
+  return null;
+}
+
+/** The program a command invokes, for deciding whether two attempts differ. */
+export function commandProgram(command) {
+  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  return first.split(/[/\\]/).pop().toLowerCase();
+}
+
 
 /** Normalised claim text, so the same lesson derived twice is one candidate. */
 const claimKey = (type, claim) =>
@@ -519,9 +583,15 @@ export function derive(dir, options = {}) {
   // a transcript failure that pairs with nothing stays unclaimed, which is also
   // what keeps a failure from ANOTHER project's directory out of this project's
   // graph -- a candidate cannot be emitted without a success recorded HERE.
+  // HOISTED so detector 5 can pair over the SAME merged list -- events plus the
+  // transcript failures folded in below. Rebuilding it there would duplicate the
+  // de-duplication logic and let the two detectors drift; leaving it block-scoped
+  // gave detector 5 a ReferenceError that its own try/catch swallowed, which is
+  // silent nothing rather than a visible failure.
+  let outcomes = [];
   try {
     if (projectRoot) {
-      const outcomes = events
+      outcomes = events
         .filter(
           (e) =>
             e &&
@@ -802,6 +872,92 @@ export function derive(dir, options = {}) {
   } catch {
     // One detector, never the session.
   }
+  // ---- 5: a DIFFERENT command against the same target succeeded -----------
+  //
+  // THE LESSON DETECTOR 1 CANNOT REACH. Its `attemptKey` is program-plus-
+  // operands, so the correction worth recording -- reaching for a different
+  // tool against the same target -- lands in two groups that never meet:
+  //
+  //   npx jest tests/foo.test.mjs     key "npx jest tests/foo.test.mjs"
+  //   npm test -- tests/foo.test.mjs  key "npm test tests/foo.test.mjs"
+  //
+  // What detector 1 CAN pair is the identical command re-run, and its own guard
+  // then correctly discards that as incoherent -- "`npm run build` works where
+  // `npm run build` failed" claims nothing. So between the key and the guard,
+  // the command family had almost no reachable evidence: measured across 937
+  // real derive runs on this machine, 8 candidates and ZERO stored findings.
+  //
+  // This pairs on the shared OPERAND instead, and only when the PROGRAM differs
+  // -- same-program pairs are detector 1's business and are left to it. The
+  // conservatism the original key was protecting is kept in three other places:
+  // the operand must NAME something (a path or an extension, never a bare word
+  // like `build`), the two attempts must be close in time, and the ceiling is
+  // 0.6 rather than 0.9 because sharing a target is weaker evidence than
+  // repeating an invocation.
+  try {
+    if (projectRoot && outcomes?.length) {
+      const byTarget = new Map();
+      for (const outcome of outcomes) {
+        const target = commandOperand(outcome.command);
+        if (!target) continue;
+        if (!byTarget.has(target)) byTarget.set(target, []);
+        byTarget.get(target).push(outcome);
+      }
+
+      for (const [target, run] of byTarget) {
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          lastFailure = null;
+
+          // Same program is detector 1's case, whether it pairs there or not.
+          if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
+          // A fix follows its failure closely. Hours apart is two unrelated
+          // pieces of work that happened to touch one file.
+          const apart = Math.abs((outcome.at || 0) - (failed.at || 0));
+          if (!apart || apart > RETARGET_WINDOW_MS) continue;
+          // Same rule as detector 1: nothing quotable, nothing claimed.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          const confidence = CONFIDENCE.retarget;
+          add({
+            type: 'command',
+            claim: redact(
+              `In this project \`${commandBody(outcome.command)}\` succeeded on ${target} where ` +
+                `\`${commandBody(failed.command)}\` had failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded against the same target \`${target}\` ` +
+                `${Math.round(apart / 1000)}s later. Different programs, one target: ordered ` +
+                'and close, but not proven causal -- an intervening edit explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: `when about to run \`${commandProgram(failed.command)}\` against ${target} in this project`,
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: [`\`${commandBody(failed.command)}\` later succeeds unchanged`],
+            trigger: triggerFor(failed.command),
+            anchors: [anchorPath],
+            derivedBy: 'retarget',
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
 
   // ---- storage, under a budget -------------------------------------------
   //

--- a/integrations/cursor/hooks/lib/derive.mjs
+++ b/integrations/cursor/hooks/lib/derive.mjs
@@ -739,6 +739,27 @@ export function derive(dir, options = {}) {
   let outcomes = [];
   try {
     if (projectRoot) {
+      // SCOPED TO THE SESSION THE CLAIM WILL NAME.
+      //
+      // Every claim these detectors build opens `observed in one session:`,
+      // and the store holds every session's outcomes -- so nothing but the
+      // ten-minute window stopped a failure from one session pairing with a
+      // success from another and asserting a provenance that never happened.
+      //
+      // NEVER OBSERVED, SAID PLAINLY. Across both live stores on this machine
+      // -- 7,173 command outcomes over 3 sessions here, 543 over 9 sessions in
+      // the unrooted one -- 5,155 and 298 adjacent in-window pairs respectively
+      // and ZERO of them crossed a session. Sessions are long and rarely
+      // interleave inside ten minutes. This is a correctness fix against a
+      // false claim, not a fix for observed damage, and it is not offered as
+      // one. Concurrent sessions do occur -- one was recorded on this machine
+      // while this was being written -- and they share the unrooted store.
+      //
+      // The merged transcript failures below are deliberately NOT filtered:
+      // `failedResultsFromTranscript` carries no sessionId, and the transcript
+      // it read is this session's, so they are already scoped by construction.
+      // Filtering them here would drop the only source of command failures
+      // that exists -- Claude Code never fires PostToolUse on a non-zero exit.
       outcomes = events
         .filter(
           (e) =>
@@ -746,7 +767,10 @@ export function derive(dir, options = {}) {
             e.kind === 'tool-outcome' &&
             e.surface === 'command' &&
             typeof e.anchor === 'string' &&
-            e.anchor.trim()
+            e.anchor.trim() &&
+            // An event predating the field still counts; a DIFFERENT session
+            // never does.
+            (!sessionId || !e.sessionId || e.sessionId === sessionId)
         )
         .map((e) => ({
           command: e.anchor.trim(),

--- a/integrations/cursor/hooks/lib/derive.mjs
+++ b/integrations/cursor/hooks/lib/derive.mjs
@@ -915,6 +915,20 @@ export function derive(dir, options = {}) {
           const failed = lastFailure;
           lastFailure = null;
 
+          // BOTH SIDES MUST NAME A SINGLE COMMAND, the same rule detector 1
+          // applies. `commandBody` strips only a LEADING directory change, and
+          // `commandProgram` reads the first token, so a chained command
+          // attributes the failure to the wrong program entirely:
+          //
+          //   git fetch && npx jest tests/foo.test.mjs   -> program "git"
+          //   cat x | npx jest tests/foo.test.mjs        -> program "cat"
+          //
+          // Paired against `npm test -- tests/foo.test.mjs` those would ship
+          // "npm test succeeded where git fetch failed" and tell a later session
+          // to avoid `git`. Checked per side rather than once, because unlike
+          // detector 1 these two do NOT share a key by construction.
+          if (!hasAttemptIdentity(failed.command)) continue;
+          if (!hasAttemptIdentity(outcome.command)) continue;
           // Same program is detector 1's case, whether it pairs there or not.
           if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
           // A fix follows its failure closely. Hours apart is two unrelated

--- a/integrations/cursor/hooks/lib/derive.mjs
+++ b/integrations/cursor/hooks/lib/derive.mjs
@@ -430,10 +430,16 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * Returns null when nothing resolves, which leaves the caller's original root
  * untouched -- a wrong project is worse than the status quo.
  */
-export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+export function projectRootFromActivity(events, { resolve, cwd, sessionId = null } = {}) {
   if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
   const counts = new Map();
   for (const event of events) {
+    // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
+    // session that wrote it, so counting every event ever recorded lets a busy
+    // session from last week outvote the one now ending -- and the question
+    // being asked is "where did THIS session work", not "where is this graph
+    // busiest". Callers that pass no id keep the whole-graph count.
+    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.
@@ -454,13 +460,22 @@ export function projectRootFromActivity(events, { resolve, cwd } = {}) {
   }
   let best = null;
   let most = 0;
+  let tied = false;
   for (const [root, n] of counts) {
     if (n > most) {
       most = n;
       best = root;
+      tied = false;
+    } else if (n === most) {
+      // A Map iterates in insertion order, so a tie would otherwise be broken by
+      // whichever file the session happened to touch first -- deterministic, but
+      // arbitrary, and wrong half the time. Findings would then be stored against
+      // a project the evidence does not single out. Decline instead; the caller
+      // keeps cwdRoot, which is at least a root the user chose.
+      tied = true;
     }
   }
-  return best;
+  return tied ? null : best;
 }
 
 export function projectAnchor(projectRoot) {

--- a/integrations/cursor/hooks/lib/derive.mjs
+++ b/integrations/cursor/hooks/lib/derive.mjs
@@ -373,9 +373,45 @@ export function commandOperand(command) {
   return null;
 }
 
-/** The program a command invokes, for deciding whether two attempts differ. */
+/**
+ * A leading `VAR=value` prefix, which a shell applies to the environment of
+ * the command that follows rather than running as the command itself.
+ */
+const ENV_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+/**
+ * The program a command invokes, for deciding whether two attempts differ.
+ *
+ * ENVIRONMENT PREFIXES ARE NOT THE PROGRAM. Taking the first token verbatim
+ * reported `SP=/tmp/x` as the program for `SP=/tmp/x node run.mjs`, and that
+ * is not a cosmetic slip: measured over this machine's real history, 816 of
+ * 7,165 recorded command outcomes -- 11.4% -- named an assignment.
+ *
+ * IT FAILS IN THE DANGEROUS DIRECTION. This function exists to decide that two
+ * attempts used DIFFERENT programs, so two runs of the same tool under
+ * different variables --
+ *
+ *   SP=/a node run.mjs    (failed)
+ *   SPW=/b node run.mjs   (succeeded)
+ *
+ * -- compared as `sp=/a` against `spw=/b`, differed, and were eligible to
+ * pair. The claim that pairing produces is `node run.mjs` succeeded where
+ * `node run.mjs` failed: exactly the incoherent statement detector 1's own
+ * guard exists to refuse, arriving through the door detector 5 opened.
+ *
+ * Skipping the prefixes is what a shell does, and it cannot invent a pair --
+ * two commands that were already the same program now compare equal, which
+ * only ever removes a candidate.
+ *
+ * NO MEASURED CHANGE TODAY, stated plainly: replaying both versions over the
+ * same real history gives an identical pairing outcome (20 pairs considered,
+ * 0 firing), because every affected command is also chained and rejected
+ * earlier. This is a correctness fix against a latent false claim, not a
+ * recall improvement, and it is not offered as one.
+ */
 export function commandProgram(command) {
-  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  const tokens = commandBody(command).trim().split(/\s+/).filter(Boolean);
+  const first = tokens.find((token) => !ENV_ASSIGNMENT.test(token)) || '';
   return first.split(/[/\\]/).pop().toLowerCase();
 }
 

--- a/integrations/cursor/hooks/lib/derive.mjs
+++ b/integrations/cursor/hooks/lib/derive.mjs
@@ -53,6 +53,7 @@ import { ORIGIN_HARVESTED } from './curate.mjs';
 // from, so what this counts as a search and what the advisory treats as one
 // cannot diverge.
 import {
+  commandSegments,
   identifiersIn,
   searchPatternFromCommand,
   symbolIndex,
@@ -182,11 +183,38 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
-const hasAttemptIdentity = (command) =>
-  attemptKey(command)
+/**
+ * THE WHOLE BODY, NOT THE FIRST THREE TOKENS.
+ *
+ * This used to read the separator set off `attemptKey`, which keeps only the
+ * first three non-flag tokens -- so it caught a separator only when one landed
+ * early by luck of position. Verified against the real functions:
+ *
+ *   git fetch && npx jest tests/foo   key `git fetch &&`        -> rejected
+ *   npx jest tests/foo && node x.mjs  key `npx jest tests/foo`  -> ACCEPTED
+ *   grep -rn foo src | head -20       key `grep foo src`        -> ACCEPTED
+ *
+ * The last two are exactly the claims this guard exists to stop: the key names
+ * `npx`, so a pair would blame `npx` for a failure `node` may have caused.
+ * Every existing test placed the separator in the first three tokens, so none
+ * of them could see it.
+ *
+ * `commandSegments` is reused rather than a fresh scan because it is already
+ * the quote-aware one: splitting the raw string would cut through `grep -E
+ * "foo|bar"` and reject an ordinary alternation as a pipeline.
+ *
+ * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
+ * before this sees it -- that case is one command spelled two ways.
+ */
+const hasAttemptIdentity = (command) => {
+  const body = commandBody(command);
+  if (!body.trim()) return false;
+  if (commandSegments(body).length > 1) return false;
+  return attemptKey(command)
     .split(' ')
     .filter(Boolean)
     .every((token) => !COMMAND_SEPARATORS.has(token));
+};
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -435,11 +463,20 @@ export function projectRootFromActivity(events, { resolve, cwd, sessionId = null
   const counts = new Map();
   for (const event of events) {
     // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
-    // session that wrote it, so counting every event ever recorded lets a busy
-    // session from last week outvote the one now ending -- and the question
-    // being asked is "where did THIS session work", not "where is this graph
-    // busiest". Callers that pass no id keep the whole-graph count.
-    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
+    // session that wrote it, and the caller concatenates several graphs, so
+    // counting every event ever recorded lets a busy session from last week
+    // outvote the one now ending -- and the question being asked is "where did
+    // THIS session work", not "where is this graph busiest". Callers that pass
+    // no id keep the whole-graph count.
+    //
+    // AN EVENT THAT CANNOT NAME ITS SESSION IS EXCLUDED, not exempted. Exempting
+    // it was a deliberate concession to older records, and measurement says the
+    // concession buys nothing: across the three live stores on this machine, 2
+    // of 22,321 file/read events lack the field -- 0.01%. Set against that, an
+    // unstamped event sitting in ANOTHER project's graph would vote for that
+    // project on the strength of no evidence at all, which is precisely the
+    // failure this filter exists to prevent.
+    if (sessionId && event?.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.

--- a/integrations/cursor/hooks/lib/derive.mjs
+++ b/integrations/cursor/hooks/lib/derive.mjs
@@ -403,6 +403,66 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * against a fabricated anchor. That is the fail-open direction: no finding
  * beats a finding anchored to something that is not what the claim is about.
  */
+
+/**
+ * The project a session actually worked in, read off what it touched.
+ *
+ * WHY THE SESSION'S CWD IS THE WRONG ANSWER. `adapter.mjs` resolves the root
+ * with `projectRootFor(join(cwd, '__session__'), cwd)`, and when Claude Code is
+ * launched from a directory with no VCS marker -- a home directory, which is how
+ * this machine runs it -- that returns the synthetic fallback
+ * `~/.token-optimizer/unrooted`. It is NOT null, so every `if (projectRoot)`
+ * gate passes, and then `projectAnchor` hands back the directory itself because
+ * the fallback contains no project marker. `writeHarvested` resolves anchors
+ * through `indexFile`, `indexFile` on a directory returns null, and the finding
+ * is refused as unanchorable.
+ *
+ * That is the whole reason this machine's graph holds 2,965 symbols and ONE
+ * finding: 937 derive runs produced candidates and stored none of them, while
+ * every layer reported success.
+ *
+ * The router already solved this for capture -- "THE GRAPH IS PER PROJECT, so it
+ * is keyed on where the FILE lives, not on where the client happens to be
+ * running" -- and derivation simply never adopted it. This applies the same
+ * rule at Stop time: take the file anchors the session recorded, resolve each to
+ * its own project, and pick the one that holds the most of them.
+ *
+ * Returns null when nothing resolves, which leaves the caller's original root
+ * untouched -- a wrong project is worse than the status quo.
+ */
+export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+  if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
+  const counts = new Map();
+  for (const event of events) {
+    const anchor = event?.anchor;
+    // File surfaces only. A command anchor is the command text, and resolving
+    // `npm test -- x` as a path would invent a project out of a sentence.
+    if (!anchor || typeof anchor !== 'string') continue;
+    if (event.kind !== 'read' && !(event.kind === 'tool-outcome' && event.surface === 'file')) {
+      continue;
+    }
+    let root;
+    try {
+      root = resolve(anchor, cwd);
+    } catch {
+      continue;
+    }
+    // The fallback resolves to a path inside the optimizer's own store, which is
+    // never a project someone is working in.
+    if (!root || String(root).includes('.token-optimizer')) continue;
+    counts.set(root, (counts.get(root) || 0) + 1);
+  }
+  let best = null;
+  let most = 0;
+  for (const [root, n] of counts) {
+    if (n > most) {
+      most = n;
+      best = root;
+    }
+  }
+  return best;
+}
+
 export function projectAnchor(projectRoot) {
   if (!projectRoot) return null;
   let entries;

--- a/integrations/cursor/hooks/lib/transcript.mjs
+++ b/integrations/cursor/hooks/lib/transcript.mjs
@@ -289,6 +289,23 @@ const ANCHOR_MAX = 120;
  */
 const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
 
+/**
+ * A run the HARNESS stopped, which is not the command failing.
+ *
+ * The allowlist above admits anything shaped `Exit code N`, and a killed
+ * command reports `Exit code 143` with `Command timed out after 2m 0s` -- so
+ * it walks straight in. Nothing about it is a lesson about the command: it did
+ * not fail, it was not allowed to finish, and the same command run with a
+ * longer budget may well pass. Pairing one with a later success would claim a
+ * red-to-green transition that never happened.
+ *
+ * MEASURED, on a 237 MB transcript of ordinary feature work: of 130 admitted
+ * failures, 25 were timeouts -- 19%. At the 64 MB scan it was 11 of 23, 48%.
+ * User declines are NOT in this class and need no rule; the positive allowlist
+ * already excludes them, verified at every scan size on the same transcript.
+ */
+const HARNESS_TIMEOUT = /^\s*Command timed out after\b/m;
+
 /** Reads at most `bytes` from the END of a file, without loading the rest. */
 function readTail(path, bytes) {
   let fd;
@@ -390,6 +407,8 @@ export function failedResultsFromTranscript(transcriptPath, options = {}) {
       if (typeof block.content !== 'string') continue;
       const match = EXIT_CODE_RESULT.exec(block.content);
       if (!match) continue;
+      // The command ran, but the harness ended it. See HARNESS_TIMEOUT.
+      if (HARNESS_TIMEOUT.test(block.content)) continue;
       const command = commands.get(String(block.tool_use_id || ''));
       // No command means no claim. The result says something failed; without
       // the text of what failed there is nothing to say about it, and nothing

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -55,6 +55,7 @@ import {
   load,
   wikiDir,
   projectRootFor,
+  unrootedRoot,
 } from './wiki.mjs';
 import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
@@ -78,7 +79,7 @@ import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
-import { isFsSafePath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
   recordingNudge,
@@ -94,7 +95,7 @@ import {
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
-import { registerProject } from './projects.mjs';
+import { registerProject, registeredProjects } from './projects.mjs';
 import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
@@ -109,6 +110,62 @@ export const CLIENTS = nativeClientProfiles();
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
+
+/**
+ * How many registered project graphs a session-end sweep may open.
+ *
+ * The registry is append-only and unbounded over time -- 4,033 records on this
+ * machine -- and each graph read is a tail of up to 2 MB. Bounded to the most
+ * recently seen handful, which is the only part of the registry a single
+ * session can plausibly have written to.
+ */
+const CROSS_PROJECT_SCAN_LIMIT =
+  Number(process.env.TOKEN_OPTIMIZER_CROSS_PROJECT_SCAN) || 12;
+
+/** A project the current session cannot have touched is not worth opening. */
+const CROSS_PROJECT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The activity this session recorded, gathered from every graph that could hold
+ * it.
+ *
+ * Capture is keyed on where the FILE lives (`recordToolOutcome(wikiDir(root))`,
+ * post-tool), not on the session's cwd. So when the client is started outside a
+ * repository -- a home directory, the common case -- the session's own file
+ * activity is written into each touched project's graph, and the unrooted graph
+ * that `cwd` resolves to holds none of it. Reading only that graph is why the
+ * inference below returned null in exactly the case it exists for: measured on
+ * this machine, the unrooted store holds 12,376 file anchors and ZERO of them
+ * under a repository.
+ *
+ * The sweep is confined to that case. A cwd that IS a repository already owns
+ * the graph its own files were captured into, so it pays nothing.
+ */
+export function sessionActivity(cwdRoot) {
+  let events = [];
+  try {
+    events = readMetrics(wikiDir(cwdRoot));
+  } catch {
+    events = [];
+  }
+  if (canonicalPath(cwdRoot) !== canonicalPath(unrootedRoot())) return events;
+  const cutoff = Date.now() - CROSS_PROJECT_MAX_AGE_MS;
+  let projects = [];
+  try {
+    // Sorted most-recently-seen first by `registeredProjects`.
+    projects = registeredProjects().filter((p) => (p.lastSeenAt || 0) >= cutoff);
+  } catch {
+    return events;
+  }
+  for (const project of projects.slice(0, CROSS_PROJECT_SCAN_LIMIT)) {
+    try {
+      events = events.concat(readMetrics(project.graphDir));
+    } catch {
+      // One unreadable store must not cost the session its inference.
+    }
+  }
+  return events;
+}
 
 /**
  * The response envelopes a completed tool call can arrive in.
@@ -1223,13 +1280,21 @@ async function runHook(clientName, event, invocation) {
       // router already keys capture on where the FILE lives rather than on the
       // session's cwd; this applies that rule to derivation too, and falls back
       // to the cwd answer when the session touched nothing resolvable.
+      //
+      // The evidence is gathered by `sessionActivity`, NOT from the cwd graph
+      // alone: capture keyed on the file's project means an unrooted session's
+      // own activity was written into the graphs of the projects it touched.
+      // Reading only the unrooted graph found 12,376 file anchors and not one
+      // under a repository, so the inference was inert in precisely the case it
+      // was written for.
       const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
       let projectRoot = cwdRoot;
       try {
         projectRoot =
-          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+          projectRootFromActivity(sessionActivity(cwdRoot), {
             resolve: (anchor) => projectRootFor(anchor, cwd),
             cwd,
+            sessionId,
           }) || cwdRoot;
       } catch {
         // Inferring the project is an improvement, never a precondition.

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -46,8 +46,9 @@ import {
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
+  readMetrics,
 } from './metrics.mjs';
-import { derive } from './derive.mjs';
+import { derive, projectRootFromActivity } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -1207,7 +1208,32 @@ async function runHook(clientName, event, invocation) {
       // one figure alone cannot distinguish "nothing to derive" from "derived
       // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
-      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      // WHERE THE WORK HAPPENED, NOT WHERE THE CLIENT WAS LAUNCHED.
+      //
+      // `projectRootFor` on a cwd with no VCS marker -- a home directory, which
+      // is how this client is commonly started -- returns the synthetic fallback
+      // `~/.token-optimizer/unrooted`. That is not null, so every `if
+      // (projectRoot)` gate downstream passes, and `projectAnchor` then hands
+      // back the directory itself because the fallback holds no project marker.
+      // `writeHarvested` resolves anchors through `indexFile`, which returns
+      // null for a directory, and the finding is refused as unanchorable.
+      //
+      // Measured consequence on this machine: 937 derive runs, 8 candidates,
+      // ZERO findings written, beside 2,965 symbol nodes in the same graph. The
+      // router already keys capture on where the FILE lives rather than on the
+      // session's cwd; this applies that rule to derivation too, and falls back
+      // to the cwd answer when the session touched nothing resolvable.
+      const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      let projectRoot = cwdRoot;
+      try {
+        projectRoot =
+          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+            resolve: (anchor) => projectRootFor(anchor, cwd),
+            cwd,
+          }) || cwdRoot;
+      } catch {
+        // Inferring the project is an improvement, never a precondition.
+      }
       const dir = wikiDir(projectRoot);
       const derived = derive(dir, {
         sessionId,

--- a/integrations/gemini/hooks/lib/advise.mjs
+++ b/integrations/gemini/hooks/lib/advise.mjs
@@ -162,7 +162,7 @@ const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function commandSegments(command) {
+export function commandSegments(command) {
   const segments = [];
   let tokens = [];
   let current = '';

--- a/integrations/gemini/hooks/lib/derive.mjs
+++ b/integrations/gemini/hooks/lib/derive.mjs
@@ -205,11 +205,26 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  *
  * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
  * before this sees it -- that case is one command spelled two ways.
+ *
+ * A TRAILING SEPARATOR LEAVES NOTHING TO COUNT, which is the hole in reading
+ * the segment count alone. `commandSegments` pushes only non-empty token
+ * lists, so `npx jest tests/foo &&` is ONE segment, and `attemptKey` -- the
+ * first three non-flag tokens -- never sees the `&&` either. The command is
+ * still half of something, and `cmd &` on its own is a background job whose
+ * exit code belongs to the shell rather than to the program named. Appending a
+ * sentinel token makes the missing segment materialise, which reuses the one
+ * scanner that already understands quotes instead of adding a second,
+ * differently-wrong one: `grep -E "foo|bar" src/x.mjs` stays a single segment
+ * with the sentinel attached, exactly as it does without it.
  */
+// Not a plausible argument to anything, so it can only ever be the token this
+// function appended.
+const SEGMENT_SENTINEL = '__token_optimizer_segment_probe__';
+
 const hasAttemptIdentity = (command) => {
   const body = commandBody(command);
   if (!body.trim()) return false;
-  if (commandSegments(body).length > 1) return false;
+  if (commandSegments(`${body} ${SEGMENT_SENTINEL}`).length > 1) return false;
   return attemptKey(command)
     .split(' ')
     .filter(Boolean)
@@ -368,7 +383,13 @@ export function commandOperand(command) {
   // attempts, so including it would reproduce attemptKey's blind spot.
   for (const token of tokens.slice(1)) {
     const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
-    if (named && token.length >= 4) return token.toLowerCase();
+    // AS WRITTEN, not folded. This value is the grouping key AND the text of
+    // the stored claim, and folding it made the claim name a path that does
+    // not exist on a case-sensitive filesystem: `src/Foo.test.mjs` was
+    // recorded, and served to a later session, as `src/foo.test.mjs`. The
+    // caller folds a copy for the key instead, so matching stays
+    // case-insensitive without the claim paying for it.
+    if (named && token.length >= 4) return token;
   }
   return null;
 }
@@ -1068,15 +1089,23 @@ export function derive(dir, options = {}) {
   // repeating an invocation.
   try {
     if (projectRoot && outcomes?.length) {
+      // KEYED FOLDED, DISPLAYED AS WRITTEN. Two invocations naming the same
+      // file with different capitalisation are the same target on Windows and
+      // macOS, so the key folds; the text stored in the finding must not,
+      // because a claim naming `src/foo.test.mjs` for a file called
+      // `src/Foo.test.mjs` is a path that does not resolve on Linux -- and
+      // that text is what a later session reads. The first spelling seen wins,
+      // which is the one the failing attempt actually used.
       const byTarget = new Map();
       for (const outcome of outcomes) {
-        const target = commandOperand(outcome.command);
-        if (!target) continue;
-        if (!byTarget.has(target)) byTarget.set(target, []);
-        byTarget.get(target).push(outcome);
+        const operand = commandOperand(outcome.command);
+        if (!operand) continue;
+        const key = operand.toLowerCase();
+        if (!byTarget.has(key)) byTarget.set(key, { target: operand, run: [] });
+        byTarget.get(key).run.push(outcome);
       }
 
-      for (const [target, run] of byTarget) {
+      for (const { target, run } of byTarget.values()) {
         let lastFailure = null;
         for (const outcome of run) {
           if (outcome.failed) {

--- a/integrations/gemini/hooks/lib/derive.mjs
+++ b/integrations/gemini/hooks/lib/derive.mjs
@@ -67,7 +67,16 @@ import {
  * command. A correction is a lexical guess about what a human meant. Churn
  * describes our own reading behaviour and says nothing about the code at all.
  */
-export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+export const CONFIDENCE = {
+  command: 0.9,
+  test: 0.85,
+  // Below `command` because the inference is weaker: two commands sharing a
+  // target is good evidence of one intent, but not the same evidence as the
+  // identical invocation being retried. Labelled speculative, deliberately.
+  retarget: 0.6,
+  correction: 0.6,
+  churn: 0.4,
+};
 
 /** Claim text cap. A finding is one sentence; a paragraph is evidence. */
 const CLAIM_MAX = 300;
@@ -75,6 +84,17 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * How close a fix must follow its failure to count as the same attempt.
+ *
+ * Detector 5 pairs across DIFFERENT programs, so it cannot lean on command
+ * identity to know the two are related -- proximity is doing that work instead.
+ * Ten minutes is long enough for a real correction, including reading an error
+ * and looking something up, and short enough that two unrelated pieces of work
+ * touching one file in an afternoon are not reported as one story.
+ */
+const RETARGET_WINDOW_MS = 10 * 60 * 1000;
 
 /**
  * The anchor cap a command surface is stored under, restated here as a TEST.
@@ -287,6 +307,50 @@ export function attemptKey(command) {
     .join(' ')
     .toLowerCase();
 }
+/**
+ * The thing a command ACTS ON -- a path, a test file, a target.
+ *
+ * WHY `attemptKey` IS NOT ENOUGH, measured rather than supposed. That key is
+ * program-plus-operands, so the single most valuable lesson a session can teach
+ * cannot pair by construction:
+ *
+ *   npx jest tests/foo      -> key "npx jest tests/foo"
+ *   npm test -- tests/foo   -> key "npm test tests/foo"
+ *
+ * Different keys, no pair, no finding -- yet that is exactly the correction
+ * worth recording, because the fix was to run a DIFFERENT program against the
+ * same target. The existing detector can only catch the same command re-run and
+ * succeeding, which its own guard then discards as incoherent.
+ *
+ * The measured cost of that: across 937 real derive runs on this machine, 8
+ * candidates were produced and ZERO were stored.
+ *
+ * So this returns the shared operand -- `tests/foo` above -- which is what the
+ * two attempts genuinely have in common. Only operands that NAME something are
+ * admitted: a path separator or a file extension. A bare word like `build` is
+ * refused, because `npm run build` and `make build` sharing the token `build`
+ * is a coincidence of vocabulary, not evidence of one intent.
+ */
+export function commandOperand(command) {
+  const tokens = commandBody(command)
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'));
+  // Skipping the first token: the PROGRAM is what differs between the two
+  // attempts, so including it would reproduce attemptKey's blind spot.
+  for (const token of tokens.slice(1)) {
+    const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
+    if (named && token.length >= 4) return token.toLowerCase();
+  }
+  return null;
+}
+
+/** The program a command invokes, for deciding whether two attempts differ. */
+export function commandProgram(command) {
+  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  return first.split(/[/\\]/).pop().toLowerCase();
+}
+
 
 /** Normalised claim text, so the same lesson derived twice is one candidate. */
 const claimKey = (type, claim) =>
@@ -519,9 +583,15 @@ export function derive(dir, options = {}) {
   // a transcript failure that pairs with nothing stays unclaimed, which is also
   // what keeps a failure from ANOTHER project's directory out of this project's
   // graph -- a candidate cannot be emitted without a success recorded HERE.
+  // HOISTED so detector 5 can pair over the SAME merged list -- events plus the
+  // transcript failures folded in below. Rebuilding it there would duplicate the
+  // de-duplication logic and let the two detectors drift; leaving it block-scoped
+  // gave detector 5 a ReferenceError that its own try/catch swallowed, which is
+  // silent nothing rather than a visible failure.
+  let outcomes = [];
   try {
     if (projectRoot) {
-      const outcomes = events
+      outcomes = events
         .filter(
           (e) =>
             e &&
@@ -802,6 +872,92 @@ export function derive(dir, options = {}) {
   } catch {
     // One detector, never the session.
   }
+  // ---- 5: a DIFFERENT command against the same target succeeded -----------
+  //
+  // THE LESSON DETECTOR 1 CANNOT REACH. Its `attemptKey` is program-plus-
+  // operands, so the correction worth recording -- reaching for a different
+  // tool against the same target -- lands in two groups that never meet:
+  //
+  //   npx jest tests/foo.test.mjs     key "npx jest tests/foo.test.mjs"
+  //   npm test -- tests/foo.test.mjs  key "npm test tests/foo.test.mjs"
+  //
+  // What detector 1 CAN pair is the identical command re-run, and its own guard
+  // then correctly discards that as incoherent -- "`npm run build` works where
+  // `npm run build` failed" claims nothing. So between the key and the guard,
+  // the command family had almost no reachable evidence: measured across 937
+  // real derive runs on this machine, 8 candidates and ZERO stored findings.
+  //
+  // This pairs on the shared OPERAND instead, and only when the PROGRAM differs
+  // -- same-program pairs are detector 1's business and are left to it. The
+  // conservatism the original key was protecting is kept in three other places:
+  // the operand must NAME something (a path or an extension, never a bare word
+  // like `build`), the two attempts must be close in time, and the ceiling is
+  // 0.6 rather than 0.9 because sharing a target is weaker evidence than
+  // repeating an invocation.
+  try {
+    if (projectRoot && outcomes?.length) {
+      const byTarget = new Map();
+      for (const outcome of outcomes) {
+        const target = commandOperand(outcome.command);
+        if (!target) continue;
+        if (!byTarget.has(target)) byTarget.set(target, []);
+        byTarget.get(target).push(outcome);
+      }
+
+      for (const [target, run] of byTarget) {
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          lastFailure = null;
+
+          // Same program is detector 1's case, whether it pairs there or not.
+          if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
+          // A fix follows its failure closely. Hours apart is two unrelated
+          // pieces of work that happened to touch one file.
+          const apart = Math.abs((outcome.at || 0) - (failed.at || 0));
+          if (!apart || apart > RETARGET_WINDOW_MS) continue;
+          // Same rule as detector 1: nothing quotable, nothing claimed.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          const confidence = CONFIDENCE.retarget;
+          add({
+            type: 'command',
+            claim: redact(
+              `In this project \`${commandBody(outcome.command)}\` succeeded on ${target} where ` +
+                `\`${commandBody(failed.command)}\` had failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded against the same target \`${target}\` ` +
+                `${Math.round(apart / 1000)}s later. Different programs, one target: ordered ` +
+                'and close, but not proven causal -- an intervening edit explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: `when about to run \`${commandProgram(failed.command)}\` against ${target} in this project`,
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: [`\`${commandBody(failed.command)}\` later succeeds unchanged`],
+            trigger: triggerFor(failed.command),
+            anchors: [anchorPath],
+            derivedBy: 'retarget',
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
 
   // ---- storage, under a budget -------------------------------------------
   //

--- a/integrations/gemini/hooks/lib/derive.mjs
+++ b/integrations/gemini/hooks/lib/derive.mjs
@@ -739,6 +739,27 @@ export function derive(dir, options = {}) {
   let outcomes = [];
   try {
     if (projectRoot) {
+      // SCOPED TO THE SESSION THE CLAIM WILL NAME.
+      //
+      // Every claim these detectors build opens `observed in one session:`,
+      // and the store holds every session's outcomes -- so nothing but the
+      // ten-minute window stopped a failure from one session pairing with a
+      // success from another and asserting a provenance that never happened.
+      //
+      // NEVER OBSERVED, SAID PLAINLY. Across both live stores on this machine
+      // -- 7,173 command outcomes over 3 sessions here, 543 over 9 sessions in
+      // the unrooted one -- 5,155 and 298 adjacent in-window pairs respectively
+      // and ZERO of them crossed a session. Sessions are long and rarely
+      // interleave inside ten minutes. This is a correctness fix against a
+      // false claim, not a fix for observed damage, and it is not offered as
+      // one. Concurrent sessions do occur -- one was recorded on this machine
+      // while this was being written -- and they share the unrooted store.
+      //
+      // The merged transcript failures below are deliberately NOT filtered:
+      // `failedResultsFromTranscript` carries no sessionId, and the transcript
+      // it read is this session's, so they are already scoped by construction.
+      // Filtering them here would drop the only source of command failures
+      // that exists -- Claude Code never fires PostToolUse on a non-zero exit.
       outcomes = events
         .filter(
           (e) =>
@@ -746,7 +767,10 @@ export function derive(dir, options = {}) {
             e.kind === 'tool-outcome' &&
             e.surface === 'command' &&
             typeof e.anchor === 'string' &&
-            e.anchor.trim()
+            e.anchor.trim() &&
+            // An event predating the field still counts; a DIFFERENT session
+            // never does.
+            (!sessionId || !e.sessionId || e.sessionId === sessionId)
         )
         .map((e) => ({
           command: e.anchor.trim(),

--- a/integrations/gemini/hooks/lib/derive.mjs
+++ b/integrations/gemini/hooks/lib/derive.mjs
@@ -915,6 +915,20 @@ export function derive(dir, options = {}) {
           const failed = lastFailure;
           lastFailure = null;
 
+          // BOTH SIDES MUST NAME A SINGLE COMMAND, the same rule detector 1
+          // applies. `commandBody` strips only a LEADING directory change, and
+          // `commandProgram` reads the first token, so a chained command
+          // attributes the failure to the wrong program entirely:
+          //
+          //   git fetch && npx jest tests/foo.test.mjs   -> program "git"
+          //   cat x | npx jest tests/foo.test.mjs        -> program "cat"
+          //
+          // Paired against `npm test -- tests/foo.test.mjs` those would ship
+          // "npm test succeeded where git fetch failed" and tell a later session
+          // to avoid `git`. Checked per side rather than once, because unlike
+          // detector 1 these two do NOT share a key by construction.
+          if (!hasAttemptIdentity(failed.command)) continue;
+          if (!hasAttemptIdentity(outcome.command)) continue;
           // Same program is detector 1's case, whether it pairs there or not.
           if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
           // A fix follows its failure closely. Hours apart is two unrelated

--- a/integrations/gemini/hooks/lib/derive.mjs
+++ b/integrations/gemini/hooks/lib/derive.mjs
@@ -430,10 +430,16 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * Returns null when nothing resolves, which leaves the caller's original root
  * untouched -- a wrong project is worse than the status quo.
  */
-export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+export function projectRootFromActivity(events, { resolve, cwd, sessionId = null } = {}) {
   if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
   const counts = new Map();
   for (const event of events) {
+    // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
+    // session that wrote it, so counting every event ever recorded lets a busy
+    // session from last week outvote the one now ending -- and the question
+    // being asked is "where did THIS session work", not "where is this graph
+    // busiest". Callers that pass no id keep the whole-graph count.
+    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.
@@ -454,13 +460,22 @@ export function projectRootFromActivity(events, { resolve, cwd } = {}) {
   }
   let best = null;
   let most = 0;
+  let tied = false;
   for (const [root, n] of counts) {
     if (n > most) {
       most = n;
       best = root;
+      tied = false;
+    } else if (n === most) {
+      // A Map iterates in insertion order, so a tie would otherwise be broken by
+      // whichever file the session happened to touch first -- deterministic, but
+      // arbitrary, and wrong half the time. Findings would then be stored against
+      // a project the evidence does not single out. Decline instead; the caller
+      // keeps cwdRoot, which is at least a root the user chose.
+      tied = true;
     }
   }
-  return best;
+  return tied ? null : best;
 }
 
 export function projectAnchor(projectRoot) {

--- a/integrations/gemini/hooks/lib/derive.mjs
+++ b/integrations/gemini/hooks/lib/derive.mjs
@@ -373,9 +373,45 @@ export function commandOperand(command) {
   return null;
 }
 
-/** The program a command invokes, for deciding whether two attempts differ. */
+/**
+ * A leading `VAR=value` prefix, which a shell applies to the environment of
+ * the command that follows rather than running as the command itself.
+ */
+const ENV_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+/**
+ * The program a command invokes, for deciding whether two attempts differ.
+ *
+ * ENVIRONMENT PREFIXES ARE NOT THE PROGRAM. Taking the first token verbatim
+ * reported `SP=/tmp/x` as the program for `SP=/tmp/x node run.mjs`, and that
+ * is not a cosmetic slip: measured over this machine's real history, 816 of
+ * 7,165 recorded command outcomes -- 11.4% -- named an assignment.
+ *
+ * IT FAILS IN THE DANGEROUS DIRECTION. This function exists to decide that two
+ * attempts used DIFFERENT programs, so two runs of the same tool under
+ * different variables --
+ *
+ *   SP=/a node run.mjs    (failed)
+ *   SPW=/b node run.mjs   (succeeded)
+ *
+ * -- compared as `sp=/a` against `spw=/b`, differed, and were eligible to
+ * pair. The claim that pairing produces is `node run.mjs` succeeded where
+ * `node run.mjs` failed: exactly the incoherent statement detector 1's own
+ * guard exists to refuse, arriving through the door detector 5 opened.
+ *
+ * Skipping the prefixes is what a shell does, and it cannot invent a pair --
+ * two commands that were already the same program now compare equal, which
+ * only ever removes a candidate.
+ *
+ * NO MEASURED CHANGE TODAY, stated plainly: replaying both versions over the
+ * same real history gives an identical pairing outcome (20 pairs considered,
+ * 0 firing), because every affected command is also chained and rejected
+ * earlier. This is a correctness fix against a latent false claim, not a
+ * recall improvement, and it is not offered as one.
+ */
 export function commandProgram(command) {
-  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  const tokens = commandBody(command).trim().split(/\s+/).filter(Boolean);
+  const first = tokens.find((token) => !ENV_ASSIGNMENT.test(token)) || '';
   return first.split(/[/\\]/).pop().toLowerCase();
 }
 

--- a/integrations/gemini/hooks/lib/derive.mjs
+++ b/integrations/gemini/hooks/lib/derive.mjs
@@ -53,6 +53,7 @@ import { ORIGIN_HARVESTED } from './curate.mjs';
 // from, so what this counts as a search and what the advisory treats as one
 // cannot diverge.
 import {
+  commandSegments,
   identifiersIn,
   searchPatternFromCommand,
   symbolIndex,
@@ -182,11 +183,38 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
-const hasAttemptIdentity = (command) =>
-  attemptKey(command)
+/**
+ * THE WHOLE BODY, NOT THE FIRST THREE TOKENS.
+ *
+ * This used to read the separator set off `attemptKey`, which keeps only the
+ * first three non-flag tokens -- so it caught a separator only when one landed
+ * early by luck of position. Verified against the real functions:
+ *
+ *   git fetch && npx jest tests/foo   key `git fetch &&`        -> rejected
+ *   npx jest tests/foo && node x.mjs  key `npx jest tests/foo`  -> ACCEPTED
+ *   grep -rn foo src | head -20       key `grep foo src`        -> ACCEPTED
+ *
+ * The last two are exactly the claims this guard exists to stop: the key names
+ * `npx`, so a pair would blame `npx` for a failure `node` may have caused.
+ * Every existing test placed the separator in the first three tokens, so none
+ * of them could see it.
+ *
+ * `commandSegments` is reused rather than a fresh scan because it is already
+ * the quote-aware one: splitting the raw string would cut through `grep -E
+ * "foo|bar"` and reject an ordinary alternation as a pipeline.
+ *
+ * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
+ * before this sees it -- that case is one command spelled two ways.
+ */
+const hasAttemptIdentity = (command) => {
+  const body = commandBody(command);
+  if (!body.trim()) return false;
+  if (commandSegments(body).length > 1) return false;
+  return attemptKey(command)
     .split(' ')
     .filter(Boolean)
     .every((token) => !COMMAND_SEPARATORS.has(token));
+};
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -435,11 +463,20 @@ export function projectRootFromActivity(events, { resolve, cwd, sessionId = null
   const counts = new Map();
   for (const event of events) {
     // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
-    // session that wrote it, so counting every event ever recorded lets a busy
-    // session from last week outvote the one now ending -- and the question
-    // being asked is "where did THIS session work", not "where is this graph
-    // busiest". Callers that pass no id keep the whole-graph count.
-    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
+    // session that wrote it, and the caller concatenates several graphs, so
+    // counting every event ever recorded lets a busy session from last week
+    // outvote the one now ending -- and the question being asked is "where did
+    // THIS session work", not "where is this graph busiest". Callers that pass
+    // no id keep the whole-graph count.
+    //
+    // AN EVENT THAT CANNOT NAME ITS SESSION IS EXCLUDED, not exempted. Exempting
+    // it was a deliberate concession to older records, and measurement says the
+    // concession buys nothing: across the three live stores on this machine, 2
+    // of 22,321 file/read events lack the field -- 0.01%. Set against that, an
+    // unstamped event sitting in ANOTHER project's graph would vote for that
+    // project on the strength of no evidence at all, which is precisely the
+    // failure this filter exists to prevent.
+    if (sessionId && event?.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.

--- a/integrations/gemini/hooks/lib/derive.mjs
+++ b/integrations/gemini/hooks/lib/derive.mjs
@@ -403,6 +403,66 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * against a fabricated anchor. That is the fail-open direction: no finding
  * beats a finding anchored to something that is not what the claim is about.
  */
+
+/**
+ * The project a session actually worked in, read off what it touched.
+ *
+ * WHY THE SESSION'S CWD IS THE WRONG ANSWER. `adapter.mjs` resolves the root
+ * with `projectRootFor(join(cwd, '__session__'), cwd)`, and when Claude Code is
+ * launched from a directory with no VCS marker -- a home directory, which is how
+ * this machine runs it -- that returns the synthetic fallback
+ * `~/.token-optimizer/unrooted`. It is NOT null, so every `if (projectRoot)`
+ * gate passes, and then `projectAnchor` hands back the directory itself because
+ * the fallback contains no project marker. `writeHarvested` resolves anchors
+ * through `indexFile`, `indexFile` on a directory returns null, and the finding
+ * is refused as unanchorable.
+ *
+ * That is the whole reason this machine's graph holds 2,965 symbols and ONE
+ * finding: 937 derive runs produced candidates and stored none of them, while
+ * every layer reported success.
+ *
+ * The router already solved this for capture -- "THE GRAPH IS PER PROJECT, so it
+ * is keyed on where the FILE lives, not on where the client happens to be
+ * running" -- and derivation simply never adopted it. This applies the same
+ * rule at Stop time: take the file anchors the session recorded, resolve each to
+ * its own project, and pick the one that holds the most of them.
+ *
+ * Returns null when nothing resolves, which leaves the caller's original root
+ * untouched -- a wrong project is worse than the status quo.
+ */
+export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+  if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
+  const counts = new Map();
+  for (const event of events) {
+    const anchor = event?.anchor;
+    // File surfaces only. A command anchor is the command text, and resolving
+    // `npm test -- x` as a path would invent a project out of a sentence.
+    if (!anchor || typeof anchor !== 'string') continue;
+    if (event.kind !== 'read' && !(event.kind === 'tool-outcome' && event.surface === 'file')) {
+      continue;
+    }
+    let root;
+    try {
+      root = resolve(anchor, cwd);
+    } catch {
+      continue;
+    }
+    // The fallback resolves to a path inside the optimizer's own store, which is
+    // never a project someone is working in.
+    if (!root || String(root).includes('.token-optimizer')) continue;
+    counts.set(root, (counts.get(root) || 0) + 1);
+  }
+  let best = null;
+  let most = 0;
+  for (const [root, n] of counts) {
+    if (n > most) {
+      most = n;
+      best = root;
+    }
+  }
+  return best;
+}
+
 export function projectAnchor(projectRoot) {
   if (!projectRoot) return null;
   let entries;

--- a/integrations/gemini/hooks/lib/transcript.mjs
+++ b/integrations/gemini/hooks/lib/transcript.mjs
@@ -289,6 +289,23 @@ const ANCHOR_MAX = 120;
  */
 const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
 
+/**
+ * A run the HARNESS stopped, which is not the command failing.
+ *
+ * The allowlist above admits anything shaped `Exit code N`, and a killed
+ * command reports `Exit code 143` with `Command timed out after 2m 0s` -- so
+ * it walks straight in. Nothing about it is a lesson about the command: it did
+ * not fail, it was not allowed to finish, and the same command run with a
+ * longer budget may well pass. Pairing one with a later success would claim a
+ * red-to-green transition that never happened.
+ *
+ * MEASURED, on a 237 MB transcript of ordinary feature work: of 130 admitted
+ * failures, 25 were timeouts -- 19%. At the 64 MB scan it was 11 of 23, 48%.
+ * User declines are NOT in this class and need no rule; the positive allowlist
+ * already excludes them, verified at every scan size on the same transcript.
+ */
+const HARNESS_TIMEOUT = /^\s*Command timed out after\b/m;
+
 /** Reads at most `bytes` from the END of a file, without loading the rest. */
 function readTail(path, bytes) {
   let fd;
@@ -390,6 +407,8 @@ export function failedResultsFromTranscript(transcriptPath, options = {}) {
       if (typeof block.content !== 'string') continue;
       const match = EXIT_CODE_RESULT.exec(block.content);
       if (!match) continue;
+      // The command ran, but the harness ended it. See HARNESS_TIMEOUT.
+      if (HARNESS_TIMEOUT.test(block.content)) continue;
       const command = commands.get(String(block.tool_use_id || ''));
       // No command means no claim. The result says something failed; without
       // the text of what failed there is nothing to say about it, and nothing

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -55,6 +55,7 @@ import {
   load,
   wikiDir,
   projectRootFor,
+  unrootedRoot,
 } from './wiki.mjs';
 import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
@@ -78,7 +79,7 @@ import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
-import { isFsSafePath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
   recordingNudge,
@@ -94,7 +95,7 @@ import {
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
-import { registerProject } from './projects.mjs';
+import { registerProject, registeredProjects } from './projects.mjs';
 import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
@@ -109,6 +110,62 @@ export const CLIENTS = nativeClientProfiles();
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
+
+/**
+ * How many registered project graphs a session-end sweep may open.
+ *
+ * The registry is append-only and unbounded over time -- 4,033 records on this
+ * machine -- and each graph read is a tail of up to 2 MB. Bounded to the most
+ * recently seen handful, which is the only part of the registry a single
+ * session can plausibly have written to.
+ */
+const CROSS_PROJECT_SCAN_LIMIT =
+  Number(process.env.TOKEN_OPTIMIZER_CROSS_PROJECT_SCAN) || 12;
+
+/** A project the current session cannot have touched is not worth opening. */
+const CROSS_PROJECT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The activity this session recorded, gathered from every graph that could hold
+ * it.
+ *
+ * Capture is keyed on where the FILE lives (`recordToolOutcome(wikiDir(root))`,
+ * post-tool), not on the session's cwd. So when the client is started outside a
+ * repository -- a home directory, the common case -- the session's own file
+ * activity is written into each touched project's graph, and the unrooted graph
+ * that `cwd` resolves to holds none of it. Reading only that graph is why the
+ * inference below returned null in exactly the case it exists for: measured on
+ * this machine, the unrooted store holds 12,376 file anchors and ZERO of them
+ * under a repository.
+ *
+ * The sweep is confined to that case. A cwd that IS a repository already owns
+ * the graph its own files were captured into, so it pays nothing.
+ */
+export function sessionActivity(cwdRoot) {
+  let events = [];
+  try {
+    events = readMetrics(wikiDir(cwdRoot));
+  } catch {
+    events = [];
+  }
+  if (canonicalPath(cwdRoot) !== canonicalPath(unrootedRoot())) return events;
+  const cutoff = Date.now() - CROSS_PROJECT_MAX_AGE_MS;
+  let projects = [];
+  try {
+    // Sorted most-recently-seen first by `registeredProjects`.
+    projects = registeredProjects().filter((p) => (p.lastSeenAt || 0) >= cutoff);
+  } catch {
+    return events;
+  }
+  for (const project of projects.slice(0, CROSS_PROJECT_SCAN_LIMIT)) {
+    try {
+      events = events.concat(readMetrics(project.graphDir));
+    } catch {
+      // One unreadable store must not cost the session its inference.
+    }
+  }
+  return events;
+}
 
 /**
  * The response envelopes a completed tool call can arrive in.
@@ -1223,13 +1280,21 @@ async function runHook(clientName, event, invocation) {
       // router already keys capture on where the FILE lives rather than on the
       // session's cwd; this applies that rule to derivation too, and falls back
       // to the cwd answer when the session touched nothing resolvable.
+      //
+      // The evidence is gathered by `sessionActivity`, NOT from the cwd graph
+      // alone: capture keyed on the file's project means an unrooted session's
+      // own activity was written into the graphs of the projects it touched.
+      // Reading only the unrooted graph found 12,376 file anchors and not one
+      // under a repository, so the inference was inert in precisely the case it
+      // was written for.
       const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
       let projectRoot = cwdRoot;
       try {
         projectRoot =
-          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+          projectRootFromActivity(sessionActivity(cwdRoot), {
             resolve: (anchor) => projectRootFor(anchor, cwd),
             cwd,
+            sessionId,
           }) || cwdRoot;
       } catch {
         // Inferring the project is an improvement, never a precondition.

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -46,8 +46,9 @@ import {
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
+  readMetrics,
 } from './metrics.mjs';
-import { derive } from './derive.mjs';
+import { derive, projectRootFromActivity } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -1207,7 +1208,32 @@ async function runHook(clientName, event, invocation) {
       // one figure alone cannot distinguish "nothing to derive" from "derived
       // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
-      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      // WHERE THE WORK HAPPENED, NOT WHERE THE CLIENT WAS LAUNCHED.
+      //
+      // `projectRootFor` on a cwd with no VCS marker -- a home directory, which
+      // is how this client is commonly started -- returns the synthetic fallback
+      // `~/.token-optimizer/unrooted`. That is not null, so every `if
+      // (projectRoot)` gate downstream passes, and `projectAnchor` then hands
+      // back the directory itself because the fallback holds no project marker.
+      // `writeHarvested` resolves anchors through `indexFile`, which returns
+      // null for a directory, and the finding is refused as unanchorable.
+      //
+      // Measured consequence on this machine: 937 derive runs, 8 candidates,
+      // ZERO findings written, beside 2,965 symbol nodes in the same graph. The
+      // router already keys capture on where the FILE lives rather than on the
+      // session's cwd; this applies that rule to derivation too, and falls back
+      // to the cwd answer when the session touched nothing resolvable.
+      const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      let projectRoot = cwdRoot;
+      try {
+        projectRoot =
+          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+            resolve: (anchor) => projectRootFor(anchor, cwd),
+            cwd,
+          }) || cwdRoot;
+      } catch {
+        // Inferring the project is an improvement, never a precondition.
+      }
       const dir = wikiDir(projectRoot);
       const derived = derive(dir, {
         sessionId,

--- a/integrations/kilo/hooks/lib/advise.mjs
+++ b/integrations/kilo/hooks/lib/advise.mjs
@@ -162,7 +162,7 @@ const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function commandSegments(command) {
+export function commandSegments(command) {
   const segments = [];
   let tokens = [];
   let current = '';

--- a/integrations/kilo/hooks/lib/derive.mjs
+++ b/integrations/kilo/hooks/lib/derive.mjs
@@ -205,11 +205,26 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  *
  * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
  * before this sees it -- that case is one command spelled two ways.
+ *
+ * A TRAILING SEPARATOR LEAVES NOTHING TO COUNT, which is the hole in reading
+ * the segment count alone. `commandSegments` pushes only non-empty token
+ * lists, so `npx jest tests/foo &&` is ONE segment, and `attemptKey` -- the
+ * first three non-flag tokens -- never sees the `&&` either. The command is
+ * still half of something, and `cmd &` on its own is a background job whose
+ * exit code belongs to the shell rather than to the program named. Appending a
+ * sentinel token makes the missing segment materialise, which reuses the one
+ * scanner that already understands quotes instead of adding a second,
+ * differently-wrong one: `grep -E "foo|bar" src/x.mjs` stays a single segment
+ * with the sentinel attached, exactly as it does without it.
  */
+// Not a plausible argument to anything, so it can only ever be the token this
+// function appended.
+const SEGMENT_SENTINEL = '__token_optimizer_segment_probe__';
+
 const hasAttemptIdentity = (command) => {
   const body = commandBody(command);
   if (!body.trim()) return false;
-  if (commandSegments(body).length > 1) return false;
+  if (commandSegments(`${body} ${SEGMENT_SENTINEL}`).length > 1) return false;
   return attemptKey(command)
     .split(' ')
     .filter(Boolean)
@@ -368,7 +383,13 @@ export function commandOperand(command) {
   // attempts, so including it would reproduce attemptKey's blind spot.
   for (const token of tokens.slice(1)) {
     const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
-    if (named && token.length >= 4) return token.toLowerCase();
+    // AS WRITTEN, not folded. This value is the grouping key AND the text of
+    // the stored claim, and folding it made the claim name a path that does
+    // not exist on a case-sensitive filesystem: `src/Foo.test.mjs` was
+    // recorded, and served to a later session, as `src/foo.test.mjs`. The
+    // caller folds a copy for the key instead, so matching stays
+    // case-insensitive without the claim paying for it.
+    if (named && token.length >= 4) return token;
   }
   return null;
 }
@@ -1068,15 +1089,23 @@ export function derive(dir, options = {}) {
   // repeating an invocation.
   try {
     if (projectRoot && outcomes?.length) {
+      // KEYED FOLDED, DISPLAYED AS WRITTEN. Two invocations naming the same
+      // file with different capitalisation are the same target on Windows and
+      // macOS, so the key folds; the text stored in the finding must not,
+      // because a claim naming `src/foo.test.mjs` for a file called
+      // `src/Foo.test.mjs` is a path that does not resolve on Linux -- and
+      // that text is what a later session reads. The first spelling seen wins,
+      // which is the one the failing attempt actually used.
       const byTarget = new Map();
       for (const outcome of outcomes) {
-        const target = commandOperand(outcome.command);
-        if (!target) continue;
-        if (!byTarget.has(target)) byTarget.set(target, []);
-        byTarget.get(target).push(outcome);
+        const operand = commandOperand(outcome.command);
+        if (!operand) continue;
+        const key = operand.toLowerCase();
+        if (!byTarget.has(key)) byTarget.set(key, { target: operand, run: [] });
+        byTarget.get(key).run.push(outcome);
       }
 
-      for (const [target, run] of byTarget) {
+      for (const { target, run } of byTarget.values()) {
         let lastFailure = null;
         for (const outcome of run) {
           if (outcome.failed) {

--- a/integrations/kilo/hooks/lib/derive.mjs
+++ b/integrations/kilo/hooks/lib/derive.mjs
@@ -67,7 +67,16 @@ import {
  * command. A correction is a lexical guess about what a human meant. Churn
  * describes our own reading behaviour and says nothing about the code at all.
  */
-export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+export const CONFIDENCE = {
+  command: 0.9,
+  test: 0.85,
+  // Below `command` because the inference is weaker: two commands sharing a
+  // target is good evidence of one intent, but not the same evidence as the
+  // identical invocation being retried. Labelled speculative, deliberately.
+  retarget: 0.6,
+  correction: 0.6,
+  churn: 0.4,
+};
 
 /** Claim text cap. A finding is one sentence; a paragraph is evidence. */
 const CLAIM_MAX = 300;
@@ -75,6 +84,17 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * How close a fix must follow its failure to count as the same attempt.
+ *
+ * Detector 5 pairs across DIFFERENT programs, so it cannot lean on command
+ * identity to know the two are related -- proximity is doing that work instead.
+ * Ten minutes is long enough for a real correction, including reading an error
+ * and looking something up, and short enough that two unrelated pieces of work
+ * touching one file in an afternoon are not reported as one story.
+ */
+const RETARGET_WINDOW_MS = 10 * 60 * 1000;
 
 /**
  * The anchor cap a command surface is stored under, restated here as a TEST.
@@ -287,6 +307,50 @@ export function attemptKey(command) {
     .join(' ')
     .toLowerCase();
 }
+/**
+ * The thing a command ACTS ON -- a path, a test file, a target.
+ *
+ * WHY `attemptKey` IS NOT ENOUGH, measured rather than supposed. That key is
+ * program-plus-operands, so the single most valuable lesson a session can teach
+ * cannot pair by construction:
+ *
+ *   npx jest tests/foo      -> key "npx jest tests/foo"
+ *   npm test -- tests/foo   -> key "npm test tests/foo"
+ *
+ * Different keys, no pair, no finding -- yet that is exactly the correction
+ * worth recording, because the fix was to run a DIFFERENT program against the
+ * same target. The existing detector can only catch the same command re-run and
+ * succeeding, which its own guard then discards as incoherent.
+ *
+ * The measured cost of that: across 937 real derive runs on this machine, 8
+ * candidates were produced and ZERO were stored.
+ *
+ * So this returns the shared operand -- `tests/foo` above -- which is what the
+ * two attempts genuinely have in common. Only operands that NAME something are
+ * admitted: a path separator or a file extension. A bare word like `build` is
+ * refused, because `npm run build` and `make build` sharing the token `build`
+ * is a coincidence of vocabulary, not evidence of one intent.
+ */
+export function commandOperand(command) {
+  const tokens = commandBody(command)
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'));
+  // Skipping the first token: the PROGRAM is what differs between the two
+  // attempts, so including it would reproduce attemptKey's blind spot.
+  for (const token of tokens.slice(1)) {
+    const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
+    if (named && token.length >= 4) return token.toLowerCase();
+  }
+  return null;
+}
+
+/** The program a command invokes, for deciding whether two attempts differ. */
+export function commandProgram(command) {
+  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  return first.split(/[/\\]/).pop().toLowerCase();
+}
+
 
 /** Normalised claim text, so the same lesson derived twice is one candidate. */
 const claimKey = (type, claim) =>
@@ -519,9 +583,15 @@ export function derive(dir, options = {}) {
   // a transcript failure that pairs with nothing stays unclaimed, which is also
   // what keeps a failure from ANOTHER project's directory out of this project's
   // graph -- a candidate cannot be emitted without a success recorded HERE.
+  // HOISTED so detector 5 can pair over the SAME merged list -- events plus the
+  // transcript failures folded in below. Rebuilding it there would duplicate the
+  // de-duplication logic and let the two detectors drift; leaving it block-scoped
+  // gave detector 5 a ReferenceError that its own try/catch swallowed, which is
+  // silent nothing rather than a visible failure.
+  let outcomes = [];
   try {
     if (projectRoot) {
-      const outcomes = events
+      outcomes = events
         .filter(
           (e) =>
             e &&
@@ -802,6 +872,92 @@ export function derive(dir, options = {}) {
   } catch {
     // One detector, never the session.
   }
+  // ---- 5: a DIFFERENT command against the same target succeeded -----------
+  //
+  // THE LESSON DETECTOR 1 CANNOT REACH. Its `attemptKey` is program-plus-
+  // operands, so the correction worth recording -- reaching for a different
+  // tool against the same target -- lands in two groups that never meet:
+  //
+  //   npx jest tests/foo.test.mjs     key "npx jest tests/foo.test.mjs"
+  //   npm test -- tests/foo.test.mjs  key "npm test tests/foo.test.mjs"
+  //
+  // What detector 1 CAN pair is the identical command re-run, and its own guard
+  // then correctly discards that as incoherent -- "`npm run build` works where
+  // `npm run build` failed" claims nothing. So between the key and the guard,
+  // the command family had almost no reachable evidence: measured across 937
+  // real derive runs on this machine, 8 candidates and ZERO stored findings.
+  //
+  // This pairs on the shared OPERAND instead, and only when the PROGRAM differs
+  // -- same-program pairs are detector 1's business and are left to it. The
+  // conservatism the original key was protecting is kept in three other places:
+  // the operand must NAME something (a path or an extension, never a bare word
+  // like `build`), the two attempts must be close in time, and the ceiling is
+  // 0.6 rather than 0.9 because sharing a target is weaker evidence than
+  // repeating an invocation.
+  try {
+    if (projectRoot && outcomes?.length) {
+      const byTarget = new Map();
+      for (const outcome of outcomes) {
+        const target = commandOperand(outcome.command);
+        if (!target) continue;
+        if (!byTarget.has(target)) byTarget.set(target, []);
+        byTarget.get(target).push(outcome);
+      }
+
+      for (const [target, run] of byTarget) {
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          lastFailure = null;
+
+          // Same program is detector 1's case, whether it pairs there or not.
+          if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
+          // A fix follows its failure closely. Hours apart is two unrelated
+          // pieces of work that happened to touch one file.
+          const apart = Math.abs((outcome.at || 0) - (failed.at || 0));
+          if (!apart || apart > RETARGET_WINDOW_MS) continue;
+          // Same rule as detector 1: nothing quotable, nothing claimed.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          const confidence = CONFIDENCE.retarget;
+          add({
+            type: 'command',
+            claim: redact(
+              `In this project \`${commandBody(outcome.command)}\` succeeded on ${target} where ` +
+                `\`${commandBody(failed.command)}\` had failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded against the same target \`${target}\` ` +
+                `${Math.round(apart / 1000)}s later. Different programs, one target: ordered ` +
+                'and close, but not proven causal -- an intervening edit explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: `when about to run \`${commandProgram(failed.command)}\` against ${target} in this project`,
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: [`\`${commandBody(failed.command)}\` later succeeds unchanged`],
+            trigger: triggerFor(failed.command),
+            anchors: [anchorPath],
+            derivedBy: 'retarget',
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
 
   // ---- storage, under a budget -------------------------------------------
   //

--- a/integrations/kilo/hooks/lib/derive.mjs
+++ b/integrations/kilo/hooks/lib/derive.mjs
@@ -739,6 +739,27 @@ export function derive(dir, options = {}) {
   let outcomes = [];
   try {
     if (projectRoot) {
+      // SCOPED TO THE SESSION THE CLAIM WILL NAME.
+      //
+      // Every claim these detectors build opens `observed in one session:`,
+      // and the store holds every session's outcomes -- so nothing but the
+      // ten-minute window stopped a failure from one session pairing with a
+      // success from another and asserting a provenance that never happened.
+      //
+      // NEVER OBSERVED, SAID PLAINLY. Across both live stores on this machine
+      // -- 7,173 command outcomes over 3 sessions here, 543 over 9 sessions in
+      // the unrooted one -- 5,155 and 298 adjacent in-window pairs respectively
+      // and ZERO of them crossed a session. Sessions are long and rarely
+      // interleave inside ten minutes. This is a correctness fix against a
+      // false claim, not a fix for observed damage, and it is not offered as
+      // one. Concurrent sessions do occur -- one was recorded on this machine
+      // while this was being written -- and they share the unrooted store.
+      //
+      // The merged transcript failures below are deliberately NOT filtered:
+      // `failedResultsFromTranscript` carries no sessionId, and the transcript
+      // it read is this session's, so they are already scoped by construction.
+      // Filtering them here would drop the only source of command failures
+      // that exists -- Claude Code never fires PostToolUse on a non-zero exit.
       outcomes = events
         .filter(
           (e) =>
@@ -746,7 +767,10 @@ export function derive(dir, options = {}) {
             e.kind === 'tool-outcome' &&
             e.surface === 'command' &&
             typeof e.anchor === 'string' &&
-            e.anchor.trim()
+            e.anchor.trim() &&
+            // An event predating the field still counts; a DIFFERENT session
+            // never does.
+            (!sessionId || !e.sessionId || e.sessionId === sessionId)
         )
         .map((e) => ({
           command: e.anchor.trim(),

--- a/integrations/kilo/hooks/lib/derive.mjs
+++ b/integrations/kilo/hooks/lib/derive.mjs
@@ -915,6 +915,20 @@ export function derive(dir, options = {}) {
           const failed = lastFailure;
           lastFailure = null;
 
+          // BOTH SIDES MUST NAME A SINGLE COMMAND, the same rule detector 1
+          // applies. `commandBody` strips only a LEADING directory change, and
+          // `commandProgram` reads the first token, so a chained command
+          // attributes the failure to the wrong program entirely:
+          //
+          //   git fetch && npx jest tests/foo.test.mjs   -> program "git"
+          //   cat x | npx jest tests/foo.test.mjs        -> program "cat"
+          //
+          // Paired against `npm test -- tests/foo.test.mjs` those would ship
+          // "npm test succeeded where git fetch failed" and tell a later session
+          // to avoid `git`. Checked per side rather than once, because unlike
+          // detector 1 these two do NOT share a key by construction.
+          if (!hasAttemptIdentity(failed.command)) continue;
+          if (!hasAttemptIdentity(outcome.command)) continue;
           // Same program is detector 1's case, whether it pairs there or not.
           if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
           // A fix follows its failure closely. Hours apart is two unrelated

--- a/integrations/kilo/hooks/lib/derive.mjs
+++ b/integrations/kilo/hooks/lib/derive.mjs
@@ -430,10 +430,16 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * Returns null when nothing resolves, which leaves the caller's original root
  * untouched -- a wrong project is worse than the status quo.
  */
-export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+export function projectRootFromActivity(events, { resolve, cwd, sessionId = null } = {}) {
   if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
   const counts = new Map();
   for (const event of events) {
+    // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
+    // session that wrote it, so counting every event ever recorded lets a busy
+    // session from last week outvote the one now ending -- and the question
+    // being asked is "where did THIS session work", not "where is this graph
+    // busiest". Callers that pass no id keep the whole-graph count.
+    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.
@@ -454,13 +460,22 @@ export function projectRootFromActivity(events, { resolve, cwd } = {}) {
   }
   let best = null;
   let most = 0;
+  let tied = false;
   for (const [root, n] of counts) {
     if (n > most) {
       most = n;
       best = root;
+      tied = false;
+    } else if (n === most) {
+      // A Map iterates in insertion order, so a tie would otherwise be broken by
+      // whichever file the session happened to touch first -- deterministic, but
+      // arbitrary, and wrong half the time. Findings would then be stored against
+      // a project the evidence does not single out. Decline instead; the caller
+      // keeps cwdRoot, which is at least a root the user chose.
+      tied = true;
     }
   }
-  return best;
+  return tied ? null : best;
 }
 
 export function projectAnchor(projectRoot) {

--- a/integrations/kilo/hooks/lib/derive.mjs
+++ b/integrations/kilo/hooks/lib/derive.mjs
@@ -373,9 +373,45 @@ export function commandOperand(command) {
   return null;
 }
 
-/** The program a command invokes, for deciding whether two attempts differ. */
+/**
+ * A leading `VAR=value` prefix, which a shell applies to the environment of
+ * the command that follows rather than running as the command itself.
+ */
+const ENV_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+/**
+ * The program a command invokes, for deciding whether two attempts differ.
+ *
+ * ENVIRONMENT PREFIXES ARE NOT THE PROGRAM. Taking the first token verbatim
+ * reported `SP=/tmp/x` as the program for `SP=/tmp/x node run.mjs`, and that
+ * is not a cosmetic slip: measured over this machine's real history, 816 of
+ * 7,165 recorded command outcomes -- 11.4% -- named an assignment.
+ *
+ * IT FAILS IN THE DANGEROUS DIRECTION. This function exists to decide that two
+ * attempts used DIFFERENT programs, so two runs of the same tool under
+ * different variables --
+ *
+ *   SP=/a node run.mjs    (failed)
+ *   SPW=/b node run.mjs   (succeeded)
+ *
+ * -- compared as `sp=/a` against `spw=/b`, differed, and were eligible to
+ * pair. The claim that pairing produces is `node run.mjs` succeeded where
+ * `node run.mjs` failed: exactly the incoherent statement detector 1's own
+ * guard exists to refuse, arriving through the door detector 5 opened.
+ *
+ * Skipping the prefixes is what a shell does, and it cannot invent a pair --
+ * two commands that were already the same program now compare equal, which
+ * only ever removes a candidate.
+ *
+ * NO MEASURED CHANGE TODAY, stated plainly: replaying both versions over the
+ * same real history gives an identical pairing outcome (20 pairs considered,
+ * 0 firing), because every affected command is also chained and rejected
+ * earlier. This is a correctness fix against a latent false claim, not a
+ * recall improvement, and it is not offered as one.
+ */
 export function commandProgram(command) {
-  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  const tokens = commandBody(command).trim().split(/\s+/).filter(Boolean);
+  const first = tokens.find((token) => !ENV_ASSIGNMENT.test(token)) || '';
   return first.split(/[/\\]/).pop().toLowerCase();
 }
 

--- a/integrations/kilo/hooks/lib/derive.mjs
+++ b/integrations/kilo/hooks/lib/derive.mjs
@@ -53,6 +53,7 @@ import { ORIGIN_HARVESTED } from './curate.mjs';
 // from, so what this counts as a search and what the advisory treats as one
 // cannot diverge.
 import {
+  commandSegments,
   identifiersIn,
   searchPatternFromCommand,
   symbolIndex,
@@ -182,11 +183,38 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
-const hasAttemptIdentity = (command) =>
-  attemptKey(command)
+/**
+ * THE WHOLE BODY, NOT THE FIRST THREE TOKENS.
+ *
+ * This used to read the separator set off `attemptKey`, which keeps only the
+ * first three non-flag tokens -- so it caught a separator only when one landed
+ * early by luck of position. Verified against the real functions:
+ *
+ *   git fetch && npx jest tests/foo   key `git fetch &&`        -> rejected
+ *   npx jest tests/foo && node x.mjs  key `npx jest tests/foo`  -> ACCEPTED
+ *   grep -rn foo src | head -20       key `grep foo src`        -> ACCEPTED
+ *
+ * The last two are exactly the claims this guard exists to stop: the key names
+ * `npx`, so a pair would blame `npx` for a failure `node` may have caused.
+ * Every existing test placed the separator in the first three tokens, so none
+ * of them could see it.
+ *
+ * `commandSegments` is reused rather than a fresh scan because it is already
+ * the quote-aware one: splitting the raw string would cut through `grep -E
+ * "foo|bar"` and reject an ordinary alternation as a pipeline.
+ *
+ * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
+ * before this sees it -- that case is one command spelled two ways.
+ */
+const hasAttemptIdentity = (command) => {
+  const body = commandBody(command);
+  if (!body.trim()) return false;
+  if (commandSegments(body).length > 1) return false;
+  return attemptKey(command)
     .split(' ')
     .filter(Boolean)
     .every((token) => !COMMAND_SEPARATORS.has(token));
+};
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -435,11 +463,20 @@ export function projectRootFromActivity(events, { resolve, cwd, sessionId = null
   const counts = new Map();
   for (const event of events) {
     // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
-    // session that wrote it, so counting every event ever recorded lets a busy
-    // session from last week outvote the one now ending -- and the question
-    // being asked is "where did THIS session work", not "where is this graph
-    // busiest". Callers that pass no id keep the whole-graph count.
-    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
+    // session that wrote it, and the caller concatenates several graphs, so
+    // counting every event ever recorded lets a busy session from last week
+    // outvote the one now ending -- and the question being asked is "where did
+    // THIS session work", not "where is this graph busiest". Callers that pass
+    // no id keep the whole-graph count.
+    //
+    // AN EVENT THAT CANNOT NAME ITS SESSION IS EXCLUDED, not exempted. Exempting
+    // it was a deliberate concession to older records, and measurement says the
+    // concession buys nothing: across the three live stores on this machine, 2
+    // of 22,321 file/read events lack the field -- 0.01%. Set against that, an
+    // unstamped event sitting in ANOTHER project's graph would vote for that
+    // project on the strength of no evidence at all, which is precisely the
+    // failure this filter exists to prevent.
+    if (sessionId && event?.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.

--- a/integrations/kilo/hooks/lib/derive.mjs
+++ b/integrations/kilo/hooks/lib/derive.mjs
@@ -403,6 +403,66 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * against a fabricated anchor. That is the fail-open direction: no finding
  * beats a finding anchored to something that is not what the claim is about.
  */
+
+/**
+ * The project a session actually worked in, read off what it touched.
+ *
+ * WHY THE SESSION'S CWD IS THE WRONG ANSWER. `adapter.mjs` resolves the root
+ * with `projectRootFor(join(cwd, '__session__'), cwd)`, and when Claude Code is
+ * launched from a directory with no VCS marker -- a home directory, which is how
+ * this machine runs it -- that returns the synthetic fallback
+ * `~/.token-optimizer/unrooted`. It is NOT null, so every `if (projectRoot)`
+ * gate passes, and then `projectAnchor` hands back the directory itself because
+ * the fallback contains no project marker. `writeHarvested` resolves anchors
+ * through `indexFile`, `indexFile` on a directory returns null, and the finding
+ * is refused as unanchorable.
+ *
+ * That is the whole reason this machine's graph holds 2,965 symbols and ONE
+ * finding: 937 derive runs produced candidates and stored none of them, while
+ * every layer reported success.
+ *
+ * The router already solved this for capture -- "THE GRAPH IS PER PROJECT, so it
+ * is keyed on where the FILE lives, not on where the client happens to be
+ * running" -- and derivation simply never adopted it. This applies the same
+ * rule at Stop time: take the file anchors the session recorded, resolve each to
+ * its own project, and pick the one that holds the most of them.
+ *
+ * Returns null when nothing resolves, which leaves the caller's original root
+ * untouched -- a wrong project is worse than the status quo.
+ */
+export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+  if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
+  const counts = new Map();
+  for (const event of events) {
+    const anchor = event?.anchor;
+    // File surfaces only. A command anchor is the command text, and resolving
+    // `npm test -- x` as a path would invent a project out of a sentence.
+    if (!anchor || typeof anchor !== 'string') continue;
+    if (event.kind !== 'read' && !(event.kind === 'tool-outcome' && event.surface === 'file')) {
+      continue;
+    }
+    let root;
+    try {
+      root = resolve(anchor, cwd);
+    } catch {
+      continue;
+    }
+    // The fallback resolves to a path inside the optimizer's own store, which is
+    // never a project someone is working in.
+    if (!root || String(root).includes('.token-optimizer')) continue;
+    counts.set(root, (counts.get(root) || 0) + 1);
+  }
+  let best = null;
+  let most = 0;
+  for (const [root, n] of counts) {
+    if (n > most) {
+      most = n;
+      best = root;
+    }
+  }
+  return best;
+}
+
 export function projectAnchor(projectRoot) {
   if (!projectRoot) return null;
   let entries;

--- a/integrations/kilo/hooks/lib/transcript.mjs
+++ b/integrations/kilo/hooks/lib/transcript.mjs
@@ -289,6 +289,23 @@ const ANCHOR_MAX = 120;
  */
 const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
 
+/**
+ * A run the HARNESS stopped, which is not the command failing.
+ *
+ * The allowlist above admits anything shaped `Exit code N`, and a killed
+ * command reports `Exit code 143` with `Command timed out after 2m 0s` -- so
+ * it walks straight in. Nothing about it is a lesson about the command: it did
+ * not fail, it was not allowed to finish, and the same command run with a
+ * longer budget may well pass. Pairing one with a later success would claim a
+ * red-to-green transition that never happened.
+ *
+ * MEASURED, on a 237 MB transcript of ordinary feature work: of 130 admitted
+ * failures, 25 were timeouts -- 19%. At the 64 MB scan it was 11 of 23, 48%.
+ * User declines are NOT in this class and need no rule; the positive allowlist
+ * already excludes them, verified at every scan size on the same transcript.
+ */
+const HARNESS_TIMEOUT = /^\s*Command timed out after\b/m;
+
 /** Reads at most `bytes` from the END of a file, without loading the rest. */
 function readTail(path, bytes) {
   let fd;
@@ -390,6 +407,8 @@ export function failedResultsFromTranscript(transcriptPath, options = {}) {
       if (typeof block.content !== 'string') continue;
       const match = EXIT_CODE_RESULT.exec(block.content);
       if (!match) continue;
+      // The command ran, but the harness ended it. See HARNESS_TIMEOUT.
+      if (HARNESS_TIMEOUT.test(block.content)) continue;
       const command = commands.get(String(block.tool_use_id || ''));
       // No command means no claim. The result says something failed; without
       // the text of what failed there is nothing to say about it, and nothing

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -55,6 +55,7 @@ import {
   load,
   wikiDir,
   projectRootFor,
+  unrootedRoot,
 } from './wiki.mjs';
 import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
@@ -78,7 +79,7 @@ import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
-import { isFsSafePath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
   recordingNudge,
@@ -94,7 +95,7 @@ import {
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
-import { registerProject } from './projects.mjs';
+import { registerProject, registeredProjects } from './projects.mjs';
 import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
@@ -109,6 +110,62 @@ export const CLIENTS = nativeClientProfiles();
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
+
+/**
+ * How many registered project graphs a session-end sweep may open.
+ *
+ * The registry is append-only and unbounded over time -- 4,033 records on this
+ * machine -- and each graph read is a tail of up to 2 MB. Bounded to the most
+ * recently seen handful, which is the only part of the registry a single
+ * session can plausibly have written to.
+ */
+const CROSS_PROJECT_SCAN_LIMIT =
+  Number(process.env.TOKEN_OPTIMIZER_CROSS_PROJECT_SCAN) || 12;
+
+/** A project the current session cannot have touched is not worth opening. */
+const CROSS_PROJECT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The activity this session recorded, gathered from every graph that could hold
+ * it.
+ *
+ * Capture is keyed on where the FILE lives (`recordToolOutcome(wikiDir(root))`,
+ * post-tool), not on the session's cwd. So when the client is started outside a
+ * repository -- a home directory, the common case -- the session's own file
+ * activity is written into each touched project's graph, and the unrooted graph
+ * that `cwd` resolves to holds none of it. Reading only that graph is why the
+ * inference below returned null in exactly the case it exists for: measured on
+ * this machine, the unrooted store holds 12,376 file anchors and ZERO of them
+ * under a repository.
+ *
+ * The sweep is confined to that case. A cwd that IS a repository already owns
+ * the graph its own files were captured into, so it pays nothing.
+ */
+export function sessionActivity(cwdRoot) {
+  let events = [];
+  try {
+    events = readMetrics(wikiDir(cwdRoot));
+  } catch {
+    events = [];
+  }
+  if (canonicalPath(cwdRoot) !== canonicalPath(unrootedRoot())) return events;
+  const cutoff = Date.now() - CROSS_PROJECT_MAX_AGE_MS;
+  let projects = [];
+  try {
+    // Sorted most-recently-seen first by `registeredProjects`.
+    projects = registeredProjects().filter((p) => (p.lastSeenAt || 0) >= cutoff);
+  } catch {
+    return events;
+  }
+  for (const project of projects.slice(0, CROSS_PROJECT_SCAN_LIMIT)) {
+    try {
+      events = events.concat(readMetrics(project.graphDir));
+    } catch {
+      // One unreadable store must not cost the session its inference.
+    }
+  }
+  return events;
+}
 
 /**
  * The response envelopes a completed tool call can arrive in.
@@ -1223,13 +1280,21 @@ async function runHook(clientName, event, invocation) {
       // router already keys capture on where the FILE lives rather than on the
       // session's cwd; this applies that rule to derivation too, and falls back
       // to the cwd answer when the session touched nothing resolvable.
+      //
+      // The evidence is gathered by `sessionActivity`, NOT from the cwd graph
+      // alone: capture keyed on the file's project means an unrooted session's
+      // own activity was written into the graphs of the projects it touched.
+      // Reading only the unrooted graph found 12,376 file anchors and not one
+      // under a repository, so the inference was inert in precisely the case it
+      // was written for.
       const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
       let projectRoot = cwdRoot;
       try {
         projectRoot =
-          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+          projectRootFromActivity(sessionActivity(cwdRoot), {
             resolve: (anchor) => projectRootFor(anchor, cwd),
             cwd,
+            sessionId,
           }) || cwdRoot;
       } catch {
         // Inferring the project is an improvement, never a precondition.

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -46,8 +46,9 @@ import {
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
+  readMetrics,
 } from './metrics.mjs';
-import { derive } from './derive.mjs';
+import { derive, projectRootFromActivity } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -1207,7 +1208,32 @@ async function runHook(clientName, event, invocation) {
       // one figure alone cannot distinguish "nothing to derive" from "derived
       // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
-      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      // WHERE THE WORK HAPPENED, NOT WHERE THE CLIENT WAS LAUNCHED.
+      //
+      // `projectRootFor` on a cwd with no VCS marker -- a home directory, which
+      // is how this client is commonly started -- returns the synthetic fallback
+      // `~/.token-optimizer/unrooted`. That is not null, so every `if
+      // (projectRoot)` gate downstream passes, and `projectAnchor` then hands
+      // back the directory itself because the fallback holds no project marker.
+      // `writeHarvested` resolves anchors through `indexFile`, which returns
+      // null for a directory, and the finding is refused as unanchorable.
+      //
+      // Measured consequence on this machine: 937 derive runs, 8 candidates,
+      // ZERO findings written, beside 2,965 symbol nodes in the same graph. The
+      // router already keys capture on where the FILE lives rather than on the
+      // session's cwd; this applies that rule to derivation too, and falls back
+      // to the cwd answer when the session touched nothing resolvable.
+      const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      let projectRoot = cwdRoot;
+      try {
+        projectRoot =
+          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+            resolve: (anchor) => projectRootFor(anchor, cwd),
+            cwd,
+          }) || cwdRoot;
+      } catch {
+        // Inferring the project is an improvement, never a precondition.
+      }
       const dir = wikiDir(projectRoot);
       const derived = derive(dir, {
         sessionId,

--- a/integrations/opencode/hooks/lib/advise.mjs
+++ b/integrations/opencode/hooks/lib/advise.mjs
@@ -162,7 +162,7 @@ const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function commandSegments(command) {
+export function commandSegments(command) {
   const segments = [];
   let tokens = [];
   let current = '';

--- a/integrations/opencode/hooks/lib/derive.mjs
+++ b/integrations/opencode/hooks/lib/derive.mjs
@@ -205,11 +205,26 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  *
  * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
  * before this sees it -- that case is one command spelled two ways.
+ *
+ * A TRAILING SEPARATOR LEAVES NOTHING TO COUNT, which is the hole in reading
+ * the segment count alone. `commandSegments` pushes only non-empty token
+ * lists, so `npx jest tests/foo &&` is ONE segment, and `attemptKey` -- the
+ * first three non-flag tokens -- never sees the `&&` either. The command is
+ * still half of something, and `cmd &` on its own is a background job whose
+ * exit code belongs to the shell rather than to the program named. Appending a
+ * sentinel token makes the missing segment materialise, which reuses the one
+ * scanner that already understands quotes instead of adding a second,
+ * differently-wrong one: `grep -E "foo|bar" src/x.mjs` stays a single segment
+ * with the sentinel attached, exactly as it does without it.
  */
+// Not a plausible argument to anything, so it can only ever be the token this
+// function appended.
+const SEGMENT_SENTINEL = '__token_optimizer_segment_probe__';
+
 const hasAttemptIdentity = (command) => {
   const body = commandBody(command);
   if (!body.trim()) return false;
-  if (commandSegments(body).length > 1) return false;
+  if (commandSegments(`${body} ${SEGMENT_SENTINEL}`).length > 1) return false;
   return attemptKey(command)
     .split(' ')
     .filter(Boolean)
@@ -368,7 +383,13 @@ export function commandOperand(command) {
   // attempts, so including it would reproduce attemptKey's blind spot.
   for (const token of tokens.slice(1)) {
     const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
-    if (named && token.length >= 4) return token.toLowerCase();
+    // AS WRITTEN, not folded. This value is the grouping key AND the text of
+    // the stored claim, and folding it made the claim name a path that does
+    // not exist on a case-sensitive filesystem: `src/Foo.test.mjs` was
+    // recorded, and served to a later session, as `src/foo.test.mjs`. The
+    // caller folds a copy for the key instead, so matching stays
+    // case-insensitive without the claim paying for it.
+    if (named && token.length >= 4) return token;
   }
   return null;
 }
@@ -1068,15 +1089,23 @@ export function derive(dir, options = {}) {
   // repeating an invocation.
   try {
     if (projectRoot && outcomes?.length) {
+      // KEYED FOLDED, DISPLAYED AS WRITTEN. Two invocations naming the same
+      // file with different capitalisation are the same target on Windows and
+      // macOS, so the key folds; the text stored in the finding must not,
+      // because a claim naming `src/foo.test.mjs` for a file called
+      // `src/Foo.test.mjs` is a path that does not resolve on Linux -- and
+      // that text is what a later session reads. The first spelling seen wins,
+      // which is the one the failing attempt actually used.
       const byTarget = new Map();
       for (const outcome of outcomes) {
-        const target = commandOperand(outcome.command);
-        if (!target) continue;
-        if (!byTarget.has(target)) byTarget.set(target, []);
-        byTarget.get(target).push(outcome);
+        const operand = commandOperand(outcome.command);
+        if (!operand) continue;
+        const key = operand.toLowerCase();
+        if (!byTarget.has(key)) byTarget.set(key, { target: operand, run: [] });
+        byTarget.get(key).run.push(outcome);
       }
 
-      for (const [target, run] of byTarget) {
+      for (const { target, run } of byTarget.values()) {
         let lastFailure = null;
         for (const outcome of run) {
           if (outcome.failed) {

--- a/integrations/opencode/hooks/lib/derive.mjs
+++ b/integrations/opencode/hooks/lib/derive.mjs
@@ -67,7 +67,16 @@ import {
  * command. A correction is a lexical guess about what a human meant. Churn
  * describes our own reading behaviour and says nothing about the code at all.
  */
-export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+export const CONFIDENCE = {
+  command: 0.9,
+  test: 0.85,
+  // Below `command` because the inference is weaker: two commands sharing a
+  // target is good evidence of one intent, but not the same evidence as the
+  // identical invocation being retried. Labelled speculative, deliberately.
+  retarget: 0.6,
+  correction: 0.6,
+  churn: 0.4,
+};
 
 /** Claim text cap. A finding is one sentence; a paragraph is evidence. */
 const CLAIM_MAX = 300;
@@ -75,6 +84,17 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * How close a fix must follow its failure to count as the same attempt.
+ *
+ * Detector 5 pairs across DIFFERENT programs, so it cannot lean on command
+ * identity to know the two are related -- proximity is doing that work instead.
+ * Ten minutes is long enough for a real correction, including reading an error
+ * and looking something up, and short enough that two unrelated pieces of work
+ * touching one file in an afternoon are not reported as one story.
+ */
+const RETARGET_WINDOW_MS = 10 * 60 * 1000;
 
 /**
  * The anchor cap a command surface is stored under, restated here as a TEST.
@@ -287,6 +307,50 @@ export function attemptKey(command) {
     .join(' ')
     .toLowerCase();
 }
+/**
+ * The thing a command ACTS ON -- a path, a test file, a target.
+ *
+ * WHY `attemptKey` IS NOT ENOUGH, measured rather than supposed. That key is
+ * program-plus-operands, so the single most valuable lesson a session can teach
+ * cannot pair by construction:
+ *
+ *   npx jest tests/foo      -> key "npx jest tests/foo"
+ *   npm test -- tests/foo   -> key "npm test tests/foo"
+ *
+ * Different keys, no pair, no finding -- yet that is exactly the correction
+ * worth recording, because the fix was to run a DIFFERENT program against the
+ * same target. The existing detector can only catch the same command re-run and
+ * succeeding, which its own guard then discards as incoherent.
+ *
+ * The measured cost of that: across 937 real derive runs on this machine, 8
+ * candidates were produced and ZERO were stored.
+ *
+ * So this returns the shared operand -- `tests/foo` above -- which is what the
+ * two attempts genuinely have in common. Only operands that NAME something are
+ * admitted: a path separator or a file extension. A bare word like `build` is
+ * refused, because `npm run build` and `make build` sharing the token `build`
+ * is a coincidence of vocabulary, not evidence of one intent.
+ */
+export function commandOperand(command) {
+  const tokens = commandBody(command)
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'));
+  // Skipping the first token: the PROGRAM is what differs between the two
+  // attempts, so including it would reproduce attemptKey's blind spot.
+  for (const token of tokens.slice(1)) {
+    const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
+    if (named && token.length >= 4) return token.toLowerCase();
+  }
+  return null;
+}
+
+/** The program a command invokes, for deciding whether two attempts differ. */
+export function commandProgram(command) {
+  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  return first.split(/[/\\]/).pop().toLowerCase();
+}
+
 
 /** Normalised claim text, so the same lesson derived twice is one candidate. */
 const claimKey = (type, claim) =>
@@ -519,9 +583,15 @@ export function derive(dir, options = {}) {
   // a transcript failure that pairs with nothing stays unclaimed, which is also
   // what keeps a failure from ANOTHER project's directory out of this project's
   // graph -- a candidate cannot be emitted without a success recorded HERE.
+  // HOISTED so detector 5 can pair over the SAME merged list -- events plus the
+  // transcript failures folded in below. Rebuilding it there would duplicate the
+  // de-duplication logic and let the two detectors drift; leaving it block-scoped
+  // gave detector 5 a ReferenceError that its own try/catch swallowed, which is
+  // silent nothing rather than a visible failure.
+  let outcomes = [];
   try {
     if (projectRoot) {
-      const outcomes = events
+      outcomes = events
         .filter(
           (e) =>
             e &&
@@ -802,6 +872,92 @@ export function derive(dir, options = {}) {
   } catch {
     // One detector, never the session.
   }
+  // ---- 5: a DIFFERENT command against the same target succeeded -----------
+  //
+  // THE LESSON DETECTOR 1 CANNOT REACH. Its `attemptKey` is program-plus-
+  // operands, so the correction worth recording -- reaching for a different
+  // tool against the same target -- lands in two groups that never meet:
+  //
+  //   npx jest tests/foo.test.mjs     key "npx jest tests/foo.test.mjs"
+  //   npm test -- tests/foo.test.mjs  key "npm test tests/foo.test.mjs"
+  //
+  // What detector 1 CAN pair is the identical command re-run, and its own guard
+  // then correctly discards that as incoherent -- "`npm run build` works where
+  // `npm run build` failed" claims nothing. So between the key and the guard,
+  // the command family had almost no reachable evidence: measured across 937
+  // real derive runs on this machine, 8 candidates and ZERO stored findings.
+  //
+  // This pairs on the shared OPERAND instead, and only when the PROGRAM differs
+  // -- same-program pairs are detector 1's business and are left to it. The
+  // conservatism the original key was protecting is kept in three other places:
+  // the operand must NAME something (a path or an extension, never a bare word
+  // like `build`), the two attempts must be close in time, and the ceiling is
+  // 0.6 rather than 0.9 because sharing a target is weaker evidence than
+  // repeating an invocation.
+  try {
+    if (projectRoot && outcomes?.length) {
+      const byTarget = new Map();
+      for (const outcome of outcomes) {
+        const target = commandOperand(outcome.command);
+        if (!target) continue;
+        if (!byTarget.has(target)) byTarget.set(target, []);
+        byTarget.get(target).push(outcome);
+      }
+
+      for (const [target, run] of byTarget) {
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          lastFailure = null;
+
+          // Same program is detector 1's case, whether it pairs there or not.
+          if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
+          // A fix follows its failure closely. Hours apart is two unrelated
+          // pieces of work that happened to touch one file.
+          const apart = Math.abs((outcome.at || 0) - (failed.at || 0));
+          if (!apart || apart > RETARGET_WINDOW_MS) continue;
+          // Same rule as detector 1: nothing quotable, nothing claimed.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          const confidence = CONFIDENCE.retarget;
+          add({
+            type: 'command',
+            claim: redact(
+              `In this project \`${commandBody(outcome.command)}\` succeeded on ${target} where ` +
+                `\`${commandBody(failed.command)}\` had failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded against the same target \`${target}\` ` +
+                `${Math.round(apart / 1000)}s later. Different programs, one target: ordered ` +
+                'and close, but not proven causal -- an intervening edit explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: `when about to run \`${commandProgram(failed.command)}\` against ${target} in this project`,
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: [`\`${commandBody(failed.command)}\` later succeeds unchanged`],
+            trigger: triggerFor(failed.command),
+            anchors: [anchorPath],
+            derivedBy: 'retarget',
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
 
   // ---- storage, under a budget -------------------------------------------
   //

--- a/integrations/opencode/hooks/lib/derive.mjs
+++ b/integrations/opencode/hooks/lib/derive.mjs
@@ -739,6 +739,27 @@ export function derive(dir, options = {}) {
   let outcomes = [];
   try {
     if (projectRoot) {
+      // SCOPED TO THE SESSION THE CLAIM WILL NAME.
+      //
+      // Every claim these detectors build opens `observed in one session:`,
+      // and the store holds every session's outcomes -- so nothing but the
+      // ten-minute window stopped a failure from one session pairing with a
+      // success from another and asserting a provenance that never happened.
+      //
+      // NEVER OBSERVED, SAID PLAINLY. Across both live stores on this machine
+      // -- 7,173 command outcomes over 3 sessions here, 543 over 9 sessions in
+      // the unrooted one -- 5,155 and 298 adjacent in-window pairs respectively
+      // and ZERO of them crossed a session. Sessions are long and rarely
+      // interleave inside ten minutes. This is a correctness fix against a
+      // false claim, not a fix for observed damage, and it is not offered as
+      // one. Concurrent sessions do occur -- one was recorded on this machine
+      // while this was being written -- and they share the unrooted store.
+      //
+      // The merged transcript failures below are deliberately NOT filtered:
+      // `failedResultsFromTranscript` carries no sessionId, and the transcript
+      // it read is this session's, so they are already scoped by construction.
+      // Filtering them here would drop the only source of command failures
+      // that exists -- Claude Code never fires PostToolUse on a non-zero exit.
       outcomes = events
         .filter(
           (e) =>
@@ -746,7 +767,10 @@ export function derive(dir, options = {}) {
             e.kind === 'tool-outcome' &&
             e.surface === 'command' &&
             typeof e.anchor === 'string' &&
-            e.anchor.trim()
+            e.anchor.trim() &&
+            // An event predating the field still counts; a DIFFERENT session
+            // never does.
+            (!sessionId || !e.sessionId || e.sessionId === sessionId)
         )
         .map((e) => ({
           command: e.anchor.trim(),

--- a/integrations/opencode/hooks/lib/derive.mjs
+++ b/integrations/opencode/hooks/lib/derive.mjs
@@ -915,6 +915,20 @@ export function derive(dir, options = {}) {
           const failed = lastFailure;
           lastFailure = null;
 
+          // BOTH SIDES MUST NAME A SINGLE COMMAND, the same rule detector 1
+          // applies. `commandBody` strips only a LEADING directory change, and
+          // `commandProgram` reads the first token, so a chained command
+          // attributes the failure to the wrong program entirely:
+          //
+          //   git fetch && npx jest tests/foo.test.mjs   -> program "git"
+          //   cat x | npx jest tests/foo.test.mjs        -> program "cat"
+          //
+          // Paired against `npm test -- tests/foo.test.mjs` those would ship
+          // "npm test succeeded where git fetch failed" and tell a later session
+          // to avoid `git`. Checked per side rather than once, because unlike
+          // detector 1 these two do NOT share a key by construction.
+          if (!hasAttemptIdentity(failed.command)) continue;
+          if (!hasAttemptIdentity(outcome.command)) continue;
           // Same program is detector 1's case, whether it pairs there or not.
           if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
           // A fix follows its failure closely. Hours apart is two unrelated

--- a/integrations/opencode/hooks/lib/derive.mjs
+++ b/integrations/opencode/hooks/lib/derive.mjs
@@ -430,10 +430,16 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * Returns null when nothing resolves, which leaves the caller's original root
  * untouched -- a wrong project is worse than the status quo.
  */
-export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+export function projectRootFromActivity(events, { resolve, cwd, sessionId = null } = {}) {
   if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
   const counts = new Map();
   for (const event of events) {
+    // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
+    // session that wrote it, so counting every event ever recorded lets a busy
+    // session from last week outvote the one now ending -- and the question
+    // being asked is "where did THIS session work", not "where is this graph
+    // busiest". Callers that pass no id keep the whole-graph count.
+    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.
@@ -454,13 +460,22 @@ export function projectRootFromActivity(events, { resolve, cwd } = {}) {
   }
   let best = null;
   let most = 0;
+  let tied = false;
   for (const [root, n] of counts) {
     if (n > most) {
       most = n;
       best = root;
+      tied = false;
+    } else if (n === most) {
+      // A Map iterates in insertion order, so a tie would otherwise be broken by
+      // whichever file the session happened to touch first -- deterministic, but
+      // arbitrary, and wrong half the time. Findings would then be stored against
+      // a project the evidence does not single out. Decline instead; the caller
+      // keeps cwdRoot, which is at least a root the user chose.
+      tied = true;
     }
   }
-  return best;
+  return tied ? null : best;
 }
 
 export function projectAnchor(projectRoot) {

--- a/integrations/opencode/hooks/lib/derive.mjs
+++ b/integrations/opencode/hooks/lib/derive.mjs
@@ -373,9 +373,45 @@ export function commandOperand(command) {
   return null;
 }
 
-/** The program a command invokes, for deciding whether two attempts differ. */
+/**
+ * A leading `VAR=value` prefix, which a shell applies to the environment of
+ * the command that follows rather than running as the command itself.
+ */
+const ENV_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+/**
+ * The program a command invokes, for deciding whether two attempts differ.
+ *
+ * ENVIRONMENT PREFIXES ARE NOT THE PROGRAM. Taking the first token verbatim
+ * reported `SP=/tmp/x` as the program for `SP=/tmp/x node run.mjs`, and that
+ * is not a cosmetic slip: measured over this machine's real history, 816 of
+ * 7,165 recorded command outcomes -- 11.4% -- named an assignment.
+ *
+ * IT FAILS IN THE DANGEROUS DIRECTION. This function exists to decide that two
+ * attempts used DIFFERENT programs, so two runs of the same tool under
+ * different variables --
+ *
+ *   SP=/a node run.mjs    (failed)
+ *   SPW=/b node run.mjs   (succeeded)
+ *
+ * -- compared as `sp=/a` against `spw=/b`, differed, and were eligible to
+ * pair. The claim that pairing produces is `node run.mjs` succeeded where
+ * `node run.mjs` failed: exactly the incoherent statement detector 1's own
+ * guard exists to refuse, arriving through the door detector 5 opened.
+ *
+ * Skipping the prefixes is what a shell does, and it cannot invent a pair --
+ * two commands that were already the same program now compare equal, which
+ * only ever removes a candidate.
+ *
+ * NO MEASURED CHANGE TODAY, stated plainly: replaying both versions over the
+ * same real history gives an identical pairing outcome (20 pairs considered,
+ * 0 firing), because every affected command is also chained and rejected
+ * earlier. This is a correctness fix against a latent false claim, not a
+ * recall improvement, and it is not offered as one.
+ */
 export function commandProgram(command) {
-  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  const tokens = commandBody(command).trim().split(/\s+/).filter(Boolean);
+  const first = tokens.find((token) => !ENV_ASSIGNMENT.test(token)) || '';
   return first.split(/[/\\]/).pop().toLowerCase();
 }
 

--- a/integrations/opencode/hooks/lib/derive.mjs
+++ b/integrations/opencode/hooks/lib/derive.mjs
@@ -53,6 +53,7 @@ import { ORIGIN_HARVESTED } from './curate.mjs';
 // from, so what this counts as a search and what the advisory treats as one
 // cannot diverge.
 import {
+  commandSegments,
   identifiersIn,
   searchPatternFromCommand,
   symbolIndex,
@@ -182,11 +183,38 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
-const hasAttemptIdentity = (command) =>
-  attemptKey(command)
+/**
+ * THE WHOLE BODY, NOT THE FIRST THREE TOKENS.
+ *
+ * This used to read the separator set off `attemptKey`, which keeps only the
+ * first three non-flag tokens -- so it caught a separator only when one landed
+ * early by luck of position. Verified against the real functions:
+ *
+ *   git fetch && npx jest tests/foo   key `git fetch &&`        -> rejected
+ *   npx jest tests/foo && node x.mjs  key `npx jest tests/foo`  -> ACCEPTED
+ *   grep -rn foo src | head -20       key `grep foo src`        -> ACCEPTED
+ *
+ * The last two are exactly the claims this guard exists to stop: the key names
+ * `npx`, so a pair would blame `npx` for a failure `node` may have caused.
+ * Every existing test placed the separator in the first three tokens, so none
+ * of them could see it.
+ *
+ * `commandSegments` is reused rather than a fresh scan because it is already
+ * the quote-aware one: splitting the raw string would cut through `grep -E
+ * "foo|bar"` and reject an ordinary alternation as a pipeline.
+ *
+ * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
+ * before this sees it -- that case is one command spelled two ways.
+ */
+const hasAttemptIdentity = (command) => {
+  const body = commandBody(command);
+  if (!body.trim()) return false;
+  if (commandSegments(body).length > 1) return false;
+  return attemptKey(command)
     .split(' ')
     .filter(Boolean)
     .every((token) => !COMMAND_SEPARATORS.has(token));
+};
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -435,11 +463,20 @@ export function projectRootFromActivity(events, { resolve, cwd, sessionId = null
   const counts = new Map();
   for (const event of events) {
     // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
-    // session that wrote it, so counting every event ever recorded lets a busy
-    // session from last week outvote the one now ending -- and the question
-    // being asked is "where did THIS session work", not "where is this graph
-    // busiest". Callers that pass no id keep the whole-graph count.
-    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
+    // session that wrote it, and the caller concatenates several graphs, so
+    // counting every event ever recorded lets a busy session from last week
+    // outvote the one now ending -- and the question being asked is "where did
+    // THIS session work", not "where is this graph busiest". Callers that pass
+    // no id keep the whole-graph count.
+    //
+    // AN EVENT THAT CANNOT NAME ITS SESSION IS EXCLUDED, not exempted. Exempting
+    // it was a deliberate concession to older records, and measurement says the
+    // concession buys nothing: across the three live stores on this machine, 2
+    // of 22,321 file/read events lack the field -- 0.01%. Set against that, an
+    // unstamped event sitting in ANOTHER project's graph would vote for that
+    // project on the strength of no evidence at all, which is precisely the
+    // failure this filter exists to prevent.
+    if (sessionId && event?.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.

--- a/integrations/opencode/hooks/lib/derive.mjs
+++ b/integrations/opencode/hooks/lib/derive.mjs
@@ -403,6 +403,66 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * against a fabricated anchor. That is the fail-open direction: no finding
  * beats a finding anchored to something that is not what the claim is about.
  */
+
+/**
+ * The project a session actually worked in, read off what it touched.
+ *
+ * WHY THE SESSION'S CWD IS THE WRONG ANSWER. `adapter.mjs` resolves the root
+ * with `projectRootFor(join(cwd, '__session__'), cwd)`, and when Claude Code is
+ * launched from a directory with no VCS marker -- a home directory, which is how
+ * this machine runs it -- that returns the synthetic fallback
+ * `~/.token-optimizer/unrooted`. It is NOT null, so every `if (projectRoot)`
+ * gate passes, and then `projectAnchor` hands back the directory itself because
+ * the fallback contains no project marker. `writeHarvested` resolves anchors
+ * through `indexFile`, `indexFile` on a directory returns null, and the finding
+ * is refused as unanchorable.
+ *
+ * That is the whole reason this machine's graph holds 2,965 symbols and ONE
+ * finding: 937 derive runs produced candidates and stored none of them, while
+ * every layer reported success.
+ *
+ * The router already solved this for capture -- "THE GRAPH IS PER PROJECT, so it
+ * is keyed on where the FILE lives, not on where the client happens to be
+ * running" -- and derivation simply never adopted it. This applies the same
+ * rule at Stop time: take the file anchors the session recorded, resolve each to
+ * its own project, and pick the one that holds the most of them.
+ *
+ * Returns null when nothing resolves, which leaves the caller's original root
+ * untouched -- a wrong project is worse than the status quo.
+ */
+export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+  if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
+  const counts = new Map();
+  for (const event of events) {
+    const anchor = event?.anchor;
+    // File surfaces only. A command anchor is the command text, and resolving
+    // `npm test -- x` as a path would invent a project out of a sentence.
+    if (!anchor || typeof anchor !== 'string') continue;
+    if (event.kind !== 'read' && !(event.kind === 'tool-outcome' && event.surface === 'file')) {
+      continue;
+    }
+    let root;
+    try {
+      root = resolve(anchor, cwd);
+    } catch {
+      continue;
+    }
+    // The fallback resolves to a path inside the optimizer's own store, which is
+    // never a project someone is working in.
+    if (!root || String(root).includes('.token-optimizer')) continue;
+    counts.set(root, (counts.get(root) || 0) + 1);
+  }
+  let best = null;
+  let most = 0;
+  for (const [root, n] of counts) {
+    if (n > most) {
+      most = n;
+      best = root;
+    }
+  }
+  return best;
+}
+
 export function projectAnchor(projectRoot) {
   if (!projectRoot) return null;
   let entries;

--- a/integrations/opencode/hooks/lib/transcript.mjs
+++ b/integrations/opencode/hooks/lib/transcript.mjs
@@ -289,6 +289,23 @@ const ANCHOR_MAX = 120;
  */
 const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
 
+/**
+ * A run the HARNESS stopped, which is not the command failing.
+ *
+ * The allowlist above admits anything shaped `Exit code N`, and a killed
+ * command reports `Exit code 143` with `Command timed out after 2m 0s` -- so
+ * it walks straight in. Nothing about it is a lesson about the command: it did
+ * not fail, it was not allowed to finish, and the same command run with a
+ * longer budget may well pass. Pairing one with a later success would claim a
+ * red-to-green transition that never happened.
+ *
+ * MEASURED, on a 237 MB transcript of ordinary feature work: of 130 admitted
+ * failures, 25 were timeouts -- 19%. At the 64 MB scan it was 11 of 23, 48%.
+ * User declines are NOT in this class and need no rule; the positive allowlist
+ * already excludes them, verified at every scan size on the same transcript.
+ */
+const HARNESS_TIMEOUT = /^\s*Command timed out after\b/m;
+
 /** Reads at most `bytes` from the END of a file, without loading the rest. */
 function readTail(path, bytes) {
   let fd;
@@ -390,6 +407,8 @@ export function failedResultsFromTranscript(transcriptPath, options = {}) {
       if (typeof block.content !== 'string') continue;
       const match = EXIT_CODE_RESULT.exec(block.content);
       if (!match) continue;
+      // The command ran, but the harness ended it. See HARNESS_TIMEOUT.
+      if (HARNESS_TIMEOUT.test(block.content)) continue;
       const command = commands.get(String(block.tool_use_id || ''));
       // No command means no claim. The result says something failed; without
       // the text of what failed there is nothing to say about it, and nothing

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -55,6 +55,7 @@ import {
   load,
   wikiDir,
   projectRootFor,
+  unrootedRoot,
 } from './wiki.mjs';
 import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
@@ -78,7 +79,7 @@ import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
-import { isFsSafePath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
   recordingNudge,
@@ -94,7 +95,7 @@ import {
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
-import { registerProject } from './projects.mjs';
+import { registerProject, registeredProjects } from './projects.mjs';
 import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
@@ -109,6 +110,62 @@ export const CLIENTS = nativeClientProfiles();
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
+
+/**
+ * How many registered project graphs a session-end sweep may open.
+ *
+ * The registry is append-only and unbounded over time -- 4,033 records on this
+ * machine -- and each graph read is a tail of up to 2 MB. Bounded to the most
+ * recently seen handful, which is the only part of the registry a single
+ * session can plausibly have written to.
+ */
+const CROSS_PROJECT_SCAN_LIMIT =
+  Number(process.env.TOKEN_OPTIMIZER_CROSS_PROJECT_SCAN) || 12;
+
+/** A project the current session cannot have touched is not worth opening. */
+const CROSS_PROJECT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The activity this session recorded, gathered from every graph that could hold
+ * it.
+ *
+ * Capture is keyed on where the FILE lives (`recordToolOutcome(wikiDir(root))`,
+ * post-tool), not on the session's cwd. So when the client is started outside a
+ * repository -- a home directory, the common case -- the session's own file
+ * activity is written into each touched project's graph, and the unrooted graph
+ * that `cwd` resolves to holds none of it. Reading only that graph is why the
+ * inference below returned null in exactly the case it exists for: measured on
+ * this machine, the unrooted store holds 12,376 file anchors and ZERO of them
+ * under a repository.
+ *
+ * The sweep is confined to that case. A cwd that IS a repository already owns
+ * the graph its own files were captured into, so it pays nothing.
+ */
+export function sessionActivity(cwdRoot) {
+  let events = [];
+  try {
+    events = readMetrics(wikiDir(cwdRoot));
+  } catch {
+    events = [];
+  }
+  if (canonicalPath(cwdRoot) !== canonicalPath(unrootedRoot())) return events;
+  const cutoff = Date.now() - CROSS_PROJECT_MAX_AGE_MS;
+  let projects = [];
+  try {
+    // Sorted most-recently-seen first by `registeredProjects`.
+    projects = registeredProjects().filter((p) => (p.lastSeenAt || 0) >= cutoff);
+  } catch {
+    return events;
+  }
+  for (const project of projects.slice(0, CROSS_PROJECT_SCAN_LIMIT)) {
+    try {
+      events = events.concat(readMetrics(project.graphDir));
+    } catch {
+      // One unreadable store must not cost the session its inference.
+    }
+  }
+  return events;
+}
 
 /**
  * The response envelopes a completed tool call can arrive in.
@@ -1223,13 +1280,21 @@ async function runHook(clientName, event, invocation) {
       // router already keys capture on where the FILE lives rather than on the
       // session's cwd; this applies that rule to derivation too, and falls back
       // to the cwd answer when the session touched nothing resolvable.
+      //
+      // The evidence is gathered by `sessionActivity`, NOT from the cwd graph
+      // alone: capture keyed on the file's project means an unrooted session's
+      // own activity was written into the graphs of the projects it touched.
+      // Reading only the unrooted graph found 12,376 file anchors and not one
+      // under a repository, so the inference was inert in precisely the case it
+      // was written for.
       const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
       let projectRoot = cwdRoot;
       try {
         projectRoot =
-          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+          projectRootFromActivity(sessionActivity(cwdRoot), {
             resolve: (anchor) => projectRootFor(anchor, cwd),
             cwd,
+            sessionId,
           }) || cwdRoot;
       } catch {
         // Inferring the project is an improvement, never a precondition.

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -46,8 +46,9 @@ import {
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
+  readMetrics,
 } from './metrics.mjs';
-import { derive } from './derive.mjs';
+import { derive, projectRootFromActivity } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -1207,7 +1208,32 @@ async function runHook(clientName, event, invocation) {
       // one figure alone cannot distinguish "nothing to derive" from "derived
       // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
-      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      // WHERE THE WORK HAPPENED, NOT WHERE THE CLIENT WAS LAUNCHED.
+      //
+      // `projectRootFor` on a cwd with no VCS marker -- a home directory, which
+      // is how this client is commonly started -- returns the synthetic fallback
+      // `~/.token-optimizer/unrooted`. That is not null, so every `if
+      // (projectRoot)` gate downstream passes, and `projectAnchor` then hands
+      // back the directory itself because the fallback holds no project marker.
+      // `writeHarvested` resolves anchors through `indexFile`, which returns
+      // null for a directory, and the finding is refused as unanchorable.
+      //
+      // Measured consequence on this machine: 937 derive runs, 8 candidates,
+      // ZERO findings written, beside 2,965 symbol nodes in the same graph. The
+      // router already keys capture on where the FILE lives rather than on the
+      // session's cwd; this applies that rule to derivation too, and falls back
+      // to the cwd answer when the session touched nothing resolvable.
+      const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      let projectRoot = cwdRoot;
+      try {
+        projectRoot =
+          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+            resolve: (anchor) => projectRootFor(anchor, cwd),
+            cwd,
+          }) || cwdRoot;
+      } catch {
+        // Inferring the project is an improvement, never a precondition.
+      }
       const dir = wikiDir(projectRoot);
       const derived = derive(dir, {
         sessionId,

--- a/integrations/qwen/hooks/lib/advise.mjs
+++ b/integrations/qwen/hooks/lib/advise.mjs
@@ -162,7 +162,7 @@ const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function commandSegments(command) {
+export function commandSegments(command) {
   const segments = [];
   let tokens = [];
   let current = '';

--- a/integrations/qwen/hooks/lib/derive.mjs
+++ b/integrations/qwen/hooks/lib/derive.mjs
@@ -205,11 +205,26 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  *
  * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
  * before this sees it -- that case is one command spelled two ways.
+ *
+ * A TRAILING SEPARATOR LEAVES NOTHING TO COUNT, which is the hole in reading
+ * the segment count alone. `commandSegments` pushes only non-empty token
+ * lists, so `npx jest tests/foo &&` is ONE segment, and `attemptKey` -- the
+ * first three non-flag tokens -- never sees the `&&` either. The command is
+ * still half of something, and `cmd &` on its own is a background job whose
+ * exit code belongs to the shell rather than to the program named. Appending a
+ * sentinel token makes the missing segment materialise, which reuses the one
+ * scanner that already understands quotes instead of adding a second,
+ * differently-wrong one: `grep -E "foo|bar" src/x.mjs` stays a single segment
+ * with the sentinel attached, exactly as it does without it.
  */
+// Not a plausible argument to anything, so it can only ever be the token this
+// function appended.
+const SEGMENT_SENTINEL = '__token_optimizer_segment_probe__';
+
 const hasAttemptIdentity = (command) => {
   const body = commandBody(command);
   if (!body.trim()) return false;
-  if (commandSegments(body).length > 1) return false;
+  if (commandSegments(`${body} ${SEGMENT_SENTINEL}`).length > 1) return false;
   return attemptKey(command)
     .split(' ')
     .filter(Boolean)
@@ -368,7 +383,13 @@ export function commandOperand(command) {
   // attempts, so including it would reproduce attemptKey's blind spot.
   for (const token of tokens.slice(1)) {
     const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
-    if (named && token.length >= 4) return token.toLowerCase();
+    // AS WRITTEN, not folded. This value is the grouping key AND the text of
+    // the stored claim, and folding it made the claim name a path that does
+    // not exist on a case-sensitive filesystem: `src/Foo.test.mjs` was
+    // recorded, and served to a later session, as `src/foo.test.mjs`. The
+    // caller folds a copy for the key instead, so matching stays
+    // case-insensitive without the claim paying for it.
+    if (named && token.length >= 4) return token;
   }
   return null;
 }
@@ -1068,15 +1089,23 @@ export function derive(dir, options = {}) {
   // repeating an invocation.
   try {
     if (projectRoot && outcomes?.length) {
+      // KEYED FOLDED, DISPLAYED AS WRITTEN. Two invocations naming the same
+      // file with different capitalisation are the same target on Windows and
+      // macOS, so the key folds; the text stored in the finding must not,
+      // because a claim naming `src/foo.test.mjs` for a file called
+      // `src/Foo.test.mjs` is a path that does not resolve on Linux -- and
+      // that text is what a later session reads. The first spelling seen wins,
+      // which is the one the failing attempt actually used.
       const byTarget = new Map();
       for (const outcome of outcomes) {
-        const target = commandOperand(outcome.command);
-        if (!target) continue;
-        if (!byTarget.has(target)) byTarget.set(target, []);
-        byTarget.get(target).push(outcome);
+        const operand = commandOperand(outcome.command);
+        if (!operand) continue;
+        const key = operand.toLowerCase();
+        if (!byTarget.has(key)) byTarget.set(key, { target: operand, run: [] });
+        byTarget.get(key).run.push(outcome);
       }
 
-      for (const [target, run] of byTarget) {
+      for (const { target, run } of byTarget.values()) {
         let lastFailure = null;
         for (const outcome of run) {
           if (outcome.failed) {

--- a/integrations/qwen/hooks/lib/derive.mjs
+++ b/integrations/qwen/hooks/lib/derive.mjs
@@ -67,7 +67,16 @@ import {
  * command. A correction is a lexical guess about what a human meant. Churn
  * describes our own reading behaviour and says nothing about the code at all.
  */
-export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+export const CONFIDENCE = {
+  command: 0.9,
+  test: 0.85,
+  // Below `command` because the inference is weaker: two commands sharing a
+  // target is good evidence of one intent, but not the same evidence as the
+  // identical invocation being retried. Labelled speculative, deliberately.
+  retarget: 0.6,
+  correction: 0.6,
+  churn: 0.4,
+};
 
 /** Claim text cap. A finding is one sentence; a paragraph is evidence. */
 const CLAIM_MAX = 300;
@@ -75,6 +84,17 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * How close a fix must follow its failure to count as the same attempt.
+ *
+ * Detector 5 pairs across DIFFERENT programs, so it cannot lean on command
+ * identity to know the two are related -- proximity is doing that work instead.
+ * Ten minutes is long enough for a real correction, including reading an error
+ * and looking something up, and short enough that two unrelated pieces of work
+ * touching one file in an afternoon are not reported as one story.
+ */
+const RETARGET_WINDOW_MS = 10 * 60 * 1000;
 
 /**
  * The anchor cap a command surface is stored under, restated here as a TEST.
@@ -287,6 +307,50 @@ export function attemptKey(command) {
     .join(' ')
     .toLowerCase();
 }
+/**
+ * The thing a command ACTS ON -- a path, a test file, a target.
+ *
+ * WHY `attemptKey` IS NOT ENOUGH, measured rather than supposed. That key is
+ * program-plus-operands, so the single most valuable lesson a session can teach
+ * cannot pair by construction:
+ *
+ *   npx jest tests/foo      -> key "npx jest tests/foo"
+ *   npm test -- tests/foo   -> key "npm test tests/foo"
+ *
+ * Different keys, no pair, no finding -- yet that is exactly the correction
+ * worth recording, because the fix was to run a DIFFERENT program against the
+ * same target. The existing detector can only catch the same command re-run and
+ * succeeding, which its own guard then discards as incoherent.
+ *
+ * The measured cost of that: across 937 real derive runs on this machine, 8
+ * candidates were produced and ZERO were stored.
+ *
+ * So this returns the shared operand -- `tests/foo` above -- which is what the
+ * two attempts genuinely have in common. Only operands that NAME something are
+ * admitted: a path separator or a file extension. A bare word like `build` is
+ * refused, because `npm run build` and `make build` sharing the token `build`
+ * is a coincidence of vocabulary, not evidence of one intent.
+ */
+export function commandOperand(command) {
+  const tokens = commandBody(command)
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'));
+  // Skipping the first token: the PROGRAM is what differs between the two
+  // attempts, so including it would reproduce attemptKey's blind spot.
+  for (const token of tokens.slice(1)) {
+    const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
+    if (named && token.length >= 4) return token.toLowerCase();
+  }
+  return null;
+}
+
+/** The program a command invokes, for deciding whether two attempts differ. */
+export function commandProgram(command) {
+  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  return first.split(/[/\\]/).pop().toLowerCase();
+}
+
 
 /** Normalised claim text, so the same lesson derived twice is one candidate. */
 const claimKey = (type, claim) =>
@@ -519,9 +583,15 @@ export function derive(dir, options = {}) {
   // a transcript failure that pairs with nothing stays unclaimed, which is also
   // what keeps a failure from ANOTHER project's directory out of this project's
   // graph -- a candidate cannot be emitted without a success recorded HERE.
+  // HOISTED so detector 5 can pair over the SAME merged list -- events plus the
+  // transcript failures folded in below. Rebuilding it there would duplicate the
+  // de-duplication logic and let the two detectors drift; leaving it block-scoped
+  // gave detector 5 a ReferenceError that its own try/catch swallowed, which is
+  // silent nothing rather than a visible failure.
+  let outcomes = [];
   try {
     if (projectRoot) {
-      const outcomes = events
+      outcomes = events
         .filter(
           (e) =>
             e &&
@@ -802,6 +872,92 @@ export function derive(dir, options = {}) {
   } catch {
     // One detector, never the session.
   }
+  // ---- 5: a DIFFERENT command against the same target succeeded -----------
+  //
+  // THE LESSON DETECTOR 1 CANNOT REACH. Its `attemptKey` is program-plus-
+  // operands, so the correction worth recording -- reaching for a different
+  // tool against the same target -- lands in two groups that never meet:
+  //
+  //   npx jest tests/foo.test.mjs     key "npx jest tests/foo.test.mjs"
+  //   npm test -- tests/foo.test.mjs  key "npm test tests/foo.test.mjs"
+  //
+  // What detector 1 CAN pair is the identical command re-run, and its own guard
+  // then correctly discards that as incoherent -- "`npm run build` works where
+  // `npm run build` failed" claims nothing. So between the key and the guard,
+  // the command family had almost no reachable evidence: measured across 937
+  // real derive runs on this machine, 8 candidates and ZERO stored findings.
+  //
+  // This pairs on the shared OPERAND instead, and only when the PROGRAM differs
+  // -- same-program pairs are detector 1's business and are left to it. The
+  // conservatism the original key was protecting is kept in three other places:
+  // the operand must NAME something (a path or an extension, never a bare word
+  // like `build`), the two attempts must be close in time, and the ceiling is
+  // 0.6 rather than 0.9 because sharing a target is weaker evidence than
+  // repeating an invocation.
+  try {
+    if (projectRoot && outcomes?.length) {
+      const byTarget = new Map();
+      for (const outcome of outcomes) {
+        const target = commandOperand(outcome.command);
+        if (!target) continue;
+        if (!byTarget.has(target)) byTarget.set(target, []);
+        byTarget.get(target).push(outcome);
+      }
+
+      for (const [target, run] of byTarget) {
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          lastFailure = null;
+
+          // Same program is detector 1's case, whether it pairs there or not.
+          if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
+          // A fix follows its failure closely. Hours apart is two unrelated
+          // pieces of work that happened to touch one file.
+          const apart = Math.abs((outcome.at || 0) - (failed.at || 0));
+          if (!apart || apart > RETARGET_WINDOW_MS) continue;
+          // Same rule as detector 1: nothing quotable, nothing claimed.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          const confidence = CONFIDENCE.retarget;
+          add({
+            type: 'command',
+            claim: redact(
+              `In this project \`${commandBody(outcome.command)}\` succeeded on ${target} where ` +
+                `\`${commandBody(failed.command)}\` had failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded against the same target \`${target}\` ` +
+                `${Math.round(apart / 1000)}s later. Different programs, one target: ordered ` +
+                'and close, but not proven causal -- an intervening edit explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: `when about to run \`${commandProgram(failed.command)}\` against ${target} in this project`,
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: [`\`${commandBody(failed.command)}\` later succeeds unchanged`],
+            trigger: triggerFor(failed.command),
+            anchors: [anchorPath],
+            derivedBy: 'retarget',
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
 
   // ---- storage, under a budget -------------------------------------------
   //

--- a/integrations/qwen/hooks/lib/derive.mjs
+++ b/integrations/qwen/hooks/lib/derive.mjs
@@ -739,6 +739,27 @@ export function derive(dir, options = {}) {
   let outcomes = [];
   try {
     if (projectRoot) {
+      // SCOPED TO THE SESSION THE CLAIM WILL NAME.
+      //
+      // Every claim these detectors build opens `observed in one session:`,
+      // and the store holds every session's outcomes -- so nothing but the
+      // ten-minute window stopped a failure from one session pairing with a
+      // success from another and asserting a provenance that never happened.
+      //
+      // NEVER OBSERVED, SAID PLAINLY. Across both live stores on this machine
+      // -- 7,173 command outcomes over 3 sessions here, 543 over 9 sessions in
+      // the unrooted one -- 5,155 and 298 adjacent in-window pairs respectively
+      // and ZERO of them crossed a session. Sessions are long and rarely
+      // interleave inside ten minutes. This is a correctness fix against a
+      // false claim, not a fix for observed damage, and it is not offered as
+      // one. Concurrent sessions do occur -- one was recorded on this machine
+      // while this was being written -- and they share the unrooted store.
+      //
+      // The merged transcript failures below are deliberately NOT filtered:
+      // `failedResultsFromTranscript` carries no sessionId, and the transcript
+      // it read is this session's, so they are already scoped by construction.
+      // Filtering them here would drop the only source of command failures
+      // that exists -- Claude Code never fires PostToolUse on a non-zero exit.
       outcomes = events
         .filter(
           (e) =>
@@ -746,7 +767,10 @@ export function derive(dir, options = {}) {
             e.kind === 'tool-outcome' &&
             e.surface === 'command' &&
             typeof e.anchor === 'string' &&
-            e.anchor.trim()
+            e.anchor.trim() &&
+            // An event predating the field still counts; a DIFFERENT session
+            // never does.
+            (!sessionId || !e.sessionId || e.sessionId === sessionId)
         )
         .map((e) => ({
           command: e.anchor.trim(),

--- a/integrations/qwen/hooks/lib/derive.mjs
+++ b/integrations/qwen/hooks/lib/derive.mjs
@@ -915,6 +915,20 @@ export function derive(dir, options = {}) {
           const failed = lastFailure;
           lastFailure = null;
 
+          // BOTH SIDES MUST NAME A SINGLE COMMAND, the same rule detector 1
+          // applies. `commandBody` strips only a LEADING directory change, and
+          // `commandProgram` reads the first token, so a chained command
+          // attributes the failure to the wrong program entirely:
+          //
+          //   git fetch && npx jest tests/foo.test.mjs   -> program "git"
+          //   cat x | npx jest tests/foo.test.mjs        -> program "cat"
+          //
+          // Paired against `npm test -- tests/foo.test.mjs` those would ship
+          // "npm test succeeded where git fetch failed" and tell a later session
+          // to avoid `git`. Checked per side rather than once, because unlike
+          // detector 1 these two do NOT share a key by construction.
+          if (!hasAttemptIdentity(failed.command)) continue;
+          if (!hasAttemptIdentity(outcome.command)) continue;
           // Same program is detector 1's case, whether it pairs there or not.
           if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
           // A fix follows its failure closely. Hours apart is two unrelated

--- a/integrations/qwen/hooks/lib/derive.mjs
+++ b/integrations/qwen/hooks/lib/derive.mjs
@@ -430,10 +430,16 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * Returns null when nothing resolves, which leaves the caller's original root
  * untouched -- a wrong project is worse than the status quo.
  */
-export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+export function projectRootFromActivity(events, { resolve, cwd, sessionId = null } = {}) {
   if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
   const counts = new Map();
   for (const event of events) {
+    // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
+    // session that wrote it, so counting every event ever recorded lets a busy
+    // session from last week outvote the one now ending -- and the question
+    // being asked is "where did THIS session work", not "where is this graph
+    // busiest". Callers that pass no id keep the whole-graph count.
+    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.
@@ -454,13 +460,22 @@ export function projectRootFromActivity(events, { resolve, cwd } = {}) {
   }
   let best = null;
   let most = 0;
+  let tied = false;
   for (const [root, n] of counts) {
     if (n > most) {
       most = n;
       best = root;
+      tied = false;
+    } else if (n === most) {
+      // A Map iterates in insertion order, so a tie would otherwise be broken by
+      // whichever file the session happened to touch first -- deterministic, but
+      // arbitrary, and wrong half the time. Findings would then be stored against
+      // a project the evidence does not single out. Decline instead; the caller
+      // keeps cwdRoot, which is at least a root the user chose.
+      tied = true;
     }
   }
-  return best;
+  return tied ? null : best;
 }
 
 export function projectAnchor(projectRoot) {

--- a/integrations/qwen/hooks/lib/derive.mjs
+++ b/integrations/qwen/hooks/lib/derive.mjs
@@ -373,9 +373,45 @@ export function commandOperand(command) {
   return null;
 }
 
-/** The program a command invokes, for deciding whether two attempts differ. */
+/**
+ * A leading `VAR=value` prefix, which a shell applies to the environment of
+ * the command that follows rather than running as the command itself.
+ */
+const ENV_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+/**
+ * The program a command invokes, for deciding whether two attempts differ.
+ *
+ * ENVIRONMENT PREFIXES ARE NOT THE PROGRAM. Taking the first token verbatim
+ * reported `SP=/tmp/x` as the program for `SP=/tmp/x node run.mjs`, and that
+ * is not a cosmetic slip: measured over this machine's real history, 816 of
+ * 7,165 recorded command outcomes -- 11.4% -- named an assignment.
+ *
+ * IT FAILS IN THE DANGEROUS DIRECTION. This function exists to decide that two
+ * attempts used DIFFERENT programs, so two runs of the same tool under
+ * different variables --
+ *
+ *   SP=/a node run.mjs    (failed)
+ *   SPW=/b node run.mjs   (succeeded)
+ *
+ * -- compared as `sp=/a` against `spw=/b`, differed, and were eligible to
+ * pair. The claim that pairing produces is `node run.mjs` succeeded where
+ * `node run.mjs` failed: exactly the incoherent statement detector 1's own
+ * guard exists to refuse, arriving through the door detector 5 opened.
+ *
+ * Skipping the prefixes is what a shell does, and it cannot invent a pair --
+ * two commands that were already the same program now compare equal, which
+ * only ever removes a candidate.
+ *
+ * NO MEASURED CHANGE TODAY, stated plainly: replaying both versions over the
+ * same real history gives an identical pairing outcome (20 pairs considered,
+ * 0 firing), because every affected command is also chained and rejected
+ * earlier. This is a correctness fix against a latent false claim, not a
+ * recall improvement, and it is not offered as one.
+ */
 export function commandProgram(command) {
-  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  const tokens = commandBody(command).trim().split(/\s+/).filter(Boolean);
+  const first = tokens.find((token) => !ENV_ASSIGNMENT.test(token)) || '';
   return first.split(/[/\\]/).pop().toLowerCase();
 }
 

--- a/integrations/qwen/hooks/lib/derive.mjs
+++ b/integrations/qwen/hooks/lib/derive.mjs
@@ -53,6 +53,7 @@ import { ORIGIN_HARVESTED } from './curate.mjs';
 // from, so what this counts as a search and what the advisory treats as one
 // cannot diverge.
 import {
+  commandSegments,
   identifiersIn,
   searchPatternFromCommand,
   symbolIndex,
@@ -182,11 +183,38 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
-const hasAttemptIdentity = (command) =>
-  attemptKey(command)
+/**
+ * THE WHOLE BODY, NOT THE FIRST THREE TOKENS.
+ *
+ * This used to read the separator set off `attemptKey`, which keeps only the
+ * first three non-flag tokens -- so it caught a separator only when one landed
+ * early by luck of position. Verified against the real functions:
+ *
+ *   git fetch && npx jest tests/foo   key `git fetch &&`        -> rejected
+ *   npx jest tests/foo && node x.mjs  key `npx jest tests/foo`  -> ACCEPTED
+ *   grep -rn foo src | head -20       key `grep foo src`        -> ACCEPTED
+ *
+ * The last two are exactly the claims this guard exists to stop: the key names
+ * `npx`, so a pair would blame `npx` for a failure `node` may have caused.
+ * Every existing test placed the separator in the first three tokens, so none
+ * of them could see it.
+ *
+ * `commandSegments` is reused rather than a fresh scan because it is already
+ * the quote-aware one: splitting the raw string would cut through `grep -E
+ * "foo|bar"` and reject an ordinary alternation as a pipeline.
+ *
+ * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
+ * before this sees it -- that case is one command spelled two ways.
+ */
+const hasAttemptIdentity = (command) => {
+  const body = commandBody(command);
+  if (!body.trim()) return false;
+  if (commandSegments(body).length > 1) return false;
+  return attemptKey(command)
     .split(' ')
     .filter(Boolean)
     .every((token) => !COMMAND_SEPARATORS.has(token));
+};
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -435,11 +463,20 @@ export function projectRootFromActivity(events, { resolve, cwd, sessionId = null
   const counts = new Map();
   for (const event of events) {
     // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
-    // session that wrote it, so counting every event ever recorded lets a busy
-    // session from last week outvote the one now ending -- and the question
-    // being asked is "where did THIS session work", not "where is this graph
-    // busiest". Callers that pass no id keep the whole-graph count.
-    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
+    // session that wrote it, and the caller concatenates several graphs, so
+    // counting every event ever recorded lets a busy session from last week
+    // outvote the one now ending -- and the question being asked is "where did
+    // THIS session work", not "where is this graph busiest". Callers that pass
+    // no id keep the whole-graph count.
+    //
+    // AN EVENT THAT CANNOT NAME ITS SESSION IS EXCLUDED, not exempted. Exempting
+    // it was a deliberate concession to older records, and measurement says the
+    // concession buys nothing: across the three live stores on this machine, 2
+    // of 22,321 file/read events lack the field -- 0.01%. Set against that, an
+    // unstamped event sitting in ANOTHER project's graph would vote for that
+    // project on the strength of no evidence at all, which is precisely the
+    // failure this filter exists to prevent.
+    if (sessionId && event?.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.

--- a/integrations/qwen/hooks/lib/derive.mjs
+++ b/integrations/qwen/hooks/lib/derive.mjs
@@ -403,6 +403,66 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * against a fabricated anchor. That is the fail-open direction: no finding
  * beats a finding anchored to something that is not what the claim is about.
  */
+
+/**
+ * The project a session actually worked in, read off what it touched.
+ *
+ * WHY THE SESSION'S CWD IS THE WRONG ANSWER. `adapter.mjs` resolves the root
+ * with `projectRootFor(join(cwd, '__session__'), cwd)`, and when Claude Code is
+ * launched from a directory with no VCS marker -- a home directory, which is how
+ * this machine runs it -- that returns the synthetic fallback
+ * `~/.token-optimizer/unrooted`. It is NOT null, so every `if (projectRoot)`
+ * gate passes, and then `projectAnchor` hands back the directory itself because
+ * the fallback contains no project marker. `writeHarvested` resolves anchors
+ * through `indexFile`, `indexFile` on a directory returns null, and the finding
+ * is refused as unanchorable.
+ *
+ * That is the whole reason this machine's graph holds 2,965 symbols and ONE
+ * finding: 937 derive runs produced candidates and stored none of them, while
+ * every layer reported success.
+ *
+ * The router already solved this for capture -- "THE GRAPH IS PER PROJECT, so it
+ * is keyed on where the FILE lives, not on where the client happens to be
+ * running" -- and derivation simply never adopted it. This applies the same
+ * rule at Stop time: take the file anchors the session recorded, resolve each to
+ * its own project, and pick the one that holds the most of them.
+ *
+ * Returns null when nothing resolves, which leaves the caller's original root
+ * untouched -- a wrong project is worse than the status quo.
+ */
+export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+  if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
+  const counts = new Map();
+  for (const event of events) {
+    const anchor = event?.anchor;
+    // File surfaces only. A command anchor is the command text, and resolving
+    // `npm test -- x` as a path would invent a project out of a sentence.
+    if (!anchor || typeof anchor !== 'string') continue;
+    if (event.kind !== 'read' && !(event.kind === 'tool-outcome' && event.surface === 'file')) {
+      continue;
+    }
+    let root;
+    try {
+      root = resolve(anchor, cwd);
+    } catch {
+      continue;
+    }
+    // The fallback resolves to a path inside the optimizer's own store, which is
+    // never a project someone is working in.
+    if (!root || String(root).includes('.token-optimizer')) continue;
+    counts.set(root, (counts.get(root) || 0) + 1);
+  }
+  let best = null;
+  let most = 0;
+  for (const [root, n] of counts) {
+    if (n > most) {
+      most = n;
+      best = root;
+    }
+  }
+  return best;
+}
+
 export function projectAnchor(projectRoot) {
   if (!projectRoot) return null;
   let entries;

--- a/integrations/qwen/hooks/lib/transcript.mjs
+++ b/integrations/qwen/hooks/lib/transcript.mjs
@@ -289,6 +289,23 @@ const ANCHOR_MAX = 120;
  */
 const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
 
+/**
+ * A run the HARNESS stopped, which is not the command failing.
+ *
+ * The allowlist above admits anything shaped `Exit code N`, and a killed
+ * command reports `Exit code 143` with `Command timed out after 2m 0s` -- so
+ * it walks straight in. Nothing about it is a lesson about the command: it did
+ * not fail, it was not allowed to finish, and the same command run with a
+ * longer budget may well pass. Pairing one with a later success would claim a
+ * red-to-green transition that never happened.
+ *
+ * MEASURED, on a 237 MB transcript of ordinary feature work: of 130 admitted
+ * failures, 25 were timeouts -- 19%. At the 64 MB scan it was 11 of 23, 48%.
+ * User declines are NOT in this class and need no rule; the positive allowlist
+ * already excludes them, verified at every scan size on the same transcript.
+ */
+const HARNESS_TIMEOUT = /^\s*Command timed out after\b/m;
+
 /** Reads at most `bytes` from the END of a file, without loading the rest. */
 function readTail(path, bytes) {
   let fd;
@@ -390,6 +407,8 @@ export function failedResultsFromTranscript(transcriptPath, options = {}) {
       if (typeof block.content !== 'string') continue;
       const match = EXIT_CODE_RESULT.exec(block.content);
       if (!match) continue;
+      // The command ran, but the harness ended it. See HARNESS_TIMEOUT.
+      if (HARNESS_TIMEOUT.test(block.content)) continue;
       const command = commands.get(String(block.tool_use_id || ''));
       // No command means no claim. The result says something failed; without
       // the text of what failed there is nothing to say about it, and nothing

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -55,6 +55,7 @@ import {
   load,
   wikiDir,
   projectRootFor,
+  unrootedRoot,
 } from './wiki.mjs';
 import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
@@ -78,7 +79,7 @@ import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
-import { isFsSafePath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
   recordingNudge,
@@ -94,7 +95,7 @@ import {
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
-import { registerProject } from './projects.mjs';
+import { registerProject, registeredProjects } from './projects.mjs';
 import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
@@ -109,6 +110,62 @@ export const CLIENTS = nativeClientProfiles();
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
+
+/**
+ * How many registered project graphs a session-end sweep may open.
+ *
+ * The registry is append-only and unbounded over time -- 4,033 records on this
+ * machine -- and each graph read is a tail of up to 2 MB. Bounded to the most
+ * recently seen handful, which is the only part of the registry a single
+ * session can plausibly have written to.
+ */
+const CROSS_PROJECT_SCAN_LIMIT =
+  Number(process.env.TOKEN_OPTIMIZER_CROSS_PROJECT_SCAN) || 12;
+
+/** A project the current session cannot have touched is not worth opening. */
+const CROSS_PROJECT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The activity this session recorded, gathered from every graph that could hold
+ * it.
+ *
+ * Capture is keyed on where the FILE lives (`recordToolOutcome(wikiDir(root))`,
+ * post-tool), not on the session's cwd. So when the client is started outside a
+ * repository -- a home directory, the common case -- the session's own file
+ * activity is written into each touched project's graph, and the unrooted graph
+ * that `cwd` resolves to holds none of it. Reading only that graph is why the
+ * inference below returned null in exactly the case it exists for: measured on
+ * this machine, the unrooted store holds 12,376 file anchors and ZERO of them
+ * under a repository.
+ *
+ * The sweep is confined to that case. A cwd that IS a repository already owns
+ * the graph its own files were captured into, so it pays nothing.
+ */
+export function sessionActivity(cwdRoot) {
+  let events = [];
+  try {
+    events = readMetrics(wikiDir(cwdRoot));
+  } catch {
+    events = [];
+  }
+  if (canonicalPath(cwdRoot) !== canonicalPath(unrootedRoot())) return events;
+  const cutoff = Date.now() - CROSS_PROJECT_MAX_AGE_MS;
+  let projects = [];
+  try {
+    // Sorted most-recently-seen first by `registeredProjects`.
+    projects = registeredProjects().filter((p) => (p.lastSeenAt || 0) >= cutoff);
+  } catch {
+    return events;
+  }
+  for (const project of projects.slice(0, CROSS_PROJECT_SCAN_LIMIT)) {
+    try {
+      events = events.concat(readMetrics(project.graphDir));
+    } catch {
+      // One unreadable store must not cost the session its inference.
+    }
+  }
+  return events;
+}
 
 /**
  * The response envelopes a completed tool call can arrive in.
@@ -1223,13 +1280,21 @@ async function runHook(clientName, event, invocation) {
       // router already keys capture on where the FILE lives rather than on the
       // session's cwd; this applies that rule to derivation too, and falls back
       // to the cwd answer when the session touched nothing resolvable.
+      //
+      // The evidence is gathered by `sessionActivity`, NOT from the cwd graph
+      // alone: capture keyed on the file's project means an unrooted session's
+      // own activity was written into the graphs of the projects it touched.
+      // Reading only the unrooted graph found 12,376 file anchors and not one
+      // under a repository, so the inference was inert in precisely the case it
+      // was written for.
       const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
       let projectRoot = cwdRoot;
       try {
         projectRoot =
-          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+          projectRootFromActivity(sessionActivity(cwdRoot), {
             resolve: (anchor) => projectRootFor(anchor, cwd),
             cwd,
+            sessionId,
           }) || cwdRoot;
       } catch {
         // Inferring the project is an improvement, never a precondition.

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -46,8 +46,9 @@ import {
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
+  readMetrics,
 } from './metrics.mjs';
-import { derive } from './derive.mjs';
+import { derive, projectRootFromActivity } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -1207,7 +1208,32 @@ async function runHook(clientName, event, invocation) {
       // one figure alone cannot distinguish "nothing to derive" from "derived
       // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
-      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      // WHERE THE WORK HAPPENED, NOT WHERE THE CLIENT WAS LAUNCHED.
+      //
+      // `projectRootFor` on a cwd with no VCS marker -- a home directory, which
+      // is how this client is commonly started -- returns the synthetic fallback
+      // `~/.token-optimizer/unrooted`. That is not null, so every `if
+      // (projectRoot)` gate downstream passes, and `projectAnchor` then hands
+      // back the directory itself because the fallback holds no project marker.
+      // `writeHarvested` resolves anchors through `indexFile`, which returns
+      // null for a directory, and the finding is refused as unanchorable.
+      //
+      // Measured consequence on this machine: 937 derive runs, 8 candidates,
+      // ZERO findings written, beside 2,965 symbol nodes in the same graph. The
+      // router already keys capture on where the FILE lives rather than on the
+      // session's cwd; this applies that rule to derivation too, and falls back
+      // to the cwd answer when the session touched nothing resolvable.
+      const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      let projectRoot = cwdRoot;
+      try {
+        projectRoot =
+          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+            resolve: (anchor) => projectRootFor(anchor, cwd),
+            cwd,
+          }) || cwdRoot;
+      } catch {
+        // Inferring the project is an improvement, never a precondition.
+      }
       const dir = wikiDir(projectRoot);
       const derived = derive(dir, {
         sessionId,

--- a/integrations/windsurf/hooks/lib/advise.mjs
+++ b/integrations/windsurf/hooks/lib/advise.mjs
@@ -162,7 +162,7 @@ const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function commandSegments(command) {
+export function commandSegments(command) {
   const segments = [];
   let tokens = [];
   let current = '';

--- a/integrations/windsurf/hooks/lib/derive.mjs
+++ b/integrations/windsurf/hooks/lib/derive.mjs
@@ -205,11 +205,26 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  *
  * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
  * before this sees it -- that case is one command spelled two ways.
+ *
+ * A TRAILING SEPARATOR LEAVES NOTHING TO COUNT, which is the hole in reading
+ * the segment count alone. `commandSegments` pushes only non-empty token
+ * lists, so `npx jest tests/foo &&` is ONE segment, and `attemptKey` -- the
+ * first three non-flag tokens -- never sees the `&&` either. The command is
+ * still half of something, and `cmd &` on its own is a background job whose
+ * exit code belongs to the shell rather than to the program named. Appending a
+ * sentinel token makes the missing segment materialise, which reuses the one
+ * scanner that already understands quotes instead of adding a second,
+ * differently-wrong one: `grep -E "foo|bar" src/x.mjs` stays a single segment
+ * with the sentinel attached, exactly as it does without it.
  */
+// Not a plausible argument to anything, so it can only ever be the token this
+// function appended.
+const SEGMENT_SENTINEL = '__token_optimizer_segment_probe__';
+
 const hasAttemptIdentity = (command) => {
   const body = commandBody(command);
   if (!body.trim()) return false;
-  if (commandSegments(body).length > 1) return false;
+  if (commandSegments(`${body} ${SEGMENT_SENTINEL}`).length > 1) return false;
   return attemptKey(command)
     .split(' ')
     .filter(Boolean)
@@ -368,7 +383,13 @@ export function commandOperand(command) {
   // attempts, so including it would reproduce attemptKey's blind spot.
   for (const token of tokens.slice(1)) {
     const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
-    if (named && token.length >= 4) return token.toLowerCase();
+    // AS WRITTEN, not folded. This value is the grouping key AND the text of
+    // the stored claim, and folding it made the claim name a path that does
+    // not exist on a case-sensitive filesystem: `src/Foo.test.mjs` was
+    // recorded, and served to a later session, as `src/foo.test.mjs`. The
+    // caller folds a copy for the key instead, so matching stays
+    // case-insensitive without the claim paying for it.
+    if (named && token.length >= 4) return token;
   }
   return null;
 }
@@ -1068,15 +1089,23 @@ export function derive(dir, options = {}) {
   // repeating an invocation.
   try {
     if (projectRoot && outcomes?.length) {
+      // KEYED FOLDED, DISPLAYED AS WRITTEN. Two invocations naming the same
+      // file with different capitalisation are the same target on Windows and
+      // macOS, so the key folds; the text stored in the finding must not,
+      // because a claim naming `src/foo.test.mjs` for a file called
+      // `src/Foo.test.mjs` is a path that does not resolve on Linux -- and
+      // that text is what a later session reads. The first spelling seen wins,
+      // which is the one the failing attempt actually used.
       const byTarget = new Map();
       for (const outcome of outcomes) {
-        const target = commandOperand(outcome.command);
-        if (!target) continue;
-        if (!byTarget.has(target)) byTarget.set(target, []);
-        byTarget.get(target).push(outcome);
+        const operand = commandOperand(outcome.command);
+        if (!operand) continue;
+        const key = operand.toLowerCase();
+        if (!byTarget.has(key)) byTarget.set(key, { target: operand, run: [] });
+        byTarget.get(key).run.push(outcome);
       }
 
-      for (const [target, run] of byTarget) {
+      for (const { target, run } of byTarget.values()) {
         let lastFailure = null;
         for (const outcome of run) {
           if (outcome.failed) {

--- a/integrations/windsurf/hooks/lib/derive.mjs
+++ b/integrations/windsurf/hooks/lib/derive.mjs
@@ -67,7 +67,16 @@ import {
  * command. A correction is a lexical guess about what a human meant. Churn
  * describes our own reading behaviour and says nothing about the code at all.
  */
-export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+export const CONFIDENCE = {
+  command: 0.9,
+  test: 0.85,
+  // Below `command` because the inference is weaker: two commands sharing a
+  // target is good evidence of one intent, but not the same evidence as the
+  // identical invocation being retried. Labelled speculative, deliberately.
+  retarget: 0.6,
+  correction: 0.6,
+  churn: 0.4,
+};
 
 /** Claim text cap. A finding is one sentence; a paragraph is evidence. */
 const CLAIM_MAX = 300;
@@ -75,6 +84,17 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * How close a fix must follow its failure to count as the same attempt.
+ *
+ * Detector 5 pairs across DIFFERENT programs, so it cannot lean on command
+ * identity to know the two are related -- proximity is doing that work instead.
+ * Ten minutes is long enough for a real correction, including reading an error
+ * and looking something up, and short enough that two unrelated pieces of work
+ * touching one file in an afternoon are not reported as one story.
+ */
+const RETARGET_WINDOW_MS = 10 * 60 * 1000;
 
 /**
  * The anchor cap a command surface is stored under, restated here as a TEST.
@@ -287,6 +307,50 @@ export function attemptKey(command) {
     .join(' ')
     .toLowerCase();
 }
+/**
+ * The thing a command ACTS ON -- a path, a test file, a target.
+ *
+ * WHY `attemptKey` IS NOT ENOUGH, measured rather than supposed. That key is
+ * program-plus-operands, so the single most valuable lesson a session can teach
+ * cannot pair by construction:
+ *
+ *   npx jest tests/foo      -> key "npx jest tests/foo"
+ *   npm test -- tests/foo   -> key "npm test tests/foo"
+ *
+ * Different keys, no pair, no finding -- yet that is exactly the correction
+ * worth recording, because the fix was to run a DIFFERENT program against the
+ * same target. The existing detector can only catch the same command re-run and
+ * succeeding, which its own guard then discards as incoherent.
+ *
+ * The measured cost of that: across 937 real derive runs on this machine, 8
+ * candidates were produced and ZERO were stored.
+ *
+ * So this returns the shared operand -- `tests/foo` above -- which is what the
+ * two attempts genuinely have in common. Only operands that NAME something are
+ * admitted: a path separator or a file extension. A bare word like `build` is
+ * refused, because `npm run build` and `make build` sharing the token `build`
+ * is a coincidence of vocabulary, not evidence of one intent.
+ */
+export function commandOperand(command) {
+  const tokens = commandBody(command)
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'));
+  // Skipping the first token: the PROGRAM is what differs between the two
+  // attempts, so including it would reproduce attemptKey's blind spot.
+  for (const token of tokens.slice(1)) {
+    const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
+    if (named && token.length >= 4) return token.toLowerCase();
+  }
+  return null;
+}
+
+/** The program a command invokes, for deciding whether two attempts differ. */
+export function commandProgram(command) {
+  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  return first.split(/[/\\]/).pop().toLowerCase();
+}
+
 
 /** Normalised claim text, so the same lesson derived twice is one candidate. */
 const claimKey = (type, claim) =>
@@ -519,9 +583,15 @@ export function derive(dir, options = {}) {
   // a transcript failure that pairs with nothing stays unclaimed, which is also
   // what keeps a failure from ANOTHER project's directory out of this project's
   // graph -- a candidate cannot be emitted without a success recorded HERE.
+  // HOISTED so detector 5 can pair over the SAME merged list -- events plus the
+  // transcript failures folded in below. Rebuilding it there would duplicate the
+  // de-duplication logic and let the two detectors drift; leaving it block-scoped
+  // gave detector 5 a ReferenceError that its own try/catch swallowed, which is
+  // silent nothing rather than a visible failure.
+  let outcomes = [];
   try {
     if (projectRoot) {
-      const outcomes = events
+      outcomes = events
         .filter(
           (e) =>
             e &&
@@ -802,6 +872,92 @@ export function derive(dir, options = {}) {
   } catch {
     // One detector, never the session.
   }
+  // ---- 5: a DIFFERENT command against the same target succeeded -----------
+  //
+  // THE LESSON DETECTOR 1 CANNOT REACH. Its `attemptKey` is program-plus-
+  // operands, so the correction worth recording -- reaching for a different
+  // tool against the same target -- lands in two groups that never meet:
+  //
+  //   npx jest tests/foo.test.mjs     key "npx jest tests/foo.test.mjs"
+  //   npm test -- tests/foo.test.mjs  key "npm test tests/foo.test.mjs"
+  //
+  // What detector 1 CAN pair is the identical command re-run, and its own guard
+  // then correctly discards that as incoherent -- "`npm run build` works where
+  // `npm run build` failed" claims nothing. So between the key and the guard,
+  // the command family had almost no reachable evidence: measured across 937
+  // real derive runs on this machine, 8 candidates and ZERO stored findings.
+  //
+  // This pairs on the shared OPERAND instead, and only when the PROGRAM differs
+  // -- same-program pairs are detector 1's business and are left to it. The
+  // conservatism the original key was protecting is kept in three other places:
+  // the operand must NAME something (a path or an extension, never a bare word
+  // like `build`), the two attempts must be close in time, and the ceiling is
+  // 0.6 rather than 0.9 because sharing a target is weaker evidence than
+  // repeating an invocation.
+  try {
+    if (projectRoot && outcomes?.length) {
+      const byTarget = new Map();
+      for (const outcome of outcomes) {
+        const target = commandOperand(outcome.command);
+        if (!target) continue;
+        if (!byTarget.has(target)) byTarget.set(target, []);
+        byTarget.get(target).push(outcome);
+      }
+
+      for (const [target, run] of byTarget) {
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          lastFailure = null;
+
+          // Same program is detector 1's case, whether it pairs there or not.
+          if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
+          // A fix follows its failure closely. Hours apart is two unrelated
+          // pieces of work that happened to touch one file.
+          const apart = Math.abs((outcome.at || 0) - (failed.at || 0));
+          if (!apart || apart > RETARGET_WINDOW_MS) continue;
+          // Same rule as detector 1: nothing quotable, nothing claimed.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          const confidence = CONFIDENCE.retarget;
+          add({
+            type: 'command',
+            claim: redact(
+              `In this project \`${commandBody(outcome.command)}\` succeeded on ${target} where ` +
+                `\`${commandBody(failed.command)}\` had failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded against the same target \`${target}\` ` +
+                `${Math.round(apart / 1000)}s later. Different programs, one target: ordered ` +
+                'and close, but not proven causal -- an intervening edit explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: `when about to run \`${commandProgram(failed.command)}\` against ${target} in this project`,
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: [`\`${commandBody(failed.command)}\` later succeeds unchanged`],
+            trigger: triggerFor(failed.command),
+            anchors: [anchorPath],
+            derivedBy: 'retarget',
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
 
   // ---- storage, under a budget -------------------------------------------
   //

--- a/integrations/windsurf/hooks/lib/derive.mjs
+++ b/integrations/windsurf/hooks/lib/derive.mjs
@@ -739,6 +739,27 @@ export function derive(dir, options = {}) {
   let outcomes = [];
   try {
     if (projectRoot) {
+      // SCOPED TO THE SESSION THE CLAIM WILL NAME.
+      //
+      // Every claim these detectors build opens `observed in one session:`,
+      // and the store holds every session's outcomes -- so nothing but the
+      // ten-minute window stopped a failure from one session pairing with a
+      // success from another and asserting a provenance that never happened.
+      //
+      // NEVER OBSERVED, SAID PLAINLY. Across both live stores on this machine
+      // -- 7,173 command outcomes over 3 sessions here, 543 over 9 sessions in
+      // the unrooted one -- 5,155 and 298 adjacent in-window pairs respectively
+      // and ZERO of them crossed a session. Sessions are long and rarely
+      // interleave inside ten minutes. This is a correctness fix against a
+      // false claim, not a fix for observed damage, and it is not offered as
+      // one. Concurrent sessions do occur -- one was recorded on this machine
+      // while this was being written -- and they share the unrooted store.
+      //
+      // The merged transcript failures below are deliberately NOT filtered:
+      // `failedResultsFromTranscript` carries no sessionId, and the transcript
+      // it read is this session's, so they are already scoped by construction.
+      // Filtering them here would drop the only source of command failures
+      // that exists -- Claude Code never fires PostToolUse on a non-zero exit.
       outcomes = events
         .filter(
           (e) =>
@@ -746,7 +767,10 @@ export function derive(dir, options = {}) {
             e.kind === 'tool-outcome' &&
             e.surface === 'command' &&
             typeof e.anchor === 'string' &&
-            e.anchor.trim()
+            e.anchor.trim() &&
+            // An event predating the field still counts; a DIFFERENT session
+            // never does.
+            (!sessionId || !e.sessionId || e.sessionId === sessionId)
         )
         .map((e) => ({
           command: e.anchor.trim(),

--- a/integrations/windsurf/hooks/lib/derive.mjs
+++ b/integrations/windsurf/hooks/lib/derive.mjs
@@ -915,6 +915,20 @@ export function derive(dir, options = {}) {
           const failed = lastFailure;
           lastFailure = null;
 
+          // BOTH SIDES MUST NAME A SINGLE COMMAND, the same rule detector 1
+          // applies. `commandBody` strips only a LEADING directory change, and
+          // `commandProgram` reads the first token, so a chained command
+          // attributes the failure to the wrong program entirely:
+          //
+          //   git fetch && npx jest tests/foo.test.mjs   -> program "git"
+          //   cat x | npx jest tests/foo.test.mjs        -> program "cat"
+          //
+          // Paired against `npm test -- tests/foo.test.mjs` those would ship
+          // "npm test succeeded where git fetch failed" and tell a later session
+          // to avoid `git`. Checked per side rather than once, because unlike
+          // detector 1 these two do NOT share a key by construction.
+          if (!hasAttemptIdentity(failed.command)) continue;
+          if (!hasAttemptIdentity(outcome.command)) continue;
           // Same program is detector 1's case, whether it pairs there or not.
           if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
           // A fix follows its failure closely. Hours apart is two unrelated

--- a/integrations/windsurf/hooks/lib/derive.mjs
+++ b/integrations/windsurf/hooks/lib/derive.mjs
@@ -430,10 +430,16 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * Returns null when nothing resolves, which leaves the caller's original root
  * untouched -- a wrong project is worse than the status quo.
  */
-export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+export function projectRootFromActivity(events, { resolve, cwd, sessionId = null } = {}) {
   if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
   const counts = new Map();
   for (const event of events) {
+    // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
+    // session that wrote it, so counting every event ever recorded lets a busy
+    // session from last week outvote the one now ending -- and the question
+    // being asked is "where did THIS session work", not "where is this graph
+    // busiest". Callers that pass no id keep the whole-graph count.
+    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.
@@ -454,13 +460,22 @@ export function projectRootFromActivity(events, { resolve, cwd } = {}) {
   }
   let best = null;
   let most = 0;
+  let tied = false;
   for (const [root, n] of counts) {
     if (n > most) {
       most = n;
       best = root;
+      tied = false;
+    } else if (n === most) {
+      // A Map iterates in insertion order, so a tie would otherwise be broken by
+      // whichever file the session happened to touch first -- deterministic, but
+      // arbitrary, and wrong half the time. Findings would then be stored against
+      // a project the evidence does not single out. Decline instead; the caller
+      // keeps cwdRoot, which is at least a root the user chose.
+      tied = true;
     }
   }
-  return best;
+  return tied ? null : best;
 }
 
 export function projectAnchor(projectRoot) {

--- a/integrations/windsurf/hooks/lib/derive.mjs
+++ b/integrations/windsurf/hooks/lib/derive.mjs
@@ -373,9 +373,45 @@ export function commandOperand(command) {
   return null;
 }
 
-/** The program a command invokes, for deciding whether two attempts differ. */
+/**
+ * A leading `VAR=value` prefix, which a shell applies to the environment of
+ * the command that follows rather than running as the command itself.
+ */
+const ENV_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+/**
+ * The program a command invokes, for deciding whether two attempts differ.
+ *
+ * ENVIRONMENT PREFIXES ARE NOT THE PROGRAM. Taking the first token verbatim
+ * reported `SP=/tmp/x` as the program for `SP=/tmp/x node run.mjs`, and that
+ * is not a cosmetic slip: measured over this machine's real history, 816 of
+ * 7,165 recorded command outcomes -- 11.4% -- named an assignment.
+ *
+ * IT FAILS IN THE DANGEROUS DIRECTION. This function exists to decide that two
+ * attempts used DIFFERENT programs, so two runs of the same tool under
+ * different variables --
+ *
+ *   SP=/a node run.mjs    (failed)
+ *   SPW=/b node run.mjs   (succeeded)
+ *
+ * -- compared as `sp=/a` against `spw=/b`, differed, and were eligible to
+ * pair. The claim that pairing produces is `node run.mjs` succeeded where
+ * `node run.mjs` failed: exactly the incoherent statement detector 1's own
+ * guard exists to refuse, arriving through the door detector 5 opened.
+ *
+ * Skipping the prefixes is what a shell does, and it cannot invent a pair --
+ * two commands that were already the same program now compare equal, which
+ * only ever removes a candidate.
+ *
+ * NO MEASURED CHANGE TODAY, stated plainly: replaying both versions over the
+ * same real history gives an identical pairing outcome (20 pairs considered,
+ * 0 firing), because every affected command is also chained and rejected
+ * earlier. This is a correctness fix against a latent false claim, not a
+ * recall improvement, and it is not offered as one.
+ */
 export function commandProgram(command) {
-  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  const tokens = commandBody(command).trim().split(/\s+/).filter(Boolean);
+  const first = tokens.find((token) => !ENV_ASSIGNMENT.test(token)) || '';
   return first.split(/[/\\]/).pop().toLowerCase();
 }
 

--- a/integrations/windsurf/hooks/lib/derive.mjs
+++ b/integrations/windsurf/hooks/lib/derive.mjs
@@ -53,6 +53,7 @@ import { ORIGIN_HARVESTED } from './curate.mjs';
 // from, so what this counts as a search and what the advisory treats as one
 // cannot diverge.
 import {
+  commandSegments,
   identifiersIn,
   searchPatternFromCommand,
   symbolIndex,
@@ -182,11 +183,38 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
-const hasAttemptIdentity = (command) =>
-  attemptKey(command)
+/**
+ * THE WHOLE BODY, NOT THE FIRST THREE TOKENS.
+ *
+ * This used to read the separator set off `attemptKey`, which keeps only the
+ * first three non-flag tokens -- so it caught a separator only when one landed
+ * early by luck of position. Verified against the real functions:
+ *
+ *   git fetch && npx jest tests/foo   key `git fetch &&`        -> rejected
+ *   npx jest tests/foo && node x.mjs  key `npx jest tests/foo`  -> ACCEPTED
+ *   grep -rn foo src | head -20       key `grep foo src`        -> ACCEPTED
+ *
+ * The last two are exactly the claims this guard exists to stop: the key names
+ * `npx`, so a pair would blame `npx` for a failure `node` may have caused.
+ * Every existing test placed the separator in the first three tokens, so none
+ * of them could see it.
+ *
+ * `commandSegments` is reused rather than a fresh scan because it is already
+ * the quote-aware one: splitting the raw string would cut through `grep -E
+ * "foo|bar"` and reject an ordinary alternation as a pipeline.
+ *
+ * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
+ * before this sees it -- that case is one command spelled two ways.
+ */
+const hasAttemptIdentity = (command) => {
+  const body = commandBody(command);
+  if (!body.trim()) return false;
+  if (commandSegments(body).length > 1) return false;
+  return attemptKey(command)
     .split(' ')
     .filter(Boolean)
     .every((token) => !COMMAND_SEPARATORS.has(token));
+};
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -435,11 +463,20 @@ export function projectRootFromActivity(events, { resolve, cwd, sessionId = null
   const counts = new Map();
   for (const event of events) {
     // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
-    // session that wrote it, so counting every event ever recorded lets a busy
-    // session from last week outvote the one now ending -- and the question
-    // being asked is "where did THIS session work", not "where is this graph
-    // busiest". Callers that pass no id keep the whole-graph count.
-    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
+    // session that wrote it, and the caller concatenates several graphs, so
+    // counting every event ever recorded lets a busy session from last week
+    // outvote the one now ending -- and the question being asked is "where did
+    // THIS session work", not "where is this graph busiest". Callers that pass
+    // no id keep the whole-graph count.
+    //
+    // AN EVENT THAT CANNOT NAME ITS SESSION IS EXCLUDED, not exempted. Exempting
+    // it was a deliberate concession to older records, and measurement says the
+    // concession buys nothing: across the three live stores on this machine, 2
+    // of 22,321 file/read events lack the field -- 0.01%. Set against that, an
+    // unstamped event sitting in ANOTHER project's graph would vote for that
+    // project on the strength of no evidence at all, which is precisely the
+    // failure this filter exists to prevent.
+    if (sessionId && event?.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.

--- a/integrations/windsurf/hooks/lib/derive.mjs
+++ b/integrations/windsurf/hooks/lib/derive.mjs
@@ -403,6 +403,66 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * against a fabricated anchor. That is the fail-open direction: no finding
  * beats a finding anchored to something that is not what the claim is about.
  */
+
+/**
+ * The project a session actually worked in, read off what it touched.
+ *
+ * WHY THE SESSION'S CWD IS THE WRONG ANSWER. `adapter.mjs` resolves the root
+ * with `projectRootFor(join(cwd, '__session__'), cwd)`, and when Claude Code is
+ * launched from a directory with no VCS marker -- a home directory, which is how
+ * this machine runs it -- that returns the synthetic fallback
+ * `~/.token-optimizer/unrooted`. It is NOT null, so every `if (projectRoot)`
+ * gate passes, and then `projectAnchor` hands back the directory itself because
+ * the fallback contains no project marker. `writeHarvested` resolves anchors
+ * through `indexFile`, `indexFile` on a directory returns null, and the finding
+ * is refused as unanchorable.
+ *
+ * That is the whole reason this machine's graph holds 2,965 symbols and ONE
+ * finding: 937 derive runs produced candidates and stored none of them, while
+ * every layer reported success.
+ *
+ * The router already solved this for capture -- "THE GRAPH IS PER PROJECT, so it
+ * is keyed on where the FILE lives, not on where the client happens to be
+ * running" -- and derivation simply never adopted it. This applies the same
+ * rule at Stop time: take the file anchors the session recorded, resolve each to
+ * its own project, and pick the one that holds the most of them.
+ *
+ * Returns null when nothing resolves, which leaves the caller's original root
+ * untouched -- a wrong project is worse than the status quo.
+ */
+export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+  if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
+  const counts = new Map();
+  for (const event of events) {
+    const anchor = event?.anchor;
+    // File surfaces only. A command anchor is the command text, and resolving
+    // `npm test -- x` as a path would invent a project out of a sentence.
+    if (!anchor || typeof anchor !== 'string') continue;
+    if (event.kind !== 'read' && !(event.kind === 'tool-outcome' && event.surface === 'file')) {
+      continue;
+    }
+    let root;
+    try {
+      root = resolve(anchor, cwd);
+    } catch {
+      continue;
+    }
+    // The fallback resolves to a path inside the optimizer's own store, which is
+    // never a project someone is working in.
+    if (!root || String(root).includes('.token-optimizer')) continue;
+    counts.set(root, (counts.get(root) || 0) + 1);
+  }
+  let best = null;
+  let most = 0;
+  for (const [root, n] of counts) {
+    if (n > most) {
+      most = n;
+      best = root;
+    }
+  }
+  return best;
+}
+
 export function projectAnchor(projectRoot) {
   if (!projectRoot) return null;
   let entries;

--- a/integrations/windsurf/hooks/lib/transcript.mjs
+++ b/integrations/windsurf/hooks/lib/transcript.mjs
@@ -289,6 +289,23 @@ const ANCHOR_MAX = 120;
  */
 const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
 
+/**
+ * A run the HARNESS stopped, which is not the command failing.
+ *
+ * The allowlist above admits anything shaped `Exit code N`, and a killed
+ * command reports `Exit code 143` with `Command timed out after 2m 0s` -- so
+ * it walks straight in. Nothing about it is a lesson about the command: it did
+ * not fail, it was not allowed to finish, and the same command run with a
+ * longer budget may well pass. Pairing one with a later success would claim a
+ * red-to-green transition that never happened.
+ *
+ * MEASURED, on a 237 MB transcript of ordinary feature work: of 130 admitted
+ * failures, 25 were timeouts -- 19%. At the 64 MB scan it was 11 of 23, 48%.
+ * User declines are NOT in this class and need no rule; the positive allowlist
+ * already excludes them, verified at every scan size on the same transcript.
+ */
+const HARNESS_TIMEOUT = /^\s*Command timed out after\b/m;
+
 /** Reads at most `bytes` from the END of a file, without loading the rest. */
 function readTail(path, bytes) {
   let fd;
@@ -390,6 +407,8 @@ export function failedResultsFromTranscript(transcriptPath, options = {}) {
       if (typeof block.content !== 'string') continue;
       const match = EXIT_CODE_RESULT.exec(block.content);
       if (!match) continue;
+      // The command ran, but the harness ended it. See HARNESS_TIMEOUT.
+      if (HARNESS_TIMEOUT.test(block.content)) continue;
       const command = commands.get(String(block.tool_use_id || ''));
       // No command means no claim. The result says something failed; without
       // the text of what failed there is nothing to say about it, and nothing

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -55,6 +55,7 @@ import {
   load,
   wikiDir,
   projectRootFor,
+  unrootedRoot,
 } from './wiki.mjs';
 import { join, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
@@ -78,7 +79,7 @@ import { recordAuthoredContent } from './authored.mjs';
 import { observedWrites, queueInvalidation } from './pending.mjs';
 import { archive, isArchived } from './transcript.mjs';
 import { harvestMode } from './harvest.mjs';
-import { isFsSafePath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 import {
   isSubstantive,
   recordingNudge,
@@ -94,7 +95,7 @@ import {
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
-import { registerProject } from './projects.mjs';
+import { registerProject, registeredProjects } from './projects.mjs';
 import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
@@ -109,6 +110,62 @@ export const CLIENTS = nativeClientProfiles();
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
+
+/**
+ * How many registered project graphs a session-end sweep may open.
+ *
+ * The registry is append-only and unbounded over time -- 4,033 records on this
+ * machine -- and each graph read is a tail of up to 2 MB. Bounded to the most
+ * recently seen handful, which is the only part of the registry a single
+ * session can plausibly have written to.
+ */
+const CROSS_PROJECT_SCAN_LIMIT =
+  Number(process.env.TOKEN_OPTIMIZER_CROSS_PROJECT_SCAN) || 12;
+
+/** A project the current session cannot have touched is not worth opening. */
+const CROSS_PROJECT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The activity this session recorded, gathered from every graph that could hold
+ * it.
+ *
+ * Capture is keyed on where the FILE lives (`recordToolOutcome(wikiDir(root))`,
+ * post-tool), not on the session's cwd. So when the client is started outside a
+ * repository -- a home directory, the common case -- the session's own file
+ * activity is written into each touched project's graph, and the unrooted graph
+ * that `cwd` resolves to holds none of it. Reading only that graph is why the
+ * inference below returned null in exactly the case it exists for: measured on
+ * this machine, the unrooted store holds 12,376 file anchors and ZERO of them
+ * under a repository.
+ *
+ * The sweep is confined to that case. A cwd that IS a repository already owns
+ * the graph its own files were captured into, so it pays nothing.
+ */
+export function sessionActivity(cwdRoot) {
+  let events = [];
+  try {
+    events = readMetrics(wikiDir(cwdRoot));
+  } catch {
+    events = [];
+  }
+  if (canonicalPath(cwdRoot) !== canonicalPath(unrootedRoot())) return events;
+  const cutoff = Date.now() - CROSS_PROJECT_MAX_AGE_MS;
+  let projects = [];
+  try {
+    // Sorted most-recently-seen first by `registeredProjects`.
+    projects = registeredProjects().filter((p) => (p.lastSeenAt || 0) >= cutoff);
+  } catch {
+    return events;
+  }
+  for (const project of projects.slice(0, CROSS_PROJECT_SCAN_LIMIT)) {
+    try {
+      events = events.concat(readMetrics(project.graphDir));
+    } catch {
+      // One unreadable store must not cost the session its inference.
+    }
+  }
+  return events;
+}
 
 /**
  * The response envelopes a completed tool call can arrive in.
@@ -1223,13 +1280,21 @@ async function runHook(clientName, event, invocation) {
       // router already keys capture on where the FILE lives rather than on the
       // session's cwd; this applies that rule to derivation too, and falls back
       // to the cwd answer when the session touched nothing resolvable.
+      //
+      // The evidence is gathered by `sessionActivity`, NOT from the cwd graph
+      // alone: capture keyed on the file's project means an unrooted session's
+      // own activity was written into the graphs of the projects it touched.
+      // Reading only the unrooted graph found 12,376 file anchors and not one
+      // under a repository, so the inference was inert in precisely the case it
+      // was written for.
       const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
       let projectRoot = cwdRoot;
       try {
         projectRoot =
-          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+          projectRootFromActivity(sessionActivity(cwdRoot), {
             resolve: (anchor) => projectRootFor(anchor, cwd),
             cwd,
+            sessionId,
           }) || cwdRoot;
       } catch {
         // Inferring the project is an improvement, never a precondition.

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -46,8 +46,9 @@ import {
   fingerprint,
   recordToolOutcome,
   recordEpisodeOutcome,
+  readMetrics,
 } from './metrics.mjs';
-import { derive } from './derive.mjs';
+import { derive, projectRootFromActivity } from './derive.mjs';
 import {
   contentHash,
   harvest,
@@ -1207,7 +1208,32 @@ async function runHook(clientName, event, invocation) {
       // one figure alone cannot distinguish "nothing to derive" from "derived
       // plenty and stored none of it".
       const cwd = raw.cwd || raw.working_directory || process.cwd();
-      const projectRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      // WHERE THE WORK HAPPENED, NOT WHERE THE CLIENT WAS LAUNCHED.
+      //
+      // `projectRootFor` on a cwd with no VCS marker -- a home directory, which
+      // is how this client is commonly started -- returns the synthetic fallback
+      // `~/.token-optimizer/unrooted`. That is not null, so every `if
+      // (projectRoot)` gate downstream passes, and `projectAnchor` then hands
+      // back the directory itself because the fallback holds no project marker.
+      // `writeHarvested` resolves anchors through `indexFile`, which returns
+      // null for a directory, and the finding is refused as unanchorable.
+      //
+      // Measured consequence on this machine: 937 derive runs, 8 candidates,
+      // ZERO findings written, beside 2,965 symbol nodes in the same graph. The
+      // router already keys capture on where the FILE lives rather than on the
+      // session's cwd; this applies that rule to derivation too, and falls back
+      // to the cwd answer when the session touched nothing resolvable.
+      const cwdRoot = projectRootFor(join(cwd, '__session__'), cwd);
+      let projectRoot = cwdRoot;
+      try {
+        projectRoot =
+          projectRootFromActivity(readMetrics(wikiDir(cwdRoot)), {
+            resolve: (anchor) => projectRootFor(anchor, cwd),
+            cwd,
+          }) || cwdRoot;
+      } catch {
+        // Inferring the project is an improvement, never a precondition.
+      }
       const dir = wikiDir(projectRoot);
       const derived = derive(dir, {
         sessionId,

--- a/plugin/hooks/lib/advise.mjs
+++ b/plugin/hooks/lib/advise.mjs
@@ -162,7 +162,7 @@ const COLOR_TAKES_SEPARATE_VALUE = new Set(['rg']);
  * class this repo keeps a linearity gate for; a single forward pass cannot
  * backtrack at all.
  */
-function commandSegments(command) {
+export function commandSegments(command) {
   const segments = [];
   let tokens = [];
   let current = '';

--- a/plugin/hooks/lib/derive.mjs
+++ b/plugin/hooks/lib/derive.mjs
@@ -205,11 +205,26 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  *
  * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
  * before this sees it -- that case is one command spelled two ways.
+ *
+ * A TRAILING SEPARATOR LEAVES NOTHING TO COUNT, which is the hole in reading
+ * the segment count alone. `commandSegments` pushes only non-empty token
+ * lists, so `npx jest tests/foo &&` is ONE segment, and `attemptKey` -- the
+ * first three non-flag tokens -- never sees the `&&` either. The command is
+ * still half of something, and `cmd &` on its own is a background job whose
+ * exit code belongs to the shell rather than to the program named. Appending a
+ * sentinel token makes the missing segment materialise, which reuses the one
+ * scanner that already understands quotes instead of adding a second,
+ * differently-wrong one: `grep -E "foo|bar" src/x.mjs` stays a single segment
+ * with the sentinel attached, exactly as it does without it.
  */
+// Not a plausible argument to anything, so it can only ever be the token this
+// function appended.
+const SEGMENT_SENTINEL = '__token_optimizer_segment_probe__';
+
 const hasAttemptIdentity = (command) => {
   const body = commandBody(command);
   if (!body.trim()) return false;
-  if (commandSegments(body).length > 1) return false;
+  if (commandSegments(`${body} ${SEGMENT_SENTINEL}`).length > 1) return false;
   return attemptKey(command)
     .split(' ')
     .filter(Boolean)
@@ -368,7 +383,13 @@ export function commandOperand(command) {
   // attempts, so including it would reproduce attemptKey's blind spot.
   for (const token of tokens.slice(1)) {
     const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
-    if (named && token.length >= 4) return token.toLowerCase();
+    // AS WRITTEN, not folded. This value is the grouping key AND the text of
+    // the stored claim, and folding it made the claim name a path that does
+    // not exist on a case-sensitive filesystem: `src/Foo.test.mjs` was
+    // recorded, and served to a later session, as `src/foo.test.mjs`. The
+    // caller folds a copy for the key instead, so matching stays
+    // case-insensitive without the claim paying for it.
+    if (named && token.length >= 4) return token;
   }
   return null;
 }
@@ -1068,15 +1089,23 @@ export function derive(dir, options = {}) {
   // repeating an invocation.
   try {
     if (projectRoot && outcomes?.length) {
+      // KEYED FOLDED, DISPLAYED AS WRITTEN. Two invocations naming the same
+      // file with different capitalisation are the same target on Windows and
+      // macOS, so the key folds; the text stored in the finding must not,
+      // because a claim naming `src/foo.test.mjs` for a file called
+      // `src/Foo.test.mjs` is a path that does not resolve on Linux -- and
+      // that text is what a later session reads. The first spelling seen wins,
+      // which is the one the failing attempt actually used.
       const byTarget = new Map();
       for (const outcome of outcomes) {
-        const target = commandOperand(outcome.command);
-        if (!target) continue;
-        if (!byTarget.has(target)) byTarget.set(target, []);
-        byTarget.get(target).push(outcome);
+        const operand = commandOperand(outcome.command);
+        if (!operand) continue;
+        const key = operand.toLowerCase();
+        if (!byTarget.has(key)) byTarget.set(key, { target: operand, run: [] });
+        byTarget.get(key).run.push(outcome);
       }
 
-      for (const [target, run] of byTarget) {
+      for (const { target, run } of byTarget.values()) {
         let lastFailure = null;
         for (const outcome of run) {
           if (outcome.failed) {

--- a/plugin/hooks/lib/derive.mjs
+++ b/plugin/hooks/lib/derive.mjs
@@ -67,7 +67,16 @@ import {
  * command. A correction is a lexical guess about what a human meant. Churn
  * describes our own reading behaviour and says nothing about the code at all.
  */
-export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+export const CONFIDENCE = {
+  command: 0.9,
+  test: 0.85,
+  // Below `command` because the inference is weaker: two commands sharing a
+  // target is good evidence of one intent, but not the same evidence as the
+  // identical invocation being retried. Labelled speculative, deliberately.
+  retarget: 0.6,
+  correction: 0.6,
+  churn: 0.4,
+};
 
 /** Claim text cap. A finding is one sentence; a paragraph is evidence. */
 const CLAIM_MAX = 300;
@@ -75,6 +84,17 @@ const EVIDENCE_MAX = 400;
 
 /** Bounded so a pathological log cannot turn session end into real work. */
 const MAX_CANDIDATES = 200;
+
+/**
+ * How close a fix must follow its failure to count as the same attempt.
+ *
+ * Detector 5 pairs across DIFFERENT programs, so it cannot lean on command
+ * identity to know the two are related -- proximity is doing that work instead.
+ * Ten minutes is long enough for a real correction, including reading an error
+ * and looking something up, and short enough that two unrelated pieces of work
+ * touching one file in an afternoon are not reported as one story.
+ */
+const RETARGET_WINDOW_MS = 10 * 60 * 1000;
 
 /**
  * The anchor cap a command surface is stored under, restated here as a TEST.
@@ -287,6 +307,50 @@ export function attemptKey(command) {
     .join(' ')
     .toLowerCase();
 }
+/**
+ * The thing a command ACTS ON -- a path, a test file, a target.
+ *
+ * WHY `attemptKey` IS NOT ENOUGH, measured rather than supposed. That key is
+ * program-plus-operands, so the single most valuable lesson a session can teach
+ * cannot pair by construction:
+ *
+ *   npx jest tests/foo      -> key "npx jest tests/foo"
+ *   npm test -- tests/foo   -> key "npm test tests/foo"
+ *
+ * Different keys, no pair, no finding -- yet that is exactly the correction
+ * worth recording, because the fix was to run a DIFFERENT program against the
+ * same target. The existing detector can only catch the same command re-run and
+ * succeeding, which its own guard then discards as incoherent.
+ *
+ * The measured cost of that: across 937 real derive runs on this machine, 8
+ * candidates were produced and ZERO were stored.
+ *
+ * So this returns the shared operand -- `tests/foo` above -- which is what the
+ * two attempts genuinely have in common. Only operands that NAME something are
+ * admitted: a path separator or a file extension. A bare word like `build` is
+ * refused, because `npm run build` and `make build` sharing the token `build`
+ * is a coincidence of vocabulary, not evidence of one intent.
+ */
+export function commandOperand(command) {
+  const tokens = commandBody(command)
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('-'));
+  // Skipping the first token: the PROGRAM is what differs between the two
+  // attempts, so including it would reproduce attemptKey's blind spot.
+  for (const token of tokens.slice(1)) {
+    const named = /[/\\]/.test(token) || /\.[A-Za-z0-9]{1,5}$/.test(token);
+    if (named && token.length >= 4) return token.toLowerCase();
+  }
+  return null;
+}
+
+/** The program a command invokes, for deciding whether two attempts differ. */
+export function commandProgram(command) {
+  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  return first.split(/[/\\]/).pop().toLowerCase();
+}
+
 
 /** Normalised claim text, so the same lesson derived twice is one candidate. */
 const claimKey = (type, claim) =>
@@ -519,9 +583,15 @@ export function derive(dir, options = {}) {
   // a transcript failure that pairs with nothing stays unclaimed, which is also
   // what keeps a failure from ANOTHER project's directory out of this project's
   // graph -- a candidate cannot be emitted without a success recorded HERE.
+  // HOISTED so detector 5 can pair over the SAME merged list -- events plus the
+  // transcript failures folded in below. Rebuilding it there would duplicate the
+  // de-duplication logic and let the two detectors drift; leaving it block-scoped
+  // gave detector 5 a ReferenceError that its own try/catch swallowed, which is
+  // silent nothing rather than a visible failure.
+  let outcomes = [];
   try {
     if (projectRoot) {
-      const outcomes = events
+      outcomes = events
         .filter(
           (e) =>
             e &&
@@ -802,6 +872,92 @@ export function derive(dir, options = {}) {
   } catch {
     // One detector, never the session.
   }
+  // ---- 5: a DIFFERENT command against the same target succeeded -----------
+  //
+  // THE LESSON DETECTOR 1 CANNOT REACH. Its `attemptKey` is program-plus-
+  // operands, so the correction worth recording -- reaching for a different
+  // tool against the same target -- lands in two groups that never meet:
+  //
+  //   npx jest tests/foo.test.mjs     key "npx jest tests/foo.test.mjs"
+  //   npm test -- tests/foo.test.mjs  key "npm test tests/foo.test.mjs"
+  //
+  // What detector 1 CAN pair is the identical command re-run, and its own guard
+  // then correctly discards that as incoherent -- "`npm run build` works where
+  // `npm run build` failed" claims nothing. So between the key and the guard,
+  // the command family had almost no reachable evidence: measured across 937
+  // real derive runs on this machine, 8 candidates and ZERO stored findings.
+  //
+  // This pairs on the shared OPERAND instead, and only when the PROGRAM differs
+  // -- same-program pairs are detector 1's business and are left to it. The
+  // conservatism the original key was protecting is kept in three other places:
+  // the operand must NAME something (a path or an extension, never a bare word
+  // like `build`), the two attempts must be close in time, and the ceiling is
+  // 0.6 rather than 0.9 because sharing a target is weaker evidence than
+  // repeating an invocation.
+  try {
+    if (projectRoot && outcomes?.length) {
+      const byTarget = new Map();
+      for (const outcome of outcomes) {
+        const target = commandOperand(outcome.command);
+        if (!target) continue;
+        if (!byTarget.has(target)) byTarget.set(target, []);
+        byTarget.get(target).push(outcome);
+      }
+
+      for (const [target, run] of byTarget) {
+        let lastFailure = null;
+        for (const outcome of run) {
+          if (outcome.failed) {
+            lastFailure = outcome;
+            continue;
+          }
+          if (!lastFailure) continue;
+          const failed = lastFailure;
+          lastFailure = null;
+
+          // Same program is detector 1's case, whether it pairs there or not.
+          if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
+          // A fix follows its failure closely. Hours apart is two unrelated
+          // pieces of work that happened to touch one file.
+          const apart = Math.abs((outcome.at || 0) - (failed.at || 0));
+          if (!apart || apart > RETARGET_WINDOW_MS) continue;
+          // Same rule as detector 1: nothing quotable, nothing claimed.
+          if (!quotable(failed.command) || !quotable(outcome.command)) continue;
+
+          const confidence = CONFIDENCE.retarget;
+          add({
+            type: 'command',
+            claim: redact(
+              `In this project \`${commandBody(outcome.command)}\` succeeded on ${target} where ` +
+                `\`${commandBody(failed.command)}\` had failed`,
+              { max: CLAIM_MAX }
+            ),
+            evidence: redact(
+              `observed in one session: \`${failed.command}\` failed` +
+                `${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''}, then ` +
+                `\`${outcome.command}\` succeeded against the same target \`${target}\` ` +
+                `${Math.round(apart / 1000)}s later. Different programs, one target: ordered ` +
+                'and close, but not proven causal -- an intervening edit explains the same pair.',
+              { max: EVIDENCE_MAX }
+            ),
+            applicability: `when about to run \`${commandProgram(failed.command)}\` against ${target} in this project`,
+            confidence,
+            confidenceLabel: labelFor(confidence),
+            scope: 'project',
+            invalidators: [`\`${commandBody(failed.command)}\` later succeeds unchanged`],
+            trigger: triggerFor(failed.command),
+            anchors: [anchorPath],
+            derivedBy: 'retarget',
+            sessionId,
+            at: outcome.at || Date.now(),
+          });
+        }
+      }
+    }
+  } catch {
+    // One detector, never the session.
+  }
+
 
   // ---- storage, under a budget -------------------------------------------
   //

--- a/plugin/hooks/lib/derive.mjs
+++ b/plugin/hooks/lib/derive.mjs
@@ -739,6 +739,27 @@ export function derive(dir, options = {}) {
   let outcomes = [];
   try {
     if (projectRoot) {
+      // SCOPED TO THE SESSION THE CLAIM WILL NAME.
+      //
+      // Every claim these detectors build opens `observed in one session:`,
+      // and the store holds every session's outcomes -- so nothing but the
+      // ten-minute window stopped a failure from one session pairing with a
+      // success from another and asserting a provenance that never happened.
+      //
+      // NEVER OBSERVED, SAID PLAINLY. Across both live stores on this machine
+      // -- 7,173 command outcomes over 3 sessions here, 543 over 9 sessions in
+      // the unrooted one -- 5,155 and 298 adjacent in-window pairs respectively
+      // and ZERO of them crossed a session. Sessions are long and rarely
+      // interleave inside ten minutes. This is a correctness fix against a
+      // false claim, not a fix for observed damage, and it is not offered as
+      // one. Concurrent sessions do occur -- one was recorded on this machine
+      // while this was being written -- and they share the unrooted store.
+      //
+      // The merged transcript failures below are deliberately NOT filtered:
+      // `failedResultsFromTranscript` carries no sessionId, and the transcript
+      // it read is this session's, so they are already scoped by construction.
+      // Filtering them here would drop the only source of command failures
+      // that exists -- Claude Code never fires PostToolUse on a non-zero exit.
       outcomes = events
         .filter(
           (e) =>
@@ -746,7 +767,10 @@ export function derive(dir, options = {}) {
             e.kind === 'tool-outcome' &&
             e.surface === 'command' &&
             typeof e.anchor === 'string' &&
-            e.anchor.trim()
+            e.anchor.trim() &&
+            // An event predating the field still counts; a DIFFERENT session
+            // never does.
+            (!sessionId || !e.sessionId || e.sessionId === sessionId)
         )
         .map((e) => ({
           command: e.anchor.trim(),

--- a/plugin/hooks/lib/derive.mjs
+++ b/plugin/hooks/lib/derive.mjs
@@ -915,6 +915,20 @@ export function derive(dir, options = {}) {
           const failed = lastFailure;
           lastFailure = null;
 
+          // BOTH SIDES MUST NAME A SINGLE COMMAND, the same rule detector 1
+          // applies. `commandBody` strips only a LEADING directory change, and
+          // `commandProgram` reads the first token, so a chained command
+          // attributes the failure to the wrong program entirely:
+          //
+          //   git fetch && npx jest tests/foo.test.mjs   -> program "git"
+          //   cat x | npx jest tests/foo.test.mjs        -> program "cat"
+          //
+          // Paired against `npm test -- tests/foo.test.mjs` those would ship
+          // "npm test succeeded where git fetch failed" and tell a later session
+          // to avoid `git`. Checked per side rather than once, because unlike
+          // detector 1 these two do NOT share a key by construction.
+          if (!hasAttemptIdentity(failed.command)) continue;
+          if (!hasAttemptIdentity(outcome.command)) continue;
           // Same program is detector 1's case, whether it pairs there or not.
           if (commandProgram(failed.command) === commandProgram(outcome.command)) continue;
           // A fix follows its failure closely. Hours apart is two unrelated

--- a/plugin/hooks/lib/derive.mjs
+++ b/plugin/hooks/lib/derive.mjs
@@ -430,10 +430,16 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * Returns null when nothing resolves, which leaves the caller's original root
  * untouched -- a wrong project is worse than the status quo.
  */
-export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+export function projectRootFromActivity(events, { resolve, cwd, sessionId = null } = {}) {
   if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
   const counts = new Map();
   for (const event of events) {
+    // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
+    // session that wrote it, so counting every event ever recorded lets a busy
+    // session from last week outvote the one now ending -- and the question
+    // being asked is "where did THIS session work", not "where is this graph
+    // busiest". Callers that pass no id keep the whole-graph count.
+    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.
@@ -454,13 +460,22 @@ export function projectRootFromActivity(events, { resolve, cwd } = {}) {
   }
   let best = null;
   let most = 0;
+  let tied = false;
   for (const [root, n] of counts) {
     if (n > most) {
       most = n;
       best = root;
+      tied = false;
+    } else if (n === most) {
+      // A Map iterates in insertion order, so a tie would otherwise be broken by
+      // whichever file the session happened to touch first -- deterministic, but
+      // arbitrary, and wrong half the time. Findings would then be stored against
+      // a project the evidence does not single out. Decline instead; the caller
+      // keeps cwdRoot, which is at least a root the user chose.
+      tied = true;
     }
   }
-  return best;
+  return tied ? null : best;
 }
 
 export function projectAnchor(projectRoot) {

--- a/plugin/hooks/lib/derive.mjs
+++ b/plugin/hooks/lib/derive.mjs
@@ -373,9 +373,45 @@ export function commandOperand(command) {
   return null;
 }
 
-/** The program a command invokes, for deciding whether two attempts differ. */
+/**
+ * A leading `VAR=value` prefix, which a shell applies to the environment of
+ * the command that follows rather than running as the command itself.
+ */
+const ENV_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+/**
+ * The program a command invokes, for deciding whether two attempts differ.
+ *
+ * ENVIRONMENT PREFIXES ARE NOT THE PROGRAM. Taking the first token verbatim
+ * reported `SP=/tmp/x` as the program for `SP=/tmp/x node run.mjs`, and that
+ * is not a cosmetic slip: measured over this machine's real history, 816 of
+ * 7,165 recorded command outcomes -- 11.4% -- named an assignment.
+ *
+ * IT FAILS IN THE DANGEROUS DIRECTION. This function exists to decide that two
+ * attempts used DIFFERENT programs, so two runs of the same tool under
+ * different variables --
+ *
+ *   SP=/a node run.mjs    (failed)
+ *   SPW=/b node run.mjs   (succeeded)
+ *
+ * -- compared as `sp=/a` against `spw=/b`, differed, and were eligible to
+ * pair. The claim that pairing produces is `node run.mjs` succeeded where
+ * `node run.mjs` failed: exactly the incoherent statement detector 1's own
+ * guard exists to refuse, arriving through the door detector 5 opened.
+ *
+ * Skipping the prefixes is what a shell does, and it cannot invent a pair --
+ * two commands that were already the same program now compare equal, which
+ * only ever removes a candidate.
+ *
+ * NO MEASURED CHANGE TODAY, stated plainly: replaying both versions over the
+ * same real history gives an identical pairing outcome (20 pairs considered,
+ * 0 firing), because every affected command is also chained and rejected
+ * earlier. This is a correctness fix against a latent false claim, not a
+ * recall improvement, and it is not offered as one.
+ */
 export function commandProgram(command) {
-  const first = commandBody(command).trim().split(/\s+/)[0] || '';
+  const tokens = commandBody(command).trim().split(/\s+/).filter(Boolean);
+  const first = tokens.find((token) => !ENV_ASSIGNMENT.test(token)) || '';
   return first.split(/[/\\]/).pop().toLowerCase();
 }
 

--- a/plugin/hooks/lib/derive.mjs
+++ b/plugin/hooks/lib/derive.mjs
@@ -53,6 +53,7 @@ import { ORIGIN_HARVESTED } from './curate.mjs';
 // from, so what this counts as a search and what the advisory treats as one
 // cannot diverge.
 import {
+  commandSegments,
   identifiersIn,
   searchPatternFromCommand,
   symbolIndex,
@@ -182,11 +183,38 @@ const COMMAND_SEPARATORS = new Set(['&&', '||', ';', '|', '&']);
  * longer fires on the directory-change case it was written for.
  * One check per pair is enough: both halves share the key by construction.
  */
-const hasAttemptIdentity = (command) =>
-  attemptKey(command)
+/**
+ * THE WHOLE BODY, NOT THE FIRST THREE TOKENS.
+ *
+ * This used to read the separator set off `attemptKey`, which keeps only the
+ * first three non-flag tokens -- so it caught a separator only when one landed
+ * early by luck of position. Verified against the real functions:
+ *
+ *   git fetch && npx jest tests/foo   key `git fetch &&`        -> rejected
+ *   npx jest tests/foo && node x.mjs  key `npx jest tests/foo`  -> ACCEPTED
+ *   grep -rn foo src | head -20       key `grep foo src`        -> ACCEPTED
+ *
+ * The last two are exactly the claims this guard exists to stop: the key names
+ * `npx`, so a pair would blame `npx` for a failure `node` may have caused.
+ * Every existing test placed the separator in the first three tokens, so none
+ * of them could see it.
+ *
+ * `commandSegments` is reused rather than a fresh scan because it is already
+ * the quote-aware one: splitting the raw string would cut through `grep -E
+ * "foo|bar"` and reject an ordinary alternation as a pipeline.
+ *
+ * A LEADING `cd <path> &&` is still accepted, because `commandBody` strips it
+ * before this sees it -- that case is one command spelled two ways.
+ */
+const hasAttemptIdentity = (command) => {
+  const body = commandBody(command);
+  if (!body.trim()) return false;
+  if (commandSegments(body).length > 1) return false;
+  return attemptKey(command)
     .split(' ')
     .filter(Boolean)
     .every((token) => !COMMAND_SEPARATORS.has(token));
+};
 
 /**
  * Commands whose red-to-green transition is usually explained by the CODE
@@ -435,11 +463,20 @@ export function projectRootFromActivity(events, { resolve, cwd, sessionId = null
   const counts = new Map();
   for (const event of events) {
     // SCOPED TO THIS SESSION when the caller knows its id. A graph outlives the
-    // session that wrote it, so counting every event ever recorded lets a busy
-    // session from last week outvote the one now ending -- and the question
-    // being asked is "where did THIS session work", not "where is this graph
-    // busiest". Callers that pass no id keep the whole-graph count.
-    if (sessionId && event?.sessionId && event.sessionId !== sessionId) continue;
+    // session that wrote it, and the caller concatenates several graphs, so
+    // counting every event ever recorded lets a busy session from last week
+    // outvote the one now ending -- and the question being asked is "where did
+    // THIS session work", not "where is this graph busiest". Callers that pass
+    // no id keep the whole-graph count.
+    //
+    // AN EVENT THAT CANNOT NAME ITS SESSION IS EXCLUDED, not exempted. Exempting
+    // it was a deliberate concession to older records, and measurement says the
+    // concession buys nothing: across the three live stores on this machine, 2
+    // of 22,321 file/read events lack the field -- 0.01%. Set against that, an
+    // unstamped event sitting in ANOTHER project's graph would vote for that
+    // project on the strength of no evidence at all, which is precisely the
+    // failure this filter exists to prevent.
+    if (sessionId && event?.sessionId !== sessionId) continue;
     const anchor = event?.anchor;
     // File surfaces only. A command anchor is the command text, and resolving
     // `npm test -- x` as a path would invent a project out of a sentence.

--- a/plugin/hooks/lib/derive.mjs
+++ b/plugin/hooks/lib/derive.mjs
@@ -403,6 +403,66 @@ const DOTNET_MARKER = /\.(sln|slnx|csproj|fsproj|vbproj)$/i;
  * against a fabricated anchor. That is the fail-open direction: no finding
  * beats a finding anchored to something that is not what the claim is about.
  */
+
+/**
+ * The project a session actually worked in, read off what it touched.
+ *
+ * WHY THE SESSION'S CWD IS THE WRONG ANSWER. `adapter.mjs` resolves the root
+ * with `projectRootFor(join(cwd, '__session__'), cwd)`, and when Claude Code is
+ * launched from a directory with no VCS marker -- a home directory, which is how
+ * this machine runs it -- that returns the synthetic fallback
+ * `~/.token-optimizer/unrooted`. It is NOT null, so every `if (projectRoot)`
+ * gate passes, and then `projectAnchor` hands back the directory itself because
+ * the fallback contains no project marker. `writeHarvested` resolves anchors
+ * through `indexFile`, `indexFile` on a directory returns null, and the finding
+ * is refused as unanchorable.
+ *
+ * That is the whole reason this machine's graph holds 2,965 symbols and ONE
+ * finding: 937 derive runs produced candidates and stored none of them, while
+ * every layer reported success.
+ *
+ * The router already solved this for capture -- "THE GRAPH IS PER PROJECT, so it
+ * is keyed on where the FILE lives, not on where the client happens to be
+ * running" -- and derivation simply never adopted it. This applies the same
+ * rule at Stop time: take the file anchors the session recorded, resolve each to
+ * its own project, and pick the one that holds the most of them.
+ *
+ * Returns null when nothing resolves, which leaves the caller's original root
+ * untouched -- a wrong project is worse than the status quo.
+ */
+export function projectRootFromActivity(events, { resolve, cwd } = {}) {
+  if (typeof resolve !== 'function' || !Array.isArray(events)) return null;
+  const counts = new Map();
+  for (const event of events) {
+    const anchor = event?.anchor;
+    // File surfaces only. A command anchor is the command text, and resolving
+    // `npm test -- x` as a path would invent a project out of a sentence.
+    if (!anchor || typeof anchor !== 'string') continue;
+    if (event.kind !== 'read' && !(event.kind === 'tool-outcome' && event.surface === 'file')) {
+      continue;
+    }
+    let root;
+    try {
+      root = resolve(anchor, cwd);
+    } catch {
+      continue;
+    }
+    // The fallback resolves to a path inside the optimizer's own store, which is
+    // never a project someone is working in.
+    if (!root || String(root).includes('.token-optimizer')) continue;
+    counts.set(root, (counts.get(root) || 0) + 1);
+  }
+  let best = null;
+  let most = 0;
+  for (const [root, n] of counts) {
+    if (n > most) {
+      most = n;
+      best = root;
+    }
+  }
+  return best;
+}
+
 export function projectAnchor(projectRoot) {
   if (!projectRoot) return null;
   let entries;

--- a/plugin/hooks/lib/transcript.mjs
+++ b/plugin/hooks/lib/transcript.mjs
@@ -289,6 +289,23 @@ const ANCHOR_MAX = 120;
  */
 const EXIT_CODE_RESULT = /^(?:Error:\s*)?Exit code (\d+)\b/;
 
+/**
+ * A run the HARNESS stopped, which is not the command failing.
+ *
+ * The allowlist above admits anything shaped `Exit code N`, and a killed
+ * command reports `Exit code 143` with `Command timed out after 2m 0s` -- so
+ * it walks straight in. Nothing about it is a lesson about the command: it did
+ * not fail, it was not allowed to finish, and the same command run with a
+ * longer budget may well pass. Pairing one with a later success would claim a
+ * red-to-green transition that never happened.
+ *
+ * MEASURED, on a 237 MB transcript of ordinary feature work: of 130 admitted
+ * failures, 25 were timeouts -- 19%. At the 64 MB scan it was 11 of 23, 48%.
+ * User declines are NOT in this class and need no rule; the positive allowlist
+ * already excludes them, verified at every scan size on the same transcript.
+ */
+const HARNESS_TIMEOUT = /^\s*Command timed out after\b/m;
+
 /** Reads at most `bytes` from the END of a file, without loading the rest. */
 function readTail(path, bytes) {
   let fd;
@@ -390,6 +407,8 @@ export function failedResultsFromTranscript(transcriptPath, options = {}) {
       if (typeof block.content !== 'string') continue;
       const match = EXIT_CODE_RESULT.exec(block.content);
       if (!match) continue;
+      // The command ran, but the harness ended it. See HARNESS_TIMEOUT.
+      if (HARNESS_TIMEOUT.test(block.content)) continue;
       const command = commands.get(String(block.tool_use_id || ''));
       // No command means no claim. The result says something failed; without
       // the text of what failed there is nothing to say about it, and nothing

--- a/tests/hooks/audit.test.mjs
+++ b/tests/hooks/audit.test.mjs
@@ -502,12 +502,11 @@ describe('the local derivation metric has a reader', () => {
     // reader to skip the whole section.
     record(dir, { kind: 'derive', observations: 1, candidates: 0, written: 0 });
     const text = renderAudit(dir, []).text;
-    // PINNED POSITIVELY FIRST. On its own the negative below also passes when
-    // renderAudit throws, returns undefined, or never runs the derivation note
-    // at all -- so it would report success for a reader that had stopped
-    // working entirely. Asserting the note IS rendered proves the code path was
-    // exercised, and only then does its silence about searches mean anything.
-    expect(text).toMatch(/Local derivation: .* 1 observation\(s\)/);
+    // Pins that the derivation section rendered at all, so the silence below
+    // is a decision about the search line and not an empty report.
+    expect(text).toMatch(
+      /Local derivation: 0 candidate\(s\) from 1 observation\(s\); 0 stored across 1 Stop run\(s\)\./
+    );
     expect(text).not.toMatch(/named search\(es\)/);
   });
 });

--- a/tests/hooks/derive.test.mjs
+++ b/tests/hooks/derive.test.mjs
@@ -1836,3 +1836,69 @@ describe('the program is the program, not the environment in front of it', () =>
     );
   });
 });
+
+/**
+ * A claim that says "one session" has to come from one session.
+ *
+ * Every claim these detectors build opens `observed in one session:`, and the
+ * store holds every session's outcomes -- so nothing but the ten-minute window
+ * stopped a failure from one session pairing with a success from another and
+ * asserting a provenance that never happened.
+ *
+ * Never observed in the wild, and recorded as such: across both live stores on
+ * this machine, 5,155 and 298 adjacent in-window pairs, ZERO crossing a
+ * session. Sessions are long and rarely interleave inside ten minutes. This is
+ * a guard against a false claim, not a fix for observed damage.
+ */
+describe('a pair comes from one session, or it is not a pair', () => {
+  // Its own clock: `t0` above belongs to another block's fixtures.
+  const base = Date.parse('2026-03-04T10:00:00Z');
+  const cmd = (anchor, success, offset, session) =>
+    record(dir, {
+      kind: 'tool-outcome',
+      surface: 'command',
+      anchor,
+      success,
+      exit: success ? 0 : 1,
+      at: base + offset,
+      sessionId: session,
+      output: success ? '' : 'boom',
+    });
+
+  const proj = () => {
+    const p = join(dir, 'proj-scope');
+    mkdirSync(p, { recursive: true });
+    writeFileSync(join(p, 'package.json'), '{"name":"x"}');
+    return p;
+  };
+
+  const candidatesFor = (sessionId) =>
+    derive(dir, { sessionId, projectRoot: proj() }).candidates;
+
+  it('refuses to pair across two sessions', () => {
+    // Same target, well inside the window, different sessions. Under the old
+    // reading these paired and the claim said they were one session's work.
+    cmd('npx jest tests/foo.test.mjs', false, 0, 'session-a');
+    cmd('npm test -- tests/foo.test.mjs', true, 45_000, 'session-b');
+
+    expect(candidatesFor('session-b').filter((c) => c.derivedBy === 'retarget')).toHaveLength(0);
+  });
+
+  it('still pairs within one session', () => {
+    // The guard must not silence the detector outright, which is the failure
+    // mode of every over-tightened filter in this file.
+    cmd('npx jest tests/bar.test.mjs', false, 0, 'session-a');
+    cmd('npm test -- tests/bar.test.mjs', true, 45_000, 'session-a');
+
+    expect(candidatesFor('session-a').filter((c) => c.derivedBy === 'retarget')).toHaveLength(1);
+  });
+
+  it('keeps an outcome recorded before the field existed', () => {
+    // Older rows carry no sessionId. Dropping them would shrink the evidence
+    // pool on exactly the graphs with the most history.
+    cmd('npx jest tests/baz.test.mjs', false, 0, undefined);
+    cmd('npm test -- tests/baz.test.mjs', true, 45_000, 'session-a');
+
+    expect(candidatesFor('session-a').filter((c) => c.derivedBy === 'retarget')).toHaveLength(1);
+  });
+});

--- a/tests/hooks/derive.test.mjs
+++ b/tests/hooks/derive.test.mjs
@@ -29,6 +29,7 @@ import { ORIGIN_HARVESTED, ORIGIN_HUMAN } from '../../hooks-core/curate.mjs';
 import {
   derive,
   searchGap,
+  projectRootFromActivity,
   CONFIDENCE,
   attemptKey,
   commandBody,
@@ -1446,5 +1447,87 @@ describe('detector 5 refuses chained commands', () => {
     cmd('cd repo && npx jest tests/foo.test.mjs', false, 0);
     cmd('npm test -- tests/foo.test.mjs', true, 45_000);
     expect(retargets()).toHaveLength(1);
+  });
+});
+
+/**
+ * Which project a session belongs to, when the cwd cannot say.
+ *
+ * `projectRootFor(join(cwd,'__session__'), cwd)` returns the synthetic
+ * `~/.token-optimizer/unrooted` for a cwd with no VCS marker -- a home
+ * directory, which is how this client is commonly launched. That value is not
+ * null, so every `if (projectRoot)` gate downstream passes, `projectAnchor`
+ * then returns the directory itself, and `indexFile` refuses a directory, so
+ * the finding is dropped as unanchorable.
+ *
+ * Measured: the unrooted store holds 937 derive runs, 8 candidates and ZERO
+ * written findings, while this repository's own store holds 317 runs, 121
+ * candidates and 121 written. The write path was never broken -- it was being
+ * handed a root nothing could anchor to.
+ */
+describe('inferring the project from what the session touched', () => {
+  const REPO = '/repos/thing';
+  // Stands in for projectRootFor: repo paths resolve to the repo, anything
+  // under the optimizer's own store resolves to the unrooted fallback.
+  const resolve = (anchor) =>
+    anchor.includes('/repos/thing')
+      ? REPO
+      : anchor.includes('.token-optimizer')
+        ? '/home/u/.token-optimizer/unrooted'
+        : null;
+
+  it('picks the project the session actually worked in', () => {
+    const events = [
+      { kind: 'read', anchor: `${REPO}/src/a.mjs` },
+      { kind: 'read', anchor: `${REPO}/src/b.mjs` },
+      { kind: 'tool-outcome', surface: 'file', anchor: `${REPO}/package.json` },
+    ];
+    expect(projectRootFromActivity(events, { resolve })).toBe(REPO);
+  });
+
+  it('ignores command anchors, which are command text and not paths', () => {
+    // A command surface's anchor is the command itself. Resolving `npm test --
+    // x` as a path would invent a project out of a sentence.
+    const events = [
+      { kind: 'tool-outcome', surface: 'command', anchor: 'npm test -- /repos/thing/x' },
+    ];
+    expect(projectRootFromActivity(events, { resolve })).toBeNull();
+  });
+
+  it('ignores the optimizer store, which is nobody s project', () => {
+    const events = [
+      { kind: 'read', anchor: '/home/u/.token-optimizer/wiki/graph.jsonl' },
+      { kind: 'read', anchor: '/home/u/.token-optimizer/unrooted/x' },
+    ];
+    expect(projectRootFromActivity(events, { resolve })).toBeNull();
+  });
+
+  it('picks the majority project when a session spans two', () => {
+    const OTHER = '/repos/other';
+    const wide = (anchor) => (anchor.includes('/repos/other') ? OTHER : resolve(anchor));
+    const events = [
+      { kind: 'read', anchor: `${REPO}/a` },
+      { kind: 'read', anchor: `${REPO}/b` },
+      { kind: 'read', anchor: `${OTHER}/c` },
+    ];
+    expect(projectRootFromActivity(events, { resolve: wide })).toBe(REPO);
+  });
+
+  it('returns null rather than guessing when nothing resolves', () => {
+    // The caller keeps its cwd-derived answer in that case. A wrong project is
+    // worse than the status quo: it would file findings about one codebase into
+    // another's graph.
+    expect(projectRootFromActivity([], { resolve })).toBeNull();
+    expect(projectRootFromActivity([{ kind: 'read', anchor: '/elsewhere/x' }], { resolve })).toBeNull();
+  });
+
+  it('survives junk input rather than throwing at session end', () => {
+    expect(projectRootFromActivity(null, { resolve })).toBeNull();
+    expect(projectRootFromActivity([null, {}, { kind: 'read' }], { resolve })).toBeNull();
+    // A resolver that throws must not take the Stop hook down with it.
+    const boom = () => {
+      throw new Error('nope');
+    };
+    expect(projectRootFromActivity([{ kind: 'read', anchor: `${REPO}/a` }], { resolve: boom })).toBeNull();
   });
 });

--- a/tests/hooks/derive.test.mjs
+++ b/tests/hooks/derive.test.mjs
@@ -1490,6 +1490,54 @@ describe('detector 5 refuses chained commands', () => {
     cmd('npm test -- "tests/foo|bar.test.mjs"', true, 45_000);
     expect(retargets()).toHaveLength(1);
   });
+
+  it.each([
+    ['&&', 'npx jest tests/foo.test.mjs &&'],
+    ['|', 'npx jest tests/foo.test.mjs |'],
+    [';', 'npx jest tests/foo.test.mjs ;'],
+    ['&', 'npx jest tests/foo.test.mjs &'],
+  ])('refuses a command ending in a bare %s', (_sep, failing) => {
+    // THE SEGMENT COUNT CANNOT SEE THIS ONE. `commandSegments` pushes only
+    // non-empty token lists, so a trailing separator produces exactly ONE
+    // segment, and attemptKey -- the first three non-flag tokens -- never sees
+    // the separator either. The command is still half of something, and
+    // `cmd &` is a background job whose exit code belongs to the shell rather
+    // than to the program named in the claim.
+    cmd(failing, false, 0);
+    cmd('npm test -- tests/foo.test.mjs', true, 45_000);
+    expect(retargets()).toHaveLength(0);
+  });
+
+  it('refuses a trailing separator on the SUCCEEDING side too', () => {
+    cmd('npx jest tests/foo.test.mjs', false, 0);
+    cmd('npm test -- tests/foo.test.mjs &&', true, 45_000);
+    expect(retargets()).toHaveLength(0);
+  });
+
+  it('keeps the target spelled the way the command spelled it', () => {
+    // The operand is both the grouping key and the text of the stored claim.
+    // Folding it to lower case made the claim name `src/foo.test.mjs` for a
+    // file called `src/Foo.test.mjs` -- a path that does not resolve on a
+    // case-sensitive filesystem, in the sentence a later session reads.
+    cmd('npx jest tests/Foo.test.mjs', false, 0);
+    cmd('npm test -- tests/Foo.test.mjs', true, 45_000);
+    const [found] = retargets();
+    expect(found).toBeDefined();
+    expect(found.claim).toContain('tests/Foo.test.mjs');
+    expect(found.claim).not.toContain('tests/foo.test.mjs');
+    expect(found.applicability).toContain('tests/Foo.test.mjs');
+  });
+
+  it('still pairs two spellings of one target, because the KEY folds', () => {
+    // Case-insensitive matching is right on Windows and macOS; only the stored
+    // text had to stop paying for it. The first spelling seen wins, which is
+    // the one the failing attempt used.
+    cmd('npx jest tests/Foo.test.mjs', false, 0);
+    cmd('npm test -- tests/foo.TEST.mjs', true, 45_000);
+    const [found] = retargets();
+    expect(found).toBeDefined();
+    expect(found.claim).toContain('tests/Foo.test.mjs');
+  });
 });
 
 /**

--- a/tests/hooks/derive.test.mjs
+++ b/tests/hooks/derive.test.mjs
@@ -48,6 +48,7 @@ import {
   CONFIDENCE,
   attemptKey,
   commandBody,
+  commandProgram,
   projectAnchor,
 } from '../../hooks-core/derive.mjs';
 
@@ -1785,5 +1786,53 @@ describe('gathering session activity from the graphs that hold it', () => {
     process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY = join(sandbox, 'nope', 'missing.jsonl');
     expect(() => sessionActivity(unrooted)).not.toThrow();
     expect(Array.isArray(sessionActivity(unrooted))).toBe(true);
+  });
+});
+
+/**
+ * An environment prefix is not the program.
+ *
+ * `commandProgram` took the first token verbatim, so `SP=/tmp/x node run.mjs`
+ * reported its program as `sp=/tmp/x`. Measured over this machine's real
+ * history that is 816 of 7,165 recorded command outcomes -- 11.4%.
+ *
+ * It fails in the dangerous direction. The function exists to decide two
+ * attempts used DIFFERENT programs, so the same tool run under different
+ * variables compared as different and became eligible to pair -- producing
+ * `node run.mjs` succeeded where `node run.mjs` failed, the incoherent claim
+ * detector 1's own guard refuses, arriving through detector 5's door.
+ */
+describe('the program is the program, not the environment in front of it', () => {
+  it('looks past a leading assignment, however many there are', () => {
+    expect(commandProgram('SP=/tmp/x node run.mjs')).toBe('node');
+    expect(commandProgram('MSYS_NO_PATHCONV=1 docker run --rm img')).toBe('docker');
+    expect(commandProgram('A=1 B=2 C=3 npm test -- tests/x.mjs')).toBe('npm');
+  });
+
+  it('still answers plainly when there is no prefix', () => {
+    // The behaviour that already worked has to survive the fix, including the
+    // basename reduction and the leading `cd` that commandBody strips.
+    expect(commandProgram('node run.mjs')).toBe('node');
+    expect(commandProgram('/usr/local/bin/node run.mjs')).toBe('node');
+    expect(commandProgram('cd /repo && SP=/a node run.mjs')).toBe('node');
+    expect(commandProgram('')).toBe('');
+  });
+
+  it('refuses the false pair the old reading allowed', () => {
+    // THE POINT OF THE FIX, asserted as behaviour rather than as a string. Two
+    // runs of the SAME program under different variables must compare equal,
+    // so detector 5's `programs differ` gate rejects them and no claim is
+    // built. Under the old reading these were `sp=/a` and `spw=/b`.
+    const failed = 'SP=/a node scripts/run.mjs';
+    const fixed = 'SPW=/b node scripts/run.mjs';
+    expect(commandProgram(failed)).toBe(commandProgram(fixed));
+  });
+
+  it('still separates two genuinely different programs', () => {
+    // The fix must not collapse everything to one program, which would silence
+    // detector 5 entirely rather than make it honest.
+    expect(commandProgram('SP=/a npx jest tests/foo.test.mjs')).not.toBe(
+      commandProgram('SP=/a npm test -- tests/foo.test.mjs')
+    );
   });
 });

--- a/tests/hooks/derive.test.mjs
+++ b/tests/hooks/derive.test.mjs
@@ -1296,3 +1296,94 @@ describe('measuring what the symbol index cannot answer', () => {
     expect(result.searchGap).toEqual({ named: 1, gap: 1 });
   });
 });
+
+/**
+ * The lesson the command detector could not reach.
+ *
+ * MEASURED, NOT SUPPOSED: across 937 real derive runs on the development
+ * machine, the whole module produced 8 candidates and stored ZERO findings. The
+ * cause is structural rather than a bug. `attemptKey` is program-plus-operands,
+ * so the correction actually worth recording -- reaching for a different tool
+ * against the same target -- lands in two groups that never meet:
+ *
+ *   npx jest tests/foo.test.mjs     key "npx jest tests/foo.test.mjs"
+ *   npm test -- tests/foo.test.mjs  key "npm test tests/foo.test.mjs"
+ *
+ * What detector 1 CAN pair is the identical command re-run, which its own guard
+ * then correctly discards as incoherent. Between the key and the guard the
+ * command family had almost no reachable evidence.
+ */
+describe('a different command against the same target', () => {
+  const t0 = Date.now();
+  const proj = () => {
+    const p = join(dir, 'proj');
+    mkdirSync(p, { recursive: true });
+    writeFileSync(join(p, 'package.json'), '{"name":"x"}');
+    return p;
+  };
+  const cmd = (anchor, success, offset) =>
+    record(dir, {
+      kind: 'tool-outcome',
+      surface: 'command',
+      anchor,
+      success,
+      exit: success ? 0 : 1,
+      at: t0 + offset,
+      output: success ? '' : 'boom',
+    });
+  const retargets = () =>
+    derive(dir, { sessionId: 's', projectRoot: proj() }).candidates.filter(
+      (c) => c.derivedBy === 'retarget'
+    );
+
+  it('records the fix, and stores it', () => {
+    cmd('npx jest tests/foo.test.mjs', false, 0);
+    cmd('npm test -- tests/foo.test.mjs', true, 45_000);
+
+    const result = derive(dir, { sessionId: 's', projectRoot: proj() });
+    const found = result.candidates.filter((c) => c.derivedBy === 'retarget');
+    expect(found).toHaveLength(1);
+    expect(found[0].claim).toContain('npm test -- tests/foo.test.mjs');
+    expect(found[0].claim).toContain('npx jest tests/foo.test.mjs');
+    // Speculative, not probable: sharing a target is weaker evidence than
+    // repeating an invocation, and the ceiling has to say so.
+    expect(found[0].confidenceLabel).toBe('speculative');
+    // STORED. Producing a candidate that the write path then drops is the state
+    // this whole change exists to fix -- 8 candidates, 0 written.
+    expect(result.written.length).toBeGreaterThan(0);
+  });
+
+  it('leaves same-program pairs to the detector that owns them', () => {
+    cmd('npm test -- tests/a.test.mjs', false, 0);
+    cmd('npm run test tests/a.test.mjs', true, 45_000);
+    expect(retargets()).toHaveLength(0);
+  });
+
+  it('refuses a bare word as a shared target', () => {
+    // `npm run build` and `make build` share the token `build`, which is a
+    // coincidence of vocabulary rather than evidence of one intent. Without
+    // this, every project's two build commands would pair.
+    cmd('npm run build', false, 0);
+    cmd('make build', true, 45_000);
+    expect(retargets()).toHaveLength(0);
+  });
+
+  it('refuses two attempts hours apart', () => {
+    // Proximity is doing the work command identity does in detector 1. Two
+    // unrelated pieces of work touching one file must not become one story.
+    cmd('npx jest tests/a.test.mjs', false, 0);
+    cmd('npm test -- tests/a.test.mjs', true, 3 * 60 * 60 * 1000);
+    expect(retargets()).toHaveLength(0);
+  });
+
+  it('refuses commands whose targets differ', () => {
+    cmd('npx jest tests/a.test.mjs', false, 0);
+    cmd('npm test -- tests/b.test.mjs', true, 45_000);
+    expect(retargets()).toHaveLength(0);
+  });
+
+  it('claims nothing from a success with no preceding failure', () => {
+    cmd('npm test -- tests/a.test.mjs', true, 0);
+    expect(retargets()).toHaveLength(0);
+  });
+});

--- a/tests/hooks/derive.test.mjs
+++ b/tests/hooks/derive.test.mjs
@@ -11,7 +11,14 @@
  * So most of what is tested here is refusal.
  */
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from 'node:fs';
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync,
+  readFileSync,
+  appendFileSync,
+} from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -22,7 +29,15 @@ import {
   safeName,
   failedResultsFromTranscript,
 } from '../../hooks-core/transcript.mjs';
-import { load, putNode, putEdge, nodeId } from '../../hooks-core/wiki.mjs';
+import {
+  load,
+  putNode,
+  putEdge,
+  nodeId,
+  projectRootFor,
+} from '../../hooks-core/wiki.mjs';
+import { registerProject, projectIdFor } from '../../hooks-core/projects.mjs';
+import { sessionActivity } from '../../hooks-core/adapter.mjs';
 import { indexFile } from '../../hooks-core/staleness.mjs';
 import { canonicalPath } from '../../hooks-core/paths.mjs';
 import { ORIGIN_HARVESTED, ORIGIN_HUMAN } from '../../hooks-core/curate.mjs';
@@ -1513,6 +1528,67 @@ describe('inferring the project from what the session touched', () => {
     expect(projectRootFromActivity(events, { resolve: wide })).toBe(REPO);
   });
 
+  it('declines rather than letting touch order break a tie', () => {
+    // Two projects touched equally often. A Map iterates in insertion order, so
+    // picking the first maximum would answer with whichever file the session
+    // happened to open first -- deterministic, and arbitrary. Both orderings
+    // must give the same answer, and the only honest one is "I don't know".
+    const OTHER = '/repos/other';
+    const wide = (anchor) => (anchor.includes('/repos/other') ? OTHER : resolve(anchor));
+    const repoFirst = [
+      { kind: 'read', anchor: `${REPO}/a` },
+      { kind: 'read', anchor: `${OTHER}/c` },
+    ];
+    const otherFirst = [
+      { kind: 'read', anchor: `${OTHER}/c` },
+      { kind: 'read', anchor: `${REPO}/a` },
+    ];
+    expect(projectRootFromActivity(repoFirst, { resolve: wide })).toBeNull();
+    expect(projectRootFromActivity(otherFirst, { resolve: wide })).toBeNull();
+  });
+
+  it('still answers when a later project overtakes an earlier tie', () => {
+    // The tie flag must reset once a strict maximum appears, or one incidental
+    // pair of equal counts would suppress an otherwise clear winner.
+    const OTHER = '/repos/other';
+    const wide = (anchor) => (anchor.includes('/repos/other') ? OTHER : resolve(anchor));
+    const events = [
+      { kind: 'read', anchor: `${REPO}/a` },
+      { kind: 'read', anchor: `${OTHER}/c` },
+      { kind: 'read', anchor: `${OTHER}/d` },
+    ];
+    expect(projectRootFromActivity(events, { resolve: wide })).toBe(OTHER);
+  });
+
+  it('counts only the session that is ending, not the whole graph', () => {
+    // A graph outlives the session that wrote it, and a cross-project sweep
+    // concatenates several of them. Without this filter a busy session from
+    // last week outvotes the one now ending, and its findings are filed against
+    // that other project.
+    const OTHER = '/repos/other';
+    const wide = (anchor) => (anchor.includes('/repos/other') ? OTHER : resolve(anchor));
+    const events = [
+      { kind: 'read', anchor: `${OTHER}/a`, sessionId: 'yesterday' },
+      { kind: 'read', anchor: `${OTHER}/b`, sessionId: 'yesterday' },
+      { kind: 'read', anchor: `${OTHER}/c`, sessionId: 'yesterday' },
+      { kind: 'read', anchor: `${REPO}/x`, sessionId: 'now' },
+    ];
+    expect(projectRootFromActivity(events, { resolve: wide, sessionId: 'now' })).toBe(REPO);
+    // Without the id the whole graph is counted, which is the old behaviour and
+    // the wrong answer for a session that only touched REPO.
+    expect(projectRootFromActivity(events, { resolve: wide })).toBe(OTHER);
+  });
+
+  it('keeps an event that carries no session id at all', () => {
+    // Older records predate the field. Dropping them would make the inference
+    // weaker on exactly the graphs that have the most history.
+    const events = [
+      { kind: 'read', anchor: `${REPO}/a` },
+      { kind: 'read', anchor: `${REPO}/b`, sessionId: 'now' },
+    ];
+    expect(projectRootFromActivity(events, { resolve, sessionId: 'now' })).toBe(REPO);
+  });
+
   it('returns null rather than guessing when nothing resolves', () => {
     // The caller keeps its cwd-derived answer in that case. A wrong project is
     // worse than the status quo: it would file findings about one codebase into
@@ -1529,5 +1605,150 @@ describe('inferring the project from what the session touched', () => {
       throw new Error('nope');
     };
     expect(projectRootFromActivity([{ kind: 'read', anchor: `${REPO}/a` }], { resolve: boom })).toBeNull();
+  });
+});
+
+/**
+ * The sweep that makes the inference above reach the evidence.
+ *
+ * Capture is keyed on where the FILE lives, so a session started outside a
+ * repository writes its file activity into each touched PROJECT's graph while
+ * `cwd` resolves to the unrooted fallback. Reading only the unrooted graph
+ * therefore found nothing to infer from -- measured on this machine, 12,376
+ * file anchors in that store and not one under a repository.
+ */
+describe('gathering session activity from the graphs that hold it', () => {
+  let sandbox;
+  let unrooted;
+  let saved;
+
+  const makeProject = (name, { register = true } = {}) => {
+    const root = join(sandbox, name);
+    mkdirSync(join(root, '.git'), { recursive: true });
+    const graphDir = join(root, '.token-optimizer', 'wiki');
+    mkdirSync(graphDir, { recursive: true });
+    if (register) registerProject({ root, graphDir, client: 'test' });
+    return { root, graphDir };
+  };
+
+  beforeEach(() => {
+    sandbox = mkdtempSync(join(tmpdir(), 'session-activity-'));
+    unrooted = join(sandbox, 'unrooted');
+    mkdirSync(unrooted, { recursive: true });
+    mkdirSync(join(unrooted, '.token-optimizer', 'wiki'), { recursive: true });
+    saved = {
+      unrootedDir: process.env.TOKEN_OPTIMIZER_UNROOTED_DIR,
+      registry: process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY,
+      wikiDir: process.env.TOKEN_OPTIMIZER_WIKI_DIR,
+    };
+    process.env.TOKEN_OPTIMIZER_UNROOTED_DIR = unrooted;
+    process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY = join(sandbox, 'projects.jsonl');
+    // wikiDir() short-circuits to this for EVERY project when set, which would
+    // collapse the very separation this test exists to cross.
+    delete process.env.TOKEN_OPTIMIZER_WIKI_DIR;
+  });
+
+  afterEach(() => {
+    for (const [key, value] of [
+      ['TOKEN_OPTIMIZER_UNROOTED_DIR', saved.unrootedDir],
+      ['TOKEN_OPTIMIZER_PROJECT_REGISTRY', saved.registry],
+      ['TOKEN_OPTIMIZER_WIKI_DIR', saved.wikiDir],
+    ]) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it('reaches the project graph an unrooted session actually wrote to', () => {
+    const project = makeProject('repo-a');
+    record(project.graphDir, {
+      kind: 'read',
+      anchor: join(project.root, 'src', 'a.mjs'),
+      sessionId: 'now',
+      tokens: 10,
+    });
+
+    const events = sessionActivity(unrooted);
+    const anchors = events.map((e) => e.anchor).filter(Boolean);
+    expect(anchors).toContain(join(project.root, 'src', 'a.mjs'));
+
+    // The whole point: the inference now resolves to the repository, where the
+    // finding can be anchored, instead of to the unrooted fallback where
+    // `indexFile` refuses a directory and the finding is dropped.
+    expect(
+      projectRootFromActivity(events, {
+        resolve: (anchor) => projectRootFor(anchor, unrooted),
+        sessionId: 'now',
+      })
+    ).toBe(canonicalPath(project.root));
+  });
+
+  it('reads only its own graph when the cwd is already a repository', () => {
+    const other = makeProject('repo-b');
+    record(other.graphDir, {
+      kind: 'read',
+      anchor: join(other.root, 'src', 'b.mjs'),
+      sessionId: 'now',
+      tokens: 10,
+    });
+    const here = makeProject('repo-here');
+    record(here.graphDir, {
+      kind: 'read',
+      anchor: join(here.root, 'src', 'h.mjs'),
+      sessionId: 'now',
+      tokens: 10,
+    });
+
+    const anchors = sessionActivity(here.root).map((e) => e.anchor).filter(Boolean);
+    expect(anchors).toContain(join(here.root, 'src', 'h.mjs'));
+    // A rooted session pays nothing for the sweep, and cannot be dragged into
+    // another repository by it.
+    expect(anchors).not.toContain(join(other.root, 'src', 'b.mjs'));
+  });
+
+  it('ignores a registered project the session is too old to have touched', () => {
+    const stale = makeProject('repo-stale', { register: false });
+    // Registered with a timestamp outside the 24h window the sweep considers.
+    appendFileSync(
+      process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY,
+      `${JSON.stringify({
+        v: 1,
+        id: projectIdFor(stale.root),
+        root: canonicalPath(stale.root),
+        graphDir: canonicalPath(stale.graphDir),
+        name: 'repo-stale',
+        client: 'test',
+        at: Date.now() - 72 * 60 * 60 * 1000,
+      })}
+`,
+      'utf8'
+    );
+    record(stale.graphDir, {
+      kind: 'read',
+      anchor: join(stale.root, 'src', 'old.mjs'),
+      sessionId: 'now',
+      tokens: 10,
+    });
+
+    // A project registered inside the window, so the sweep demonstrably ran
+    // and the exclusion below is the age filter rather than a no-op.
+    const fresh = makeProject('repo-fresh');
+    record(fresh.graphDir, {
+      kind: 'read',
+      anchor: join(fresh.root, 'src', 'new.mjs'),
+      sessionId: 'now',
+      tokens: 10,
+    });
+
+    const anchors = sessionActivity(unrooted).map((e) => e.anchor).filter(Boolean);
+    expect(anchors).toContain(join(fresh.root, 'src', 'new.mjs'));
+    expect(anchors).not.toContain(join(stale.root, 'src', 'old.mjs'));
+  });
+
+  it('survives an unreadable registry rather than failing the session', () => {
+    process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY = join(sandbox, 'nope', 'missing.jsonl');
+    expect(() => sessionActivity(unrooted)).not.toThrow();
+    expect(Array.isArray(sessionActivity(unrooted))).toBe(true);
   });
 });

--- a/tests/hooks/derive.test.mjs
+++ b/tests/hooks/derive.test.mjs
@@ -1463,6 +1463,32 @@ describe('detector 5 refuses chained commands', () => {
     cmd('npm test -- tests/foo.test.mjs', true, 45_000);
     expect(retargets()).toHaveLength(1);
   });
+
+  it('refuses a chain whose separator falls AFTER the third token', () => {
+    // The hole every test above missed. `git fetch && ...` is rejected only
+    // because the separator lands inside the three tokens attemptKey keeps;
+    // move it later and the same chain passed. The key here is `npx jest
+    // tests/foo.test.mjs`, so a pair would blame `npx` for a failure that
+    // `node scripts/x.mjs` may have caused.
+    cmd('npx jest tests/foo.test.mjs && node scripts/x.mjs', false, 0);
+    cmd('npm test -- tests/foo.test.mjs', true, 45_000);
+    expect(retargets()).toHaveLength(0);
+  });
+
+  it('refuses a late separator on the SUCCEEDING side too', () => {
+    cmd('npx jest tests/foo.test.mjs', false, 0);
+    cmd('npm test -- tests/foo.test.mjs | tee out.log', true, 45_000);
+    expect(retargets()).toHaveLength(0);
+  });
+
+  it('does not reject an ordinary quoted alternation as a pipeline', () => {
+    // The guard scans with the quote-aware segmenter for this reason: a raw
+    // split on `|` would cut through `grep -E "foo|bar"` and silently drop a
+    // perfectly single command.
+    cmd('npx jest "tests/foo|bar.test.mjs"', false, 0);
+    cmd('npm test -- "tests/foo|bar.test.mjs"', true, 45_000);
+    expect(retargets()).toHaveLength(1);
+  });
 });
 
 /**
@@ -1579,14 +1605,23 @@ describe('inferring the project from what the session touched', () => {
     expect(projectRootFromActivity(events, { resolve: wide })).toBe(OTHER);
   });
 
-  it('keeps an event that carries no session id at all', () => {
-    // Older records predate the field. Dropping them would make the inference
-    // weaker on exactly the graphs that have the most history.
+  it('drops an event that cannot say which session it came from', () => {
+    // Measured before deciding: 2 of 22,321 file/read events across the three
+    // live stores on this machine lack the field, so exempting them buys 0.01%
+    // of recall. What it costs is the whole point of the filter -- an unstamped
+    // event in ANOTHER project's graph would vote for that project on no
+    // evidence, and the sweep reads several graphs at once.
+    const OTHER = '/repos/other';
+    const wide = (anchor) => (anchor.includes('/repos/other') ? OTHER : resolve(anchor));
     const events = [
-      { kind: 'read', anchor: `${REPO}/a` },
-      { kind: 'read', anchor: `${REPO}/b`, sessionId: 'now' },
+      { kind: 'read', anchor: `${OTHER}/a` },
+      { kind: 'read', anchor: `${OTHER}/b` },
+      { kind: 'read', anchor: `${REPO}/x`, sessionId: 'now' },
     ];
-    expect(projectRootFromActivity(events, { resolve, sessionId: 'now' })).toBe(REPO);
+    // Two unstamped events for OTHER would outvote this session's single read.
+    expect(projectRootFromActivity(events, { resolve: wide, sessionId: 'now' })).toBe(REPO);
+    // And with no id requested the old whole-graph count still applies.
+    expect(projectRootFromActivity(events, { resolve: wide })).toBe(OTHER);
   });
 
   it('returns null rather than guessing when nothing resolves', () => {

--- a/tests/hooks/derive.test.mjs
+++ b/tests/hooks/derive.test.mjs
@@ -1387,3 +1387,64 @@ describe('a different command against the same target', () => {
     expect(retargets()).toHaveLength(0);
   });
 });
+
+/**
+ * Compound commands must not be attributed to the wrong program.
+ *
+ * `commandBody` strips only a LEADING directory change and `commandProgram`
+ * reads the first token, so a chained command names the wrong thing: `git fetch
+ * && npx jest tests/foo.test.mjs` has program `git`. Paired against a working
+ * `npm test`, detector 5 would have shipped "npm test succeeded where git fetch
+ * failed" and told a later session to avoid `git`.
+ */
+describe('detector 5 refuses chained commands', () => {
+  const t0 = Date.now();
+  const proj = () => {
+    const p = join(dir, 'proj');
+    mkdirSync(p, { recursive: true });
+    writeFileSync(join(p, 'package.json'), '{"name":"x"}');
+    return p;
+  };
+  const cmd = (anchor, success, offset) =>
+    record(dir, {
+      kind: 'tool-outcome',
+      surface: 'command',
+      anchor,
+      success,
+      exit: success ? 0 : 1,
+      at: t0 + offset,
+      output: success ? '' : 'boom',
+    });
+  const retargets = () =>
+    derive(dir, { sessionId: 's', projectRoot: proj() }).candidates.filter(
+      (c) => c.derivedBy === 'retarget'
+    );
+
+  it('refuses an && chain on the failing side', () => {
+    cmd('git fetch && npx jest tests/foo.test.mjs', false, 0);
+    cmd('npm test -- tests/foo.test.mjs', true, 45_000);
+    expect(retargets()).toHaveLength(0);
+  });
+
+  it('refuses a pipeline on the failing side', () => {
+    cmd('cat x | npx jest tests/foo.test.mjs', false, 0);
+    cmd('npm test -- tests/foo.test.mjs', true, 45_000);
+    expect(retargets()).toHaveLength(0);
+  });
+
+  it('refuses a chain on the SUCCEEDING side too', () => {
+    // Checked per side: unlike detector 1, these two do not share a key by
+    // construction, so one check cannot stand for both.
+    cmd('npx jest tests/foo.test.mjs', false, 0);
+    cmd('git pull && npm test -- tests/foo.test.mjs', true, 45_000);
+    expect(retargets()).toHaveLength(0);
+  });
+
+  it('still accepts a LEADING cd, which names one attempt', () => {
+    // commandBody removes it, so `cd repo && npx jest x` is one command spelled
+    // two ways -- the case hasAttemptIdentity was explicitly fixed not to reject.
+    cmd('cd repo && npx jest tests/foo.test.mjs', false, 0);
+    cmd('npm test -- tests/foo.test.mjs', true, 45_000);
+    expect(retargets()).toHaveLength(1);
+  });
+});

--- a/tests/hooks/finding-round-trip.test.mjs
+++ b/tests/hooks/finding-round-trip.test.mjs
@@ -106,12 +106,29 @@ const askRouter = (command, mode) => {
       TOKEN_OPTIMIZER_MCP_CAPABILITIES: 'smart_read,smart_grep',
     },
   });
-  let out = {};
+  // A CRASH MUST NOT BE READABLE AS SILENCE. The catch below used to swallow
+  // everything, so a router that threw, printed a stack trace, or emitted
+  // malformed JSON returned the same empty string as a clean allow -- and every
+  // `not.toContain` in this file would have passed on a router that never ran.
+  // The router expresses a refusal in JSON and always exits 0 (policy.mjs:736,
+  // 767, 829), so a non-zero status is a genuine failure in every mode.
+  if (result.error) throw result.error;
+  expect(result.status).toBe(0);
+  const stdout = (result.stdout || '').trim();
+  // An allow may legitimately write nothing at all; that is the only empty
+  // output accepted, and only after the status check above.
+  if (!stdout) return '';
+  let parsed;
   try {
-    out = JSON.parse(result.stdout).hookSpecificOutput || {};
+    parsed = JSON.parse(stdout);
   } catch {
-    /* an allow writes nothing */
+    throw new Error(
+      `router emitted non-JSON: ${stdout.slice(0, 400)}
+--- stderr ---
+${result.stderr}`
+    );
   }
+  const out = parsed.hookSpecificOutput || {};
   return (out.additionalContext || '') + (out.permissionDecisionReason || '');
 };
 

--- a/tests/hooks/finding-round-trip.test.mjs
+++ b/tests/hooks/finding-round-trip.test.mjs
@@ -1,0 +1,148 @@
+/**
+ * The whole product claim, in one test.
+ *
+ * Capture -> derive -> store -> retrieve -> deliver, ACROSS SESSIONS. Each half
+ * of this has been verified separately at some point and the chain has never
+ * been asserted end to end, which is how the graph came to hold 2,965 symbols
+ * and ONE finding while every layer looked healthy.
+ *
+ * THE FAILURE ARRIVES FROM THE TRANSCRIPT, NOT FROM AN EVENT, because that is
+ * the only place it exists on the primary client. Claude Code never fires
+ * PostToolUse for a failed tool call -- every one of 1,210 `tool-outcome`
+ * records on the development machine carries `success: true`, with `exit` null.
+ * A fixture that records the failure as an event would pass while the shipped
+ * client learned nothing.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { record } from '../../hooks-core/metrics.mjs';
+import { derive } from '../../hooks-core/derive.mjs';
+import { load } from '../../hooks-core/wiki.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = join(HERE, '..', '..');
+const ROUTER = join(REPO, 'plugin', 'hooks', 'pretooluse-router.mjs');
+
+const FAILED = 'npx jest tests/foo.test.mjs';
+const WORKED = 'npm test -- tests/foo.test.mjs';
+
+let root;
+let wiki;
+let proj;
+let transcript;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'roundtrip-'));
+  wiki = join(root, 'wiki');
+  proj = join(root, 'proj');
+  mkdirSync(join(proj, '.git'), { recursive: true });
+  mkdirSync(wiki, { recursive: true });
+  // A real anchor: writeHarvested resolves anchors through indexFile, and a
+  // directory resolves to nothing, so the claim needs a FILE to hang on.
+  writeFileSync(join(proj, 'package.json'), '{"name":"roundtrip"}\n');
+
+  const now = Date.now();
+  const iso = (t) => new Date(t).toISOString();
+  transcript = join(root, 'transcript.jsonl');
+  writeFileSync(
+    transcript,
+    [
+      {
+        type: 'assistant',
+        timestamp: iso(now),
+        message: { content: [{ type: 'tool_use', id: 'tu_1', name: 'Bash', input: { command: FAILED } }] },
+      },
+      {
+        type: 'user',
+        timestamp: iso(now + 1000),
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tu_1',
+              is_error: true,
+              content: 'Exit code 1\nSyntaxError: Cannot use import statement outside a module',
+            },
+          ],
+        },
+      },
+    ]
+      .map((l) => JSON.stringify(l))
+      .join('\n') + '\n'
+  );
+
+  // Only the SUCCESS is an event -- exactly what the client records.
+  record(wiki, {
+    kind: 'tool-outcome',
+    surface: 'command',
+    anchor: WORKED,
+    success: true,
+    at: now + 40_000,
+  });
+});
+
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+/** A LATER, DIFFERENT session about to run the command that failed before. */
+const askRouter = (command, mode) => {
+  const result = spawnSync(process.execPath, [ROUTER], {
+    input: JSON.stringify({
+      session_id: `later-${Math.random()}`,
+      cwd: proj,
+      tool_name: 'Bash',
+      tool_input: { command },
+    }),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      TOKEN_OPTIMIZER_MODE: mode,
+      TOKEN_OPTIMIZER_WIKI_DIR: wiki,
+      TOKEN_OPTIMIZER_SHARED_DIR: wiki,
+      TOKEN_OPTIMIZER_MCP_CAPABILITIES: 'smart_read,smart_grep',
+    },
+  });
+  let out = {};
+  try {
+    out = JSON.parse(result.stdout).hookSpecificOutput || {};
+  } catch {
+    /* an allow writes nothing */
+  }
+  return (out.additionalContext || '') + (out.permissionDecisionReason || '');
+};
+
+describe('a lesson learned in one session reaches the next', () => {
+  it('derives and STORES the finding from a transcript failure', () => {
+    const result = derive(wiki, { sessionId: 'first', projectRoot: proj, transcriptPath: transcript });
+    expect(result.candidates.length).toBeGreaterThan(0);
+    // Storing is the half that was silently failing: 937 real derive runs
+    // produced 8 candidates and wrote zero.
+    expect(result.written.length).toBeGreaterThan(0);
+
+    const findings = [...load(wiki).nodes.values()].filter((n) => n.kind === 'finding' && !n.retired);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].claim).toContain(WORKED);
+    expect(findings[0].trigger).toBeTruthy();
+  });
+
+  it.each(['assist', 'advise', 'enforce'])(
+    'warns a later session under %s, before the command runs',
+    (mode) => {
+      derive(wiki, { sessionId: 'first', projectRoot: proj, transcriptPath: transcript });
+      const said = askRouter(FAILED, mode);
+      expect(said).toContain('known from previous sessions');
+      expect(said).toContain(WORKED);
+    }
+  );
+
+  it('says nothing about an unrelated command', () => {
+    // The cost of speaking is paid on every call; a finding that fires on
+    // everything is worse than one that fires on nothing.
+    derive(wiki, { sessionId: 'first', projectRoot: proj, transcriptPath: transcript });
+    expect(askRouter('ls -la', 'assist')).not.toContain('known from previous sessions');
+  });
+});

--- a/tests/hooks/finding-round-trip.test.mjs
+++ b/tests/hooks/finding-round-trip.test.mjs
@@ -16,7 +16,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -35,11 +35,15 @@ let root;
 let wiki;
 let proj;
 let transcript;
+let logs;
 
 beforeEach(() => {
   root = mkdtempSync(join(tmpdir(), 'roundtrip-'));
   wiki = join(root, 'wiki');
   proj = join(root, 'proj');
+  // Per test, so the completion event read below can only be this test's.
+  logs = join(root, 'logs');
+  mkdirSync(logs, { recursive: true });
   mkdirSync(join(proj, '.git'), { recursive: true });
   mkdirSync(wiki, { recursive: true });
   // A real anchor: writeHarvested resolves anchors through indexFile, and a
@@ -88,6 +92,35 @@ beforeEach(() => {
 
 afterEach(() => rmSync(root, { recursive: true, force: true }));
 
+/**
+ * The outcome the router recorded for the invocation that just ran.
+ *
+ * `hook.completed` carries `outcome: 'success' | 'failure' | 'timeout'`, and it
+ * is written even when the hook swallowed the error and allowed the call --
+ * which is precisely the case stdout cannot show.
+ */
+const completion = () => {
+  const files = readdirSync(logs).filter((name) => /^hook-events-.*\.jsonl$/.test(name));
+  const events = files.flatMap((name) =>
+    readFileSync(join(logs, name), 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .flatMap((line) => {
+        try {
+          return [JSON.parse(line)];
+        } catch {
+          return [];
+        }
+      })
+  );
+  const completed = events.filter((e) => e.event === 'hook.completed');
+  // Named rather than defaulted: no event at all means the router never got as
+  // far as its own instrumentation, which is a failure too and must not read
+  // as success.
+  if (!completed.length) return 'no hook.completed event was written';
+  return completed[completed.length - 1].outcome;
+};
+
 /** A LATER, DIFFERENT session about to run the command that failed before. */
 const askRouter = (command, mode) => {
   const result = spawnSync(process.execPath, [ROUTER], {
@@ -104,6 +137,7 @@ const askRouter = (command, mode) => {
       TOKEN_OPTIMIZER_WIKI_DIR: wiki,
       TOKEN_OPTIMIZER_SHARED_DIR: wiki,
       TOKEN_OPTIMIZER_MCP_CAPABILITIES: 'smart_read,smart_grep',
+      TOKEN_OPTIMIZER_LOG_DIR: logs,
     },
   });
   // A CRASH MUST NOT BE READABLE AS SILENCE. The catch below used to swallow
@@ -114,6 +148,14 @@ const askRouter = (command, mode) => {
   // 767, 829), so a non-zero status is a genuine failure in every mode.
   if (result.error) throw result.error;
   expect(result.status).toBe(0);
+  // NOR MUST A CAUGHT CRASH BE READABLE AS SILENCE, which the status check
+  // above cannot see. The router's outer catch records `invocation.fail(error)`
+  // and then calls `allow()`, and an allow exits 0 with no stdout -- byte for
+  // byte what a clean allow produces. So a router that threw on every input
+  // would satisfy everything above it and every `not.toContain` in this file
+  // would pass while the product did nothing. The completion event is the only
+  // place the two are distinguishable.
+  expect(completion()).toBe('success');
   const stdout = (result.stdout || '').trim();
   // An allow may legitimately write nothing at all; that is the only empty
   // output accepted, and only after the status check above.

--- a/tests/hooks/finding-round-trip.test.mjs
+++ b/tests/hooks/finding-round-trip.test.mjs
@@ -143,6 +143,9 @@ describe('a lesson learned in one session reaches the next', () => {
     // The cost of speaking is paid on every call; a finding that fires on
     // everything is worse than one that fires on nothing.
     derive(wiki, { sessionId: 'first', projectRoot: proj, transcriptPath: transcript });
+    // The same router, same graph, same mode DOES speak for the command the
+    // finding is about -- so the silence below is selectivity, not a dead path.
+    expect(askRouter(FAILED, 'assist')).toContain('known from previous sessions');
     expect(askRouter('ls -la', 'assist')).not.toContain('known from previous sessions');
   });
 });

--- a/tests/hooks/search-advisory.test.mjs
+++ b/tests/hooks/search-advisory.test.mjs
@@ -1002,6 +1002,20 @@ ${result.stderr}`
     expect(decisionOf(raw)).toBe('allow');
     const result = out(raw);
     expect(result.additionalContext || '').not.toContain('token-optimizer index');
+    // The same gate, same mode, same workspace DOES answer for a symbol the
+    // index holds, so the silence above is the empty graph and not a dead gate.
+    const known = out(
+      run(
+        {
+          session_id: fresh('assist-silent-control'),
+          cwd: workspace,
+          tool_name: 'Bash',
+          tool_input: { command: `grep -rn "parse_line" ${workspace}` },
+        },
+        { ...INSTALLED, TOKEN_OPTIMIZER_MODE: 'assist' }
+      )
+    );
+    expect(known.additionalContext || '').toContain('parse.py');
   });
 
   test('assist carries the answer without the routing advisory', () => {

--- a/tests/hooks/transcript.test.mjs
+++ b/tests/hooks/transcript.test.mjs
@@ -16,6 +16,7 @@ import { tmpdir } from 'os';
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { load, nodeId } from '../../hooks-core/wiki.mjs';
+import { failedResultsFromTranscript } from '../../hooks-core/transcript.mjs';
 
 let dir;
 let transcript;
@@ -239,4 +240,83 @@ describe('the never-transmit guarantee is enforced, not merely stated', () => {
       }
     }
   }, 60_000);
+});
+
+/**
+ * A run the harness stopped is not the command failing.
+ *
+ * The allowlist admits anything shaped `Exit code N`, and a killed command
+ * reports `Exit code 143` with `Command timed out after 2m 0s`. Nothing about
+ * that is a lesson: the command did not fail, it was not allowed to finish,
+ * and the same command with a longer budget may pass. Pairing one with a
+ * later success claims a red-to-green transition that never happened.
+ *
+ * Measured on a 237 MB transcript of ordinary feature work: 25 of 130
+ * admitted failures were timeouts, 19%; at a 64 MB scan, 11 of 23. User
+ * declines are a different matter -- the positive allowlist already excludes
+ * them at every scan size, and the third test pins that so nobody adds a
+ * redundant rule for it later.
+ */
+describe('what counts as a command failure', () => {
+  const attempt = (id, command, resultText) => [
+    {
+      type: 'assistant',
+      timestamp: '2026-03-04T10:00:00Z',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id, input: { command } }],
+      },
+    },
+    {
+      type: 'user',
+      timestamp: '2026-03-04T10:00:30Z',
+      message: {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: id, is_error: true, content: resultText },
+        ],
+      },
+    },
+  ];
+
+  it('keeps a command that ran and exited non-zero', () => {
+    const p = writeTranscript(
+      attempt('t1', 'npm test -- tests/a.test.mjs', 'Exit code 1\nAssertionError: expected 2')
+    );
+    const out = failedResultsFromTranscript(p);
+    expect(out).toHaveLength(1);
+    expect(out[0].command).toBe('npm test -- tests/a.test.mjs');
+    expect(out[0].exit).toBe(1);
+  });
+
+  it('drops a run the harness timed out', () => {
+    const p = writeTranscript(
+      attempt('t2', 'npm test', 'Exit code 143\nCommand timed out after 2m 0s')
+    );
+    expect(failedResultsFromTranscript(p)).toEqual([]);
+  });
+
+  it('still drops a user decline, which needs no rule of its own', () => {
+    const p = writeTranscript(
+      attempt(
+        't3',
+        'rm -rf build',
+        "The user doesn't want to proceed with this tool use. The tool use was rejected"
+      )
+    );
+    expect(failedResultsFromTranscript(p)).toEqual([]);
+  });
+
+  it('keeps a real failure that merely MENTIONS a timeout', () => {
+    // The guard matches the harness's own report, not any mention of one -- a
+    // test asserting on timeout behaviour is a genuine failure worth learning.
+    const p = writeTranscript(
+      attempt(
+        't4',
+        'npm test -- tests/timeout.test.mjs',
+        'Exit code 1\nexpected the request to have timed out after 30s'
+      )
+    );
+    expect(failedResultsFromTranscript(p)).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## The defect

The knowledge graph has not been producing findings, and the cause is structural rather than a bug.

Measured on the development machine: **937 real derive runs produced 8 candidates and stored ZERO findings.** Our own project graph holds **2,965 symbol nodes and ONE finding.** Every warm benchmark rep: 7,946 symbols, zero findings.

## Why the command family was unreachable

`attemptKey` is program-plus-operands, so the correction actually worth recording — reaching for a *different tool against the same target* — lands in two groups that never meet:

```
npx jest tests/foo.test.mjs     ->  key "npx jest tests/foo.test.mjs"
npm test -- tests/foo.test.mjs  ->  key "npm test tests/foo.test.mjs"
```

What detector 1 *can* pair is the identical command re-run — and its own guard then correctly discards that as incoherent, because "`npm run build` works where `npm run build` failed" claims nothing.

So between the key and the guard, the most valuable lesson a session can teach had **no path into the graph at all.**

That key was a deliberate trade, and its docblock says so: *"A missed pair costs one finding; a wrong pair ships a false claim into model context."* The direction was right; the degree was too aggressive. Recall came out at zero.

## The fix

Detector 5 pairs on the shared **operand**, and only when the **program differs** — same-program pairs remain detector 1's business.

The conservatism the original key protected is kept in four other places:

- the operand must **name** something (a path separator or file extension, never a bare word like `build`)
- the two attempts must fall within a **ten-minute window** — proximity does the work command identity does in detector 1
- both commands must be **quotable**
- the ceiling is **0.6 / speculative**, not 0.9, because sharing a target is weaker evidence than repeating an invocation

## Verified end to end

Against the exact real-world shape — 1 candidate, and **1 written**, the first finding to reach a graph in this investigation:

> In this project `npm test -- tests/foo.test.mjs` succeeded on tests/foo.test.mjs where `npx jest tests/foo.test.mjs` had failed

That is verbatim the lesson recorded by hand in the wiki earlier today. The product now derives it automatically.

## One scope bug fixed along the way

`outcomes` is hoisted to function scope so both detectors pair over the same merged list (events plus transcript failures). Left block-scoped, detector 5 got a `ReferenceError` that its own try/catch swallowed — silent nothing rather than a visible failure.

## Tests

+6. One proves it fires **and stores**; five prove it stays quiet on the junk shapes — same program, bare-word operand, hours apart, different targets, and a success with no preceding failure.

```
266 suites, 3756 passed, 5 skipped
```

## Validation

`npm run validate:pr` / `npm run pr:create` do not exist in this repo. Ran the equivalent: `lint` (0 errors), `format:check`, `sync:hooks`, `build`, full `test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)