### PR TITLE
fix(router): answer a refused read instead of spending a turn on it

### DIFF
--- a/plugin/hooks/pretooluse-router.mjs
+++ b/plugin/hooks/pretooluse-router.mjs
@@ -544,16 +544,7 @@ ${nudge}`
       if (substitution) {
         allowWithRewrite(
           { ...payload.tool_input, file_path: substitution.target },
-          [
-            context,
-            `token-optimizer replaced this read with a structural outline of ` +
-              `${payload.tool_input.file_path} (${substitution.found.lines} lines, ` +
-              `${Math.round(substitution.found.bytes / 1024)}KB). Every symbol is ` +
-              `listed with its line number; read the original with offset and limit ` +
-              `for any region you need in full.`,
-          ]
-            .filter(Boolean)
-            .join('\n\n')
+          [context, outlineNotice(payload, substitution)].filter(Boolean).join('\n\n')
         );
       }
     }
@@ -703,6 +694,25 @@ function turnsSoFar(sessionId) {
  * call it already made, which is why it costs nothing on the short tasks where
  * a fixed setup cost would sink us.
  */
+/**
+ * What the model is told when its read is answered with an outline.
+ *
+ * ONE WORDING FOR BOTH PATHS. The allowed path and the refusal path now both
+ * substitute, and two copies of this sentence would drift -- which matters more
+ * than usual here, because an unannounced rewrite is the failure mode
+ * `allowWithRewrite` documents: a model that distrusts its output re-reads, and
+ * spends the exact turn the substitution exists to save.
+ */
+function outlineNotice(payload, substitution) {
+  return (
+    `token-optimizer replaced this read with a structural outline of ` +
+    `${payload.tool_input.file_path} (${substitution.found.lines} lines, ` +
+    `${Math.round(substitution.found.bytes / 1024)}KB). Every symbol is ` +
+    `listed with its line number; read the original with offset and limit ` +
+    `for any region you need in full.`
+  );
+}
+
 function outlineSubstitution(payload) {
   const filePath = payload.tool_input?.file_path;
   if (!filePath) return null;
@@ -875,6 +885,40 @@ function compactorFor(sessionId, command) {
         // reason names the optimizer tool that makes the NEXT call cheaper,
         // and dropping it leaves only a byte notice that teaches nothing.
         [reason, boundNotice(bounded.maxBytes)].filter(Boolean).join('\n\n')
+      );
+    }
+  }
+
+  // AND THE SAME FOR A READ, which is where the turn actually goes.
+  //
+  // `outlineSubstitution` was reachable only from the allowed path above, and a
+  // Read large enough to be worth outlining is precisely a Read that earns a
+  // verdict -- so the substitution was unreachable for every file it was built
+  // for. Measured on a 156 KB Python file with smart_read registered: the
+  // router answered `deny` with no `updatedInput`, while `substitutionFor` on
+  // that same path offered an 8,379-character outline, 5.2% of the file. The
+  // cheaper answer existed and was never consulted.
+  //
+  // This is the same shape as the two defects already recorded in this file --
+  // the output bound wired only to the refusal branch, and the advisory wired
+  // only to the allowed one. A capability reachable from one branch is not
+  // shipped; it is half shipped, on whichever side nobody measured.
+  //
+  // WHY IT PAYS. A refusal costs about one extra turn, and turns are the whole
+  // measured deficit: on the 16 THOL tasks with complete data, enforce ran 20.0
+  // turns against control's 14.4 for a median cost of 1.724x, and the extra
+  // turns track the MCP redirects at 0.90 turns per redirected call. A rewrite
+  // delivers the same substitution for none of that.
+  //
+  // Gated on `refusalsEnabled()` for the reason the Bash arm gives: under assist
+  // this read is already going through untouched, and bounding it there would
+  // be new behaviour rather than a cheaper spelling of an existing refusal.
+  if (payload.tool_name === 'Read' && refusalsEnabled()) {
+    const substitution = outlineSubstitution(payload);
+    if (substitution) {
+      allowWithRewrite(
+        { ...payload.tool_input, file_path: substitution.target },
+        [reason, outlineNotice(payload, substitution)].filter(Boolean).join('\n\n')
       );
     }
   }

--- a/tests/hooks/outline-substitution.test.mjs
+++ b/tests/hooks/outline-substitution.test.mjs
@@ -17,7 +17,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -139,5 +139,129 @@ describe('the router supplies the signal', () => {
     const fresh = read(`outline-${randomUUID()}`);
     expect(fresh).not.toBeNull();
     expect(fresh).not.toBe(big);
+  });
+});
+
+/**
+ * The substitution has to survive a verdict, or it never fires for a real file.
+ *
+ * `outlineSubstitution` was reachable only from the router's allowed path, and
+ * a Read large enough to be worth outlining is precisely a Read that earns a
+ * verdict -- so with the MCP server registered, every file the mechanism was
+ * built for took the refusal path instead and the outline was never consulted.
+ *
+ * Measured on a 156 KB Python file with smart_read registered: the router
+ * answered `deny` with no `updatedInput`, while `substitutionFor` on that same
+ * path offered an 8,379-character outline -- 5.2% of the file. The cheaper
+ * answer existed and was skipped, and a refusal costs about one extra turn.
+ * Across the 16 THOL tasks with complete data that is the whole deficit:
+ * enforce ran 20.0 turns against control's 14.4 for a median 1.724x cost, with
+ * the extra turns tracking MCP redirects at 0.90 turns per redirected call.
+ */
+describe('a refused read is answered, not just refused', () => {
+  const INSTALLED = 'smart_read,smart_write,smart_edit,smart_glob,smart_grep';
+
+  /** Runs the packaged entry with the server registered and returns the decision. */
+  const read = (mode, { file = big, capabilities = INSTALLED } = {}) => {
+    const result = spawnSync(
+      process.execPath,
+      [join(ROOT, 'plugin/hooks/pretooluse-router.mjs')],
+      {
+        input: JSON.stringify({
+          session_id: `refused-${randomUUID()}`,
+          cwd: workspace,
+          tool_name: 'Read',
+          tool_input: { file_path: file },
+        }),
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          TOKEN_OPTIMIZER_MODE: mode,
+          TOKEN_OPTIMIZER_MCP_CAPABILITIES: capabilities,
+        },
+      }
+    );
+    // A crash must not read as a silent allow: without this an exception in
+    // the router satisfies every 'was not denied' assertion below.
+    if (result.error) throw result.error;
+    expect(result.status).toBe(0);
+    const stdout = (result.stdout || '').trim();
+    if (!stdout) return { decision: 'allow', updatedInput: null, context: '' };
+    const out = JSON.parse(stdout).hookSpecificOutput || {};
+    return {
+      decision: out.permissionDecision || 'allow',
+      updatedInput: out.updatedInput || null,
+      context: `${out.additionalContext || ''}${out.permissionDecisionReason || ''}`,
+    };
+  };
+
+  test('enforce rewrites the read instead of spending a turn refusing it', () => {
+    const result = read('enforce');
+    // The whole point: the call goes through, so there is no retry to pay for.
+    expect(result.decision).not.toBe('deny');
+    expect(result.updatedInput?.file_path).toBeTruthy();
+    expect(result.updatedInput.file_path).not.toBe(big);
+    // And what it is pointed at is smaller than what was asked for, or the
+    // substitution saved nothing.
+    expect(statSync(result.updatedInput.file_path).size).toBeLessThan(
+      statSync(big).size
+    );
+  });
+
+  test('the rewrite is announced, naming the file it replaced', () => {
+    // An unannounced rewrite is the documented failure mode of
+    // allowWithRewrite: the spike's model distrusted the mismatched output and
+    // re-ran the command, spending the exact turn this exists to save.
+    //
+    // Asserted on the sentence ONLY `outlineNotice` emits. A first version
+    // looked for 'outline' and the file's name, and both appear in the
+    // verdict's refusal reason too -- so it passed against the unfixed router,
+    // announcing a rewrite that had not happened.
+    const result = read('enforce');
+    expect(result.updatedInput?.file_path).toBeTruthy();
+    expect(result.context).toContain('replaced this read with a structural outline');
+    expect(result.context).toContain(big);
+  });
+
+  test("the verdict's own reason still rides along", () => {
+    // Rewriting instead of refusing must not cost what the refusal would have
+    // carried -- the same rule the Bash bound above it follows. The verdict's
+    // own summary of the file arrives alongside the substitution.
+    //
+    // It does NOT carry the `Call smart_read with path=...` line, and that is
+    // correct rather than a gap: that sentence is appended by the refusal
+    // renderer, and telling the model to re-fetch through another tool a call
+    // that has just been answered is the redirect noise assist exists to drop.
+    const result = read('enforce');
+    expect(result.context).toContain('Structure and what is known about it');
+    expect(result.context).toContain('read the original with offset and limit');
+    expect(result.context).not.toContain('Call smart_read with path');
+  });
+
+  test('assist is left exactly as it was', () => {
+    // Gated on refusalsEnabled() deliberately. Under assist this read is
+    // already going through untouched, and bounding it here would be new
+    // behaviour rather than a cheaper spelling of an existing refusal -- a
+    // change that would need its own measurement before it shipped.
+    const result = read('assist');
+    expect(result.decision).not.toBe('deny');
+    expect(result.updatedInput).toBeNull();
+  });
+
+  test('a read with no outline to offer is still refused', () => {
+    // THE GUARD MUST NOT TURN EVERY REFUSAL INTO AN ALLOW. A file the outliner
+    // cannot describe has no cheaper answer, so the redirect has to stand.
+    //
+    // Markdown, not a binary: `.md` is outside OUTLINEABLE so no substitution
+    // is offered, while still being large text that earns a verdict. A 400 KB
+    // `.bin` was the first fixture here and it proved nothing -- the router
+    // allows it outright, so the test passed without ever reaching the guard.
+    const opaque = join(workspace, 'notes.md');
+    writeFileSync(opaque, '# Heading\n\nProse that is long enough to matter.\n\n'.repeat(4000));
+    const result = read('enforce', { file: opaque });
+    expect(result.decision).toBe('deny');
+    expect(result.updatedInput).toBeNull();
+    // And the refusal still names the tool that makes the next call cheaper.
+    expect(result.context).toContain('smart_read');
   });
 });


### PR DESCRIPTION
## The measurement that prompted this

The corrected THOL enforce arm finished today — the first time the enforcing posture has been measured with its MCP server actually registered. On the 16 tasks with complete data for all three arms (17 tasks × 3 reps, claude 2.1.251):

| arm | median cost vs control | cheaper on | turns | mean score |
| --- | --- | --- | --- | --- |
| assist | **0.932** | 11 of 16 | 11.5 | 0.9938 |
| enforce | **1.724** | **0 of 16** | 15.0 | 0.9688 |
| control | 1.000 | — | 11.5 | 0.9938 |

Enforcement loses on every single task. Decomposing the premium by token class:

| component | control | enforce | share of the extra |
| --- | --- | --- | --- |
| output | $0.0524 | $0.0799 | 25% |
| cache creation | $0.0566 | $0.0853 | 26% |
| **cache read** | $0.0594 | $0.1124 | **48%** |

Cache read is prefix × turns, so I split it: **77% of the extra comes from running more turns**, 23% from a larger prefix. And the extra turns track the redirects almost exactly — **+7.7 turns against 8.6 MCP calls per run, 0.90 extra turns per redirected call**. That is the refuse-then-retry round trip, priced.

`allowWithRewrite` already exists for precisely this, and its docblock already says so: *"A refusal costs about one extra turn, and turns are the whole measured deficit — 12.6 to 20.9 under enforcement, for a task-mean 1.633x."* This measurement independently reproduces that at 11.5 → 15.0 and 1.724x. The mechanism was built; the question was why enforce still refused 8.6 times a run.

## The defect

`outlineSubstitution` was reachable **only from the router's allowed path**, and a Read large enough to be worth outlining is precisely a Read that earns a verdict — so the substitution was unreachable for every file it was built for.

Probed rather than reasoned about. A 156 KB Python file, `smart_read` registered:

```
MODE=enforce   decision: deny    updatedInput: NONE   <-- +1 turn
MODE=assist    (plain allow — the full 156 KB enters context)
```

…while `substitutionFor` on that same path, same moment, offered an **8,379-character outline — 5.2% of the file**. The cheaper answer existed and was never consulted.

**This is the third instance of one shape in this file.** The output bound was wired only to the refusal branch, so the debug family it was built for was never touched. The search advisory was wired only to the allowed branch, so it fired for the benchmark arm and never for a real install. Now the outline, on the allowed branch, invisible to every file large enough to want it. A capability reachable from one branch is not shipped; it is half shipped, on whichever side nobody measured.

## The fix

A Read arm on the refusal path, mirroring the Bash bound directly above it. Same file, same content, no retry:

```
MODE=enforce   decision: allow
               updatedInput: file_path -> <outline>.txt   8,379 B vs 159,689 (5.2%)
               turns cost  : 0
```

The verdict's own reason and the substitution notice both ride along — 5,052 characters of context in place of 156 KB.

Gated on `refusalsEnabled()` for the reason the Bash arm gives: under assist this read already goes through untouched, and bounding it there would be new behaviour rather than a cheaper spelling of an existing refusal. A test pins that assist is unchanged.

The notice is factored into `outlineNotice` and shared by both paths — two copies would drift, and an unannounced rewrite is the documented failure mode of `allowWithRewrite`.

## What it deliberately does not do

A file the outliner cannot describe — a large `.md`, say — still gets the redirect, because for it there is no cheaper answer. Pinned by a test, after the first fixture for it (a 400 KB `.bin`) turned out to prove nothing: the router allows that outright, so the test passed without ever reaching the guard.

## Verification

- **+5 tests; three fail against the unfixed router**, run mutated rather than assumed (`if (false && ...)` on the new arm).
- The announcement test needed tightening for the same reason: asserting `'outline'` and the file name passed on the unfixed code, because the refusal reason contains both. It now asserts the sentence only `outlineNotice` emits.
- `tests/hooks/outline-substitution.test.mjs`: 10 passed.
- `npm run build` clean; `npm run sync:hooks:check` reports all client integrations, entries and configs in sync.

## Validation gate

`npm run validate:pr` and `npm run pr:create` do not exist in this repo. The equivalent was run manually: build, targeted tests, mutation check, lint, and the generated-artifact sync check.

**Pre-existing lint failures, not from this branch:** `tests/hooks/audit.test.mjs:500` and `tests/hooks/search-advisory.test.mjs:955` fail `local/no-vacuous-assertions` on master today. Neither file is in this diff. #377 fixes the first, #374 the second.

## What this does not settle

Whether the fix moves the benchmark. The prediction is that it removes the Read-refusal turns from the enforce arm; the share of the 8.6 MCP calls that are `smart_read` is not yet known, so the size of the win is not claimed here. That needs a re-run of the enforce arm to answer, and it should be registered before it runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
