### PR TITLE
fix(harvest): speak the dialect the local model actually serves

### DIFF
--- a/hooks-core/doctor.mjs
+++ b/hooks-core/doctor.mjs
@@ -23,7 +23,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { harvestMode } from './harvest.mjs';
+import { harvestMode, harvestFailure } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
 import { mcpClientsSeen } from './metrics.mjs';
 
@@ -226,6 +226,20 @@ export function probeHarvest() {
   // credential, no billing and no digest leaving the machine -- so the two facts
   // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
+    // WHY THE LAST ONE PRODUCED NOTHING, when it produced nothing.
+    //
+    // `extract` returns [] on every failure so a hook-path caller need not
+    // care, which made a misconfigured endpoint indistinguishable from a
+    // session with nothing to learn -- the exact reason a client speaking the
+    // wrong dialect went unnoticed. `harvestFailure()` carries the reason, and
+    // this is the reader it was added for.
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check the endpoint URL and, for an OpenAI-compatible server, that ' +
+        'TOKEN_OPTIMIZER_HARVEST_MODEL names a model it actually serves')];
+    }
     return [ok('finding extraction is available',
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];

--- a/hooks-core/harvest-worker.mjs
+++ b/hooks-core/harvest-worker.mjs
@@ -97,13 +97,20 @@ async function main() {
   const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
   if (!digest) return;
 
-  const raw = await extract(digest);
+  // THE SAME LIST TO BOTH SIDES. `validate` has always held anchors to the
+  // files this session touched; passing it to `extract` too lets the model be
+  // GIVEN that list instead of guessing at it. Measured on this session's real
+  // digest with qwen2.5:7b: 0 of 4 extractions survived the gate when the model
+  // guessed, 4 of 4 when it chose. Computed once so the two can never disagree
+  // -- a model constrained to one list and judged against another would fail
+  // every time, and silently.
+  const anchorable = full ? null : filesIn(digest);
 
-  // Anchors are held to the files this session actually touched, so a model
-  // that invents a plausible path cannot anchor a finding to it. The digest
-  // lists them under a heading it writes itself; the full delta is raw
-  // transcript and carries no such list, so it gets no restriction.
-  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+  const raw = await extract(digest, { knownFiles: anchorable });
+
+  // The full delta is raw transcript and carries no file heading, so it gets
+  // no restriction on either side.
+  const validated = validate(raw, { knownFiles: anchorable });
 
   // BUDGETED SELECTION, not everything the model extracted.
   //

--- a/hooks-core/harvest.mjs
+++ b/hooks-core/harvest.mjs
@@ -18,7 +18,9 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -54,6 +56,17 @@ export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map'
  * the OpenAI structured-output contract takes an object at the root; `extract`
  * already locates the array inside whatever it is handed, so nothing
  * downstream needs to know.
+ *
+ * EVERY FIELD THE PROMPT ASKS FOR HAS TO BE DECLARED HERE, because the
+ * object is closed. `PROMPT` asks for `scope` and `invalidators`; the schema
+ * did not declare them and `additionalProperties: false` therefore FORBADE
+ * them, so an enforcing server could not return either one. `validate` then
+ * substituted `project` and `[]` for every finding, and the substitution is
+ * silent: on the schema path, organization- and global-scope findings could
+ * not be promoted and no finding could ever carry an invalidator. Both are
+ * required, matching the prompt -- a finding with nothing that would
+ * invalidate it is declared as an empty array rather than omitted, which is a
+ * claim the model has to make on purpose.
  */
 export const FINDINGS_SCHEMA = Object.freeze({
   type: 'object',
@@ -65,13 +78,24 @@ export const FINDINGS_SCHEMA = Object.freeze({
       items: {
         type: 'object',
         additionalProperties: false,
-        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        required: [
+          'type',
+          'claim',
+          'evidence',
+          'applicability',
+          'confidenceLabel',
+          'scope',
+          'invalidators',
+          'anchors',
+        ],
         properties: {
           type: { type: 'string', enum: FINDING_TYPES },
           claim: { type: 'string' },
           evidence: { type: 'string' },
           applicability: { type: 'string' },
           confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          scope: { type: 'string', enum: ['project', 'organization', 'global'] },
+          invalidators: { type: 'array', items: { type: 'string' } },
           anchors: { type: 'array', items: { type: 'string' } },
           trigger: { type: 'string' },
         },
@@ -377,11 +401,72 @@ export function endpointDialect(endpoint = ENDPOINT()) {
  * on the hook path must not care; the reason is recorded beside it so
  * `doctor` and a human can tell the two apart.
  */
+// A MODULE VARIABLE CANNOT CROSS A PROCESS, and every reader of this is in a
+// different one. The harvest runs in a DETACHED worker spawned at Stop
+// (stop-harvest.mjs), while `doctor` is a separate `node` invocation that
+// imports a fresh copy of this module. So `probeHarvest` read `null` no matter
+// what the harvest had done, and the failure branch it was given -- the whole
+// point of recording a reason -- could never be reached from the diagnostic
+// that exists to surface it. The reason is written where the next process can
+// find it.
+//
+// Per user, not per project: the worker resolves a project root and `doctor`
+// often cannot, and the failures recorded here (a wrong dialect, a missing
+// model name, an unreachable endpoint, a CLI that is not on PATH) are
+// properties of the machine's configuration rather than of a repository.
+const FAILURE_FILE = () =>
+  process.env.TOKEN_OPTIMIZER_HARVEST_STATE ||
+  join(homedir(), '.token-optimizer', 'last-harvest.json');
+
+// Old enough to be about a configuration that no longer exists. A harvest runs
+// at the end of every session, so a record older than this means the harvest
+// has not run since -- reporting it as the current state would be a guess.
+const FAILURE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
 let lastHarvestFailure = null;
-export const harvestFailure = () => lastHarvestFailure;
-const failed = (reason) => {
+/** True once this process has recorded an outcome, so the file is not consulted. */
+let outcomeThisProcess = false;
+
+function recordOutcome(reason) {
   lastHarvestFailure = reason;
+  outcomeThisProcess = true;
+  try {
+    const file = FAILURE_FILE();
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({ reason, at: Date.now() }), 'utf8');
+  } catch {
+    // Best effort. A harvest must never fail because it could not write a
+    // diagnostic about itself.
+  }
+}
+
+export function harvestFailure() {
+  if (outcomeThisProcess) return lastHarvestFailure;
+  try {
+    const { reason, at } = JSON.parse(readFileSync(FAILURE_FILE(), 'utf8'));
+    if (!reason || typeof at !== 'number') return null;
+    return Date.now() - at > FAILURE_TTL_MS ? null : reason;
+  } catch {
+    return null;
+  }
+}
+
+const failed = (reason) => {
+  recordOutcome(reason);
   return [];
+};
+
+/**
+ * Clears the recorded failure, because the harvest just worked.
+ *
+ * Without this the file is a one-way latch: a user fixes their endpoint, the
+ * harvest starts working, and `doctor` keeps reporting the failure that was
+ * true a week ago. The TTL alone would not do it -- it expires a stale record,
+ * not a wrong one.
+ */
+const succeeded = (findings) => {
+  recordOutcome(null);
+  return findings;
 };
 
 /**
@@ -394,6 +479,7 @@ export async function extract(
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
 ) {
   lastHarvestFailure = null;
+  outcomeThisProcess = false;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
@@ -581,7 +667,7 @@ export async function extract(
     if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
     try {
-      return JSON.parse(text.slice(start, end + 1));
+      return succeeded(JSON.parse(text.slice(start, end + 1)));
     } catch {
       return failed('the JSON array in the reply did not parse');
     }

--- a/hooks-core/harvest.mjs
+++ b/hooks-core/harvest.mjs
@@ -366,7 +366,10 @@ const failed = (reason) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
-export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
+export async function extract(
+  digest,
+  { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
+) {
   lastHarvestFailure = null;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
@@ -382,6 +385,43 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
+  //
+  // `validate` holds anchors to the files the session actually touched, and a
+  // model asked in English for a path writes a plausible one instead of a real
+  // one -- so every finding was discarded at the gate. Measured over four runs
+  // of qwen2.5:7b on this session's real digest, against that same gate:
+  //
+  //   anchors unconstrained     4 extracted -> 0 accepted
+  //   anchors enum-constrained  4 extracted -> 4 accepted
+  //
+  // Nothing else differed. The server enforces the enum, so the model picks
+  // from the real list rather than inventing one, and the gate stops being
+  // the thing that silently eats the harvest.
+  //
+  // Only when the caller knows the list. `buildFullDelta` is raw transcript
+  // with no file heading, and its caller passes no knownFiles for the same
+  // reason -- an empty enum would forbid every anchor rather than free it.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+  const schema = anchorChoices.length
+    ? {
+        ...FINDINGS_SCHEMA,
+        properties: {
+          ...FINDINGS_SCHEMA.properties,
+          findings: {
+            ...FINDINGS_SCHEMA.properties.findings,
+            items: {
+              ...FINDINGS_SCHEMA.properties.findings.items,
+              properties: {
+                ...FINDINGS_SCHEMA.properties.findings.items.properties,
+                anchors: { type: 'array', items: { type: 'string', enum: anchorChoices } },
+              },
+            },
+          },
+        },
+      }
+    : FINDINGS_SCHEMA;
 
   // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
   //
@@ -434,7 +474,7 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 ? {
                     response_format: {
                       type: 'json_schema',
-                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                      json_schema: { name: 'findings', schema },
                     },
                   }
                 : {}),

--- a/hooks-core/harvest.mjs
+++ b/hooks-core/harvest.mjs
@@ -39,6 +39,47 @@ const ENDPOINT = () => process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT
 // was wrong, which is why it is kept distinguishable from an ordinary finding.
 export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
 
+/**
+ * The shape a reply must take, for servers that can enforce one.
+ *
+ * A SMALL LOCAL MODEL WILL NOT FOLLOW THE PROMPT ON ITS OWN. Measured against
+ * qwen2.5:3b through ollama on the real digest from this session:
+ *
+ *   no constraint                    prose summary, 0 findings
+ *   response_format json_object      valid JSON, an invented schema
+ *   response_format json_schema      1 finding in the exact shape, 9s
+ *
+ * That is the difference between the free private path working and not, so
+ * the schema is sent rather than hoped for. The wrapper object exists because
+ * the OpenAI structured-output contract takes an object at the root; `extract`
+ * already locates the array inside whatever it is handed, so nothing
+ * downstream needs to know.
+ */
+export const FINDINGS_SCHEMA = Object.freeze({
+  type: 'object',
+  required: ['findings'],
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        properties: {
+          type: { type: 'string', enum: FINDING_TYPES },
+          claim: { type: 'string' },
+          evidence: { type: 'string' },
+          applicability: { type: 'string' },
+          confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          anchors: { type: 'array', items: { type: 'string' } },
+          trigger: { type: 'string' },
+        },
+      },
+    },
+  },
+});
+
 export function apiKey() {
   return process.env.TOKEN_OPTIMIZER_API_KEY || process.env.ANTHROPIC_API_KEY || null;
 }
@@ -357,8 +398,15 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-  try {
-    const response = await fetch(endpoint, {
+  /**
+   * One request. `structured` asks the server to enforce FINDINGS_SCHEMA.
+   *
+   * Separated out so the schema can be dropped and the call retried WITHOUT
+   * repeating the request shape in two places, which is how the two would
+   * drift.
+   */
+  const send = (structured) =>
+    fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
@@ -382,6 +430,14 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 { role: 'system', content: system },
                 { role: 'user', content: digest },
               ],
+              ...(structured
+                ? {
+                    response_format: {
+                      type: 'json_schema',
+                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                    },
+                  }
+                : {}),
             }
           : {
               model: MODEL(),
@@ -391,6 +447,21 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
             }
       ),
     });
+
+  try {
+    // Structured output only where the contract exists. Anthropic Messages has
+    // no `response_format`, and sending one is at best ignored.
+    let response = await send(dialect === 'openai');
+
+    // RETRIED ONCE, AND ONLY FOR A REFUSAL OF THE SCHEMA ITSELF. A server that
+    // predates structured outputs rejects the request outright, and the
+    // unconstrained call still works there -- that is the configuration this
+    // whole function used to be. Narrow on purpose: a 4xx is the server saying
+    // it will not take what was sent, while a 5xx or a timeout is a condition a
+    // second identical call would only pay for twice, on a hook path.
+    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
+      response = await send(false);
+    }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();

--- a/hooks-core/harvest.mjs
+++ b/hooks-core/harvest.mjs
@@ -283,12 +283,52 @@ export function validate(raw, { knownFiles = null } = {}) {
 }
 
 /**
+ * Which wire format the configured endpoint speaks.
+ *
+ * THE ADVERTISED LOCAL PATH DID NOT WORK. Both the SessionStart notice and
+ * `doctor` tell the user to point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local
+ * model, and this client only ever spoke the Anthropic Messages dialect --
+ * `system` as a top-level field, `content[]` blocks in the reply. ollama, LM
+ * Studio and llama.cpp all serve OpenAI-compatible /v1/chat/completions,
+ * which takes the system prompt as a message and answers with
+ * `choices[].message.content`. Measured against a stand-in server answering
+ * both dialects with the identical finding: the Anthropic path returned 1 and
+ * the OpenAI path returned 0.
+ *
+ * Chosen from the URL rather than by trying one and falling back. A fallback
+ * doubles the latency of every genuine failure on a hook path, and the user
+ * configures the whole URL here, so the path is something they stated rather
+ * than something we guess.
+ */
+export function endpointDialect(endpoint = ENDPOINT()) {
+  return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
+}
+
+/**
+ * The last reason a harvest produced nothing, or null.
+ *
+ * `return []` on every failure made a misconfigured endpoint IDENTICAL to a
+ * session with nothing to learn -- which is how a local endpoint answering the
+ * wrong dialect stayed invisible. The empty result is kept, because a caller
+ * on the hook path must not care; the reason is recorded beside it so
+ * `doctor` and a human can tell the two apart.
+ */
+let lastHarvestFailure = null;
+export const harvestFailure = () => lastHarvestFailure;
+const failed = (reason) => {
+  lastHarvestFailure = reason;
+  return [];
+};
+
+/**
  * Calls the model. Returns [] on any failure -- a harvest that errors must be
  * indistinguishable, from the caller's side, from a session with nothing to
- * learn.
+ * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
 export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
-  if (!digest || !harvestEnabled()) return [];
+  lastHarvestFailure = null;
+  if (!digest) return failed('no digest');
+  if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
   // A local endpoint usually has no auth at all, so requiring a key there would
   // make the free, private path unreachable -- the one the design now prefers.
@@ -296,41 +336,90 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return [];
+  if (!local && !key) return failed('no api key for a remote endpoint');
+
+  const endpoint = ENDPOINT();
+  const dialect = endpointDialect(endpoint);
+  const system = prompt || PROMPT;
+
+  // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
+  //
+  // `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most
+  // machines that run Claude at all and says nothing about the endpoint the
+  // user pointed this at -- which may be any process listening on loopback.
+  // A local server that genuinely wants auth is still reachable: set
+  // TOKEN_OPTIMIZER_API_KEY, which is explicit about being for this.
+  //
+  // Remote is unchanged; there the key is the whole reason the call is
+  // allowed to happen.
+  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(ENDPOINT(), {
+    const response = await fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
         'content-type': 'application/json',
-        ...(key ? { 'x-api-key': key } : {}),
-        'anthropic-version': '2023-06-01',
+        // A local server usually wants no credential at all, and sending one
+        // to localhost is a leak, not a courtesy -- so a key is attached only
+        // when there is one, in the scheme the dialect expects.
+        ...(credential && dialect === 'anthropic' ? { 'x-api-key': credential } : {}),
+        ...(credential && dialect === 'openai'
+          ? { authorization: `Bearer ${credential}` }
+          : {}),
+        ...(dialect === 'anthropic' ? { 'anthropic-version': '2023-06-01' } : {}),
       },
-      body: JSON.stringify({
-        model: MODEL(),
-        max_tokens: 2048,
-        system: prompt || PROMPT,
-        messages: [{ role: 'user', content: digest }],
-      }),
+      body: JSON.stringify(
+        dialect === 'openai'
+          ? {
+              model: MODEL(),
+              max_tokens: 2048,
+              // No top-level `system` in this dialect; it is the first message.
+              messages: [
+                { role: 'system', content: system },
+                { role: 'user', content: digest },
+              ],
+            }
+          : {
+              model: MODEL(),
+              max_tokens: 2048,
+              system,
+              messages: [{ role: 'user', content: digest }],
+            }
+      ),
     });
 
-    if (!response.ok) return [];
+    if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();
-    const text = (body.content || []).filter((b) => b.type === 'text').map((b) => b.text).join('');
+
+    // BOTH SHAPES READ, whichever dialect was sent. A gateway may answer in the
+    // other one, and reading both costs a property access.
+    const text =
+      (Array.isArray(body.content)
+        ? body.content.filter((b) => b?.type === 'text').map((b) => b.text).join('')
+        : '') ||
+      (Array.isArray(body.choices)
+        ? body.choices.map((c) => c?.message?.content || '').join('')
+        : '') ||
+      '';
+    if (!text) return failed('endpoint answered in an unrecognised shape');
 
     // Models wrap JSON in prose or fences often enough that finding the array
     // is more reliable than insisting the whole response parse.
     const start = text.indexOf('[');
     const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return [];
+    if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
-    return JSON.parse(text.slice(start, end + 1));
-  } catch {
-    return [];
+    try {
+      return JSON.parse(text.slice(start, end + 1));
+    } catch {
+      return failed('the JSON array in the reply did not parse');
+    }
+  } catch (error) {
+    return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {
     clearTimeout(timer);
   }

--- a/hooks-core/harvest.mjs
+++ b/hooks-core/harvest.mjs
@@ -341,6 +341,29 @@ export function validate(raw, { knownFiles = null } = {}) {
  * configures the whole URL here, so the path is something they stated rather
  * than something we guess.
  */
+/**
+ * Which credential, if any, may travel to this endpoint.
+ *
+ * `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most machines
+ * that run Claude and says nothing about where this request is going. There is
+ * exactly one destination that key belongs to: a REMOTE ANTHROPIC endpoint.
+ *
+ *   anthropic + remote   the key -- this is what it is for
+ *   anthropic + local    explicit only -- loopback is not Anthropic
+ *   openai    + remote   explicit only -- a third-party gateway must not
+ *                        receive an Anthropic credential as a Bearer token
+ *   openai    + local    explicit only
+ *
+ * The first version of this scoped on `local` alone, which review caught: it
+ * closed the loopback leak and left the remote-gateway one wide open. Exported
+ * so all four combinations are testable without contriving DNS.
+ */
+export function credentialFor(dialect, local, env = process.env) {
+  const explicit = env.TOKEN_OPTIMIZER_API_KEY || null;
+  if (dialect === 'openai' || local) return explicit;
+  return explicit || env.ANTHROPIC_API_KEY || null;
+}
+
 export function endpointDialect(endpoint = ENDPOINT()) {
   return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
 }
@@ -433,7 +456,24 @@ export async function extract(
   //
   // Remote is unchanged; there the key is the whole reason the call is
   // allowed to happen.
-  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
+  const credential = credentialFor(dialect, local);
+
+  // THE DEFAULT MODEL IS AN ANTHROPIC ONE, AND A LOCAL SERVER HAS NEVER HEARD
+  // OF IT. `MODEL()` falls back to claude-haiku, so an endpoint configured per
+  // the documented advice -- which names only TOKEN_OPTIMIZER_HARVEST_ENDPOINT --
+  // asks ollama for a model it does not have and is refused. I hit this myself
+  // while proving the dialect fix and set the variable by hand without noticing
+  // that a user could not know to.
+  //
+  // Refused with an actionable reason rather than guessed at. Picking a default
+  // like `llama3.2` would be a guess about what the user pulled, and being wrong
+  // costs the same silent nothing this whole branch exists to remove.
+  if (dialect === 'openai' && !process.env.TOKEN_OPTIMIZER_HARVEST_MODEL) {
+    return failed(
+      'set TOKEN_OPTIMIZER_HARVEST_MODEL for an OpenAI-compatible endpoint ' +
+        `(the default ${MODEL()} is an Anthropic model no local server serves)`
+    );
+  }
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -499,8 +539,24 @@ export async function extract(
     // whole function used to be. Narrow on purpose: a 4xx is the server saying
     // it will not take what was sent, while a 5xx or a timeout is a condition a
     // second identical call would only pay for twice, on a hook path.
-    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
-      response = await send(false);
+    // NARROWED FROM ANY 4xx. Review is right that the first version retried
+    // things a retry cannot help and should not touch: a 429 is a rate limit
+    // and an immediate repeat makes it worse, while 401/403/404 are settled
+    // answers about credentials and routing. Only a 400/422 whose body names
+    // `response_format` is the server saying it will not take THE SCHEMA,
+    // which is the one case where the same request without it still works.
+    if (
+      !response.ok
+      && dialect === 'openai'
+      && (response.status === 400 || response.status === 422)
+    ) {
+      let complaint = '';
+      try {
+        complaint = await response.clone().text();
+      } catch {
+        complaint = '';
+      }
+      if (/response_format|json_schema/i.test(complaint)) response = await send(false);
     }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);

--- a/integrations/cline/hooks/token-optimizer/lib/doctor.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/doctor.mjs
@@ -25,7 +25,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { harvestMode } from './harvest.mjs';
+import { harvestMode, harvestFailure } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
 import { mcpClientsSeen } from './metrics.mjs';
 
@@ -228,6 +228,20 @@ export function probeHarvest() {
   // credential, no billing and no digest leaving the machine -- so the two facts
   // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
+    // WHY THE LAST ONE PRODUCED NOTHING, when it produced nothing.
+    //
+    // `extract` returns [] on every failure so a hook-path caller need not
+    // care, which made a misconfigured endpoint indistinguishable from a
+    // session with nothing to learn -- the exact reason a client speaking the
+    // wrong dialect went unnoticed. `harvestFailure()` carries the reason, and
+    // this is the reader it was added for.
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check the endpoint URL and, for an OpenAI-compatible server, that ' +
+        'TOKEN_OPTIMIZER_HARVEST_MODEL names a model it actually serves')];
+    }
     return [ok('finding extraction is available',
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];

--- a/integrations/cline/hooks/token-optimizer/lib/harvest-worker.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/harvest-worker.mjs
@@ -99,13 +99,20 @@ async function main() {
   const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
   if (!digest) return;
 
-  const raw = await extract(digest);
+  // THE SAME LIST TO BOTH SIDES. `validate` has always held anchors to the
+  // files this session touched; passing it to `extract` too lets the model be
+  // GIVEN that list instead of guessing at it. Measured on this session's real
+  // digest with qwen2.5:7b: 0 of 4 extractions survived the gate when the model
+  // guessed, 4 of 4 when it chose. Computed once so the two can never disagree
+  // -- a model constrained to one list and judged against another would fail
+  // every time, and silently.
+  const anchorable = full ? null : filesIn(digest);
 
-  // Anchors are held to the files this session actually touched, so a model
-  // that invents a plausible path cannot anchor a finding to it. The digest
-  // lists them under a heading it writes itself; the full delta is raw
-  // transcript and carries no such list, so it gets no restriction.
-  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+  const raw = await extract(digest, { knownFiles: anchorable });
+
+  // The full delta is raw transcript and carries no file heading, so it gets
+  // no restriction on either side.
+  const validated = validate(raw, { knownFiles: anchorable });
 
   // BUDGETED SELECTION, not everything the model extracted.
   //

--- a/integrations/cline/hooks/token-optimizer/lib/harvest.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/harvest.mjs
@@ -41,6 +41,47 @@ const ENDPOINT = () => process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT
 // was wrong, which is why it is kept distinguishable from an ordinary finding.
 export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
 
+/**
+ * The shape a reply must take, for servers that can enforce one.
+ *
+ * A SMALL LOCAL MODEL WILL NOT FOLLOW THE PROMPT ON ITS OWN. Measured against
+ * qwen2.5:3b through ollama on the real digest from this session:
+ *
+ *   no constraint                    prose summary, 0 findings
+ *   response_format json_object      valid JSON, an invented schema
+ *   response_format json_schema      1 finding in the exact shape, 9s
+ *
+ * That is the difference between the free private path working and not, so
+ * the schema is sent rather than hoped for. The wrapper object exists because
+ * the OpenAI structured-output contract takes an object at the root; `extract`
+ * already locates the array inside whatever it is handed, so nothing
+ * downstream needs to know.
+ */
+export const FINDINGS_SCHEMA = Object.freeze({
+  type: 'object',
+  required: ['findings'],
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        properties: {
+          type: { type: 'string', enum: FINDING_TYPES },
+          claim: { type: 'string' },
+          evidence: { type: 'string' },
+          applicability: { type: 'string' },
+          confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          anchors: { type: 'array', items: { type: 'string' } },
+          trigger: { type: 'string' },
+        },
+      },
+    },
+  },
+});
+
 export function apiKey() {
   return process.env.TOKEN_OPTIMIZER_API_KEY || process.env.ANTHROPIC_API_KEY || null;
 }
@@ -359,8 +400,15 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-  try {
-    const response = await fetch(endpoint, {
+  /**
+   * One request. `structured` asks the server to enforce FINDINGS_SCHEMA.
+   *
+   * Separated out so the schema can be dropped and the call retried WITHOUT
+   * repeating the request shape in two places, which is how the two would
+   * drift.
+   */
+  const send = (structured) =>
+    fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
@@ -384,6 +432,14 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 { role: 'system', content: system },
                 { role: 'user', content: digest },
               ],
+              ...(structured
+                ? {
+                    response_format: {
+                      type: 'json_schema',
+                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                    },
+                  }
+                : {}),
             }
           : {
               model: MODEL(),
@@ -393,6 +449,21 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
             }
       ),
     });
+
+  try {
+    // Structured output only where the contract exists. Anthropic Messages has
+    // no `response_format`, and sending one is at best ignored.
+    let response = await send(dialect === 'openai');
+
+    // RETRIED ONCE, AND ONLY FOR A REFUSAL OF THE SCHEMA ITSELF. A server that
+    // predates structured outputs rejects the request outright, and the
+    // unconstrained call still works there -- that is the configuration this
+    // whole function used to be. Narrow on purpose: a 4xx is the server saying
+    // it will not take what was sent, while a 5xx or a timeout is a condition a
+    // second identical call would only pay for twice, on a hook path.
+    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
+      response = await send(false);
+    }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();

--- a/integrations/cline/hooks/token-optimizer/lib/harvest.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/harvest.mjs
@@ -368,7 +368,10 @@ const failed = (reason) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
-export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
+export async function extract(
+  digest,
+  { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
+) {
   lastHarvestFailure = null;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
@@ -384,6 +387,43 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
+  //
+  // `validate` holds anchors to the files the session actually touched, and a
+  // model asked in English for a path writes a plausible one instead of a real
+  // one -- so every finding was discarded at the gate. Measured over four runs
+  // of qwen2.5:7b on this session's real digest, against that same gate:
+  //
+  //   anchors unconstrained     4 extracted -> 0 accepted
+  //   anchors enum-constrained  4 extracted -> 4 accepted
+  //
+  // Nothing else differed. The server enforces the enum, so the model picks
+  // from the real list rather than inventing one, and the gate stops being
+  // the thing that silently eats the harvest.
+  //
+  // Only when the caller knows the list. `buildFullDelta` is raw transcript
+  // with no file heading, and its caller passes no knownFiles for the same
+  // reason -- an empty enum would forbid every anchor rather than free it.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+  const schema = anchorChoices.length
+    ? {
+        ...FINDINGS_SCHEMA,
+        properties: {
+          ...FINDINGS_SCHEMA.properties,
+          findings: {
+            ...FINDINGS_SCHEMA.properties.findings,
+            items: {
+              ...FINDINGS_SCHEMA.properties.findings.items,
+              properties: {
+                ...FINDINGS_SCHEMA.properties.findings.items.properties,
+                anchors: { type: 'array', items: { type: 'string', enum: anchorChoices } },
+              },
+            },
+          },
+        },
+      }
+    : FINDINGS_SCHEMA;
 
   // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
   //
@@ -436,7 +476,7 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 ? {
                     response_format: {
                       type: 'json_schema',
-                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                      json_schema: { name: 'findings', schema },
                     },
                   }
                 : {}),

--- a/integrations/cline/hooks/token-optimizer/lib/harvest.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/harvest.mjs
@@ -285,12 +285,52 @@ export function validate(raw, { knownFiles = null } = {}) {
 }
 
 /**
+ * Which wire format the configured endpoint speaks.
+ *
+ * THE ADVERTISED LOCAL PATH DID NOT WORK. Both the SessionStart notice and
+ * `doctor` tell the user to point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local
+ * model, and this client only ever spoke the Anthropic Messages dialect --
+ * `system` as a top-level field, `content[]` blocks in the reply. ollama, LM
+ * Studio and llama.cpp all serve OpenAI-compatible /v1/chat/completions,
+ * which takes the system prompt as a message and answers with
+ * `choices[].message.content`. Measured against a stand-in server answering
+ * both dialects with the identical finding: the Anthropic path returned 1 and
+ * the OpenAI path returned 0.
+ *
+ * Chosen from the URL rather than by trying one and falling back. A fallback
+ * doubles the latency of every genuine failure on a hook path, and the user
+ * configures the whole URL here, so the path is something they stated rather
+ * than something we guess.
+ */
+export function endpointDialect(endpoint = ENDPOINT()) {
+  return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
+}
+
+/**
+ * The last reason a harvest produced nothing, or null.
+ *
+ * `return []` on every failure made a misconfigured endpoint IDENTICAL to a
+ * session with nothing to learn -- which is how a local endpoint answering the
+ * wrong dialect stayed invisible. The empty result is kept, because a caller
+ * on the hook path must not care; the reason is recorded beside it so
+ * `doctor` and a human can tell the two apart.
+ */
+let lastHarvestFailure = null;
+export const harvestFailure = () => lastHarvestFailure;
+const failed = (reason) => {
+  lastHarvestFailure = reason;
+  return [];
+};
+
+/**
  * Calls the model. Returns [] on any failure -- a harvest that errors must be
  * indistinguishable, from the caller's side, from a session with nothing to
- * learn.
+ * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
 export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
-  if (!digest || !harvestEnabled()) return [];
+  lastHarvestFailure = null;
+  if (!digest) return failed('no digest');
+  if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
   // A local endpoint usually has no auth at all, so requiring a key there would
   // make the free, private path unreachable -- the one the design now prefers.
@@ -298,41 +338,90 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return [];
+  if (!local && !key) return failed('no api key for a remote endpoint');
+
+  const endpoint = ENDPOINT();
+  const dialect = endpointDialect(endpoint);
+  const system = prompt || PROMPT;
+
+  // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
+  //
+  // `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most
+  // machines that run Claude at all and says nothing about the endpoint the
+  // user pointed this at -- which may be any process listening on loopback.
+  // A local server that genuinely wants auth is still reachable: set
+  // TOKEN_OPTIMIZER_API_KEY, which is explicit about being for this.
+  //
+  // Remote is unchanged; there the key is the whole reason the call is
+  // allowed to happen.
+  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(ENDPOINT(), {
+    const response = await fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
         'content-type': 'application/json',
-        ...(key ? { 'x-api-key': key } : {}),
-        'anthropic-version': '2023-06-01',
+        // A local server usually wants no credential at all, and sending one
+        // to localhost is a leak, not a courtesy -- so a key is attached only
+        // when there is one, in the scheme the dialect expects.
+        ...(credential && dialect === 'anthropic' ? { 'x-api-key': credential } : {}),
+        ...(credential && dialect === 'openai'
+          ? { authorization: `Bearer ${credential}` }
+          : {}),
+        ...(dialect === 'anthropic' ? { 'anthropic-version': '2023-06-01' } : {}),
       },
-      body: JSON.stringify({
-        model: MODEL(),
-        max_tokens: 2048,
-        system: prompt || PROMPT,
-        messages: [{ role: 'user', content: digest }],
-      }),
+      body: JSON.stringify(
+        dialect === 'openai'
+          ? {
+              model: MODEL(),
+              max_tokens: 2048,
+              // No top-level `system` in this dialect; it is the first message.
+              messages: [
+                { role: 'system', content: system },
+                { role: 'user', content: digest },
+              ],
+            }
+          : {
+              model: MODEL(),
+              max_tokens: 2048,
+              system,
+              messages: [{ role: 'user', content: digest }],
+            }
+      ),
     });
 
-    if (!response.ok) return [];
+    if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();
-    const text = (body.content || []).filter((b) => b.type === 'text').map((b) => b.text).join('');
+
+    // BOTH SHAPES READ, whichever dialect was sent. A gateway may answer in the
+    // other one, and reading both costs a property access.
+    const text =
+      (Array.isArray(body.content)
+        ? body.content.filter((b) => b?.type === 'text').map((b) => b.text).join('')
+        : '') ||
+      (Array.isArray(body.choices)
+        ? body.choices.map((c) => c?.message?.content || '').join('')
+        : '') ||
+      '';
+    if (!text) return failed('endpoint answered in an unrecognised shape');
 
     // Models wrap JSON in prose or fences often enough that finding the array
     // is more reliable than insisting the whole response parse.
     const start = text.indexOf('[');
     const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return [];
+    if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
-    return JSON.parse(text.slice(start, end + 1));
-  } catch {
-    return [];
+    try {
+      return JSON.parse(text.slice(start, end + 1));
+    } catch {
+      return failed('the JSON array in the reply did not parse');
+    }
+  } catch (error) {
+    return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {
     clearTimeout(timer);
   }

--- a/integrations/cline/hooks/token-optimizer/lib/harvest.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/harvest.mjs
@@ -343,6 +343,29 @@ export function validate(raw, { knownFiles = null } = {}) {
  * configures the whole URL here, so the path is something they stated rather
  * than something we guess.
  */
+/**
+ * Which credential, if any, may travel to this endpoint.
+ *
+ * `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most machines
+ * that run Claude and says nothing about where this request is going. There is
+ * exactly one destination that key belongs to: a REMOTE ANTHROPIC endpoint.
+ *
+ *   anthropic + remote   the key -- this is what it is for
+ *   anthropic + local    explicit only -- loopback is not Anthropic
+ *   openai    + remote   explicit only -- a third-party gateway must not
+ *                        receive an Anthropic credential as a Bearer token
+ *   openai    + local    explicit only
+ *
+ * The first version of this scoped on `local` alone, which review caught: it
+ * closed the loopback leak and left the remote-gateway one wide open. Exported
+ * so all four combinations are testable without contriving DNS.
+ */
+export function credentialFor(dialect, local, env = process.env) {
+  const explicit = env.TOKEN_OPTIMIZER_API_KEY || null;
+  if (dialect === 'openai' || local) return explicit;
+  return explicit || env.ANTHROPIC_API_KEY || null;
+}
+
 export function endpointDialect(endpoint = ENDPOINT()) {
   return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
 }
@@ -435,7 +458,24 @@ export async function extract(
   //
   // Remote is unchanged; there the key is the whole reason the call is
   // allowed to happen.
-  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
+  const credential = credentialFor(dialect, local);
+
+  // THE DEFAULT MODEL IS AN ANTHROPIC ONE, AND A LOCAL SERVER HAS NEVER HEARD
+  // OF IT. `MODEL()` falls back to claude-haiku, so an endpoint configured per
+  // the documented advice -- which names only TOKEN_OPTIMIZER_HARVEST_ENDPOINT --
+  // asks ollama for a model it does not have and is refused. I hit this myself
+  // while proving the dialect fix and set the variable by hand without noticing
+  // that a user could not know to.
+  //
+  // Refused with an actionable reason rather than guessed at. Picking a default
+  // like `llama3.2` would be a guess about what the user pulled, and being wrong
+  // costs the same silent nothing this whole branch exists to remove.
+  if (dialect === 'openai' && !process.env.TOKEN_OPTIMIZER_HARVEST_MODEL) {
+    return failed(
+      'set TOKEN_OPTIMIZER_HARVEST_MODEL for an OpenAI-compatible endpoint ' +
+        `(the default ${MODEL()} is an Anthropic model no local server serves)`
+    );
+  }
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -501,8 +541,24 @@ export async function extract(
     // whole function used to be. Narrow on purpose: a 4xx is the server saying
     // it will not take what was sent, while a 5xx or a timeout is a condition a
     // second identical call would only pay for twice, on a hook path.
-    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
-      response = await send(false);
+    // NARROWED FROM ANY 4xx. Review is right that the first version retried
+    // things a retry cannot help and should not touch: a 429 is a rate limit
+    // and an immediate repeat makes it worse, while 401/403/404 are settled
+    // answers about credentials and routing. Only a 400/422 whose body names
+    // `response_format` is the server saying it will not take THE SCHEMA,
+    // which is the one case where the same request without it still works.
+    if (
+      !response.ok
+      && dialect === 'openai'
+      && (response.status === 400 || response.status === 422)
+    ) {
+      let complaint = '';
+      try {
+        complaint = await response.clone().text();
+      } catch {
+        complaint = '';
+      }
+      if (/response_format|json_schema/i.test(complaint)) response = await send(false);
     }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);

--- a/integrations/cline/hooks/token-optimizer/lib/harvest.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/harvest.mjs
@@ -20,7 +20,9 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -56,6 +58,17 @@ export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map'
  * the OpenAI structured-output contract takes an object at the root; `extract`
  * already locates the array inside whatever it is handed, so nothing
  * downstream needs to know.
+ *
+ * EVERY FIELD THE PROMPT ASKS FOR HAS TO BE DECLARED HERE, because the
+ * object is closed. `PROMPT` asks for `scope` and `invalidators`; the schema
+ * did not declare them and `additionalProperties: false` therefore FORBADE
+ * them, so an enforcing server could not return either one. `validate` then
+ * substituted `project` and `[]` for every finding, and the substitution is
+ * silent: on the schema path, organization- and global-scope findings could
+ * not be promoted and no finding could ever carry an invalidator. Both are
+ * required, matching the prompt -- a finding with nothing that would
+ * invalidate it is declared as an empty array rather than omitted, which is a
+ * claim the model has to make on purpose.
  */
 export const FINDINGS_SCHEMA = Object.freeze({
   type: 'object',
@@ -67,13 +80,24 @@ export const FINDINGS_SCHEMA = Object.freeze({
       items: {
         type: 'object',
         additionalProperties: false,
-        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        required: [
+          'type',
+          'claim',
+          'evidence',
+          'applicability',
+          'confidenceLabel',
+          'scope',
+          'invalidators',
+          'anchors',
+        ],
         properties: {
           type: { type: 'string', enum: FINDING_TYPES },
           claim: { type: 'string' },
           evidence: { type: 'string' },
           applicability: { type: 'string' },
           confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          scope: { type: 'string', enum: ['project', 'organization', 'global'] },
+          invalidators: { type: 'array', items: { type: 'string' } },
           anchors: { type: 'array', items: { type: 'string' } },
           trigger: { type: 'string' },
         },
@@ -379,11 +403,72 @@ export function endpointDialect(endpoint = ENDPOINT()) {
  * on the hook path must not care; the reason is recorded beside it so
  * `doctor` and a human can tell the two apart.
  */
+// A MODULE VARIABLE CANNOT CROSS A PROCESS, and every reader of this is in a
+// different one. The harvest runs in a DETACHED worker spawned at Stop
+// (stop-harvest.mjs), while `doctor` is a separate `node` invocation that
+// imports a fresh copy of this module. So `probeHarvest` read `null` no matter
+// what the harvest had done, and the failure branch it was given -- the whole
+// point of recording a reason -- could never be reached from the diagnostic
+// that exists to surface it. The reason is written where the next process can
+// find it.
+//
+// Per user, not per project: the worker resolves a project root and `doctor`
+// often cannot, and the failures recorded here (a wrong dialect, a missing
+// model name, an unreachable endpoint, a CLI that is not on PATH) are
+// properties of the machine's configuration rather than of a repository.
+const FAILURE_FILE = () =>
+  process.env.TOKEN_OPTIMIZER_HARVEST_STATE ||
+  join(homedir(), '.token-optimizer', 'last-harvest.json');
+
+// Old enough to be about a configuration that no longer exists. A harvest runs
+// at the end of every session, so a record older than this means the harvest
+// has not run since -- reporting it as the current state would be a guess.
+const FAILURE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
 let lastHarvestFailure = null;
-export const harvestFailure = () => lastHarvestFailure;
-const failed = (reason) => {
+/** True once this process has recorded an outcome, so the file is not consulted. */
+let outcomeThisProcess = false;
+
+function recordOutcome(reason) {
   lastHarvestFailure = reason;
+  outcomeThisProcess = true;
+  try {
+    const file = FAILURE_FILE();
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({ reason, at: Date.now() }), 'utf8');
+  } catch {
+    // Best effort. A harvest must never fail because it could not write a
+    // diagnostic about itself.
+  }
+}
+
+export function harvestFailure() {
+  if (outcomeThisProcess) return lastHarvestFailure;
+  try {
+    const { reason, at } = JSON.parse(readFileSync(FAILURE_FILE(), 'utf8'));
+    if (!reason || typeof at !== 'number') return null;
+    return Date.now() - at > FAILURE_TTL_MS ? null : reason;
+  } catch {
+    return null;
+  }
+}
+
+const failed = (reason) => {
+  recordOutcome(reason);
   return [];
+};
+
+/**
+ * Clears the recorded failure, because the harvest just worked.
+ *
+ * Without this the file is a one-way latch: a user fixes their endpoint, the
+ * harvest starts working, and `doctor` keeps reporting the failure that was
+ * true a week ago. The TTL alone would not do it -- it expires a stale record,
+ * not a wrong one.
+ */
+const succeeded = (findings) => {
+  recordOutcome(null);
+  return findings;
 };
 
 /**
@@ -396,6 +481,7 @@ export async function extract(
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
 ) {
   lastHarvestFailure = null;
+  outcomeThisProcess = false;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
@@ -583,7 +669,7 @@ export async function extract(
     if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
     try {
-      return JSON.parse(text.slice(start, end + 1));
+      return succeeded(JSON.parse(text.slice(start, end + 1)));
     } catch {
       return failed('the JSON array in the reply did not parse');
     }

--- a/integrations/codex/hooks/lib/doctor.mjs
+++ b/integrations/codex/hooks/lib/doctor.mjs
@@ -25,7 +25,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { harvestMode } from './harvest.mjs';
+import { harvestMode, harvestFailure } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
 import { mcpClientsSeen } from './metrics.mjs';
 
@@ -228,6 +228,20 @@ export function probeHarvest() {
   // credential, no billing and no digest leaving the machine -- so the two facts
   // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
+    // WHY THE LAST ONE PRODUCED NOTHING, when it produced nothing.
+    //
+    // `extract` returns [] on every failure so a hook-path caller need not
+    // care, which made a misconfigured endpoint indistinguishable from a
+    // session with nothing to learn -- the exact reason a client speaking the
+    // wrong dialect went unnoticed. `harvestFailure()` carries the reason, and
+    // this is the reader it was added for.
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check the endpoint URL and, for an OpenAI-compatible server, that ' +
+        'TOKEN_OPTIMIZER_HARVEST_MODEL names a model it actually serves')];
+    }
     return [ok('finding extraction is available',
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];

--- a/integrations/codex/hooks/lib/harvest-worker.mjs
+++ b/integrations/codex/hooks/lib/harvest-worker.mjs
@@ -99,13 +99,20 @@ async function main() {
   const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
   if (!digest) return;
 
-  const raw = await extract(digest);
+  // THE SAME LIST TO BOTH SIDES. `validate` has always held anchors to the
+  // files this session touched; passing it to `extract` too lets the model be
+  // GIVEN that list instead of guessing at it. Measured on this session's real
+  // digest with qwen2.5:7b: 0 of 4 extractions survived the gate when the model
+  // guessed, 4 of 4 when it chose. Computed once so the two can never disagree
+  // -- a model constrained to one list and judged against another would fail
+  // every time, and silently.
+  const anchorable = full ? null : filesIn(digest);
 
-  // Anchors are held to the files this session actually touched, so a model
-  // that invents a plausible path cannot anchor a finding to it. The digest
-  // lists them under a heading it writes itself; the full delta is raw
-  // transcript and carries no such list, so it gets no restriction.
-  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+  const raw = await extract(digest, { knownFiles: anchorable });
+
+  // The full delta is raw transcript and carries no file heading, so it gets
+  // no restriction on either side.
+  const validated = validate(raw, { knownFiles: anchorable });
 
   // BUDGETED SELECTION, not everything the model extracted.
   //

--- a/integrations/codex/hooks/lib/harvest.mjs
+++ b/integrations/codex/hooks/lib/harvest.mjs
@@ -41,6 +41,47 @@ const ENDPOINT = () => process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT
 // was wrong, which is why it is kept distinguishable from an ordinary finding.
 export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
 
+/**
+ * The shape a reply must take, for servers that can enforce one.
+ *
+ * A SMALL LOCAL MODEL WILL NOT FOLLOW THE PROMPT ON ITS OWN. Measured against
+ * qwen2.5:3b through ollama on the real digest from this session:
+ *
+ *   no constraint                    prose summary, 0 findings
+ *   response_format json_object      valid JSON, an invented schema
+ *   response_format json_schema      1 finding in the exact shape, 9s
+ *
+ * That is the difference between the free private path working and not, so
+ * the schema is sent rather than hoped for. The wrapper object exists because
+ * the OpenAI structured-output contract takes an object at the root; `extract`
+ * already locates the array inside whatever it is handed, so nothing
+ * downstream needs to know.
+ */
+export const FINDINGS_SCHEMA = Object.freeze({
+  type: 'object',
+  required: ['findings'],
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        properties: {
+          type: { type: 'string', enum: FINDING_TYPES },
+          claim: { type: 'string' },
+          evidence: { type: 'string' },
+          applicability: { type: 'string' },
+          confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          anchors: { type: 'array', items: { type: 'string' } },
+          trigger: { type: 'string' },
+        },
+      },
+    },
+  },
+});
+
 export function apiKey() {
   return process.env.TOKEN_OPTIMIZER_API_KEY || process.env.ANTHROPIC_API_KEY || null;
 }
@@ -359,8 +400,15 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-  try {
-    const response = await fetch(endpoint, {
+  /**
+   * One request. `structured` asks the server to enforce FINDINGS_SCHEMA.
+   *
+   * Separated out so the schema can be dropped and the call retried WITHOUT
+   * repeating the request shape in two places, which is how the two would
+   * drift.
+   */
+  const send = (structured) =>
+    fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
@@ -384,6 +432,14 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 { role: 'system', content: system },
                 { role: 'user', content: digest },
               ],
+              ...(structured
+                ? {
+                    response_format: {
+                      type: 'json_schema',
+                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                    },
+                  }
+                : {}),
             }
           : {
               model: MODEL(),
@@ -393,6 +449,21 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
             }
       ),
     });
+
+  try {
+    // Structured output only where the contract exists. Anthropic Messages has
+    // no `response_format`, and sending one is at best ignored.
+    let response = await send(dialect === 'openai');
+
+    // RETRIED ONCE, AND ONLY FOR A REFUSAL OF THE SCHEMA ITSELF. A server that
+    // predates structured outputs rejects the request outright, and the
+    // unconstrained call still works there -- that is the configuration this
+    // whole function used to be. Narrow on purpose: a 4xx is the server saying
+    // it will not take what was sent, while a 5xx or a timeout is a condition a
+    // second identical call would only pay for twice, on a hook path.
+    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
+      response = await send(false);
+    }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();

--- a/integrations/codex/hooks/lib/harvest.mjs
+++ b/integrations/codex/hooks/lib/harvest.mjs
@@ -368,7 +368,10 @@ const failed = (reason) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
-export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
+export async function extract(
+  digest,
+  { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
+) {
   lastHarvestFailure = null;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
@@ -384,6 +387,43 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
+  //
+  // `validate` holds anchors to the files the session actually touched, and a
+  // model asked in English for a path writes a plausible one instead of a real
+  // one -- so every finding was discarded at the gate. Measured over four runs
+  // of qwen2.5:7b on this session's real digest, against that same gate:
+  //
+  //   anchors unconstrained     4 extracted -> 0 accepted
+  //   anchors enum-constrained  4 extracted -> 4 accepted
+  //
+  // Nothing else differed. The server enforces the enum, so the model picks
+  // from the real list rather than inventing one, and the gate stops being
+  // the thing that silently eats the harvest.
+  //
+  // Only when the caller knows the list. `buildFullDelta` is raw transcript
+  // with no file heading, and its caller passes no knownFiles for the same
+  // reason -- an empty enum would forbid every anchor rather than free it.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+  const schema = anchorChoices.length
+    ? {
+        ...FINDINGS_SCHEMA,
+        properties: {
+          ...FINDINGS_SCHEMA.properties,
+          findings: {
+            ...FINDINGS_SCHEMA.properties.findings,
+            items: {
+              ...FINDINGS_SCHEMA.properties.findings.items,
+              properties: {
+                ...FINDINGS_SCHEMA.properties.findings.items.properties,
+                anchors: { type: 'array', items: { type: 'string', enum: anchorChoices } },
+              },
+            },
+          },
+        },
+      }
+    : FINDINGS_SCHEMA;
 
   // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
   //
@@ -436,7 +476,7 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 ? {
                     response_format: {
                       type: 'json_schema',
-                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                      json_schema: { name: 'findings', schema },
                     },
                   }
                 : {}),

--- a/integrations/codex/hooks/lib/harvest.mjs
+++ b/integrations/codex/hooks/lib/harvest.mjs
@@ -285,12 +285,52 @@ export function validate(raw, { knownFiles = null } = {}) {
 }
 
 /**
+ * Which wire format the configured endpoint speaks.
+ *
+ * THE ADVERTISED LOCAL PATH DID NOT WORK. Both the SessionStart notice and
+ * `doctor` tell the user to point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local
+ * model, and this client only ever spoke the Anthropic Messages dialect --
+ * `system` as a top-level field, `content[]` blocks in the reply. ollama, LM
+ * Studio and llama.cpp all serve OpenAI-compatible /v1/chat/completions,
+ * which takes the system prompt as a message and answers with
+ * `choices[].message.content`. Measured against a stand-in server answering
+ * both dialects with the identical finding: the Anthropic path returned 1 and
+ * the OpenAI path returned 0.
+ *
+ * Chosen from the URL rather than by trying one and falling back. A fallback
+ * doubles the latency of every genuine failure on a hook path, and the user
+ * configures the whole URL here, so the path is something they stated rather
+ * than something we guess.
+ */
+export function endpointDialect(endpoint = ENDPOINT()) {
+  return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
+}
+
+/**
+ * The last reason a harvest produced nothing, or null.
+ *
+ * `return []` on every failure made a misconfigured endpoint IDENTICAL to a
+ * session with nothing to learn -- which is how a local endpoint answering the
+ * wrong dialect stayed invisible. The empty result is kept, because a caller
+ * on the hook path must not care; the reason is recorded beside it so
+ * `doctor` and a human can tell the two apart.
+ */
+let lastHarvestFailure = null;
+export const harvestFailure = () => lastHarvestFailure;
+const failed = (reason) => {
+  lastHarvestFailure = reason;
+  return [];
+};
+
+/**
  * Calls the model. Returns [] on any failure -- a harvest that errors must be
  * indistinguishable, from the caller's side, from a session with nothing to
- * learn.
+ * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
 export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
-  if (!digest || !harvestEnabled()) return [];
+  lastHarvestFailure = null;
+  if (!digest) return failed('no digest');
+  if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
   // A local endpoint usually has no auth at all, so requiring a key there would
   // make the free, private path unreachable -- the one the design now prefers.
@@ -298,41 +338,90 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return [];
+  if (!local && !key) return failed('no api key for a remote endpoint');
+
+  const endpoint = ENDPOINT();
+  const dialect = endpointDialect(endpoint);
+  const system = prompt || PROMPT;
+
+  // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
+  //
+  // `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most
+  // machines that run Claude at all and says nothing about the endpoint the
+  // user pointed this at -- which may be any process listening on loopback.
+  // A local server that genuinely wants auth is still reachable: set
+  // TOKEN_OPTIMIZER_API_KEY, which is explicit about being for this.
+  //
+  // Remote is unchanged; there the key is the whole reason the call is
+  // allowed to happen.
+  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(ENDPOINT(), {
+    const response = await fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
         'content-type': 'application/json',
-        ...(key ? { 'x-api-key': key } : {}),
-        'anthropic-version': '2023-06-01',
+        // A local server usually wants no credential at all, and sending one
+        // to localhost is a leak, not a courtesy -- so a key is attached only
+        // when there is one, in the scheme the dialect expects.
+        ...(credential && dialect === 'anthropic' ? { 'x-api-key': credential } : {}),
+        ...(credential && dialect === 'openai'
+          ? { authorization: `Bearer ${credential}` }
+          : {}),
+        ...(dialect === 'anthropic' ? { 'anthropic-version': '2023-06-01' } : {}),
       },
-      body: JSON.stringify({
-        model: MODEL(),
-        max_tokens: 2048,
-        system: prompt || PROMPT,
-        messages: [{ role: 'user', content: digest }],
-      }),
+      body: JSON.stringify(
+        dialect === 'openai'
+          ? {
+              model: MODEL(),
+              max_tokens: 2048,
+              // No top-level `system` in this dialect; it is the first message.
+              messages: [
+                { role: 'system', content: system },
+                { role: 'user', content: digest },
+              ],
+            }
+          : {
+              model: MODEL(),
+              max_tokens: 2048,
+              system,
+              messages: [{ role: 'user', content: digest }],
+            }
+      ),
     });
 
-    if (!response.ok) return [];
+    if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();
-    const text = (body.content || []).filter((b) => b.type === 'text').map((b) => b.text).join('');
+
+    // BOTH SHAPES READ, whichever dialect was sent. A gateway may answer in the
+    // other one, and reading both costs a property access.
+    const text =
+      (Array.isArray(body.content)
+        ? body.content.filter((b) => b?.type === 'text').map((b) => b.text).join('')
+        : '') ||
+      (Array.isArray(body.choices)
+        ? body.choices.map((c) => c?.message?.content || '').join('')
+        : '') ||
+      '';
+    if (!text) return failed('endpoint answered in an unrecognised shape');
 
     // Models wrap JSON in prose or fences often enough that finding the array
     // is more reliable than insisting the whole response parse.
     const start = text.indexOf('[');
     const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return [];
+    if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
-    return JSON.parse(text.slice(start, end + 1));
-  } catch {
-    return [];
+    try {
+      return JSON.parse(text.slice(start, end + 1));
+    } catch {
+      return failed('the JSON array in the reply did not parse');
+    }
+  } catch (error) {
+    return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {
     clearTimeout(timer);
   }

--- a/integrations/codex/hooks/lib/harvest.mjs
+++ b/integrations/codex/hooks/lib/harvest.mjs
@@ -343,6 +343,29 @@ export function validate(raw, { knownFiles = null } = {}) {
  * configures the whole URL here, so the path is something they stated rather
  * than something we guess.
  */
+/**
+ * Which credential, if any, may travel to this endpoint.
+ *
+ * `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most machines
+ * that run Claude and says nothing about where this request is going. There is
+ * exactly one destination that key belongs to: a REMOTE ANTHROPIC endpoint.
+ *
+ *   anthropic + remote   the key -- this is what it is for
+ *   anthropic + local    explicit only -- loopback is not Anthropic
+ *   openai    + remote   explicit only -- a third-party gateway must not
+ *                        receive an Anthropic credential as a Bearer token
+ *   openai    + local    explicit only
+ *
+ * The first version of this scoped on `local` alone, which review caught: it
+ * closed the loopback leak and left the remote-gateway one wide open. Exported
+ * so all four combinations are testable without contriving DNS.
+ */
+export function credentialFor(dialect, local, env = process.env) {
+  const explicit = env.TOKEN_OPTIMIZER_API_KEY || null;
+  if (dialect === 'openai' || local) return explicit;
+  return explicit || env.ANTHROPIC_API_KEY || null;
+}
+
 export function endpointDialect(endpoint = ENDPOINT()) {
   return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
 }
@@ -435,7 +458,24 @@ export async function extract(
   //
   // Remote is unchanged; there the key is the whole reason the call is
   // allowed to happen.
-  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
+  const credential = credentialFor(dialect, local);
+
+  // THE DEFAULT MODEL IS AN ANTHROPIC ONE, AND A LOCAL SERVER HAS NEVER HEARD
+  // OF IT. `MODEL()` falls back to claude-haiku, so an endpoint configured per
+  // the documented advice -- which names only TOKEN_OPTIMIZER_HARVEST_ENDPOINT --
+  // asks ollama for a model it does not have and is refused. I hit this myself
+  // while proving the dialect fix and set the variable by hand without noticing
+  // that a user could not know to.
+  //
+  // Refused with an actionable reason rather than guessed at. Picking a default
+  // like `llama3.2` would be a guess about what the user pulled, and being wrong
+  // costs the same silent nothing this whole branch exists to remove.
+  if (dialect === 'openai' && !process.env.TOKEN_OPTIMIZER_HARVEST_MODEL) {
+    return failed(
+      'set TOKEN_OPTIMIZER_HARVEST_MODEL for an OpenAI-compatible endpoint ' +
+        `(the default ${MODEL()} is an Anthropic model no local server serves)`
+    );
+  }
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -501,8 +541,24 @@ export async function extract(
     // whole function used to be. Narrow on purpose: a 4xx is the server saying
     // it will not take what was sent, while a 5xx or a timeout is a condition a
     // second identical call would only pay for twice, on a hook path.
-    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
-      response = await send(false);
+    // NARROWED FROM ANY 4xx. Review is right that the first version retried
+    // things a retry cannot help and should not touch: a 429 is a rate limit
+    // and an immediate repeat makes it worse, while 401/403/404 are settled
+    // answers about credentials and routing. Only a 400/422 whose body names
+    // `response_format` is the server saying it will not take THE SCHEMA,
+    // which is the one case where the same request without it still works.
+    if (
+      !response.ok
+      && dialect === 'openai'
+      && (response.status === 400 || response.status === 422)
+    ) {
+      let complaint = '';
+      try {
+        complaint = await response.clone().text();
+      } catch {
+        complaint = '';
+      }
+      if (/response_format|json_schema/i.test(complaint)) response = await send(false);
     }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);

--- a/integrations/codex/hooks/lib/harvest.mjs
+++ b/integrations/codex/hooks/lib/harvest.mjs
@@ -20,7 +20,9 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -56,6 +58,17 @@ export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map'
  * the OpenAI structured-output contract takes an object at the root; `extract`
  * already locates the array inside whatever it is handed, so nothing
  * downstream needs to know.
+ *
+ * EVERY FIELD THE PROMPT ASKS FOR HAS TO BE DECLARED HERE, because the
+ * object is closed. `PROMPT` asks for `scope` and `invalidators`; the schema
+ * did not declare them and `additionalProperties: false` therefore FORBADE
+ * them, so an enforcing server could not return either one. `validate` then
+ * substituted `project` and `[]` for every finding, and the substitution is
+ * silent: on the schema path, organization- and global-scope findings could
+ * not be promoted and no finding could ever carry an invalidator. Both are
+ * required, matching the prompt -- a finding with nothing that would
+ * invalidate it is declared as an empty array rather than omitted, which is a
+ * claim the model has to make on purpose.
  */
 export const FINDINGS_SCHEMA = Object.freeze({
   type: 'object',
@@ -67,13 +80,24 @@ export const FINDINGS_SCHEMA = Object.freeze({
       items: {
         type: 'object',
         additionalProperties: false,
-        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        required: [
+          'type',
+          'claim',
+          'evidence',
+          'applicability',
+          'confidenceLabel',
+          'scope',
+          'invalidators',
+          'anchors',
+        ],
         properties: {
           type: { type: 'string', enum: FINDING_TYPES },
           claim: { type: 'string' },
           evidence: { type: 'string' },
           applicability: { type: 'string' },
           confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          scope: { type: 'string', enum: ['project', 'organization', 'global'] },
+          invalidators: { type: 'array', items: { type: 'string' } },
           anchors: { type: 'array', items: { type: 'string' } },
           trigger: { type: 'string' },
         },
@@ -379,11 +403,72 @@ export function endpointDialect(endpoint = ENDPOINT()) {
  * on the hook path must not care; the reason is recorded beside it so
  * `doctor` and a human can tell the two apart.
  */
+// A MODULE VARIABLE CANNOT CROSS A PROCESS, and every reader of this is in a
+// different one. The harvest runs in a DETACHED worker spawned at Stop
+// (stop-harvest.mjs), while `doctor` is a separate `node` invocation that
+// imports a fresh copy of this module. So `probeHarvest` read `null` no matter
+// what the harvest had done, and the failure branch it was given -- the whole
+// point of recording a reason -- could never be reached from the diagnostic
+// that exists to surface it. The reason is written where the next process can
+// find it.
+//
+// Per user, not per project: the worker resolves a project root and `doctor`
+// often cannot, and the failures recorded here (a wrong dialect, a missing
+// model name, an unreachable endpoint, a CLI that is not on PATH) are
+// properties of the machine's configuration rather than of a repository.
+const FAILURE_FILE = () =>
+  process.env.TOKEN_OPTIMIZER_HARVEST_STATE ||
+  join(homedir(), '.token-optimizer', 'last-harvest.json');
+
+// Old enough to be about a configuration that no longer exists. A harvest runs
+// at the end of every session, so a record older than this means the harvest
+// has not run since -- reporting it as the current state would be a guess.
+const FAILURE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
 let lastHarvestFailure = null;
-export const harvestFailure = () => lastHarvestFailure;
-const failed = (reason) => {
+/** True once this process has recorded an outcome, so the file is not consulted. */
+let outcomeThisProcess = false;
+
+function recordOutcome(reason) {
   lastHarvestFailure = reason;
+  outcomeThisProcess = true;
+  try {
+    const file = FAILURE_FILE();
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({ reason, at: Date.now() }), 'utf8');
+  } catch {
+    // Best effort. A harvest must never fail because it could not write a
+    // diagnostic about itself.
+  }
+}
+
+export function harvestFailure() {
+  if (outcomeThisProcess) return lastHarvestFailure;
+  try {
+    const { reason, at } = JSON.parse(readFileSync(FAILURE_FILE(), 'utf8'));
+    if (!reason || typeof at !== 'number') return null;
+    return Date.now() - at > FAILURE_TTL_MS ? null : reason;
+  } catch {
+    return null;
+  }
+}
+
+const failed = (reason) => {
+  recordOutcome(reason);
   return [];
+};
+
+/**
+ * Clears the recorded failure, because the harvest just worked.
+ *
+ * Without this the file is a one-way latch: a user fixes their endpoint, the
+ * harvest starts working, and `doctor` keeps reporting the failure that was
+ * true a week ago. The TTL alone would not do it -- it expires a stale record,
+ * not a wrong one.
+ */
+const succeeded = (findings) => {
+  recordOutcome(null);
+  return findings;
 };
 
 /**
@@ -396,6 +481,7 @@ export async function extract(
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
 ) {
   lastHarvestFailure = null;
+  outcomeThisProcess = false;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
@@ -583,7 +669,7 @@ export async function extract(
     if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
     try {
-      return JSON.parse(text.slice(start, end + 1));
+      return succeeded(JSON.parse(text.slice(start, end + 1)));
     } catch {
       return failed('the JSON array in the reply did not parse');
     }

--- a/integrations/codex/plugin/hooks/lib/doctor.mjs
+++ b/integrations/codex/plugin/hooks/lib/doctor.mjs
@@ -25,7 +25,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { harvestMode } from './harvest.mjs';
+import { harvestMode, harvestFailure } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
 import { mcpClientsSeen } from './metrics.mjs';
 
@@ -228,6 +228,20 @@ export function probeHarvest() {
   // credential, no billing and no digest leaving the machine -- so the two facts
   // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
+    // WHY THE LAST ONE PRODUCED NOTHING, when it produced nothing.
+    //
+    // `extract` returns [] on every failure so a hook-path caller need not
+    // care, which made a misconfigured endpoint indistinguishable from a
+    // session with nothing to learn -- the exact reason a client speaking the
+    // wrong dialect went unnoticed. `harvestFailure()` carries the reason, and
+    // this is the reader it was added for.
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check the endpoint URL and, for an OpenAI-compatible server, that ' +
+        'TOKEN_OPTIMIZER_HARVEST_MODEL names a model it actually serves')];
+    }
     return [ok('finding extraction is available',
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];

--- a/integrations/codex/plugin/hooks/lib/harvest-worker.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest-worker.mjs
@@ -99,13 +99,20 @@ async function main() {
   const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
   if (!digest) return;
 
-  const raw = await extract(digest);
+  // THE SAME LIST TO BOTH SIDES. `validate` has always held anchors to the
+  // files this session touched; passing it to `extract` too lets the model be
+  // GIVEN that list instead of guessing at it. Measured on this session's real
+  // digest with qwen2.5:7b: 0 of 4 extractions survived the gate when the model
+  // guessed, 4 of 4 when it chose. Computed once so the two can never disagree
+  // -- a model constrained to one list and judged against another would fail
+  // every time, and silently.
+  const anchorable = full ? null : filesIn(digest);
 
-  // Anchors are held to the files this session actually touched, so a model
-  // that invents a plausible path cannot anchor a finding to it. The digest
-  // lists them under a heading it writes itself; the full delta is raw
-  // transcript and carries no such list, so it gets no restriction.
-  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+  const raw = await extract(digest, { knownFiles: anchorable });
+
+  // The full delta is raw transcript and carries no file heading, so it gets
+  // no restriction on either side.
+  const validated = validate(raw, { knownFiles: anchorable });
 
   // BUDGETED SELECTION, not everything the model extracted.
   //

--- a/integrations/codex/plugin/hooks/lib/harvest.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest.mjs
@@ -41,6 +41,47 @@ const ENDPOINT = () => process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT
 // was wrong, which is why it is kept distinguishable from an ordinary finding.
 export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
 
+/**
+ * The shape a reply must take, for servers that can enforce one.
+ *
+ * A SMALL LOCAL MODEL WILL NOT FOLLOW THE PROMPT ON ITS OWN. Measured against
+ * qwen2.5:3b through ollama on the real digest from this session:
+ *
+ *   no constraint                    prose summary, 0 findings
+ *   response_format json_object      valid JSON, an invented schema
+ *   response_format json_schema      1 finding in the exact shape, 9s
+ *
+ * That is the difference between the free private path working and not, so
+ * the schema is sent rather than hoped for. The wrapper object exists because
+ * the OpenAI structured-output contract takes an object at the root; `extract`
+ * already locates the array inside whatever it is handed, so nothing
+ * downstream needs to know.
+ */
+export const FINDINGS_SCHEMA = Object.freeze({
+  type: 'object',
+  required: ['findings'],
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        properties: {
+          type: { type: 'string', enum: FINDING_TYPES },
+          claim: { type: 'string' },
+          evidence: { type: 'string' },
+          applicability: { type: 'string' },
+          confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          anchors: { type: 'array', items: { type: 'string' } },
+          trigger: { type: 'string' },
+        },
+      },
+    },
+  },
+});
+
 export function apiKey() {
   return process.env.TOKEN_OPTIMIZER_API_KEY || process.env.ANTHROPIC_API_KEY || null;
 }
@@ -359,8 +400,15 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-  try {
-    const response = await fetch(endpoint, {
+  /**
+   * One request. `structured` asks the server to enforce FINDINGS_SCHEMA.
+   *
+   * Separated out so the schema can be dropped and the call retried WITHOUT
+   * repeating the request shape in two places, which is how the two would
+   * drift.
+   */
+  const send = (structured) =>
+    fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
@@ -384,6 +432,14 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 { role: 'system', content: system },
                 { role: 'user', content: digest },
               ],
+              ...(structured
+                ? {
+                    response_format: {
+                      type: 'json_schema',
+                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                    },
+                  }
+                : {}),
             }
           : {
               model: MODEL(),
@@ -393,6 +449,21 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
             }
       ),
     });
+
+  try {
+    // Structured output only where the contract exists. Anthropic Messages has
+    // no `response_format`, and sending one is at best ignored.
+    let response = await send(dialect === 'openai');
+
+    // RETRIED ONCE, AND ONLY FOR A REFUSAL OF THE SCHEMA ITSELF. A server that
+    // predates structured outputs rejects the request outright, and the
+    // unconstrained call still works there -- that is the configuration this
+    // whole function used to be. Narrow on purpose: a 4xx is the server saying
+    // it will not take what was sent, while a 5xx or a timeout is a condition a
+    // second identical call would only pay for twice, on a hook path.
+    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
+      response = await send(false);
+    }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();

--- a/integrations/codex/plugin/hooks/lib/harvest.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest.mjs
@@ -368,7 +368,10 @@ const failed = (reason) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
-export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
+export async function extract(
+  digest,
+  { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
+) {
   lastHarvestFailure = null;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
@@ -384,6 +387,43 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
+  //
+  // `validate` holds anchors to the files the session actually touched, and a
+  // model asked in English for a path writes a plausible one instead of a real
+  // one -- so every finding was discarded at the gate. Measured over four runs
+  // of qwen2.5:7b on this session's real digest, against that same gate:
+  //
+  //   anchors unconstrained     4 extracted -> 0 accepted
+  //   anchors enum-constrained  4 extracted -> 4 accepted
+  //
+  // Nothing else differed. The server enforces the enum, so the model picks
+  // from the real list rather than inventing one, and the gate stops being
+  // the thing that silently eats the harvest.
+  //
+  // Only when the caller knows the list. `buildFullDelta` is raw transcript
+  // with no file heading, and its caller passes no knownFiles for the same
+  // reason -- an empty enum would forbid every anchor rather than free it.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+  const schema = anchorChoices.length
+    ? {
+        ...FINDINGS_SCHEMA,
+        properties: {
+          ...FINDINGS_SCHEMA.properties,
+          findings: {
+            ...FINDINGS_SCHEMA.properties.findings,
+            items: {
+              ...FINDINGS_SCHEMA.properties.findings.items,
+              properties: {
+                ...FINDINGS_SCHEMA.properties.findings.items.properties,
+                anchors: { type: 'array', items: { type: 'string', enum: anchorChoices } },
+              },
+            },
+          },
+        },
+      }
+    : FINDINGS_SCHEMA;
 
   // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
   //
@@ -436,7 +476,7 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 ? {
                     response_format: {
                       type: 'json_schema',
-                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                      json_schema: { name: 'findings', schema },
                     },
                   }
                 : {}),

--- a/integrations/codex/plugin/hooks/lib/harvest.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest.mjs
@@ -285,12 +285,52 @@ export function validate(raw, { knownFiles = null } = {}) {
 }
 
 /**
+ * Which wire format the configured endpoint speaks.
+ *
+ * THE ADVERTISED LOCAL PATH DID NOT WORK. Both the SessionStart notice and
+ * `doctor` tell the user to point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local
+ * model, and this client only ever spoke the Anthropic Messages dialect --
+ * `system` as a top-level field, `content[]` blocks in the reply. ollama, LM
+ * Studio and llama.cpp all serve OpenAI-compatible /v1/chat/completions,
+ * which takes the system prompt as a message and answers with
+ * `choices[].message.content`. Measured against a stand-in server answering
+ * both dialects with the identical finding: the Anthropic path returned 1 and
+ * the OpenAI path returned 0.
+ *
+ * Chosen from the URL rather than by trying one and falling back. A fallback
+ * doubles the latency of every genuine failure on a hook path, and the user
+ * configures the whole URL here, so the path is something they stated rather
+ * than something we guess.
+ */
+export function endpointDialect(endpoint = ENDPOINT()) {
+  return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
+}
+
+/**
+ * The last reason a harvest produced nothing, or null.
+ *
+ * `return []` on every failure made a misconfigured endpoint IDENTICAL to a
+ * session with nothing to learn -- which is how a local endpoint answering the
+ * wrong dialect stayed invisible. The empty result is kept, because a caller
+ * on the hook path must not care; the reason is recorded beside it so
+ * `doctor` and a human can tell the two apart.
+ */
+let lastHarvestFailure = null;
+export const harvestFailure = () => lastHarvestFailure;
+const failed = (reason) => {
+  lastHarvestFailure = reason;
+  return [];
+};
+
+/**
  * Calls the model. Returns [] on any failure -- a harvest that errors must be
  * indistinguishable, from the caller's side, from a session with nothing to
- * learn.
+ * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
 export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
-  if (!digest || !harvestEnabled()) return [];
+  lastHarvestFailure = null;
+  if (!digest) return failed('no digest');
+  if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
   // A local endpoint usually has no auth at all, so requiring a key there would
   // make the free, private path unreachable -- the one the design now prefers.
@@ -298,41 +338,90 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return [];
+  if (!local && !key) return failed('no api key for a remote endpoint');
+
+  const endpoint = ENDPOINT();
+  const dialect = endpointDialect(endpoint);
+  const system = prompt || PROMPT;
+
+  // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
+  //
+  // `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most
+  // machines that run Claude at all and says nothing about the endpoint the
+  // user pointed this at -- which may be any process listening on loopback.
+  // A local server that genuinely wants auth is still reachable: set
+  // TOKEN_OPTIMIZER_API_KEY, which is explicit about being for this.
+  //
+  // Remote is unchanged; there the key is the whole reason the call is
+  // allowed to happen.
+  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(ENDPOINT(), {
+    const response = await fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
         'content-type': 'application/json',
-        ...(key ? { 'x-api-key': key } : {}),
-        'anthropic-version': '2023-06-01',
+        // A local server usually wants no credential at all, and sending one
+        // to localhost is a leak, not a courtesy -- so a key is attached only
+        // when there is one, in the scheme the dialect expects.
+        ...(credential && dialect === 'anthropic' ? { 'x-api-key': credential } : {}),
+        ...(credential && dialect === 'openai'
+          ? { authorization: `Bearer ${credential}` }
+          : {}),
+        ...(dialect === 'anthropic' ? { 'anthropic-version': '2023-06-01' } : {}),
       },
-      body: JSON.stringify({
-        model: MODEL(),
-        max_tokens: 2048,
-        system: prompt || PROMPT,
-        messages: [{ role: 'user', content: digest }],
-      }),
+      body: JSON.stringify(
+        dialect === 'openai'
+          ? {
+              model: MODEL(),
+              max_tokens: 2048,
+              // No top-level `system` in this dialect; it is the first message.
+              messages: [
+                { role: 'system', content: system },
+                { role: 'user', content: digest },
+              ],
+            }
+          : {
+              model: MODEL(),
+              max_tokens: 2048,
+              system,
+              messages: [{ role: 'user', content: digest }],
+            }
+      ),
     });
 
-    if (!response.ok) return [];
+    if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();
-    const text = (body.content || []).filter((b) => b.type === 'text').map((b) => b.text).join('');
+
+    // BOTH SHAPES READ, whichever dialect was sent. A gateway may answer in the
+    // other one, and reading both costs a property access.
+    const text =
+      (Array.isArray(body.content)
+        ? body.content.filter((b) => b?.type === 'text').map((b) => b.text).join('')
+        : '') ||
+      (Array.isArray(body.choices)
+        ? body.choices.map((c) => c?.message?.content || '').join('')
+        : '') ||
+      '';
+    if (!text) return failed('endpoint answered in an unrecognised shape');
 
     // Models wrap JSON in prose or fences often enough that finding the array
     // is more reliable than insisting the whole response parse.
     const start = text.indexOf('[');
     const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return [];
+    if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
-    return JSON.parse(text.slice(start, end + 1));
-  } catch {
-    return [];
+    try {
+      return JSON.parse(text.slice(start, end + 1));
+    } catch {
+      return failed('the JSON array in the reply did not parse');
+    }
+  } catch (error) {
+    return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {
     clearTimeout(timer);
   }

--- a/integrations/codex/plugin/hooks/lib/harvest.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest.mjs
@@ -343,6 +343,29 @@ export function validate(raw, { knownFiles = null } = {}) {
  * configures the whole URL here, so the path is something they stated rather
  * than something we guess.
  */
+/**
+ * Which credential, if any, may travel to this endpoint.
+ *
+ * `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most machines
+ * that run Claude and says nothing about where this request is going. There is
+ * exactly one destination that key belongs to: a REMOTE ANTHROPIC endpoint.
+ *
+ *   anthropic + remote   the key -- this is what it is for
+ *   anthropic + local    explicit only -- loopback is not Anthropic
+ *   openai    + remote   explicit only -- a third-party gateway must not
+ *                        receive an Anthropic credential as a Bearer token
+ *   openai    + local    explicit only
+ *
+ * The first version of this scoped on `local` alone, which review caught: it
+ * closed the loopback leak and left the remote-gateway one wide open. Exported
+ * so all four combinations are testable without contriving DNS.
+ */
+export function credentialFor(dialect, local, env = process.env) {
+  const explicit = env.TOKEN_OPTIMIZER_API_KEY || null;
+  if (dialect === 'openai' || local) return explicit;
+  return explicit || env.ANTHROPIC_API_KEY || null;
+}
+
 export function endpointDialect(endpoint = ENDPOINT()) {
   return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
 }
@@ -435,7 +458,24 @@ export async function extract(
   //
   // Remote is unchanged; there the key is the whole reason the call is
   // allowed to happen.
-  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
+  const credential = credentialFor(dialect, local);
+
+  // THE DEFAULT MODEL IS AN ANTHROPIC ONE, AND A LOCAL SERVER HAS NEVER HEARD
+  // OF IT. `MODEL()` falls back to claude-haiku, so an endpoint configured per
+  // the documented advice -- which names only TOKEN_OPTIMIZER_HARVEST_ENDPOINT --
+  // asks ollama for a model it does not have and is refused. I hit this myself
+  // while proving the dialect fix and set the variable by hand without noticing
+  // that a user could not know to.
+  //
+  // Refused with an actionable reason rather than guessed at. Picking a default
+  // like `llama3.2` would be a guess about what the user pulled, and being wrong
+  // costs the same silent nothing this whole branch exists to remove.
+  if (dialect === 'openai' && !process.env.TOKEN_OPTIMIZER_HARVEST_MODEL) {
+    return failed(
+      'set TOKEN_OPTIMIZER_HARVEST_MODEL for an OpenAI-compatible endpoint ' +
+        `(the default ${MODEL()} is an Anthropic model no local server serves)`
+    );
+  }
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -501,8 +541,24 @@ export async function extract(
     // whole function used to be. Narrow on purpose: a 4xx is the server saying
     // it will not take what was sent, while a 5xx or a timeout is a condition a
     // second identical call would only pay for twice, on a hook path.
-    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
-      response = await send(false);
+    // NARROWED FROM ANY 4xx. Review is right that the first version retried
+    // things a retry cannot help and should not touch: a 429 is a rate limit
+    // and an immediate repeat makes it worse, while 401/403/404 are settled
+    // answers about credentials and routing. Only a 400/422 whose body names
+    // `response_format` is the server saying it will not take THE SCHEMA,
+    // which is the one case where the same request without it still works.
+    if (
+      !response.ok
+      && dialect === 'openai'
+      && (response.status === 400 || response.status === 422)
+    ) {
+      let complaint = '';
+      try {
+        complaint = await response.clone().text();
+      } catch {
+        complaint = '';
+      }
+      if (/response_format|json_schema/i.test(complaint)) response = await send(false);
     }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);

--- a/integrations/codex/plugin/hooks/lib/harvest.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest.mjs
@@ -20,7 +20,9 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -56,6 +58,17 @@ export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map'
  * the OpenAI structured-output contract takes an object at the root; `extract`
  * already locates the array inside whatever it is handed, so nothing
  * downstream needs to know.
+ *
+ * EVERY FIELD THE PROMPT ASKS FOR HAS TO BE DECLARED HERE, because the
+ * object is closed. `PROMPT` asks for `scope` and `invalidators`; the schema
+ * did not declare them and `additionalProperties: false` therefore FORBADE
+ * them, so an enforcing server could not return either one. `validate` then
+ * substituted `project` and `[]` for every finding, and the substitution is
+ * silent: on the schema path, organization- and global-scope findings could
+ * not be promoted and no finding could ever carry an invalidator. Both are
+ * required, matching the prompt -- a finding with nothing that would
+ * invalidate it is declared as an empty array rather than omitted, which is a
+ * claim the model has to make on purpose.
  */
 export const FINDINGS_SCHEMA = Object.freeze({
   type: 'object',
@@ -67,13 +80,24 @@ export const FINDINGS_SCHEMA = Object.freeze({
       items: {
         type: 'object',
         additionalProperties: false,
-        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        required: [
+          'type',
+          'claim',
+          'evidence',
+          'applicability',
+          'confidenceLabel',
+          'scope',
+          'invalidators',
+          'anchors',
+        ],
         properties: {
           type: { type: 'string', enum: FINDING_TYPES },
           claim: { type: 'string' },
           evidence: { type: 'string' },
           applicability: { type: 'string' },
           confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          scope: { type: 'string', enum: ['project', 'organization', 'global'] },
+          invalidators: { type: 'array', items: { type: 'string' } },
           anchors: { type: 'array', items: { type: 'string' } },
           trigger: { type: 'string' },
         },
@@ -379,11 +403,72 @@ export function endpointDialect(endpoint = ENDPOINT()) {
  * on the hook path must not care; the reason is recorded beside it so
  * `doctor` and a human can tell the two apart.
  */
+// A MODULE VARIABLE CANNOT CROSS A PROCESS, and every reader of this is in a
+// different one. The harvest runs in a DETACHED worker spawned at Stop
+// (stop-harvest.mjs), while `doctor` is a separate `node` invocation that
+// imports a fresh copy of this module. So `probeHarvest` read `null` no matter
+// what the harvest had done, and the failure branch it was given -- the whole
+// point of recording a reason -- could never be reached from the diagnostic
+// that exists to surface it. The reason is written where the next process can
+// find it.
+//
+// Per user, not per project: the worker resolves a project root and `doctor`
+// often cannot, and the failures recorded here (a wrong dialect, a missing
+// model name, an unreachable endpoint, a CLI that is not on PATH) are
+// properties of the machine's configuration rather than of a repository.
+const FAILURE_FILE = () =>
+  process.env.TOKEN_OPTIMIZER_HARVEST_STATE ||
+  join(homedir(), '.token-optimizer', 'last-harvest.json');
+
+// Old enough to be about a configuration that no longer exists. A harvest runs
+// at the end of every session, so a record older than this means the harvest
+// has not run since -- reporting it as the current state would be a guess.
+const FAILURE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
 let lastHarvestFailure = null;
-export const harvestFailure = () => lastHarvestFailure;
-const failed = (reason) => {
+/** True once this process has recorded an outcome, so the file is not consulted. */
+let outcomeThisProcess = false;
+
+function recordOutcome(reason) {
   lastHarvestFailure = reason;
+  outcomeThisProcess = true;
+  try {
+    const file = FAILURE_FILE();
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({ reason, at: Date.now() }), 'utf8');
+  } catch {
+    // Best effort. A harvest must never fail because it could not write a
+    // diagnostic about itself.
+  }
+}
+
+export function harvestFailure() {
+  if (outcomeThisProcess) return lastHarvestFailure;
+  try {
+    const { reason, at } = JSON.parse(readFileSync(FAILURE_FILE(), 'utf8'));
+    if (!reason || typeof at !== 'number') return null;
+    return Date.now() - at > FAILURE_TTL_MS ? null : reason;
+  } catch {
+    return null;
+  }
+}
+
+const failed = (reason) => {
+  recordOutcome(reason);
   return [];
+};
+
+/**
+ * Clears the recorded failure, because the harvest just worked.
+ *
+ * Without this the file is a one-way latch: a user fixes their endpoint, the
+ * harvest starts working, and `doctor` keeps reporting the failure that was
+ * true a week ago. The TTL alone would not do it -- it expires a stale record,
+ * not a wrong one.
+ */
+const succeeded = (findings) => {
+  recordOutcome(null);
+  return findings;
 };
 
 /**
@@ -396,6 +481,7 @@ export async function extract(
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
 ) {
   lastHarvestFailure = null;
+  outcomeThisProcess = false;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
@@ -583,7 +669,7 @@ export async function extract(
     if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
     try {
-      return JSON.parse(text.slice(start, end + 1));
+      return succeeded(JSON.parse(text.slice(start, end + 1)));
     } catch {
       return failed('the JSON array in the reply did not parse');
     }

--- a/integrations/copilot/.github/hooks/lib/doctor.mjs
+++ b/integrations/copilot/.github/hooks/lib/doctor.mjs
@@ -25,7 +25,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { harvestMode } from './harvest.mjs';
+import { harvestMode, harvestFailure } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
 import { mcpClientsSeen } from './metrics.mjs';
 
@@ -228,6 +228,20 @@ export function probeHarvest() {
   // credential, no billing and no digest leaving the machine -- so the two facts
   // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
+    // WHY THE LAST ONE PRODUCED NOTHING, when it produced nothing.
+    //
+    // `extract` returns [] on every failure so a hook-path caller need not
+    // care, which made a misconfigured endpoint indistinguishable from a
+    // session with nothing to learn -- the exact reason a client speaking the
+    // wrong dialect went unnoticed. `harvestFailure()` carries the reason, and
+    // this is the reader it was added for.
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check the endpoint URL and, for an OpenAI-compatible server, that ' +
+        'TOKEN_OPTIMIZER_HARVEST_MODEL names a model it actually serves')];
+    }
     return [ok('finding extraction is available',
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];

--- a/integrations/copilot/.github/hooks/lib/harvest-worker.mjs
+++ b/integrations/copilot/.github/hooks/lib/harvest-worker.mjs
@@ -99,13 +99,20 @@ async function main() {
   const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
   if (!digest) return;
 
-  const raw = await extract(digest);
+  // THE SAME LIST TO BOTH SIDES. `validate` has always held anchors to the
+  // files this session touched; passing it to `extract` too lets the model be
+  // GIVEN that list instead of guessing at it. Measured on this session's real
+  // digest with qwen2.5:7b: 0 of 4 extractions survived the gate when the model
+  // guessed, 4 of 4 when it chose. Computed once so the two can never disagree
+  // -- a model constrained to one list and judged against another would fail
+  // every time, and silently.
+  const anchorable = full ? null : filesIn(digest);
 
-  // Anchors are held to the files this session actually touched, so a model
-  // that invents a plausible path cannot anchor a finding to it. The digest
-  // lists them under a heading it writes itself; the full delta is raw
-  // transcript and carries no such list, so it gets no restriction.
-  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+  const raw = await extract(digest, { knownFiles: anchorable });
+
+  // The full delta is raw transcript and carries no file heading, so it gets
+  // no restriction on either side.
+  const validated = validate(raw, { knownFiles: anchorable });
 
   // BUDGETED SELECTION, not everything the model extracted.
   //

--- a/integrations/copilot/.github/hooks/lib/harvest.mjs
+++ b/integrations/copilot/.github/hooks/lib/harvest.mjs
@@ -41,6 +41,47 @@ const ENDPOINT = () => process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT
 // was wrong, which is why it is kept distinguishable from an ordinary finding.
 export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
 
+/**
+ * The shape a reply must take, for servers that can enforce one.
+ *
+ * A SMALL LOCAL MODEL WILL NOT FOLLOW THE PROMPT ON ITS OWN. Measured against
+ * qwen2.5:3b through ollama on the real digest from this session:
+ *
+ *   no constraint                    prose summary, 0 findings
+ *   response_format json_object      valid JSON, an invented schema
+ *   response_format json_schema      1 finding in the exact shape, 9s
+ *
+ * That is the difference between the free private path working and not, so
+ * the schema is sent rather than hoped for. The wrapper object exists because
+ * the OpenAI structured-output contract takes an object at the root; `extract`
+ * already locates the array inside whatever it is handed, so nothing
+ * downstream needs to know.
+ */
+export const FINDINGS_SCHEMA = Object.freeze({
+  type: 'object',
+  required: ['findings'],
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        properties: {
+          type: { type: 'string', enum: FINDING_TYPES },
+          claim: { type: 'string' },
+          evidence: { type: 'string' },
+          applicability: { type: 'string' },
+          confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          anchors: { type: 'array', items: { type: 'string' } },
+          trigger: { type: 'string' },
+        },
+      },
+    },
+  },
+});
+
 export function apiKey() {
   return process.env.TOKEN_OPTIMIZER_API_KEY || process.env.ANTHROPIC_API_KEY || null;
 }
@@ -359,8 +400,15 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-  try {
-    const response = await fetch(endpoint, {
+  /**
+   * One request. `structured` asks the server to enforce FINDINGS_SCHEMA.
+   *
+   * Separated out so the schema can be dropped and the call retried WITHOUT
+   * repeating the request shape in two places, which is how the two would
+   * drift.
+   */
+  const send = (structured) =>
+    fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
@@ -384,6 +432,14 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 { role: 'system', content: system },
                 { role: 'user', content: digest },
               ],
+              ...(structured
+                ? {
+                    response_format: {
+                      type: 'json_schema',
+                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                    },
+                  }
+                : {}),
             }
           : {
               model: MODEL(),
@@ -393,6 +449,21 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
             }
       ),
     });
+
+  try {
+    // Structured output only where the contract exists. Anthropic Messages has
+    // no `response_format`, and sending one is at best ignored.
+    let response = await send(dialect === 'openai');
+
+    // RETRIED ONCE, AND ONLY FOR A REFUSAL OF THE SCHEMA ITSELF. A server that
+    // predates structured outputs rejects the request outright, and the
+    // unconstrained call still works there -- that is the configuration this
+    // whole function used to be. Narrow on purpose: a 4xx is the server saying
+    // it will not take what was sent, while a 5xx or a timeout is a condition a
+    // second identical call would only pay for twice, on a hook path.
+    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
+      response = await send(false);
+    }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();

--- a/integrations/copilot/.github/hooks/lib/harvest.mjs
+++ b/integrations/copilot/.github/hooks/lib/harvest.mjs
@@ -368,7 +368,10 @@ const failed = (reason) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
-export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
+export async function extract(
+  digest,
+  { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
+) {
   lastHarvestFailure = null;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
@@ -384,6 +387,43 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
+  //
+  // `validate` holds anchors to the files the session actually touched, and a
+  // model asked in English for a path writes a plausible one instead of a real
+  // one -- so every finding was discarded at the gate. Measured over four runs
+  // of qwen2.5:7b on this session's real digest, against that same gate:
+  //
+  //   anchors unconstrained     4 extracted -> 0 accepted
+  //   anchors enum-constrained  4 extracted -> 4 accepted
+  //
+  // Nothing else differed. The server enforces the enum, so the model picks
+  // from the real list rather than inventing one, and the gate stops being
+  // the thing that silently eats the harvest.
+  //
+  // Only when the caller knows the list. `buildFullDelta` is raw transcript
+  // with no file heading, and its caller passes no knownFiles for the same
+  // reason -- an empty enum would forbid every anchor rather than free it.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+  const schema = anchorChoices.length
+    ? {
+        ...FINDINGS_SCHEMA,
+        properties: {
+          ...FINDINGS_SCHEMA.properties,
+          findings: {
+            ...FINDINGS_SCHEMA.properties.findings,
+            items: {
+              ...FINDINGS_SCHEMA.properties.findings.items,
+              properties: {
+                ...FINDINGS_SCHEMA.properties.findings.items.properties,
+                anchors: { type: 'array', items: { type: 'string', enum: anchorChoices } },
+              },
+            },
+          },
+        },
+      }
+    : FINDINGS_SCHEMA;
 
   // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
   //
@@ -436,7 +476,7 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 ? {
                     response_format: {
                       type: 'json_schema',
-                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                      json_schema: { name: 'findings', schema },
                     },
                   }
                 : {}),

--- a/integrations/copilot/.github/hooks/lib/harvest.mjs
+++ b/integrations/copilot/.github/hooks/lib/harvest.mjs
@@ -285,12 +285,52 @@ export function validate(raw, { knownFiles = null } = {}) {
 }
 
 /**
+ * Which wire format the configured endpoint speaks.
+ *
+ * THE ADVERTISED LOCAL PATH DID NOT WORK. Both the SessionStart notice and
+ * `doctor` tell the user to point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local
+ * model, and this client only ever spoke the Anthropic Messages dialect --
+ * `system` as a top-level field, `content[]` blocks in the reply. ollama, LM
+ * Studio and llama.cpp all serve OpenAI-compatible /v1/chat/completions,
+ * which takes the system prompt as a message and answers with
+ * `choices[].message.content`. Measured against a stand-in server answering
+ * both dialects with the identical finding: the Anthropic path returned 1 and
+ * the OpenAI path returned 0.
+ *
+ * Chosen from the URL rather than by trying one and falling back. A fallback
+ * doubles the latency of every genuine failure on a hook path, and the user
+ * configures the whole URL here, so the path is something they stated rather
+ * than something we guess.
+ */
+export function endpointDialect(endpoint = ENDPOINT()) {
+  return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
+}
+
+/**
+ * The last reason a harvest produced nothing, or null.
+ *
+ * `return []` on every failure made a misconfigured endpoint IDENTICAL to a
+ * session with nothing to learn -- which is how a local endpoint answering the
+ * wrong dialect stayed invisible. The empty result is kept, because a caller
+ * on the hook path must not care; the reason is recorded beside it so
+ * `doctor` and a human can tell the two apart.
+ */
+let lastHarvestFailure = null;
+export const harvestFailure = () => lastHarvestFailure;
+const failed = (reason) => {
+  lastHarvestFailure = reason;
+  return [];
+};
+
+/**
  * Calls the model. Returns [] on any failure -- a harvest that errors must be
  * indistinguishable, from the caller's side, from a session with nothing to
- * learn.
+ * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
 export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
-  if (!digest || !harvestEnabled()) return [];
+  lastHarvestFailure = null;
+  if (!digest) return failed('no digest');
+  if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
   // A local endpoint usually has no auth at all, so requiring a key there would
   // make the free, private path unreachable -- the one the design now prefers.
@@ -298,41 +338,90 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return [];
+  if (!local && !key) return failed('no api key for a remote endpoint');
+
+  const endpoint = ENDPOINT();
+  const dialect = endpointDialect(endpoint);
+  const system = prompt || PROMPT;
+
+  // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
+  //
+  // `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most
+  // machines that run Claude at all and says nothing about the endpoint the
+  // user pointed this at -- which may be any process listening on loopback.
+  // A local server that genuinely wants auth is still reachable: set
+  // TOKEN_OPTIMIZER_API_KEY, which is explicit about being for this.
+  //
+  // Remote is unchanged; there the key is the whole reason the call is
+  // allowed to happen.
+  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(ENDPOINT(), {
+    const response = await fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
         'content-type': 'application/json',
-        ...(key ? { 'x-api-key': key } : {}),
-        'anthropic-version': '2023-06-01',
+        // A local server usually wants no credential at all, and sending one
+        // to localhost is a leak, not a courtesy -- so a key is attached only
+        // when there is one, in the scheme the dialect expects.
+        ...(credential && dialect === 'anthropic' ? { 'x-api-key': credential } : {}),
+        ...(credential && dialect === 'openai'
+          ? { authorization: `Bearer ${credential}` }
+          : {}),
+        ...(dialect === 'anthropic' ? { 'anthropic-version': '2023-06-01' } : {}),
       },
-      body: JSON.stringify({
-        model: MODEL(),
-        max_tokens: 2048,
-        system: prompt || PROMPT,
-        messages: [{ role: 'user', content: digest }],
-      }),
+      body: JSON.stringify(
+        dialect === 'openai'
+          ? {
+              model: MODEL(),
+              max_tokens: 2048,
+              // No top-level `system` in this dialect; it is the first message.
+              messages: [
+                { role: 'system', content: system },
+                { role: 'user', content: digest },
+              ],
+            }
+          : {
+              model: MODEL(),
+              max_tokens: 2048,
+              system,
+              messages: [{ role: 'user', content: digest }],
+            }
+      ),
     });
 
-    if (!response.ok) return [];
+    if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();
-    const text = (body.content || []).filter((b) => b.type === 'text').map((b) => b.text).join('');
+
+    // BOTH SHAPES READ, whichever dialect was sent. A gateway may answer in the
+    // other one, and reading both costs a property access.
+    const text =
+      (Array.isArray(body.content)
+        ? body.content.filter((b) => b?.type === 'text').map((b) => b.text).join('')
+        : '') ||
+      (Array.isArray(body.choices)
+        ? body.choices.map((c) => c?.message?.content || '').join('')
+        : '') ||
+      '';
+    if (!text) return failed('endpoint answered in an unrecognised shape');
 
     // Models wrap JSON in prose or fences often enough that finding the array
     // is more reliable than insisting the whole response parse.
     const start = text.indexOf('[');
     const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return [];
+    if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
-    return JSON.parse(text.slice(start, end + 1));
-  } catch {
-    return [];
+    try {
+      return JSON.parse(text.slice(start, end + 1));
+    } catch {
+      return failed('the JSON array in the reply did not parse');
+    }
+  } catch (error) {
+    return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {
     clearTimeout(timer);
   }

--- a/integrations/copilot/.github/hooks/lib/harvest.mjs
+++ b/integrations/copilot/.github/hooks/lib/harvest.mjs
@@ -343,6 +343,29 @@ export function validate(raw, { knownFiles = null } = {}) {
  * configures the whole URL here, so the path is something they stated rather
  * than something we guess.
  */
+/**
+ * Which credential, if any, may travel to this endpoint.
+ *
+ * `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most machines
+ * that run Claude and says nothing about where this request is going. There is
+ * exactly one destination that key belongs to: a REMOTE ANTHROPIC endpoint.
+ *
+ *   anthropic + remote   the key -- this is what it is for
+ *   anthropic + local    explicit only -- loopback is not Anthropic
+ *   openai    + remote   explicit only -- a third-party gateway must not
+ *                        receive an Anthropic credential as a Bearer token
+ *   openai    + local    explicit only
+ *
+ * The first version of this scoped on `local` alone, which review caught: it
+ * closed the loopback leak and left the remote-gateway one wide open. Exported
+ * so all four combinations are testable without contriving DNS.
+ */
+export function credentialFor(dialect, local, env = process.env) {
+  const explicit = env.TOKEN_OPTIMIZER_API_KEY || null;
+  if (dialect === 'openai' || local) return explicit;
+  return explicit || env.ANTHROPIC_API_KEY || null;
+}
+
 export function endpointDialect(endpoint = ENDPOINT()) {
   return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
 }
@@ -435,7 +458,24 @@ export async function extract(
   //
   // Remote is unchanged; there the key is the whole reason the call is
   // allowed to happen.
-  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
+  const credential = credentialFor(dialect, local);
+
+  // THE DEFAULT MODEL IS AN ANTHROPIC ONE, AND A LOCAL SERVER HAS NEVER HEARD
+  // OF IT. `MODEL()` falls back to claude-haiku, so an endpoint configured per
+  // the documented advice -- which names only TOKEN_OPTIMIZER_HARVEST_ENDPOINT --
+  // asks ollama for a model it does not have and is refused. I hit this myself
+  // while proving the dialect fix and set the variable by hand without noticing
+  // that a user could not know to.
+  //
+  // Refused with an actionable reason rather than guessed at. Picking a default
+  // like `llama3.2` would be a guess about what the user pulled, and being wrong
+  // costs the same silent nothing this whole branch exists to remove.
+  if (dialect === 'openai' && !process.env.TOKEN_OPTIMIZER_HARVEST_MODEL) {
+    return failed(
+      'set TOKEN_OPTIMIZER_HARVEST_MODEL for an OpenAI-compatible endpoint ' +
+        `(the default ${MODEL()} is an Anthropic model no local server serves)`
+    );
+  }
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -501,8 +541,24 @@ export async function extract(
     // whole function used to be. Narrow on purpose: a 4xx is the server saying
     // it will not take what was sent, while a 5xx or a timeout is a condition a
     // second identical call would only pay for twice, on a hook path.
-    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
-      response = await send(false);
+    // NARROWED FROM ANY 4xx. Review is right that the first version retried
+    // things a retry cannot help and should not touch: a 429 is a rate limit
+    // and an immediate repeat makes it worse, while 401/403/404 are settled
+    // answers about credentials and routing. Only a 400/422 whose body names
+    // `response_format` is the server saying it will not take THE SCHEMA,
+    // which is the one case where the same request without it still works.
+    if (
+      !response.ok
+      && dialect === 'openai'
+      && (response.status === 400 || response.status === 422)
+    ) {
+      let complaint = '';
+      try {
+        complaint = await response.clone().text();
+      } catch {
+        complaint = '';
+      }
+      if (/response_format|json_schema/i.test(complaint)) response = await send(false);
     }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);

--- a/integrations/copilot/.github/hooks/lib/harvest.mjs
+++ b/integrations/copilot/.github/hooks/lib/harvest.mjs
@@ -20,7 +20,9 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -56,6 +58,17 @@ export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map'
  * the OpenAI structured-output contract takes an object at the root; `extract`
  * already locates the array inside whatever it is handed, so nothing
  * downstream needs to know.
+ *
+ * EVERY FIELD THE PROMPT ASKS FOR HAS TO BE DECLARED HERE, because the
+ * object is closed. `PROMPT` asks for `scope` and `invalidators`; the schema
+ * did not declare them and `additionalProperties: false` therefore FORBADE
+ * them, so an enforcing server could not return either one. `validate` then
+ * substituted `project` and `[]` for every finding, and the substitution is
+ * silent: on the schema path, organization- and global-scope findings could
+ * not be promoted and no finding could ever carry an invalidator. Both are
+ * required, matching the prompt -- a finding with nothing that would
+ * invalidate it is declared as an empty array rather than omitted, which is a
+ * claim the model has to make on purpose.
  */
 export const FINDINGS_SCHEMA = Object.freeze({
   type: 'object',
@@ -67,13 +80,24 @@ export const FINDINGS_SCHEMA = Object.freeze({
       items: {
         type: 'object',
         additionalProperties: false,
-        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        required: [
+          'type',
+          'claim',
+          'evidence',
+          'applicability',
+          'confidenceLabel',
+          'scope',
+          'invalidators',
+          'anchors',
+        ],
         properties: {
           type: { type: 'string', enum: FINDING_TYPES },
           claim: { type: 'string' },
           evidence: { type: 'string' },
           applicability: { type: 'string' },
           confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          scope: { type: 'string', enum: ['project', 'organization', 'global'] },
+          invalidators: { type: 'array', items: { type: 'string' } },
           anchors: { type: 'array', items: { type: 'string' } },
           trigger: { type: 'string' },
         },
@@ -379,11 +403,72 @@ export function endpointDialect(endpoint = ENDPOINT()) {
  * on the hook path must not care; the reason is recorded beside it so
  * `doctor` and a human can tell the two apart.
  */
+// A MODULE VARIABLE CANNOT CROSS A PROCESS, and every reader of this is in a
+// different one. The harvest runs in a DETACHED worker spawned at Stop
+// (stop-harvest.mjs), while `doctor` is a separate `node` invocation that
+// imports a fresh copy of this module. So `probeHarvest` read `null` no matter
+// what the harvest had done, and the failure branch it was given -- the whole
+// point of recording a reason -- could never be reached from the diagnostic
+// that exists to surface it. The reason is written where the next process can
+// find it.
+//
+// Per user, not per project: the worker resolves a project root and `doctor`
+// often cannot, and the failures recorded here (a wrong dialect, a missing
+// model name, an unreachable endpoint, a CLI that is not on PATH) are
+// properties of the machine's configuration rather than of a repository.
+const FAILURE_FILE = () =>
+  process.env.TOKEN_OPTIMIZER_HARVEST_STATE ||
+  join(homedir(), '.token-optimizer', 'last-harvest.json');
+
+// Old enough to be about a configuration that no longer exists. A harvest runs
+// at the end of every session, so a record older than this means the harvest
+// has not run since -- reporting it as the current state would be a guess.
+const FAILURE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
 let lastHarvestFailure = null;
-export const harvestFailure = () => lastHarvestFailure;
-const failed = (reason) => {
+/** True once this process has recorded an outcome, so the file is not consulted. */
+let outcomeThisProcess = false;
+
+function recordOutcome(reason) {
   lastHarvestFailure = reason;
+  outcomeThisProcess = true;
+  try {
+    const file = FAILURE_FILE();
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({ reason, at: Date.now() }), 'utf8');
+  } catch {
+    // Best effort. A harvest must never fail because it could not write a
+    // diagnostic about itself.
+  }
+}
+
+export function harvestFailure() {
+  if (outcomeThisProcess) return lastHarvestFailure;
+  try {
+    const { reason, at } = JSON.parse(readFileSync(FAILURE_FILE(), 'utf8'));
+    if (!reason || typeof at !== 'number') return null;
+    return Date.now() - at > FAILURE_TTL_MS ? null : reason;
+  } catch {
+    return null;
+  }
+}
+
+const failed = (reason) => {
+  recordOutcome(reason);
   return [];
+};
+
+/**
+ * Clears the recorded failure, because the harvest just worked.
+ *
+ * Without this the file is a one-way latch: a user fixes their endpoint, the
+ * harvest starts working, and `doctor` keeps reporting the failure that was
+ * true a week ago. The TTL alone would not do it -- it expires a stale record,
+ * not a wrong one.
+ */
+const succeeded = (findings) => {
+  recordOutcome(null);
+  return findings;
 };
 
 /**
@@ -396,6 +481,7 @@ export async function extract(
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
 ) {
   lastHarvestFailure = null;
+  outcomeThisProcess = false;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
@@ -583,7 +669,7 @@ export async function extract(
     if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
     try {
-      return JSON.parse(text.slice(start, end + 1));
+      return succeeded(JSON.parse(text.slice(start, end + 1)));
     } catch {
       return failed('the JSON array in the reply did not parse');
     }

--- a/integrations/cursor/hooks/lib/doctor.mjs
+++ b/integrations/cursor/hooks/lib/doctor.mjs
@@ -25,7 +25,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { harvestMode } from './harvest.mjs';
+import { harvestMode, harvestFailure } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
 import { mcpClientsSeen } from './metrics.mjs';
 
@@ -228,6 +228,20 @@ export function probeHarvest() {
   // credential, no billing and no digest leaving the machine -- so the two facts
   // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
+    // WHY THE LAST ONE PRODUCED NOTHING, when it produced nothing.
+    //
+    // `extract` returns [] on every failure so a hook-path caller need not
+    // care, which made a misconfigured endpoint indistinguishable from a
+    // session with nothing to learn -- the exact reason a client speaking the
+    // wrong dialect went unnoticed. `harvestFailure()` carries the reason, and
+    // this is the reader it was added for.
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check the endpoint URL and, for an OpenAI-compatible server, that ' +
+        'TOKEN_OPTIMIZER_HARVEST_MODEL names a model it actually serves')];
+    }
     return [ok('finding extraction is available',
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];

--- a/integrations/cursor/hooks/lib/harvest-worker.mjs
+++ b/integrations/cursor/hooks/lib/harvest-worker.mjs
@@ -99,13 +99,20 @@ async function main() {
   const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
   if (!digest) return;
 
-  const raw = await extract(digest);
+  // THE SAME LIST TO BOTH SIDES. `validate` has always held anchors to the
+  // files this session touched; passing it to `extract` too lets the model be
+  // GIVEN that list instead of guessing at it. Measured on this session's real
+  // digest with qwen2.5:7b: 0 of 4 extractions survived the gate when the model
+  // guessed, 4 of 4 when it chose. Computed once so the two can never disagree
+  // -- a model constrained to one list and judged against another would fail
+  // every time, and silently.
+  const anchorable = full ? null : filesIn(digest);
 
-  // Anchors are held to the files this session actually touched, so a model
-  // that invents a plausible path cannot anchor a finding to it. The digest
-  // lists them under a heading it writes itself; the full delta is raw
-  // transcript and carries no such list, so it gets no restriction.
-  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+  const raw = await extract(digest, { knownFiles: anchorable });
+
+  // The full delta is raw transcript and carries no file heading, so it gets
+  // no restriction on either side.
+  const validated = validate(raw, { knownFiles: anchorable });
 
   // BUDGETED SELECTION, not everything the model extracted.
   //

--- a/integrations/cursor/hooks/lib/harvest.mjs
+++ b/integrations/cursor/hooks/lib/harvest.mjs
@@ -41,6 +41,47 @@ const ENDPOINT = () => process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT
 // was wrong, which is why it is kept distinguishable from an ordinary finding.
 export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
 
+/**
+ * The shape a reply must take, for servers that can enforce one.
+ *
+ * A SMALL LOCAL MODEL WILL NOT FOLLOW THE PROMPT ON ITS OWN. Measured against
+ * qwen2.5:3b through ollama on the real digest from this session:
+ *
+ *   no constraint                    prose summary, 0 findings
+ *   response_format json_object      valid JSON, an invented schema
+ *   response_format json_schema      1 finding in the exact shape, 9s
+ *
+ * That is the difference between the free private path working and not, so
+ * the schema is sent rather than hoped for. The wrapper object exists because
+ * the OpenAI structured-output contract takes an object at the root; `extract`
+ * already locates the array inside whatever it is handed, so nothing
+ * downstream needs to know.
+ */
+export const FINDINGS_SCHEMA = Object.freeze({
+  type: 'object',
+  required: ['findings'],
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        properties: {
+          type: { type: 'string', enum: FINDING_TYPES },
+          claim: { type: 'string' },
+          evidence: { type: 'string' },
+          applicability: { type: 'string' },
+          confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          anchors: { type: 'array', items: { type: 'string' } },
+          trigger: { type: 'string' },
+        },
+      },
+    },
+  },
+});
+
 export function apiKey() {
   return process.env.TOKEN_OPTIMIZER_API_KEY || process.env.ANTHROPIC_API_KEY || null;
 }
@@ -359,8 +400,15 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-  try {
-    const response = await fetch(endpoint, {
+  /**
+   * One request. `structured` asks the server to enforce FINDINGS_SCHEMA.
+   *
+   * Separated out so the schema can be dropped and the call retried WITHOUT
+   * repeating the request shape in two places, which is how the two would
+   * drift.
+   */
+  const send = (structured) =>
+    fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
@@ -384,6 +432,14 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 { role: 'system', content: system },
                 { role: 'user', content: digest },
               ],
+              ...(structured
+                ? {
+                    response_format: {
+                      type: 'json_schema',
+                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                    },
+                  }
+                : {}),
             }
           : {
               model: MODEL(),
@@ -393,6 +449,21 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
             }
       ),
     });
+
+  try {
+    // Structured output only where the contract exists. Anthropic Messages has
+    // no `response_format`, and sending one is at best ignored.
+    let response = await send(dialect === 'openai');
+
+    // RETRIED ONCE, AND ONLY FOR A REFUSAL OF THE SCHEMA ITSELF. A server that
+    // predates structured outputs rejects the request outright, and the
+    // unconstrained call still works there -- that is the configuration this
+    // whole function used to be. Narrow on purpose: a 4xx is the server saying
+    // it will not take what was sent, while a 5xx or a timeout is a condition a
+    // second identical call would only pay for twice, on a hook path.
+    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
+      response = await send(false);
+    }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();

--- a/integrations/cursor/hooks/lib/harvest.mjs
+++ b/integrations/cursor/hooks/lib/harvest.mjs
@@ -368,7 +368,10 @@ const failed = (reason) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
-export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
+export async function extract(
+  digest,
+  { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
+) {
   lastHarvestFailure = null;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
@@ -384,6 +387,43 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
+  //
+  // `validate` holds anchors to the files the session actually touched, and a
+  // model asked in English for a path writes a plausible one instead of a real
+  // one -- so every finding was discarded at the gate. Measured over four runs
+  // of qwen2.5:7b on this session's real digest, against that same gate:
+  //
+  //   anchors unconstrained     4 extracted -> 0 accepted
+  //   anchors enum-constrained  4 extracted -> 4 accepted
+  //
+  // Nothing else differed. The server enforces the enum, so the model picks
+  // from the real list rather than inventing one, and the gate stops being
+  // the thing that silently eats the harvest.
+  //
+  // Only when the caller knows the list. `buildFullDelta` is raw transcript
+  // with no file heading, and its caller passes no knownFiles for the same
+  // reason -- an empty enum would forbid every anchor rather than free it.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+  const schema = anchorChoices.length
+    ? {
+        ...FINDINGS_SCHEMA,
+        properties: {
+          ...FINDINGS_SCHEMA.properties,
+          findings: {
+            ...FINDINGS_SCHEMA.properties.findings,
+            items: {
+              ...FINDINGS_SCHEMA.properties.findings.items,
+              properties: {
+                ...FINDINGS_SCHEMA.properties.findings.items.properties,
+                anchors: { type: 'array', items: { type: 'string', enum: anchorChoices } },
+              },
+            },
+          },
+        },
+      }
+    : FINDINGS_SCHEMA;
 
   // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
   //
@@ -436,7 +476,7 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 ? {
                     response_format: {
                       type: 'json_schema',
-                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                      json_schema: { name: 'findings', schema },
                     },
                   }
                 : {}),

--- a/integrations/cursor/hooks/lib/harvest.mjs
+++ b/integrations/cursor/hooks/lib/harvest.mjs
@@ -285,12 +285,52 @@ export function validate(raw, { knownFiles = null } = {}) {
 }
 
 /**
+ * Which wire format the configured endpoint speaks.
+ *
+ * THE ADVERTISED LOCAL PATH DID NOT WORK. Both the SessionStart notice and
+ * `doctor` tell the user to point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local
+ * model, and this client only ever spoke the Anthropic Messages dialect --
+ * `system` as a top-level field, `content[]` blocks in the reply. ollama, LM
+ * Studio and llama.cpp all serve OpenAI-compatible /v1/chat/completions,
+ * which takes the system prompt as a message and answers with
+ * `choices[].message.content`. Measured against a stand-in server answering
+ * both dialects with the identical finding: the Anthropic path returned 1 and
+ * the OpenAI path returned 0.
+ *
+ * Chosen from the URL rather than by trying one and falling back. A fallback
+ * doubles the latency of every genuine failure on a hook path, and the user
+ * configures the whole URL here, so the path is something they stated rather
+ * than something we guess.
+ */
+export function endpointDialect(endpoint = ENDPOINT()) {
+  return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
+}
+
+/**
+ * The last reason a harvest produced nothing, or null.
+ *
+ * `return []` on every failure made a misconfigured endpoint IDENTICAL to a
+ * session with nothing to learn -- which is how a local endpoint answering the
+ * wrong dialect stayed invisible. The empty result is kept, because a caller
+ * on the hook path must not care; the reason is recorded beside it so
+ * `doctor` and a human can tell the two apart.
+ */
+let lastHarvestFailure = null;
+export const harvestFailure = () => lastHarvestFailure;
+const failed = (reason) => {
+  lastHarvestFailure = reason;
+  return [];
+};
+
+/**
  * Calls the model. Returns [] on any failure -- a harvest that errors must be
  * indistinguishable, from the caller's side, from a session with nothing to
- * learn.
+ * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
 export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
-  if (!digest || !harvestEnabled()) return [];
+  lastHarvestFailure = null;
+  if (!digest) return failed('no digest');
+  if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
   // A local endpoint usually has no auth at all, so requiring a key there would
   // make the free, private path unreachable -- the one the design now prefers.
@@ -298,41 +338,90 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return [];
+  if (!local && !key) return failed('no api key for a remote endpoint');
+
+  const endpoint = ENDPOINT();
+  const dialect = endpointDialect(endpoint);
+  const system = prompt || PROMPT;
+
+  // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
+  //
+  // `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most
+  // machines that run Claude at all and says nothing about the endpoint the
+  // user pointed this at -- which may be any process listening on loopback.
+  // A local server that genuinely wants auth is still reachable: set
+  // TOKEN_OPTIMIZER_API_KEY, which is explicit about being for this.
+  //
+  // Remote is unchanged; there the key is the whole reason the call is
+  // allowed to happen.
+  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(ENDPOINT(), {
+    const response = await fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
         'content-type': 'application/json',
-        ...(key ? { 'x-api-key': key } : {}),
-        'anthropic-version': '2023-06-01',
+        // A local server usually wants no credential at all, and sending one
+        // to localhost is a leak, not a courtesy -- so a key is attached only
+        // when there is one, in the scheme the dialect expects.
+        ...(credential && dialect === 'anthropic' ? { 'x-api-key': credential } : {}),
+        ...(credential && dialect === 'openai'
+          ? { authorization: `Bearer ${credential}` }
+          : {}),
+        ...(dialect === 'anthropic' ? { 'anthropic-version': '2023-06-01' } : {}),
       },
-      body: JSON.stringify({
-        model: MODEL(),
-        max_tokens: 2048,
-        system: prompt || PROMPT,
-        messages: [{ role: 'user', content: digest }],
-      }),
+      body: JSON.stringify(
+        dialect === 'openai'
+          ? {
+              model: MODEL(),
+              max_tokens: 2048,
+              // No top-level `system` in this dialect; it is the first message.
+              messages: [
+                { role: 'system', content: system },
+                { role: 'user', content: digest },
+              ],
+            }
+          : {
+              model: MODEL(),
+              max_tokens: 2048,
+              system,
+              messages: [{ role: 'user', content: digest }],
+            }
+      ),
     });
 
-    if (!response.ok) return [];
+    if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();
-    const text = (body.content || []).filter((b) => b.type === 'text').map((b) => b.text).join('');
+
+    // BOTH SHAPES READ, whichever dialect was sent. A gateway may answer in the
+    // other one, and reading both costs a property access.
+    const text =
+      (Array.isArray(body.content)
+        ? body.content.filter((b) => b?.type === 'text').map((b) => b.text).join('')
+        : '') ||
+      (Array.isArray(body.choices)
+        ? body.choices.map((c) => c?.message?.content || '').join('')
+        : '') ||
+      '';
+    if (!text) return failed('endpoint answered in an unrecognised shape');
 
     // Models wrap JSON in prose or fences often enough that finding the array
     // is more reliable than insisting the whole response parse.
     const start = text.indexOf('[');
     const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return [];
+    if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
-    return JSON.parse(text.slice(start, end + 1));
-  } catch {
-    return [];
+    try {
+      return JSON.parse(text.slice(start, end + 1));
+    } catch {
+      return failed('the JSON array in the reply did not parse');
+    }
+  } catch (error) {
+    return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {
     clearTimeout(timer);
   }

--- a/integrations/cursor/hooks/lib/harvest.mjs
+++ b/integrations/cursor/hooks/lib/harvest.mjs
@@ -343,6 +343,29 @@ export function validate(raw, { knownFiles = null } = {}) {
  * configures the whole URL here, so the path is something they stated rather
  * than something we guess.
  */
+/**
+ * Which credential, if any, may travel to this endpoint.
+ *
+ * `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most machines
+ * that run Claude and says nothing about where this request is going. There is
+ * exactly one destination that key belongs to: a REMOTE ANTHROPIC endpoint.
+ *
+ *   anthropic + remote   the key -- this is what it is for
+ *   anthropic + local    explicit only -- loopback is not Anthropic
+ *   openai    + remote   explicit only -- a third-party gateway must not
+ *                        receive an Anthropic credential as a Bearer token
+ *   openai    + local    explicit only
+ *
+ * The first version of this scoped on `local` alone, which review caught: it
+ * closed the loopback leak and left the remote-gateway one wide open. Exported
+ * so all four combinations are testable without contriving DNS.
+ */
+export function credentialFor(dialect, local, env = process.env) {
+  const explicit = env.TOKEN_OPTIMIZER_API_KEY || null;
+  if (dialect === 'openai' || local) return explicit;
+  return explicit || env.ANTHROPIC_API_KEY || null;
+}
+
 export function endpointDialect(endpoint = ENDPOINT()) {
   return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
 }
@@ -435,7 +458,24 @@ export async function extract(
   //
   // Remote is unchanged; there the key is the whole reason the call is
   // allowed to happen.
-  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
+  const credential = credentialFor(dialect, local);
+
+  // THE DEFAULT MODEL IS AN ANTHROPIC ONE, AND A LOCAL SERVER HAS NEVER HEARD
+  // OF IT. `MODEL()` falls back to claude-haiku, so an endpoint configured per
+  // the documented advice -- which names only TOKEN_OPTIMIZER_HARVEST_ENDPOINT --
+  // asks ollama for a model it does not have and is refused. I hit this myself
+  // while proving the dialect fix and set the variable by hand without noticing
+  // that a user could not know to.
+  //
+  // Refused with an actionable reason rather than guessed at. Picking a default
+  // like `llama3.2` would be a guess about what the user pulled, and being wrong
+  // costs the same silent nothing this whole branch exists to remove.
+  if (dialect === 'openai' && !process.env.TOKEN_OPTIMIZER_HARVEST_MODEL) {
+    return failed(
+      'set TOKEN_OPTIMIZER_HARVEST_MODEL for an OpenAI-compatible endpoint ' +
+        `(the default ${MODEL()} is an Anthropic model no local server serves)`
+    );
+  }
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -501,8 +541,24 @@ export async function extract(
     // whole function used to be. Narrow on purpose: a 4xx is the server saying
     // it will not take what was sent, while a 5xx or a timeout is a condition a
     // second identical call would only pay for twice, on a hook path.
-    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
-      response = await send(false);
+    // NARROWED FROM ANY 4xx. Review is right that the first version retried
+    // things a retry cannot help and should not touch: a 429 is a rate limit
+    // and an immediate repeat makes it worse, while 401/403/404 are settled
+    // answers about credentials and routing. Only a 400/422 whose body names
+    // `response_format` is the server saying it will not take THE SCHEMA,
+    // which is the one case where the same request without it still works.
+    if (
+      !response.ok
+      && dialect === 'openai'
+      && (response.status === 400 || response.status === 422)
+    ) {
+      let complaint = '';
+      try {
+        complaint = await response.clone().text();
+      } catch {
+        complaint = '';
+      }
+      if (/response_format|json_schema/i.test(complaint)) response = await send(false);
     }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);

--- a/integrations/cursor/hooks/lib/harvest.mjs
+++ b/integrations/cursor/hooks/lib/harvest.mjs
@@ -20,7 +20,9 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -56,6 +58,17 @@ export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map'
  * the OpenAI structured-output contract takes an object at the root; `extract`
  * already locates the array inside whatever it is handed, so nothing
  * downstream needs to know.
+ *
+ * EVERY FIELD THE PROMPT ASKS FOR HAS TO BE DECLARED HERE, because the
+ * object is closed. `PROMPT` asks for `scope` and `invalidators`; the schema
+ * did not declare them and `additionalProperties: false` therefore FORBADE
+ * them, so an enforcing server could not return either one. `validate` then
+ * substituted `project` and `[]` for every finding, and the substitution is
+ * silent: on the schema path, organization- and global-scope findings could
+ * not be promoted and no finding could ever carry an invalidator. Both are
+ * required, matching the prompt -- a finding with nothing that would
+ * invalidate it is declared as an empty array rather than omitted, which is a
+ * claim the model has to make on purpose.
  */
 export const FINDINGS_SCHEMA = Object.freeze({
   type: 'object',
@@ -67,13 +80,24 @@ export const FINDINGS_SCHEMA = Object.freeze({
       items: {
         type: 'object',
         additionalProperties: false,
-        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        required: [
+          'type',
+          'claim',
+          'evidence',
+          'applicability',
+          'confidenceLabel',
+          'scope',
+          'invalidators',
+          'anchors',
+        ],
         properties: {
           type: { type: 'string', enum: FINDING_TYPES },
           claim: { type: 'string' },
           evidence: { type: 'string' },
           applicability: { type: 'string' },
           confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          scope: { type: 'string', enum: ['project', 'organization', 'global'] },
+          invalidators: { type: 'array', items: { type: 'string' } },
           anchors: { type: 'array', items: { type: 'string' } },
           trigger: { type: 'string' },
         },
@@ -379,11 +403,72 @@ export function endpointDialect(endpoint = ENDPOINT()) {
  * on the hook path must not care; the reason is recorded beside it so
  * `doctor` and a human can tell the two apart.
  */
+// A MODULE VARIABLE CANNOT CROSS A PROCESS, and every reader of this is in a
+// different one. The harvest runs in a DETACHED worker spawned at Stop
+// (stop-harvest.mjs), while `doctor` is a separate `node` invocation that
+// imports a fresh copy of this module. So `probeHarvest` read `null` no matter
+// what the harvest had done, and the failure branch it was given -- the whole
+// point of recording a reason -- could never be reached from the diagnostic
+// that exists to surface it. The reason is written where the next process can
+// find it.
+//
+// Per user, not per project: the worker resolves a project root and `doctor`
+// often cannot, and the failures recorded here (a wrong dialect, a missing
+// model name, an unreachable endpoint, a CLI that is not on PATH) are
+// properties of the machine's configuration rather than of a repository.
+const FAILURE_FILE = () =>
+  process.env.TOKEN_OPTIMIZER_HARVEST_STATE ||
+  join(homedir(), '.token-optimizer', 'last-harvest.json');
+
+// Old enough to be about a configuration that no longer exists. A harvest runs
+// at the end of every session, so a record older than this means the harvest
+// has not run since -- reporting it as the current state would be a guess.
+const FAILURE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
 let lastHarvestFailure = null;
-export const harvestFailure = () => lastHarvestFailure;
-const failed = (reason) => {
+/** True once this process has recorded an outcome, so the file is not consulted. */
+let outcomeThisProcess = false;
+
+function recordOutcome(reason) {
   lastHarvestFailure = reason;
+  outcomeThisProcess = true;
+  try {
+    const file = FAILURE_FILE();
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({ reason, at: Date.now() }), 'utf8');
+  } catch {
+    // Best effort. A harvest must never fail because it could not write a
+    // diagnostic about itself.
+  }
+}
+
+export function harvestFailure() {
+  if (outcomeThisProcess) return lastHarvestFailure;
+  try {
+    const { reason, at } = JSON.parse(readFileSync(FAILURE_FILE(), 'utf8'));
+    if (!reason || typeof at !== 'number') return null;
+    return Date.now() - at > FAILURE_TTL_MS ? null : reason;
+  } catch {
+    return null;
+  }
+}
+
+const failed = (reason) => {
+  recordOutcome(reason);
   return [];
+};
+
+/**
+ * Clears the recorded failure, because the harvest just worked.
+ *
+ * Without this the file is a one-way latch: a user fixes their endpoint, the
+ * harvest starts working, and `doctor` keeps reporting the failure that was
+ * true a week ago. The TTL alone would not do it -- it expires a stale record,
+ * not a wrong one.
+ */
+const succeeded = (findings) => {
+  recordOutcome(null);
+  return findings;
 };
 
 /**
@@ -396,6 +481,7 @@ export async function extract(
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
 ) {
   lastHarvestFailure = null;
+  outcomeThisProcess = false;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
@@ -583,7 +669,7 @@ export async function extract(
     if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
     try {
-      return JSON.parse(text.slice(start, end + 1));
+      return succeeded(JSON.parse(text.slice(start, end + 1)));
     } catch {
       return failed('the JSON array in the reply did not parse');
     }

--- a/integrations/gemini/hooks/lib/doctor.mjs
+++ b/integrations/gemini/hooks/lib/doctor.mjs
@@ -25,7 +25,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { harvestMode } from './harvest.mjs';
+import { harvestMode, harvestFailure } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
 import { mcpClientsSeen } from './metrics.mjs';
 
@@ -228,6 +228,20 @@ export function probeHarvest() {
   // credential, no billing and no digest leaving the machine -- so the two facts
   // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
+    // WHY THE LAST ONE PRODUCED NOTHING, when it produced nothing.
+    //
+    // `extract` returns [] on every failure so a hook-path caller need not
+    // care, which made a misconfigured endpoint indistinguishable from a
+    // session with nothing to learn -- the exact reason a client speaking the
+    // wrong dialect went unnoticed. `harvestFailure()` carries the reason, and
+    // this is the reader it was added for.
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check the endpoint URL and, for an OpenAI-compatible server, that ' +
+        'TOKEN_OPTIMIZER_HARVEST_MODEL names a model it actually serves')];
+    }
     return [ok('finding extraction is available',
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];

--- a/integrations/gemini/hooks/lib/harvest-worker.mjs
+++ b/integrations/gemini/hooks/lib/harvest-worker.mjs
@@ -99,13 +99,20 @@ async function main() {
   const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
   if (!digest) return;
 
-  const raw = await extract(digest);
+  // THE SAME LIST TO BOTH SIDES. `validate` has always held anchors to the
+  // files this session touched; passing it to `extract` too lets the model be
+  // GIVEN that list instead of guessing at it. Measured on this session's real
+  // digest with qwen2.5:7b: 0 of 4 extractions survived the gate when the model
+  // guessed, 4 of 4 when it chose. Computed once so the two can never disagree
+  // -- a model constrained to one list and judged against another would fail
+  // every time, and silently.
+  const anchorable = full ? null : filesIn(digest);
 
-  // Anchors are held to the files this session actually touched, so a model
-  // that invents a plausible path cannot anchor a finding to it. The digest
-  // lists them under a heading it writes itself; the full delta is raw
-  // transcript and carries no such list, so it gets no restriction.
-  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+  const raw = await extract(digest, { knownFiles: anchorable });
+
+  // The full delta is raw transcript and carries no file heading, so it gets
+  // no restriction on either side.
+  const validated = validate(raw, { knownFiles: anchorable });
 
   // BUDGETED SELECTION, not everything the model extracted.
   //

--- a/integrations/gemini/hooks/lib/harvest.mjs
+++ b/integrations/gemini/hooks/lib/harvest.mjs
@@ -41,6 +41,47 @@ const ENDPOINT = () => process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT
 // was wrong, which is why it is kept distinguishable from an ordinary finding.
 export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
 
+/**
+ * The shape a reply must take, for servers that can enforce one.
+ *
+ * A SMALL LOCAL MODEL WILL NOT FOLLOW THE PROMPT ON ITS OWN. Measured against
+ * qwen2.5:3b through ollama on the real digest from this session:
+ *
+ *   no constraint                    prose summary, 0 findings
+ *   response_format json_object      valid JSON, an invented schema
+ *   response_format json_schema      1 finding in the exact shape, 9s
+ *
+ * That is the difference between the free private path working and not, so
+ * the schema is sent rather than hoped for. The wrapper object exists because
+ * the OpenAI structured-output contract takes an object at the root; `extract`
+ * already locates the array inside whatever it is handed, so nothing
+ * downstream needs to know.
+ */
+export const FINDINGS_SCHEMA = Object.freeze({
+  type: 'object',
+  required: ['findings'],
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        properties: {
+          type: { type: 'string', enum: FINDING_TYPES },
+          claim: { type: 'string' },
+          evidence: { type: 'string' },
+          applicability: { type: 'string' },
+          confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          anchors: { type: 'array', items: { type: 'string' } },
+          trigger: { type: 'string' },
+        },
+      },
+    },
+  },
+});
+
 export function apiKey() {
   return process.env.TOKEN_OPTIMIZER_API_KEY || process.env.ANTHROPIC_API_KEY || null;
 }
@@ -359,8 +400,15 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-  try {
-    const response = await fetch(endpoint, {
+  /**
+   * One request. `structured` asks the server to enforce FINDINGS_SCHEMA.
+   *
+   * Separated out so the schema can be dropped and the call retried WITHOUT
+   * repeating the request shape in two places, which is how the two would
+   * drift.
+   */
+  const send = (structured) =>
+    fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
@@ -384,6 +432,14 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 { role: 'system', content: system },
                 { role: 'user', content: digest },
               ],
+              ...(structured
+                ? {
+                    response_format: {
+                      type: 'json_schema',
+                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                    },
+                  }
+                : {}),
             }
           : {
               model: MODEL(),
@@ -393,6 +449,21 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
             }
       ),
     });
+
+  try {
+    // Structured output only where the contract exists. Anthropic Messages has
+    // no `response_format`, and sending one is at best ignored.
+    let response = await send(dialect === 'openai');
+
+    // RETRIED ONCE, AND ONLY FOR A REFUSAL OF THE SCHEMA ITSELF. A server that
+    // predates structured outputs rejects the request outright, and the
+    // unconstrained call still works there -- that is the configuration this
+    // whole function used to be. Narrow on purpose: a 4xx is the server saying
+    // it will not take what was sent, while a 5xx or a timeout is a condition a
+    // second identical call would only pay for twice, on a hook path.
+    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
+      response = await send(false);
+    }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();

--- a/integrations/gemini/hooks/lib/harvest.mjs
+++ b/integrations/gemini/hooks/lib/harvest.mjs
@@ -368,7 +368,10 @@ const failed = (reason) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
-export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
+export async function extract(
+  digest,
+  { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
+) {
   lastHarvestFailure = null;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
@@ -384,6 +387,43 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
+  //
+  // `validate` holds anchors to the files the session actually touched, and a
+  // model asked in English for a path writes a plausible one instead of a real
+  // one -- so every finding was discarded at the gate. Measured over four runs
+  // of qwen2.5:7b on this session's real digest, against that same gate:
+  //
+  //   anchors unconstrained     4 extracted -> 0 accepted
+  //   anchors enum-constrained  4 extracted -> 4 accepted
+  //
+  // Nothing else differed. The server enforces the enum, so the model picks
+  // from the real list rather than inventing one, and the gate stops being
+  // the thing that silently eats the harvest.
+  //
+  // Only when the caller knows the list. `buildFullDelta` is raw transcript
+  // with no file heading, and its caller passes no knownFiles for the same
+  // reason -- an empty enum would forbid every anchor rather than free it.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+  const schema = anchorChoices.length
+    ? {
+        ...FINDINGS_SCHEMA,
+        properties: {
+          ...FINDINGS_SCHEMA.properties,
+          findings: {
+            ...FINDINGS_SCHEMA.properties.findings,
+            items: {
+              ...FINDINGS_SCHEMA.properties.findings.items,
+              properties: {
+                ...FINDINGS_SCHEMA.properties.findings.items.properties,
+                anchors: { type: 'array', items: { type: 'string', enum: anchorChoices } },
+              },
+            },
+          },
+        },
+      }
+    : FINDINGS_SCHEMA;
 
   // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
   //
@@ -436,7 +476,7 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 ? {
                     response_format: {
                       type: 'json_schema',
-                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                      json_schema: { name: 'findings', schema },
                     },
                   }
                 : {}),

--- a/integrations/gemini/hooks/lib/harvest.mjs
+++ b/integrations/gemini/hooks/lib/harvest.mjs
@@ -285,12 +285,52 @@ export function validate(raw, { knownFiles = null } = {}) {
 }
 
 /**
+ * Which wire format the configured endpoint speaks.
+ *
+ * THE ADVERTISED LOCAL PATH DID NOT WORK. Both the SessionStart notice and
+ * `doctor` tell the user to point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local
+ * model, and this client only ever spoke the Anthropic Messages dialect --
+ * `system` as a top-level field, `content[]` blocks in the reply. ollama, LM
+ * Studio and llama.cpp all serve OpenAI-compatible /v1/chat/completions,
+ * which takes the system prompt as a message and answers with
+ * `choices[].message.content`. Measured against a stand-in server answering
+ * both dialects with the identical finding: the Anthropic path returned 1 and
+ * the OpenAI path returned 0.
+ *
+ * Chosen from the URL rather than by trying one and falling back. A fallback
+ * doubles the latency of every genuine failure on a hook path, and the user
+ * configures the whole URL here, so the path is something they stated rather
+ * than something we guess.
+ */
+export function endpointDialect(endpoint = ENDPOINT()) {
+  return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
+}
+
+/**
+ * The last reason a harvest produced nothing, or null.
+ *
+ * `return []` on every failure made a misconfigured endpoint IDENTICAL to a
+ * session with nothing to learn -- which is how a local endpoint answering the
+ * wrong dialect stayed invisible. The empty result is kept, because a caller
+ * on the hook path must not care; the reason is recorded beside it so
+ * `doctor` and a human can tell the two apart.
+ */
+let lastHarvestFailure = null;
+export const harvestFailure = () => lastHarvestFailure;
+const failed = (reason) => {
+  lastHarvestFailure = reason;
+  return [];
+};
+
+/**
  * Calls the model. Returns [] on any failure -- a harvest that errors must be
  * indistinguishable, from the caller's side, from a session with nothing to
- * learn.
+ * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
 export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
-  if (!digest || !harvestEnabled()) return [];
+  lastHarvestFailure = null;
+  if (!digest) return failed('no digest');
+  if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
   // A local endpoint usually has no auth at all, so requiring a key there would
   // make the free, private path unreachable -- the one the design now prefers.
@@ -298,41 +338,90 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return [];
+  if (!local && !key) return failed('no api key for a remote endpoint');
+
+  const endpoint = ENDPOINT();
+  const dialect = endpointDialect(endpoint);
+  const system = prompt || PROMPT;
+
+  // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
+  //
+  // `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most
+  // machines that run Claude at all and says nothing about the endpoint the
+  // user pointed this at -- which may be any process listening on loopback.
+  // A local server that genuinely wants auth is still reachable: set
+  // TOKEN_OPTIMIZER_API_KEY, which is explicit about being for this.
+  //
+  // Remote is unchanged; there the key is the whole reason the call is
+  // allowed to happen.
+  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(ENDPOINT(), {
+    const response = await fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
         'content-type': 'application/json',
-        ...(key ? { 'x-api-key': key } : {}),
-        'anthropic-version': '2023-06-01',
+        // A local server usually wants no credential at all, and sending one
+        // to localhost is a leak, not a courtesy -- so a key is attached only
+        // when there is one, in the scheme the dialect expects.
+        ...(credential && dialect === 'anthropic' ? { 'x-api-key': credential } : {}),
+        ...(credential && dialect === 'openai'
+          ? { authorization: `Bearer ${credential}` }
+          : {}),
+        ...(dialect === 'anthropic' ? { 'anthropic-version': '2023-06-01' } : {}),
       },
-      body: JSON.stringify({
-        model: MODEL(),
-        max_tokens: 2048,
-        system: prompt || PROMPT,
-        messages: [{ role: 'user', content: digest }],
-      }),
+      body: JSON.stringify(
+        dialect === 'openai'
+          ? {
+              model: MODEL(),
+              max_tokens: 2048,
+              // No top-level `system` in this dialect; it is the first message.
+              messages: [
+                { role: 'system', content: system },
+                { role: 'user', content: digest },
+              ],
+            }
+          : {
+              model: MODEL(),
+              max_tokens: 2048,
+              system,
+              messages: [{ role: 'user', content: digest }],
+            }
+      ),
     });
 
-    if (!response.ok) return [];
+    if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();
-    const text = (body.content || []).filter((b) => b.type === 'text').map((b) => b.text).join('');
+
+    // BOTH SHAPES READ, whichever dialect was sent. A gateway may answer in the
+    // other one, and reading both costs a property access.
+    const text =
+      (Array.isArray(body.content)
+        ? body.content.filter((b) => b?.type === 'text').map((b) => b.text).join('')
+        : '') ||
+      (Array.isArray(body.choices)
+        ? body.choices.map((c) => c?.message?.content || '').join('')
+        : '') ||
+      '';
+    if (!text) return failed('endpoint answered in an unrecognised shape');
 
     // Models wrap JSON in prose or fences often enough that finding the array
     // is more reliable than insisting the whole response parse.
     const start = text.indexOf('[');
     const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return [];
+    if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
-    return JSON.parse(text.slice(start, end + 1));
-  } catch {
-    return [];
+    try {
+      return JSON.parse(text.slice(start, end + 1));
+    } catch {
+      return failed('the JSON array in the reply did not parse');
+    }
+  } catch (error) {
+    return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {
     clearTimeout(timer);
   }

--- a/integrations/gemini/hooks/lib/harvest.mjs
+++ b/integrations/gemini/hooks/lib/harvest.mjs
@@ -343,6 +343,29 @@ export function validate(raw, { knownFiles = null } = {}) {
  * configures the whole URL here, so the path is something they stated rather
  * than something we guess.
  */
+/**
+ * Which credential, if any, may travel to this endpoint.
+ *
+ * `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most machines
+ * that run Claude and says nothing about where this request is going. There is
+ * exactly one destination that key belongs to: a REMOTE ANTHROPIC endpoint.
+ *
+ *   anthropic + remote   the key -- this is what it is for
+ *   anthropic + local    explicit only -- loopback is not Anthropic
+ *   openai    + remote   explicit only -- a third-party gateway must not
+ *                        receive an Anthropic credential as a Bearer token
+ *   openai    + local    explicit only
+ *
+ * The first version of this scoped on `local` alone, which review caught: it
+ * closed the loopback leak and left the remote-gateway one wide open. Exported
+ * so all four combinations are testable without contriving DNS.
+ */
+export function credentialFor(dialect, local, env = process.env) {
+  const explicit = env.TOKEN_OPTIMIZER_API_KEY || null;
+  if (dialect === 'openai' || local) return explicit;
+  return explicit || env.ANTHROPIC_API_KEY || null;
+}
+
 export function endpointDialect(endpoint = ENDPOINT()) {
   return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
 }
@@ -435,7 +458,24 @@ export async function extract(
   //
   // Remote is unchanged; there the key is the whole reason the call is
   // allowed to happen.
-  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
+  const credential = credentialFor(dialect, local);
+
+  // THE DEFAULT MODEL IS AN ANTHROPIC ONE, AND A LOCAL SERVER HAS NEVER HEARD
+  // OF IT. `MODEL()` falls back to claude-haiku, so an endpoint configured per
+  // the documented advice -- which names only TOKEN_OPTIMIZER_HARVEST_ENDPOINT --
+  // asks ollama for a model it does not have and is refused. I hit this myself
+  // while proving the dialect fix and set the variable by hand without noticing
+  // that a user could not know to.
+  //
+  // Refused with an actionable reason rather than guessed at. Picking a default
+  // like `llama3.2` would be a guess about what the user pulled, and being wrong
+  // costs the same silent nothing this whole branch exists to remove.
+  if (dialect === 'openai' && !process.env.TOKEN_OPTIMIZER_HARVEST_MODEL) {
+    return failed(
+      'set TOKEN_OPTIMIZER_HARVEST_MODEL for an OpenAI-compatible endpoint ' +
+        `(the default ${MODEL()} is an Anthropic model no local server serves)`
+    );
+  }
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -501,8 +541,24 @@ export async function extract(
     // whole function used to be. Narrow on purpose: a 4xx is the server saying
     // it will not take what was sent, while a 5xx or a timeout is a condition a
     // second identical call would only pay for twice, on a hook path.
-    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
-      response = await send(false);
+    // NARROWED FROM ANY 4xx. Review is right that the first version retried
+    // things a retry cannot help and should not touch: a 429 is a rate limit
+    // and an immediate repeat makes it worse, while 401/403/404 are settled
+    // answers about credentials and routing. Only a 400/422 whose body names
+    // `response_format` is the server saying it will not take THE SCHEMA,
+    // which is the one case where the same request without it still works.
+    if (
+      !response.ok
+      && dialect === 'openai'
+      && (response.status === 400 || response.status === 422)
+    ) {
+      let complaint = '';
+      try {
+        complaint = await response.clone().text();
+      } catch {
+        complaint = '';
+      }
+      if (/response_format|json_schema/i.test(complaint)) response = await send(false);
     }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);

--- a/integrations/gemini/hooks/lib/harvest.mjs
+++ b/integrations/gemini/hooks/lib/harvest.mjs
@@ -20,7 +20,9 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -56,6 +58,17 @@ export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map'
  * the OpenAI structured-output contract takes an object at the root; `extract`
  * already locates the array inside whatever it is handed, so nothing
  * downstream needs to know.
+ *
+ * EVERY FIELD THE PROMPT ASKS FOR HAS TO BE DECLARED HERE, because the
+ * object is closed. `PROMPT` asks for `scope` and `invalidators`; the schema
+ * did not declare them and `additionalProperties: false` therefore FORBADE
+ * them, so an enforcing server could not return either one. `validate` then
+ * substituted `project` and `[]` for every finding, and the substitution is
+ * silent: on the schema path, organization- and global-scope findings could
+ * not be promoted and no finding could ever carry an invalidator. Both are
+ * required, matching the prompt -- a finding with nothing that would
+ * invalidate it is declared as an empty array rather than omitted, which is a
+ * claim the model has to make on purpose.
  */
 export const FINDINGS_SCHEMA = Object.freeze({
   type: 'object',
@@ -67,13 +80,24 @@ export const FINDINGS_SCHEMA = Object.freeze({
       items: {
         type: 'object',
         additionalProperties: false,
-        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        required: [
+          'type',
+          'claim',
+          'evidence',
+          'applicability',
+          'confidenceLabel',
+          'scope',
+          'invalidators',
+          'anchors',
+        ],
         properties: {
           type: { type: 'string', enum: FINDING_TYPES },
           claim: { type: 'string' },
           evidence: { type: 'string' },
           applicability: { type: 'string' },
           confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          scope: { type: 'string', enum: ['project', 'organization', 'global'] },
+          invalidators: { type: 'array', items: { type: 'string' } },
           anchors: { type: 'array', items: { type: 'string' } },
           trigger: { type: 'string' },
         },
@@ -379,11 +403,72 @@ export function endpointDialect(endpoint = ENDPOINT()) {
  * on the hook path must not care; the reason is recorded beside it so
  * `doctor` and a human can tell the two apart.
  */
+// A MODULE VARIABLE CANNOT CROSS A PROCESS, and every reader of this is in a
+// different one. The harvest runs in a DETACHED worker spawned at Stop
+// (stop-harvest.mjs), while `doctor` is a separate `node` invocation that
+// imports a fresh copy of this module. So `probeHarvest` read `null` no matter
+// what the harvest had done, and the failure branch it was given -- the whole
+// point of recording a reason -- could never be reached from the diagnostic
+// that exists to surface it. The reason is written where the next process can
+// find it.
+//
+// Per user, not per project: the worker resolves a project root and `doctor`
+// often cannot, and the failures recorded here (a wrong dialect, a missing
+// model name, an unreachable endpoint, a CLI that is not on PATH) are
+// properties of the machine's configuration rather than of a repository.
+const FAILURE_FILE = () =>
+  process.env.TOKEN_OPTIMIZER_HARVEST_STATE ||
+  join(homedir(), '.token-optimizer', 'last-harvest.json');
+
+// Old enough to be about a configuration that no longer exists. A harvest runs
+// at the end of every session, so a record older than this means the harvest
+// has not run since -- reporting it as the current state would be a guess.
+const FAILURE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
 let lastHarvestFailure = null;
-export const harvestFailure = () => lastHarvestFailure;
-const failed = (reason) => {
+/** True once this process has recorded an outcome, so the file is not consulted. */
+let outcomeThisProcess = false;
+
+function recordOutcome(reason) {
   lastHarvestFailure = reason;
+  outcomeThisProcess = true;
+  try {
+    const file = FAILURE_FILE();
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({ reason, at: Date.now() }), 'utf8');
+  } catch {
+    // Best effort. A harvest must never fail because it could not write a
+    // diagnostic about itself.
+  }
+}
+
+export function harvestFailure() {
+  if (outcomeThisProcess) return lastHarvestFailure;
+  try {
+    const { reason, at } = JSON.parse(readFileSync(FAILURE_FILE(), 'utf8'));
+    if (!reason || typeof at !== 'number') return null;
+    return Date.now() - at > FAILURE_TTL_MS ? null : reason;
+  } catch {
+    return null;
+  }
+}
+
+const failed = (reason) => {
+  recordOutcome(reason);
   return [];
+};
+
+/**
+ * Clears the recorded failure, because the harvest just worked.
+ *
+ * Without this the file is a one-way latch: a user fixes their endpoint, the
+ * harvest starts working, and `doctor` keeps reporting the failure that was
+ * true a week ago. The TTL alone would not do it -- it expires a stale record,
+ * not a wrong one.
+ */
+const succeeded = (findings) => {
+  recordOutcome(null);
+  return findings;
 };
 
 /**
@@ -396,6 +481,7 @@ export async function extract(
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
 ) {
   lastHarvestFailure = null;
+  outcomeThisProcess = false;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
@@ -583,7 +669,7 @@ export async function extract(
     if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
     try {
-      return JSON.parse(text.slice(start, end + 1));
+      return succeeded(JSON.parse(text.slice(start, end + 1)));
     } catch {
       return failed('the JSON array in the reply did not parse');
     }

--- a/integrations/kilo/hooks/lib/doctor.mjs
+++ b/integrations/kilo/hooks/lib/doctor.mjs
@@ -25,7 +25,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { harvestMode } from './harvest.mjs';
+import { harvestMode, harvestFailure } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
 import { mcpClientsSeen } from './metrics.mjs';
 
@@ -228,6 +228,20 @@ export function probeHarvest() {
   // credential, no billing and no digest leaving the machine -- so the two facts
   // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
+    // WHY THE LAST ONE PRODUCED NOTHING, when it produced nothing.
+    //
+    // `extract` returns [] on every failure so a hook-path caller need not
+    // care, which made a misconfigured endpoint indistinguishable from a
+    // session with nothing to learn -- the exact reason a client speaking the
+    // wrong dialect went unnoticed. `harvestFailure()` carries the reason, and
+    // this is the reader it was added for.
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check the endpoint URL and, for an OpenAI-compatible server, that ' +
+        'TOKEN_OPTIMIZER_HARVEST_MODEL names a model it actually serves')];
+    }
     return [ok('finding extraction is available',
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];

--- a/integrations/kilo/hooks/lib/harvest-worker.mjs
+++ b/integrations/kilo/hooks/lib/harvest-worker.mjs
@@ -99,13 +99,20 @@ async function main() {
   const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
   if (!digest) return;
 
-  const raw = await extract(digest);
+  // THE SAME LIST TO BOTH SIDES. `validate` has always held anchors to the
+  // files this session touched; passing it to `extract` too lets the model be
+  // GIVEN that list instead of guessing at it. Measured on this session's real
+  // digest with qwen2.5:7b: 0 of 4 extractions survived the gate when the model
+  // guessed, 4 of 4 when it chose. Computed once so the two can never disagree
+  // -- a model constrained to one list and judged against another would fail
+  // every time, and silently.
+  const anchorable = full ? null : filesIn(digest);
 
-  // Anchors are held to the files this session actually touched, so a model
-  // that invents a plausible path cannot anchor a finding to it. The digest
-  // lists them under a heading it writes itself; the full delta is raw
-  // transcript and carries no such list, so it gets no restriction.
-  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+  const raw = await extract(digest, { knownFiles: anchorable });
+
+  // The full delta is raw transcript and carries no file heading, so it gets
+  // no restriction on either side.
+  const validated = validate(raw, { knownFiles: anchorable });
 
   // BUDGETED SELECTION, not everything the model extracted.
   //

--- a/integrations/kilo/hooks/lib/harvest.mjs
+++ b/integrations/kilo/hooks/lib/harvest.mjs
@@ -41,6 +41,47 @@ const ENDPOINT = () => process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT
 // was wrong, which is why it is kept distinguishable from an ordinary finding.
 export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
 
+/**
+ * The shape a reply must take, for servers that can enforce one.
+ *
+ * A SMALL LOCAL MODEL WILL NOT FOLLOW THE PROMPT ON ITS OWN. Measured against
+ * qwen2.5:3b through ollama on the real digest from this session:
+ *
+ *   no constraint                    prose summary, 0 findings
+ *   response_format json_object      valid JSON, an invented schema
+ *   response_format json_schema      1 finding in the exact shape, 9s
+ *
+ * That is the difference between the free private path working and not, so
+ * the schema is sent rather than hoped for. The wrapper object exists because
+ * the OpenAI structured-output contract takes an object at the root; `extract`
+ * already locates the array inside whatever it is handed, so nothing
+ * downstream needs to know.
+ */
+export const FINDINGS_SCHEMA = Object.freeze({
+  type: 'object',
+  required: ['findings'],
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        properties: {
+          type: { type: 'string', enum: FINDING_TYPES },
+          claim: { type: 'string' },
+          evidence: { type: 'string' },
+          applicability: { type: 'string' },
+          confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          anchors: { type: 'array', items: { type: 'string' } },
+          trigger: { type: 'string' },
+        },
+      },
+    },
+  },
+});
+
 export function apiKey() {
   return process.env.TOKEN_OPTIMIZER_API_KEY || process.env.ANTHROPIC_API_KEY || null;
 }
@@ -359,8 +400,15 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-  try {
-    const response = await fetch(endpoint, {
+  /**
+   * One request. `structured` asks the server to enforce FINDINGS_SCHEMA.
+   *
+   * Separated out so the schema can be dropped and the call retried WITHOUT
+   * repeating the request shape in two places, which is how the two would
+   * drift.
+   */
+  const send = (structured) =>
+    fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
@@ -384,6 +432,14 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 { role: 'system', content: system },
                 { role: 'user', content: digest },
               ],
+              ...(structured
+                ? {
+                    response_format: {
+                      type: 'json_schema',
+                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                    },
+                  }
+                : {}),
             }
           : {
               model: MODEL(),
@@ -393,6 +449,21 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
             }
       ),
     });
+
+  try {
+    // Structured output only where the contract exists. Anthropic Messages has
+    // no `response_format`, and sending one is at best ignored.
+    let response = await send(dialect === 'openai');
+
+    // RETRIED ONCE, AND ONLY FOR A REFUSAL OF THE SCHEMA ITSELF. A server that
+    // predates structured outputs rejects the request outright, and the
+    // unconstrained call still works there -- that is the configuration this
+    // whole function used to be. Narrow on purpose: a 4xx is the server saying
+    // it will not take what was sent, while a 5xx or a timeout is a condition a
+    // second identical call would only pay for twice, on a hook path.
+    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
+      response = await send(false);
+    }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();

--- a/integrations/kilo/hooks/lib/harvest.mjs
+++ b/integrations/kilo/hooks/lib/harvest.mjs
@@ -368,7 +368,10 @@ const failed = (reason) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
-export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
+export async function extract(
+  digest,
+  { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
+) {
   lastHarvestFailure = null;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
@@ -384,6 +387,43 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
+  //
+  // `validate` holds anchors to the files the session actually touched, and a
+  // model asked in English for a path writes a plausible one instead of a real
+  // one -- so every finding was discarded at the gate. Measured over four runs
+  // of qwen2.5:7b on this session's real digest, against that same gate:
+  //
+  //   anchors unconstrained     4 extracted -> 0 accepted
+  //   anchors enum-constrained  4 extracted -> 4 accepted
+  //
+  // Nothing else differed. The server enforces the enum, so the model picks
+  // from the real list rather than inventing one, and the gate stops being
+  // the thing that silently eats the harvest.
+  //
+  // Only when the caller knows the list. `buildFullDelta` is raw transcript
+  // with no file heading, and its caller passes no knownFiles for the same
+  // reason -- an empty enum would forbid every anchor rather than free it.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+  const schema = anchorChoices.length
+    ? {
+        ...FINDINGS_SCHEMA,
+        properties: {
+          ...FINDINGS_SCHEMA.properties,
+          findings: {
+            ...FINDINGS_SCHEMA.properties.findings,
+            items: {
+              ...FINDINGS_SCHEMA.properties.findings.items,
+              properties: {
+                ...FINDINGS_SCHEMA.properties.findings.items.properties,
+                anchors: { type: 'array', items: { type: 'string', enum: anchorChoices } },
+              },
+            },
+          },
+        },
+      }
+    : FINDINGS_SCHEMA;
 
   // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
   //
@@ -436,7 +476,7 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 ? {
                     response_format: {
                       type: 'json_schema',
-                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                      json_schema: { name: 'findings', schema },
                     },
                   }
                 : {}),

--- a/integrations/kilo/hooks/lib/harvest.mjs
+++ b/integrations/kilo/hooks/lib/harvest.mjs
@@ -285,12 +285,52 @@ export function validate(raw, { knownFiles = null } = {}) {
 }
 
 /**
+ * Which wire format the configured endpoint speaks.
+ *
+ * THE ADVERTISED LOCAL PATH DID NOT WORK. Both the SessionStart notice and
+ * `doctor` tell the user to point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local
+ * model, and this client only ever spoke the Anthropic Messages dialect --
+ * `system` as a top-level field, `content[]` blocks in the reply. ollama, LM
+ * Studio and llama.cpp all serve OpenAI-compatible /v1/chat/completions,
+ * which takes the system prompt as a message and answers with
+ * `choices[].message.content`. Measured against a stand-in server answering
+ * both dialects with the identical finding: the Anthropic path returned 1 and
+ * the OpenAI path returned 0.
+ *
+ * Chosen from the URL rather than by trying one and falling back. A fallback
+ * doubles the latency of every genuine failure on a hook path, and the user
+ * configures the whole URL here, so the path is something they stated rather
+ * than something we guess.
+ */
+export function endpointDialect(endpoint = ENDPOINT()) {
+  return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
+}
+
+/**
+ * The last reason a harvest produced nothing, or null.
+ *
+ * `return []` on every failure made a misconfigured endpoint IDENTICAL to a
+ * session with nothing to learn -- which is how a local endpoint answering the
+ * wrong dialect stayed invisible. The empty result is kept, because a caller
+ * on the hook path must not care; the reason is recorded beside it so
+ * `doctor` and a human can tell the two apart.
+ */
+let lastHarvestFailure = null;
+export const harvestFailure = () => lastHarvestFailure;
+const failed = (reason) => {
+  lastHarvestFailure = reason;
+  return [];
+};
+
+/**
  * Calls the model. Returns [] on any failure -- a harvest that errors must be
  * indistinguishable, from the caller's side, from a session with nothing to
- * learn.
+ * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
 export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
-  if (!digest || !harvestEnabled()) return [];
+  lastHarvestFailure = null;
+  if (!digest) return failed('no digest');
+  if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
   // A local endpoint usually has no auth at all, so requiring a key there would
   // make the free, private path unreachable -- the one the design now prefers.
@@ -298,41 +338,90 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return [];
+  if (!local && !key) return failed('no api key for a remote endpoint');
+
+  const endpoint = ENDPOINT();
+  const dialect = endpointDialect(endpoint);
+  const system = prompt || PROMPT;
+
+  // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
+  //
+  // `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most
+  // machines that run Claude at all and says nothing about the endpoint the
+  // user pointed this at -- which may be any process listening on loopback.
+  // A local server that genuinely wants auth is still reachable: set
+  // TOKEN_OPTIMIZER_API_KEY, which is explicit about being for this.
+  //
+  // Remote is unchanged; there the key is the whole reason the call is
+  // allowed to happen.
+  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(ENDPOINT(), {
+    const response = await fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
         'content-type': 'application/json',
-        ...(key ? { 'x-api-key': key } : {}),
-        'anthropic-version': '2023-06-01',
+        // A local server usually wants no credential at all, and sending one
+        // to localhost is a leak, not a courtesy -- so a key is attached only
+        // when there is one, in the scheme the dialect expects.
+        ...(credential && dialect === 'anthropic' ? { 'x-api-key': credential } : {}),
+        ...(credential && dialect === 'openai'
+          ? { authorization: `Bearer ${credential}` }
+          : {}),
+        ...(dialect === 'anthropic' ? { 'anthropic-version': '2023-06-01' } : {}),
       },
-      body: JSON.stringify({
-        model: MODEL(),
-        max_tokens: 2048,
-        system: prompt || PROMPT,
-        messages: [{ role: 'user', content: digest }],
-      }),
+      body: JSON.stringify(
+        dialect === 'openai'
+          ? {
+              model: MODEL(),
+              max_tokens: 2048,
+              // No top-level `system` in this dialect; it is the first message.
+              messages: [
+                { role: 'system', content: system },
+                { role: 'user', content: digest },
+              ],
+            }
+          : {
+              model: MODEL(),
+              max_tokens: 2048,
+              system,
+              messages: [{ role: 'user', content: digest }],
+            }
+      ),
     });
 
-    if (!response.ok) return [];
+    if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();
-    const text = (body.content || []).filter((b) => b.type === 'text').map((b) => b.text).join('');
+
+    // BOTH SHAPES READ, whichever dialect was sent. A gateway may answer in the
+    // other one, and reading both costs a property access.
+    const text =
+      (Array.isArray(body.content)
+        ? body.content.filter((b) => b?.type === 'text').map((b) => b.text).join('')
+        : '') ||
+      (Array.isArray(body.choices)
+        ? body.choices.map((c) => c?.message?.content || '').join('')
+        : '') ||
+      '';
+    if (!text) return failed('endpoint answered in an unrecognised shape');
 
     // Models wrap JSON in prose or fences often enough that finding the array
     // is more reliable than insisting the whole response parse.
     const start = text.indexOf('[');
     const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return [];
+    if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
-    return JSON.parse(text.slice(start, end + 1));
-  } catch {
-    return [];
+    try {
+      return JSON.parse(text.slice(start, end + 1));
+    } catch {
+      return failed('the JSON array in the reply did not parse');
+    }
+  } catch (error) {
+    return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {
     clearTimeout(timer);
   }

--- a/integrations/kilo/hooks/lib/harvest.mjs
+++ b/integrations/kilo/hooks/lib/harvest.mjs
@@ -343,6 +343,29 @@ export function validate(raw, { knownFiles = null } = {}) {
  * configures the whole URL here, so the path is something they stated rather
  * than something we guess.
  */
+/**
+ * Which credential, if any, may travel to this endpoint.
+ *
+ * `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most machines
+ * that run Claude and says nothing about where this request is going. There is
+ * exactly one destination that key belongs to: a REMOTE ANTHROPIC endpoint.
+ *
+ *   anthropic + remote   the key -- this is what it is for
+ *   anthropic + local    explicit only -- loopback is not Anthropic
+ *   openai    + remote   explicit only -- a third-party gateway must not
+ *                        receive an Anthropic credential as a Bearer token
+ *   openai    + local    explicit only
+ *
+ * The first version of this scoped on `local` alone, which review caught: it
+ * closed the loopback leak and left the remote-gateway one wide open. Exported
+ * so all four combinations are testable without contriving DNS.
+ */
+export function credentialFor(dialect, local, env = process.env) {
+  const explicit = env.TOKEN_OPTIMIZER_API_KEY || null;
+  if (dialect === 'openai' || local) return explicit;
+  return explicit || env.ANTHROPIC_API_KEY || null;
+}
+
 export function endpointDialect(endpoint = ENDPOINT()) {
   return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
 }
@@ -435,7 +458,24 @@ export async function extract(
   //
   // Remote is unchanged; there the key is the whole reason the call is
   // allowed to happen.
-  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
+  const credential = credentialFor(dialect, local);
+
+  // THE DEFAULT MODEL IS AN ANTHROPIC ONE, AND A LOCAL SERVER HAS NEVER HEARD
+  // OF IT. `MODEL()` falls back to claude-haiku, so an endpoint configured per
+  // the documented advice -- which names only TOKEN_OPTIMIZER_HARVEST_ENDPOINT --
+  // asks ollama for a model it does not have and is refused. I hit this myself
+  // while proving the dialect fix and set the variable by hand without noticing
+  // that a user could not know to.
+  //
+  // Refused with an actionable reason rather than guessed at. Picking a default
+  // like `llama3.2` would be a guess about what the user pulled, and being wrong
+  // costs the same silent nothing this whole branch exists to remove.
+  if (dialect === 'openai' && !process.env.TOKEN_OPTIMIZER_HARVEST_MODEL) {
+    return failed(
+      'set TOKEN_OPTIMIZER_HARVEST_MODEL for an OpenAI-compatible endpoint ' +
+        `(the default ${MODEL()} is an Anthropic model no local server serves)`
+    );
+  }
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -501,8 +541,24 @@ export async function extract(
     // whole function used to be. Narrow on purpose: a 4xx is the server saying
     // it will not take what was sent, while a 5xx or a timeout is a condition a
     // second identical call would only pay for twice, on a hook path.
-    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
-      response = await send(false);
+    // NARROWED FROM ANY 4xx. Review is right that the first version retried
+    // things a retry cannot help and should not touch: a 429 is a rate limit
+    // and an immediate repeat makes it worse, while 401/403/404 are settled
+    // answers about credentials and routing. Only a 400/422 whose body names
+    // `response_format` is the server saying it will not take THE SCHEMA,
+    // which is the one case where the same request without it still works.
+    if (
+      !response.ok
+      && dialect === 'openai'
+      && (response.status === 400 || response.status === 422)
+    ) {
+      let complaint = '';
+      try {
+        complaint = await response.clone().text();
+      } catch {
+        complaint = '';
+      }
+      if (/response_format|json_schema/i.test(complaint)) response = await send(false);
     }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);

--- a/integrations/kilo/hooks/lib/harvest.mjs
+++ b/integrations/kilo/hooks/lib/harvest.mjs
@@ -20,7 +20,9 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -56,6 +58,17 @@ export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map'
  * the OpenAI structured-output contract takes an object at the root; `extract`
  * already locates the array inside whatever it is handed, so nothing
  * downstream needs to know.
+ *
+ * EVERY FIELD THE PROMPT ASKS FOR HAS TO BE DECLARED HERE, because the
+ * object is closed. `PROMPT` asks for `scope` and `invalidators`; the schema
+ * did not declare them and `additionalProperties: false` therefore FORBADE
+ * them, so an enforcing server could not return either one. `validate` then
+ * substituted `project` and `[]` for every finding, and the substitution is
+ * silent: on the schema path, organization- and global-scope findings could
+ * not be promoted and no finding could ever carry an invalidator. Both are
+ * required, matching the prompt -- a finding with nothing that would
+ * invalidate it is declared as an empty array rather than omitted, which is a
+ * claim the model has to make on purpose.
  */
 export const FINDINGS_SCHEMA = Object.freeze({
   type: 'object',
@@ -67,13 +80,24 @@ export const FINDINGS_SCHEMA = Object.freeze({
       items: {
         type: 'object',
         additionalProperties: false,
-        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        required: [
+          'type',
+          'claim',
+          'evidence',
+          'applicability',
+          'confidenceLabel',
+          'scope',
+          'invalidators',
+          'anchors',
+        ],
         properties: {
           type: { type: 'string', enum: FINDING_TYPES },
           claim: { type: 'string' },
           evidence: { type: 'string' },
           applicability: { type: 'string' },
           confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          scope: { type: 'string', enum: ['project', 'organization', 'global'] },
+          invalidators: { type: 'array', items: { type: 'string' } },
           anchors: { type: 'array', items: { type: 'string' } },
           trigger: { type: 'string' },
         },
@@ -379,11 +403,72 @@ export function endpointDialect(endpoint = ENDPOINT()) {
  * on the hook path must not care; the reason is recorded beside it so
  * `doctor` and a human can tell the two apart.
  */
+// A MODULE VARIABLE CANNOT CROSS A PROCESS, and every reader of this is in a
+// different one. The harvest runs in a DETACHED worker spawned at Stop
+// (stop-harvest.mjs), while `doctor` is a separate `node` invocation that
+// imports a fresh copy of this module. So `probeHarvest` read `null` no matter
+// what the harvest had done, and the failure branch it was given -- the whole
+// point of recording a reason -- could never be reached from the diagnostic
+// that exists to surface it. The reason is written where the next process can
+// find it.
+//
+// Per user, not per project: the worker resolves a project root and `doctor`
+// often cannot, and the failures recorded here (a wrong dialect, a missing
+// model name, an unreachable endpoint, a CLI that is not on PATH) are
+// properties of the machine's configuration rather than of a repository.
+const FAILURE_FILE = () =>
+  process.env.TOKEN_OPTIMIZER_HARVEST_STATE ||
+  join(homedir(), '.token-optimizer', 'last-harvest.json');
+
+// Old enough to be about a configuration that no longer exists. A harvest runs
+// at the end of every session, so a record older than this means the harvest
+// has not run since -- reporting it as the current state would be a guess.
+const FAILURE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
 let lastHarvestFailure = null;
-export const harvestFailure = () => lastHarvestFailure;
-const failed = (reason) => {
+/** True once this process has recorded an outcome, so the file is not consulted. */
+let outcomeThisProcess = false;
+
+function recordOutcome(reason) {
   lastHarvestFailure = reason;
+  outcomeThisProcess = true;
+  try {
+    const file = FAILURE_FILE();
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({ reason, at: Date.now() }), 'utf8');
+  } catch {
+    // Best effort. A harvest must never fail because it could not write a
+    // diagnostic about itself.
+  }
+}
+
+export function harvestFailure() {
+  if (outcomeThisProcess) return lastHarvestFailure;
+  try {
+    const { reason, at } = JSON.parse(readFileSync(FAILURE_FILE(), 'utf8'));
+    if (!reason || typeof at !== 'number') return null;
+    return Date.now() - at > FAILURE_TTL_MS ? null : reason;
+  } catch {
+    return null;
+  }
+}
+
+const failed = (reason) => {
+  recordOutcome(reason);
   return [];
+};
+
+/**
+ * Clears the recorded failure, because the harvest just worked.
+ *
+ * Without this the file is a one-way latch: a user fixes their endpoint, the
+ * harvest starts working, and `doctor` keeps reporting the failure that was
+ * true a week ago. The TTL alone would not do it -- it expires a stale record,
+ * not a wrong one.
+ */
+const succeeded = (findings) => {
+  recordOutcome(null);
+  return findings;
 };
 
 /**
@@ -396,6 +481,7 @@ export async function extract(
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
 ) {
   lastHarvestFailure = null;
+  outcomeThisProcess = false;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
@@ -583,7 +669,7 @@ export async function extract(
     if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
     try {
-      return JSON.parse(text.slice(start, end + 1));
+      return succeeded(JSON.parse(text.slice(start, end + 1)));
     } catch {
       return failed('the JSON array in the reply did not parse');
     }

--- a/integrations/opencode/hooks/lib/doctor.mjs
+++ b/integrations/opencode/hooks/lib/doctor.mjs
@@ -25,7 +25,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { harvestMode } from './harvest.mjs';
+import { harvestMode, harvestFailure } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
 import { mcpClientsSeen } from './metrics.mjs';
 
@@ -228,6 +228,20 @@ export function probeHarvest() {
   // credential, no billing and no digest leaving the machine -- so the two facts
   // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
+    // WHY THE LAST ONE PRODUCED NOTHING, when it produced nothing.
+    //
+    // `extract` returns [] on every failure so a hook-path caller need not
+    // care, which made a misconfigured endpoint indistinguishable from a
+    // session with nothing to learn -- the exact reason a client speaking the
+    // wrong dialect went unnoticed. `harvestFailure()` carries the reason, and
+    // this is the reader it was added for.
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check the endpoint URL and, for an OpenAI-compatible server, that ' +
+        'TOKEN_OPTIMIZER_HARVEST_MODEL names a model it actually serves')];
+    }
     return [ok('finding extraction is available',
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];

--- a/integrations/opencode/hooks/lib/harvest-worker.mjs
+++ b/integrations/opencode/hooks/lib/harvest-worker.mjs
@@ -99,13 +99,20 @@ async function main() {
   const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
   if (!digest) return;
 
-  const raw = await extract(digest);
+  // THE SAME LIST TO BOTH SIDES. `validate` has always held anchors to the
+  // files this session touched; passing it to `extract` too lets the model be
+  // GIVEN that list instead of guessing at it. Measured on this session's real
+  // digest with qwen2.5:7b: 0 of 4 extractions survived the gate when the model
+  // guessed, 4 of 4 when it chose. Computed once so the two can never disagree
+  // -- a model constrained to one list and judged against another would fail
+  // every time, and silently.
+  const anchorable = full ? null : filesIn(digest);
 
-  // Anchors are held to the files this session actually touched, so a model
-  // that invents a plausible path cannot anchor a finding to it. The digest
-  // lists them under a heading it writes itself; the full delta is raw
-  // transcript and carries no such list, so it gets no restriction.
-  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+  const raw = await extract(digest, { knownFiles: anchorable });
+
+  // The full delta is raw transcript and carries no file heading, so it gets
+  // no restriction on either side.
+  const validated = validate(raw, { knownFiles: anchorable });
 
   // BUDGETED SELECTION, not everything the model extracted.
   //

--- a/integrations/opencode/hooks/lib/harvest.mjs
+++ b/integrations/opencode/hooks/lib/harvest.mjs
@@ -41,6 +41,47 @@ const ENDPOINT = () => process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT
 // was wrong, which is why it is kept distinguishable from an ordinary finding.
 export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
 
+/**
+ * The shape a reply must take, for servers that can enforce one.
+ *
+ * A SMALL LOCAL MODEL WILL NOT FOLLOW THE PROMPT ON ITS OWN. Measured against
+ * qwen2.5:3b through ollama on the real digest from this session:
+ *
+ *   no constraint                    prose summary, 0 findings
+ *   response_format json_object      valid JSON, an invented schema
+ *   response_format json_schema      1 finding in the exact shape, 9s
+ *
+ * That is the difference between the free private path working and not, so
+ * the schema is sent rather than hoped for. The wrapper object exists because
+ * the OpenAI structured-output contract takes an object at the root; `extract`
+ * already locates the array inside whatever it is handed, so nothing
+ * downstream needs to know.
+ */
+export const FINDINGS_SCHEMA = Object.freeze({
+  type: 'object',
+  required: ['findings'],
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        properties: {
+          type: { type: 'string', enum: FINDING_TYPES },
+          claim: { type: 'string' },
+          evidence: { type: 'string' },
+          applicability: { type: 'string' },
+          confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          anchors: { type: 'array', items: { type: 'string' } },
+          trigger: { type: 'string' },
+        },
+      },
+    },
+  },
+});
+
 export function apiKey() {
   return process.env.TOKEN_OPTIMIZER_API_KEY || process.env.ANTHROPIC_API_KEY || null;
 }
@@ -359,8 +400,15 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-  try {
-    const response = await fetch(endpoint, {
+  /**
+   * One request. `structured` asks the server to enforce FINDINGS_SCHEMA.
+   *
+   * Separated out so the schema can be dropped and the call retried WITHOUT
+   * repeating the request shape in two places, which is how the two would
+   * drift.
+   */
+  const send = (structured) =>
+    fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
@@ -384,6 +432,14 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 { role: 'system', content: system },
                 { role: 'user', content: digest },
               ],
+              ...(structured
+                ? {
+                    response_format: {
+                      type: 'json_schema',
+                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                    },
+                  }
+                : {}),
             }
           : {
               model: MODEL(),
@@ -393,6 +449,21 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
             }
       ),
     });
+
+  try {
+    // Structured output only where the contract exists. Anthropic Messages has
+    // no `response_format`, and sending one is at best ignored.
+    let response = await send(dialect === 'openai');
+
+    // RETRIED ONCE, AND ONLY FOR A REFUSAL OF THE SCHEMA ITSELF. A server that
+    // predates structured outputs rejects the request outright, and the
+    // unconstrained call still works there -- that is the configuration this
+    // whole function used to be. Narrow on purpose: a 4xx is the server saying
+    // it will not take what was sent, while a 5xx or a timeout is a condition a
+    // second identical call would only pay for twice, on a hook path.
+    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
+      response = await send(false);
+    }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();

--- a/integrations/opencode/hooks/lib/harvest.mjs
+++ b/integrations/opencode/hooks/lib/harvest.mjs
@@ -368,7 +368,10 @@ const failed = (reason) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
-export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
+export async function extract(
+  digest,
+  { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
+) {
   lastHarvestFailure = null;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
@@ -384,6 +387,43 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
+  //
+  // `validate` holds anchors to the files the session actually touched, and a
+  // model asked in English for a path writes a plausible one instead of a real
+  // one -- so every finding was discarded at the gate. Measured over four runs
+  // of qwen2.5:7b on this session's real digest, against that same gate:
+  //
+  //   anchors unconstrained     4 extracted -> 0 accepted
+  //   anchors enum-constrained  4 extracted -> 4 accepted
+  //
+  // Nothing else differed. The server enforces the enum, so the model picks
+  // from the real list rather than inventing one, and the gate stops being
+  // the thing that silently eats the harvest.
+  //
+  // Only when the caller knows the list. `buildFullDelta` is raw transcript
+  // with no file heading, and its caller passes no knownFiles for the same
+  // reason -- an empty enum would forbid every anchor rather than free it.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+  const schema = anchorChoices.length
+    ? {
+        ...FINDINGS_SCHEMA,
+        properties: {
+          ...FINDINGS_SCHEMA.properties,
+          findings: {
+            ...FINDINGS_SCHEMA.properties.findings,
+            items: {
+              ...FINDINGS_SCHEMA.properties.findings.items,
+              properties: {
+                ...FINDINGS_SCHEMA.properties.findings.items.properties,
+                anchors: { type: 'array', items: { type: 'string', enum: anchorChoices } },
+              },
+            },
+          },
+        },
+      }
+    : FINDINGS_SCHEMA;
 
   // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
   //
@@ -436,7 +476,7 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 ? {
                     response_format: {
                       type: 'json_schema',
-                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                      json_schema: { name: 'findings', schema },
                     },
                   }
                 : {}),

--- a/integrations/opencode/hooks/lib/harvest.mjs
+++ b/integrations/opencode/hooks/lib/harvest.mjs
@@ -285,12 +285,52 @@ export function validate(raw, { knownFiles = null } = {}) {
 }
 
 /**
+ * Which wire format the configured endpoint speaks.
+ *
+ * THE ADVERTISED LOCAL PATH DID NOT WORK. Both the SessionStart notice and
+ * `doctor` tell the user to point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local
+ * model, and this client only ever spoke the Anthropic Messages dialect --
+ * `system` as a top-level field, `content[]` blocks in the reply. ollama, LM
+ * Studio and llama.cpp all serve OpenAI-compatible /v1/chat/completions,
+ * which takes the system prompt as a message and answers with
+ * `choices[].message.content`. Measured against a stand-in server answering
+ * both dialects with the identical finding: the Anthropic path returned 1 and
+ * the OpenAI path returned 0.
+ *
+ * Chosen from the URL rather than by trying one and falling back. A fallback
+ * doubles the latency of every genuine failure on a hook path, and the user
+ * configures the whole URL here, so the path is something they stated rather
+ * than something we guess.
+ */
+export function endpointDialect(endpoint = ENDPOINT()) {
+  return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
+}
+
+/**
+ * The last reason a harvest produced nothing, or null.
+ *
+ * `return []` on every failure made a misconfigured endpoint IDENTICAL to a
+ * session with nothing to learn -- which is how a local endpoint answering the
+ * wrong dialect stayed invisible. The empty result is kept, because a caller
+ * on the hook path must not care; the reason is recorded beside it so
+ * `doctor` and a human can tell the two apart.
+ */
+let lastHarvestFailure = null;
+export const harvestFailure = () => lastHarvestFailure;
+const failed = (reason) => {
+  lastHarvestFailure = reason;
+  return [];
+};
+
+/**
  * Calls the model. Returns [] on any failure -- a harvest that errors must be
  * indistinguishable, from the caller's side, from a session with nothing to
- * learn.
+ * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
 export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
-  if (!digest || !harvestEnabled()) return [];
+  lastHarvestFailure = null;
+  if (!digest) return failed('no digest');
+  if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
   // A local endpoint usually has no auth at all, so requiring a key there would
   // make the free, private path unreachable -- the one the design now prefers.
@@ -298,41 +338,90 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return [];
+  if (!local && !key) return failed('no api key for a remote endpoint');
+
+  const endpoint = ENDPOINT();
+  const dialect = endpointDialect(endpoint);
+  const system = prompt || PROMPT;
+
+  // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
+  //
+  // `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most
+  // machines that run Claude at all and says nothing about the endpoint the
+  // user pointed this at -- which may be any process listening on loopback.
+  // A local server that genuinely wants auth is still reachable: set
+  // TOKEN_OPTIMIZER_API_KEY, which is explicit about being for this.
+  //
+  // Remote is unchanged; there the key is the whole reason the call is
+  // allowed to happen.
+  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(ENDPOINT(), {
+    const response = await fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
         'content-type': 'application/json',
-        ...(key ? { 'x-api-key': key } : {}),
-        'anthropic-version': '2023-06-01',
+        // A local server usually wants no credential at all, and sending one
+        // to localhost is a leak, not a courtesy -- so a key is attached only
+        // when there is one, in the scheme the dialect expects.
+        ...(credential && dialect === 'anthropic' ? { 'x-api-key': credential } : {}),
+        ...(credential && dialect === 'openai'
+          ? { authorization: `Bearer ${credential}` }
+          : {}),
+        ...(dialect === 'anthropic' ? { 'anthropic-version': '2023-06-01' } : {}),
       },
-      body: JSON.stringify({
-        model: MODEL(),
-        max_tokens: 2048,
-        system: prompt || PROMPT,
-        messages: [{ role: 'user', content: digest }],
-      }),
+      body: JSON.stringify(
+        dialect === 'openai'
+          ? {
+              model: MODEL(),
+              max_tokens: 2048,
+              // No top-level `system` in this dialect; it is the first message.
+              messages: [
+                { role: 'system', content: system },
+                { role: 'user', content: digest },
+              ],
+            }
+          : {
+              model: MODEL(),
+              max_tokens: 2048,
+              system,
+              messages: [{ role: 'user', content: digest }],
+            }
+      ),
     });
 
-    if (!response.ok) return [];
+    if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();
-    const text = (body.content || []).filter((b) => b.type === 'text').map((b) => b.text).join('');
+
+    // BOTH SHAPES READ, whichever dialect was sent. A gateway may answer in the
+    // other one, and reading both costs a property access.
+    const text =
+      (Array.isArray(body.content)
+        ? body.content.filter((b) => b?.type === 'text').map((b) => b.text).join('')
+        : '') ||
+      (Array.isArray(body.choices)
+        ? body.choices.map((c) => c?.message?.content || '').join('')
+        : '') ||
+      '';
+    if (!text) return failed('endpoint answered in an unrecognised shape');
 
     // Models wrap JSON in prose or fences often enough that finding the array
     // is more reliable than insisting the whole response parse.
     const start = text.indexOf('[');
     const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return [];
+    if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
-    return JSON.parse(text.slice(start, end + 1));
-  } catch {
-    return [];
+    try {
+      return JSON.parse(text.slice(start, end + 1));
+    } catch {
+      return failed('the JSON array in the reply did not parse');
+    }
+  } catch (error) {
+    return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {
     clearTimeout(timer);
   }

--- a/integrations/opencode/hooks/lib/harvest.mjs
+++ b/integrations/opencode/hooks/lib/harvest.mjs
@@ -343,6 +343,29 @@ export function validate(raw, { knownFiles = null } = {}) {
  * configures the whole URL here, so the path is something they stated rather
  * than something we guess.
  */
+/**
+ * Which credential, if any, may travel to this endpoint.
+ *
+ * `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most machines
+ * that run Claude and says nothing about where this request is going. There is
+ * exactly one destination that key belongs to: a REMOTE ANTHROPIC endpoint.
+ *
+ *   anthropic + remote   the key -- this is what it is for
+ *   anthropic + local    explicit only -- loopback is not Anthropic
+ *   openai    + remote   explicit only -- a third-party gateway must not
+ *                        receive an Anthropic credential as a Bearer token
+ *   openai    + local    explicit only
+ *
+ * The first version of this scoped on `local` alone, which review caught: it
+ * closed the loopback leak and left the remote-gateway one wide open. Exported
+ * so all four combinations are testable without contriving DNS.
+ */
+export function credentialFor(dialect, local, env = process.env) {
+  const explicit = env.TOKEN_OPTIMIZER_API_KEY || null;
+  if (dialect === 'openai' || local) return explicit;
+  return explicit || env.ANTHROPIC_API_KEY || null;
+}
+
 export function endpointDialect(endpoint = ENDPOINT()) {
   return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
 }
@@ -435,7 +458,24 @@ export async function extract(
   //
   // Remote is unchanged; there the key is the whole reason the call is
   // allowed to happen.
-  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
+  const credential = credentialFor(dialect, local);
+
+  // THE DEFAULT MODEL IS AN ANTHROPIC ONE, AND A LOCAL SERVER HAS NEVER HEARD
+  // OF IT. `MODEL()` falls back to claude-haiku, so an endpoint configured per
+  // the documented advice -- which names only TOKEN_OPTIMIZER_HARVEST_ENDPOINT --
+  // asks ollama for a model it does not have and is refused. I hit this myself
+  // while proving the dialect fix and set the variable by hand without noticing
+  // that a user could not know to.
+  //
+  // Refused with an actionable reason rather than guessed at. Picking a default
+  // like `llama3.2` would be a guess about what the user pulled, and being wrong
+  // costs the same silent nothing this whole branch exists to remove.
+  if (dialect === 'openai' && !process.env.TOKEN_OPTIMIZER_HARVEST_MODEL) {
+    return failed(
+      'set TOKEN_OPTIMIZER_HARVEST_MODEL for an OpenAI-compatible endpoint ' +
+        `(the default ${MODEL()} is an Anthropic model no local server serves)`
+    );
+  }
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -501,8 +541,24 @@ export async function extract(
     // whole function used to be. Narrow on purpose: a 4xx is the server saying
     // it will not take what was sent, while a 5xx or a timeout is a condition a
     // second identical call would only pay for twice, on a hook path.
-    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
-      response = await send(false);
+    // NARROWED FROM ANY 4xx. Review is right that the first version retried
+    // things a retry cannot help and should not touch: a 429 is a rate limit
+    // and an immediate repeat makes it worse, while 401/403/404 are settled
+    // answers about credentials and routing. Only a 400/422 whose body names
+    // `response_format` is the server saying it will not take THE SCHEMA,
+    // which is the one case where the same request without it still works.
+    if (
+      !response.ok
+      && dialect === 'openai'
+      && (response.status === 400 || response.status === 422)
+    ) {
+      let complaint = '';
+      try {
+        complaint = await response.clone().text();
+      } catch {
+        complaint = '';
+      }
+      if (/response_format|json_schema/i.test(complaint)) response = await send(false);
     }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);

--- a/integrations/opencode/hooks/lib/harvest.mjs
+++ b/integrations/opencode/hooks/lib/harvest.mjs
@@ -20,7 +20,9 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -56,6 +58,17 @@ export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map'
  * the OpenAI structured-output contract takes an object at the root; `extract`
  * already locates the array inside whatever it is handed, so nothing
  * downstream needs to know.
+ *
+ * EVERY FIELD THE PROMPT ASKS FOR HAS TO BE DECLARED HERE, because the
+ * object is closed. `PROMPT` asks for `scope` and `invalidators`; the schema
+ * did not declare them and `additionalProperties: false` therefore FORBADE
+ * them, so an enforcing server could not return either one. `validate` then
+ * substituted `project` and `[]` for every finding, and the substitution is
+ * silent: on the schema path, organization- and global-scope findings could
+ * not be promoted and no finding could ever carry an invalidator. Both are
+ * required, matching the prompt -- a finding with nothing that would
+ * invalidate it is declared as an empty array rather than omitted, which is a
+ * claim the model has to make on purpose.
  */
 export const FINDINGS_SCHEMA = Object.freeze({
   type: 'object',
@@ -67,13 +80,24 @@ export const FINDINGS_SCHEMA = Object.freeze({
       items: {
         type: 'object',
         additionalProperties: false,
-        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        required: [
+          'type',
+          'claim',
+          'evidence',
+          'applicability',
+          'confidenceLabel',
+          'scope',
+          'invalidators',
+          'anchors',
+        ],
         properties: {
           type: { type: 'string', enum: FINDING_TYPES },
           claim: { type: 'string' },
           evidence: { type: 'string' },
           applicability: { type: 'string' },
           confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          scope: { type: 'string', enum: ['project', 'organization', 'global'] },
+          invalidators: { type: 'array', items: { type: 'string' } },
           anchors: { type: 'array', items: { type: 'string' } },
           trigger: { type: 'string' },
         },
@@ -379,11 +403,72 @@ export function endpointDialect(endpoint = ENDPOINT()) {
  * on the hook path must not care; the reason is recorded beside it so
  * `doctor` and a human can tell the two apart.
  */
+// A MODULE VARIABLE CANNOT CROSS A PROCESS, and every reader of this is in a
+// different one. The harvest runs in a DETACHED worker spawned at Stop
+// (stop-harvest.mjs), while `doctor` is a separate `node` invocation that
+// imports a fresh copy of this module. So `probeHarvest` read `null` no matter
+// what the harvest had done, and the failure branch it was given -- the whole
+// point of recording a reason -- could never be reached from the diagnostic
+// that exists to surface it. The reason is written where the next process can
+// find it.
+//
+// Per user, not per project: the worker resolves a project root and `doctor`
+// often cannot, and the failures recorded here (a wrong dialect, a missing
+// model name, an unreachable endpoint, a CLI that is not on PATH) are
+// properties of the machine's configuration rather than of a repository.
+const FAILURE_FILE = () =>
+  process.env.TOKEN_OPTIMIZER_HARVEST_STATE ||
+  join(homedir(), '.token-optimizer', 'last-harvest.json');
+
+// Old enough to be about a configuration that no longer exists. A harvest runs
+// at the end of every session, so a record older than this means the harvest
+// has not run since -- reporting it as the current state would be a guess.
+const FAILURE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
 let lastHarvestFailure = null;
-export const harvestFailure = () => lastHarvestFailure;
-const failed = (reason) => {
+/** True once this process has recorded an outcome, so the file is not consulted. */
+let outcomeThisProcess = false;
+
+function recordOutcome(reason) {
   lastHarvestFailure = reason;
+  outcomeThisProcess = true;
+  try {
+    const file = FAILURE_FILE();
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({ reason, at: Date.now() }), 'utf8');
+  } catch {
+    // Best effort. A harvest must never fail because it could not write a
+    // diagnostic about itself.
+  }
+}
+
+export function harvestFailure() {
+  if (outcomeThisProcess) return lastHarvestFailure;
+  try {
+    const { reason, at } = JSON.parse(readFileSync(FAILURE_FILE(), 'utf8'));
+    if (!reason || typeof at !== 'number') return null;
+    return Date.now() - at > FAILURE_TTL_MS ? null : reason;
+  } catch {
+    return null;
+  }
+}
+
+const failed = (reason) => {
+  recordOutcome(reason);
   return [];
+};
+
+/**
+ * Clears the recorded failure, because the harvest just worked.
+ *
+ * Without this the file is a one-way latch: a user fixes their endpoint, the
+ * harvest starts working, and `doctor` keeps reporting the failure that was
+ * true a week ago. The TTL alone would not do it -- it expires a stale record,
+ * not a wrong one.
+ */
+const succeeded = (findings) => {
+  recordOutcome(null);
+  return findings;
 };
 
 /**
@@ -396,6 +481,7 @@ export async function extract(
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
 ) {
   lastHarvestFailure = null;
+  outcomeThisProcess = false;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
@@ -583,7 +669,7 @@ export async function extract(
     if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
     try {
-      return JSON.parse(text.slice(start, end + 1));
+      return succeeded(JSON.parse(text.slice(start, end + 1)));
     } catch {
       return failed('the JSON array in the reply did not parse');
     }

--- a/integrations/qwen/hooks/lib/doctor.mjs
+++ b/integrations/qwen/hooks/lib/doctor.mjs
@@ -25,7 +25,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { harvestMode } from './harvest.mjs';
+import { harvestMode, harvestFailure } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
 import { mcpClientsSeen } from './metrics.mjs';
 
@@ -228,6 +228,20 @@ export function probeHarvest() {
   // credential, no billing and no digest leaving the machine -- so the two facts
   // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
+    // WHY THE LAST ONE PRODUCED NOTHING, when it produced nothing.
+    //
+    // `extract` returns [] on every failure so a hook-path caller need not
+    // care, which made a misconfigured endpoint indistinguishable from a
+    // session with nothing to learn -- the exact reason a client speaking the
+    // wrong dialect went unnoticed. `harvestFailure()` carries the reason, and
+    // this is the reader it was added for.
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check the endpoint URL and, for an OpenAI-compatible server, that ' +
+        'TOKEN_OPTIMIZER_HARVEST_MODEL names a model it actually serves')];
+    }
     return [ok('finding extraction is available',
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];

--- a/integrations/qwen/hooks/lib/harvest-worker.mjs
+++ b/integrations/qwen/hooks/lib/harvest-worker.mjs
@@ -99,13 +99,20 @@ async function main() {
   const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
   if (!digest) return;
 
-  const raw = await extract(digest);
+  // THE SAME LIST TO BOTH SIDES. `validate` has always held anchors to the
+  // files this session touched; passing it to `extract` too lets the model be
+  // GIVEN that list instead of guessing at it. Measured on this session's real
+  // digest with qwen2.5:7b: 0 of 4 extractions survived the gate when the model
+  // guessed, 4 of 4 when it chose. Computed once so the two can never disagree
+  // -- a model constrained to one list and judged against another would fail
+  // every time, and silently.
+  const anchorable = full ? null : filesIn(digest);
 
-  // Anchors are held to the files this session actually touched, so a model
-  // that invents a plausible path cannot anchor a finding to it. The digest
-  // lists them under a heading it writes itself; the full delta is raw
-  // transcript and carries no such list, so it gets no restriction.
-  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+  const raw = await extract(digest, { knownFiles: anchorable });
+
+  // The full delta is raw transcript and carries no file heading, so it gets
+  // no restriction on either side.
+  const validated = validate(raw, { knownFiles: anchorable });
 
   // BUDGETED SELECTION, not everything the model extracted.
   //

--- a/integrations/qwen/hooks/lib/harvest.mjs
+++ b/integrations/qwen/hooks/lib/harvest.mjs
@@ -41,6 +41,47 @@ const ENDPOINT = () => process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT
 // was wrong, which is why it is kept distinguishable from an ordinary finding.
 export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
 
+/**
+ * The shape a reply must take, for servers that can enforce one.
+ *
+ * A SMALL LOCAL MODEL WILL NOT FOLLOW THE PROMPT ON ITS OWN. Measured against
+ * qwen2.5:3b through ollama on the real digest from this session:
+ *
+ *   no constraint                    prose summary, 0 findings
+ *   response_format json_object      valid JSON, an invented schema
+ *   response_format json_schema      1 finding in the exact shape, 9s
+ *
+ * That is the difference between the free private path working and not, so
+ * the schema is sent rather than hoped for. The wrapper object exists because
+ * the OpenAI structured-output contract takes an object at the root; `extract`
+ * already locates the array inside whatever it is handed, so nothing
+ * downstream needs to know.
+ */
+export const FINDINGS_SCHEMA = Object.freeze({
+  type: 'object',
+  required: ['findings'],
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        properties: {
+          type: { type: 'string', enum: FINDING_TYPES },
+          claim: { type: 'string' },
+          evidence: { type: 'string' },
+          applicability: { type: 'string' },
+          confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          anchors: { type: 'array', items: { type: 'string' } },
+          trigger: { type: 'string' },
+        },
+      },
+    },
+  },
+});
+
 export function apiKey() {
   return process.env.TOKEN_OPTIMIZER_API_KEY || process.env.ANTHROPIC_API_KEY || null;
 }
@@ -359,8 +400,15 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-  try {
-    const response = await fetch(endpoint, {
+  /**
+   * One request. `structured` asks the server to enforce FINDINGS_SCHEMA.
+   *
+   * Separated out so the schema can be dropped and the call retried WITHOUT
+   * repeating the request shape in two places, which is how the two would
+   * drift.
+   */
+  const send = (structured) =>
+    fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
@@ -384,6 +432,14 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 { role: 'system', content: system },
                 { role: 'user', content: digest },
               ],
+              ...(structured
+                ? {
+                    response_format: {
+                      type: 'json_schema',
+                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                    },
+                  }
+                : {}),
             }
           : {
               model: MODEL(),
@@ -393,6 +449,21 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
             }
       ),
     });
+
+  try {
+    // Structured output only where the contract exists. Anthropic Messages has
+    // no `response_format`, and sending one is at best ignored.
+    let response = await send(dialect === 'openai');
+
+    // RETRIED ONCE, AND ONLY FOR A REFUSAL OF THE SCHEMA ITSELF. A server that
+    // predates structured outputs rejects the request outright, and the
+    // unconstrained call still works there -- that is the configuration this
+    // whole function used to be. Narrow on purpose: a 4xx is the server saying
+    // it will not take what was sent, while a 5xx or a timeout is a condition a
+    // second identical call would only pay for twice, on a hook path.
+    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
+      response = await send(false);
+    }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();

--- a/integrations/qwen/hooks/lib/harvest.mjs
+++ b/integrations/qwen/hooks/lib/harvest.mjs
@@ -368,7 +368,10 @@ const failed = (reason) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
-export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
+export async function extract(
+  digest,
+  { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
+) {
   lastHarvestFailure = null;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
@@ -384,6 +387,43 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
+  //
+  // `validate` holds anchors to the files the session actually touched, and a
+  // model asked in English for a path writes a plausible one instead of a real
+  // one -- so every finding was discarded at the gate. Measured over four runs
+  // of qwen2.5:7b on this session's real digest, against that same gate:
+  //
+  //   anchors unconstrained     4 extracted -> 0 accepted
+  //   anchors enum-constrained  4 extracted -> 4 accepted
+  //
+  // Nothing else differed. The server enforces the enum, so the model picks
+  // from the real list rather than inventing one, and the gate stops being
+  // the thing that silently eats the harvest.
+  //
+  // Only when the caller knows the list. `buildFullDelta` is raw transcript
+  // with no file heading, and its caller passes no knownFiles for the same
+  // reason -- an empty enum would forbid every anchor rather than free it.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+  const schema = anchorChoices.length
+    ? {
+        ...FINDINGS_SCHEMA,
+        properties: {
+          ...FINDINGS_SCHEMA.properties,
+          findings: {
+            ...FINDINGS_SCHEMA.properties.findings,
+            items: {
+              ...FINDINGS_SCHEMA.properties.findings.items,
+              properties: {
+                ...FINDINGS_SCHEMA.properties.findings.items.properties,
+                anchors: { type: 'array', items: { type: 'string', enum: anchorChoices } },
+              },
+            },
+          },
+        },
+      }
+    : FINDINGS_SCHEMA;
 
   // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
   //
@@ -436,7 +476,7 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 ? {
                     response_format: {
                       type: 'json_schema',
-                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                      json_schema: { name: 'findings', schema },
                     },
                   }
                 : {}),

--- a/integrations/qwen/hooks/lib/harvest.mjs
+++ b/integrations/qwen/hooks/lib/harvest.mjs
@@ -285,12 +285,52 @@ export function validate(raw, { knownFiles = null } = {}) {
 }
 
 /**
+ * Which wire format the configured endpoint speaks.
+ *
+ * THE ADVERTISED LOCAL PATH DID NOT WORK. Both the SessionStart notice and
+ * `doctor` tell the user to point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local
+ * model, and this client only ever spoke the Anthropic Messages dialect --
+ * `system` as a top-level field, `content[]` blocks in the reply. ollama, LM
+ * Studio and llama.cpp all serve OpenAI-compatible /v1/chat/completions,
+ * which takes the system prompt as a message and answers with
+ * `choices[].message.content`. Measured against a stand-in server answering
+ * both dialects with the identical finding: the Anthropic path returned 1 and
+ * the OpenAI path returned 0.
+ *
+ * Chosen from the URL rather than by trying one and falling back. A fallback
+ * doubles the latency of every genuine failure on a hook path, and the user
+ * configures the whole URL here, so the path is something they stated rather
+ * than something we guess.
+ */
+export function endpointDialect(endpoint = ENDPOINT()) {
+  return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
+}
+
+/**
+ * The last reason a harvest produced nothing, or null.
+ *
+ * `return []` on every failure made a misconfigured endpoint IDENTICAL to a
+ * session with nothing to learn -- which is how a local endpoint answering the
+ * wrong dialect stayed invisible. The empty result is kept, because a caller
+ * on the hook path must not care; the reason is recorded beside it so
+ * `doctor` and a human can tell the two apart.
+ */
+let lastHarvestFailure = null;
+export const harvestFailure = () => lastHarvestFailure;
+const failed = (reason) => {
+  lastHarvestFailure = reason;
+  return [];
+};
+
+/**
  * Calls the model. Returns [] on any failure -- a harvest that errors must be
  * indistinguishable, from the caller's side, from a session with nothing to
- * learn.
+ * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
 export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
-  if (!digest || !harvestEnabled()) return [];
+  lastHarvestFailure = null;
+  if (!digest) return failed('no digest');
+  if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
   // A local endpoint usually has no auth at all, so requiring a key there would
   // make the free, private path unreachable -- the one the design now prefers.
@@ -298,41 +338,90 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return [];
+  if (!local && !key) return failed('no api key for a remote endpoint');
+
+  const endpoint = ENDPOINT();
+  const dialect = endpointDialect(endpoint);
+  const system = prompt || PROMPT;
+
+  // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
+  //
+  // `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most
+  // machines that run Claude at all and says nothing about the endpoint the
+  // user pointed this at -- which may be any process listening on loopback.
+  // A local server that genuinely wants auth is still reachable: set
+  // TOKEN_OPTIMIZER_API_KEY, which is explicit about being for this.
+  //
+  // Remote is unchanged; there the key is the whole reason the call is
+  // allowed to happen.
+  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(ENDPOINT(), {
+    const response = await fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
         'content-type': 'application/json',
-        ...(key ? { 'x-api-key': key } : {}),
-        'anthropic-version': '2023-06-01',
+        // A local server usually wants no credential at all, and sending one
+        // to localhost is a leak, not a courtesy -- so a key is attached only
+        // when there is one, in the scheme the dialect expects.
+        ...(credential && dialect === 'anthropic' ? { 'x-api-key': credential } : {}),
+        ...(credential && dialect === 'openai'
+          ? { authorization: `Bearer ${credential}` }
+          : {}),
+        ...(dialect === 'anthropic' ? { 'anthropic-version': '2023-06-01' } : {}),
       },
-      body: JSON.stringify({
-        model: MODEL(),
-        max_tokens: 2048,
-        system: prompt || PROMPT,
-        messages: [{ role: 'user', content: digest }],
-      }),
+      body: JSON.stringify(
+        dialect === 'openai'
+          ? {
+              model: MODEL(),
+              max_tokens: 2048,
+              // No top-level `system` in this dialect; it is the first message.
+              messages: [
+                { role: 'system', content: system },
+                { role: 'user', content: digest },
+              ],
+            }
+          : {
+              model: MODEL(),
+              max_tokens: 2048,
+              system,
+              messages: [{ role: 'user', content: digest }],
+            }
+      ),
     });
 
-    if (!response.ok) return [];
+    if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();
-    const text = (body.content || []).filter((b) => b.type === 'text').map((b) => b.text).join('');
+
+    // BOTH SHAPES READ, whichever dialect was sent. A gateway may answer in the
+    // other one, and reading both costs a property access.
+    const text =
+      (Array.isArray(body.content)
+        ? body.content.filter((b) => b?.type === 'text').map((b) => b.text).join('')
+        : '') ||
+      (Array.isArray(body.choices)
+        ? body.choices.map((c) => c?.message?.content || '').join('')
+        : '') ||
+      '';
+    if (!text) return failed('endpoint answered in an unrecognised shape');
 
     // Models wrap JSON in prose or fences often enough that finding the array
     // is more reliable than insisting the whole response parse.
     const start = text.indexOf('[');
     const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return [];
+    if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
-    return JSON.parse(text.slice(start, end + 1));
-  } catch {
-    return [];
+    try {
+      return JSON.parse(text.slice(start, end + 1));
+    } catch {
+      return failed('the JSON array in the reply did not parse');
+    }
+  } catch (error) {
+    return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {
     clearTimeout(timer);
   }

--- a/integrations/qwen/hooks/lib/harvest.mjs
+++ b/integrations/qwen/hooks/lib/harvest.mjs
@@ -343,6 +343,29 @@ export function validate(raw, { knownFiles = null } = {}) {
  * configures the whole URL here, so the path is something they stated rather
  * than something we guess.
  */
+/**
+ * Which credential, if any, may travel to this endpoint.
+ *
+ * `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most machines
+ * that run Claude and says nothing about where this request is going. There is
+ * exactly one destination that key belongs to: a REMOTE ANTHROPIC endpoint.
+ *
+ *   anthropic + remote   the key -- this is what it is for
+ *   anthropic + local    explicit only -- loopback is not Anthropic
+ *   openai    + remote   explicit only -- a third-party gateway must not
+ *                        receive an Anthropic credential as a Bearer token
+ *   openai    + local    explicit only
+ *
+ * The first version of this scoped on `local` alone, which review caught: it
+ * closed the loopback leak and left the remote-gateway one wide open. Exported
+ * so all four combinations are testable without contriving DNS.
+ */
+export function credentialFor(dialect, local, env = process.env) {
+  const explicit = env.TOKEN_OPTIMIZER_API_KEY || null;
+  if (dialect === 'openai' || local) return explicit;
+  return explicit || env.ANTHROPIC_API_KEY || null;
+}
+
 export function endpointDialect(endpoint = ENDPOINT()) {
   return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
 }
@@ -435,7 +458,24 @@ export async function extract(
   //
   // Remote is unchanged; there the key is the whole reason the call is
   // allowed to happen.
-  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
+  const credential = credentialFor(dialect, local);
+
+  // THE DEFAULT MODEL IS AN ANTHROPIC ONE, AND A LOCAL SERVER HAS NEVER HEARD
+  // OF IT. `MODEL()` falls back to claude-haiku, so an endpoint configured per
+  // the documented advice -- which names only TOKEN_OPTIMIZER_HARVEST_ENDPOINT --
+  // asks ollama for a model it does not have and is refused. I hit this myself
+  // while proving the dialect fix and set the variable by hand without noticing
+  // that a user could not know to.
+  //
+  // Refused with an actionable reason rather than guessed at. Picking a default
+  // like `llama3.2` would be a guess about what the user pulled, and being wrong
+  // costs the same silent nothing this whole branch exists to remove.
+  if (dialect === 'openai' && !process.env.TOKEN_OPTIMIZER_HARVEST_MODEL) {
+    return failed(
+      'set TOKEN_OPTIMIZER_HARVEST_MODEL for an OpenAI-compatible endpoint ' +
+        `(the default ${MODEL()} is an Anthropic model no local server serves)`
+    );
+  }
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -501,8 +541,24 @@ export async function extract(
     // whole function used to be. Narrow on purpose: a 4xx is the server saying
     // it will not take what was sent, while a 5xx or a timeout is a condition a
     // second identical call would only pay for twice, on a hook path.
-    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
-      response = await send(false);
+    // NARROWED FROM ANY 4xx. Review is right that the first version retried
+    // things a retry cannot help and should not touch: a 429 is a rate limit
+    // and an immediate repeat makes it worse, while 401/403/404 are settled
+    // answers about credentials and routing. Only a 400/422 whose body names
+    // `response_format` is the server saying it will not take THE SCHEMA,
+    // which is the one case where the same request without it still works.
+    if (
+      !response.ok
+      && dialect === 'openai'
+      && (response.status === 400 || response.status === 422)
+    ) {
+      let complaint = '';
+      try {
+        complaint = await response.clone().text();
+      } catch {
+        complaint = '';
+      }
+      if (/response_format|json_schema/i.test(complaint)) response = await send(false);
     }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);

--- a/integrations/qwen/hooks/lib/harvest.mjs
+++ b/integrations/qwen/hooks/lib/harvest.mjs
@@ -20,7 +20,9 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -56,6 +58,17 @@ export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map'
  * the OpenAI structured-output contract takes an object at the root; `extract`
  * already locates the array inside whatever it is handed, so nothing
  * downstream needs to know.
+ *
+ * EVERY FIELD THE PROMPT ASKS FOR HAS TO BE DECLARED HERE, because the
+ * object is closed. `PROMPT` asks for `scope` and `invalidators`; the schema
+ * did not declare them and `additionalProperties: false` therefore FORBADE
+ * them, so an enforcing server could not return either one. `validate` then
+ * substituted `project` and `[]` for every finding, and the substitution is
+ * silent: on the schema path, organization- and global-scope findings could
+ * not be promoted and no finding could ever carry an invalidator. Both are
+ * required, matching the prompt -- a finding with nothing that would
+ * invalidate it is declared as an empty array rather than omitted, which is a
+ * claim the model has to make on purpose.
  */
 export const FINDINGS_SCHEMA = Object.freeze({
   type: 'object',
@@ -67,13 +80,24 @@ export const FINDINGS_SCHEMA = Object.freeze({
       items: {
         type: 'object',
         additionalProperties: false,
-        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        required: [
+          'type',
+          'claim',
+          'evidence',
+          'applicability',
+          'confidenceLabel',
+          'scope',
+          'invalidators',
+          'anchors',
+        ],
         properties: {
           type: { type: 'string', enum: FINDING_TYPES },
           claim: { type: 'string' },
           evidence: { type: 'string' },
           applicability: { type: 'string' },
           confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          scope: { type: 'string', enum: ['project', 'organization', 'global'] },
+          invalidators: { type: 'array', items: { type: 'string' } },
           anchors: { type: 'array', items: { type: 'string' } },
           trigger: { type: 'string' },
         },
@@ -379,11 +403,72 @@ export function endpointDialect(endpoint = ENDPOINT()) {
  * on the hook path must not care; the reason is recorded beside it so
  * `doctor` and a human can tell the two apart.
  */
+// A MODULE VARIABLE CANNOT CROSS A PROCESS, and every reader of this is in a
+// different one. The harvest runs in a DETACHED worker spawned at Stop
+// (stop-harvest.mjs), while `doctor` is a separate `node` invocation that
+// imports a fresh copy of this module. So `probeHarvest` read `null` no matter
+// what the harvest had done, and the failure branch it was given -- the whole
+// point of recording a reason -- could never be reached from the diagnostic
+// that exists to surface it. The reason is written where the next process can
+// find it.
+//
+// Per user, not per project: the worker resolves a project root and `doctor`
+// often cannot, and the failures recorded here (a wrong dialect, a missing
+// model name, an unreachable endpoint, a CLI that is not on PATH) are
+// properties of the machine's configuration rather than of a repository.
+const FAILURE_FILE = () =>
+  process.env.TOKEN_OPTIMIZER_HARVEST_STATE ||
+  join(homedir(), '.token-optimizer', 'last-harvest.json');
+
+// Old enough to be about a configuration that no longer exists. A harvest runs
+// at the end of every session, so a record older than this means the harvest
+// has not run since -- reporting it as the current state would be a guess.
+const FAILURE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
 let lastHarvestFailure = null;
-export const harvestFailure = () => lastHarvestFailure;
-const failed = (reason) => {
+/** True once this process has recorded an outcome, so the file is not consulted. */
+let outcomeThisProcess = false;
+
+function recordOutcome(reason) {
   lastHarvestFailure = reason;
+  outcomeThisProcess = true;
+  try {
+    const file = FAILURE_FILE();
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({ reason, at: Date.now() }), 'utf8');
+  } catch {
+    // Best effort. A harvest must never fail because it could not write a
+    // diagnostic about itself.
+  }
+}
+
+export function harvestFailure() {
+  if (outcomeThisProcess) return lastHarvestFailure;
+  try {
+    const { reason, at } = JSON.parse(readFileSync(FAILURE_FILE(), 'utf8'));
+    if (!reason || typeof at !== 'number') return null;
+    return Date.now() - at > FAILURE_TTL_MS ? null : reason;
+  } catch {
+    return null;
+  }
+}
+
+const failed = (reason) => {
+  recordOutcome(reason);
   return [];
+};
+
+/**
+ * Clears the recorded failure, because the harvest just worked.
+ *
+ * Without this the file is a one-way latch: a user fixes their endpoint, the
+ * harvest starts working, and `doctor` keeps reporting the failure that was
+ * true a week ago. The TTL alone would not do it -- it expires a stale record,
+ * not a wrong one.
+ */
+const succeeded = (findings) => {
+  recordOutcome(null);
+  return findings;
 };
 
 /**
@@ -396,6 +481,7 @@ export async function extract(
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
 ) {
   lastHarvestFailure = null;
+  outcomeThisProcess = false;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
@@ -583,7 +669,7 @@ export async function extract(
     if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
     try {
-      return JSON.parse(text.slice(start, end + 1));
+      return succeeded(JSON.parse(text.slice(start, end + 1)));
     } catch {
       return failed('the JSON array in the reply did not parse');
     }

--- a/integrations/windsurf/hooks/lib/doctor.mjs
+++ b/integrations/windsurf/hooks/lib/doctor.mjs
@@ -25,7 +25,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { harvestMode } from './harvest.mjs';
+import { harvestMode, harvestFailure } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
 import { mcpClientsSeen } from './metrics.mjs';
 
@@ -228,6 +228,20 @@ export function probeHarvest() {
   // credential, no billing and no digest leaving the machine -- so the two facts
   // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
+    // WHY THE LAST ONE PRODUCED NOTHING, when it produced nothing.
+    //
+    // `extract` returns [] on every failure so a hook-path caller need not
+    // care, which made a misconfigured endpoint indistinguishable from a
+    // session with nothing to learn -- the exact reason a client speaking the
+    // wrong dialect went unnoticed. `harvestFailure()` carries the reason, and
+    // this is the reader it was added for.
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check the endpoint URL and, for an OpenAI-compatible server, that ' +
+        'TOKEN_OPTIMIZER_HARVEST_MODEL names a model it actually serves')];
+    }
     return [ok('finding extraction is available',
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];

--- a/integrations/windsurf/hooks/lib/harvest-worker.mjs
+++ b/integrations/windsurf/hooks/lib/harvest-worker.mjs
@@ -99,13 +99,20 @@ async function main() {
   const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
   if (!digest) return;
 
-  const raw = await extract(digest);
+  // THE SAME LIST TO BOTH SIDES. `validate` has always held anchors to the
+  // files this session touched; passing it to `extract` too lets the model be
+  // GIVEN that list instead of guessing at it. Measured on this session's real
+  // digest with qwen2.5:7b: 0 of 4 extractions survived the gate when the model
+  // guessed, 4 of 4 when it chose. Computed once so the two can never disagree
+  // -- a model constrained to one list and judged against another would fail
+  // every time, and silently.
+  const anchorable = full ? null : filesIn(digest);
 
-  // Anchors are held to the files this session actually touched, so a model
-  // that invents a plausible path cannot anchor a finding to it. The digest
-  // lists them under a heading it writes itself; the full delta is raw
-  // transcript and carries no such list, so it gets no restriction.
-  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+  const raw = await extract(digest, { knownFiles: anchorable });
+
+  // The full delta is raw transcript and carries no file heading, so it gets
+  // no restriction on either side.
+  const validated = validate(raw, { knownFiles: anchorable });
 
   // BUDGETED SELECTION, not everything the model extracted.
   //

--- a/integrations/windsurf/hooks/lib/harvest.mjs
+++ b/integrations/windsurf/hooks/lib/harvest.mjs
@@ -41,6 +41,47 @@ const ENDPOINT = () => process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT
 // was wrong, which is why it is kept distinguishable from an ordinary finding.
 export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
 
+/**
+ * The shape a reply must take, for servers that can enforce one.
+ *
+ * A SMALL LOCAL MODEL WILL NOT FOLLOW THE PROMPT ON ITS OWN. Measured against
+ * qwen2.5:3b through ollama on the real digest from this session:
+ *
+ *   no constraint                    prose summary, 0 findings
+ *   response_format json_object      valid JSON, an invented schema
+ *   response_format json_schema      1 finding in the exact shape, 9s
+ *
+ * That is the difference between the free private path working and not, so
+ * the schema is sent rather than hoped for. The wrapper object exists because
+ * the OpenAI structured-output contract takes an object at the root; `extract`
+ * already locates the array inside whatever it is handed, so nothing
+ * downstream needs to know.
+ */
+export const FINDINGS_SCHEMA = Object.freeze({
+  type: 'object',
+  required: ['findings'],
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        properties: {
+          type: { type: 'string', enum: FINDING_TYPES },
+          claim: { type: 'string' },
+          evidence: { type: 'string' },
+          applicability: { type: 'string' },
+          confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          anchors: { type: 'array', items: { type: 'string' } },
+          trigger: { type: 'string' },
+        },
+      },
+    },
+  },
+});
+
 export function apiKey() {
   return process.env.TOKEN_OPTIMIZER_API_KEY || process.env.ANTHROPIC_API_KEY || null;
 }
@@ -359,8 +400,15 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-  try {
-    const response = await fetch(endpoint, {
+  /**
+   * One request. `structured` asks the server to enforce FINDINGS_SCHEMA.
+   *
+   * Separated out so the schema can be dropped and the call retried WITHOUT
+   * repeating the request shape in two places, which is how the two would
+   * drift.
+   */
+  const send = (structured) =>
+    fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
@@ -384,6 +432,14 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 { role: 'system', content: system },
                 { role: 'user', content: digest },
               ],
+              ...(structured
+                ? {
+                    response_format: {
+                      type: 'json_schema',
+                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                    },
+                  }
+                : {}),
             }
           : {
               model: MODEL(),
@@ -393,6 +449,21 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
             }
       ),
     });
+
+  try {
+    // Structured output only where the contract exists. Anthropic Messages has
+    // no `response_format`, and sending one is at best ignored.
+    let response = await send(dialect === 'openai');
+
+    // RETRIED ONCE, AND ONLY FOR A REFUSAL OF THE SCHEMA ITSELF. A server that
+    // predates structured outputs rejects the request outright, and the
+    // unconstrained call still works there -- that is the configuration this
+    // whole function used to be. Narrow on purpose: a 4xx is the server saying
+    // it will not take what was sent, while a 5xx or a timeout is a condition a
+    // second identical call would only pay for twice, on a hook path.
+    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
+      response = await send(false);
+    }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();

--- a/integrations/windsurf/hooks/lib/harvest.mjs
+++ b/integrations/windsurf/hooks/lib/harvest.mjs
@@ -368,7 +368,10 @@ const failed = (reason) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
-export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
+export async function extract(
+  digest,
+  { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
+) {
   lastHarvestFailure = null;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
@@ -384,6 +387,43 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
+  //
+  // `validate` holds anchors to the files the session actually touched, and a
+  // model asked in English for a path writes a plausible one instead of a real
+  // one -- so every finding was discarded at the gate. Measured over four runs
+  // of qwen2.5:7b on this session's real digest, against that same gate:
+  //
+  //   anchors unconstrained     4 extracted -> 0 accepted
+  //   anchors enum-constrained  4 extracted -> 4 accepted
+  //
+  // Nothing else differed. The server enforces the enum, so the model picks
+  // from the real list rather than inventing one, and the gate stops being
+  // the thing that silently eats the harvest.
+  //
+  // Only when the caller knows the list. `buildFullDelta` is raw transcript
+  // with no file heading, and its caller passes no knownFiles for the same
+  // reason -- an empty enum would forbid every anchor rather than free it.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+  const schema = anchorChoices.length
+    ? {
+        ...FINDINGS_SCHEMA,
+        properties: {
+          ...FINDINGS_SCHEMA.properties,
+          findings: {
+            ...FINDINGS_SCHEMA.properties.findings,
+            items: {
+              ...FINDINGS_SCHEMA.properties.findings.items,
+              properties: {
+                ...FINDINGS_SCHEMA.properties.findings.items.properties,
+                anchors: { type: 'array', items: { type: 'string', enum: anchorChoices } },
+              },
+            },
+          },
+        },
+      }
+    : FINDINGS_SCHEMA;
 
   // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
   //
@@ -436,7 +476,7 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 ? {
                     response_format: {
                       type: 'json_schema',
-                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                      json_schema: { name: 'findings', schema },
                     },
                   }
                 : {}),

--- a/integrations/windsurf/hooks/lib/harvest.mjs
+++ b/integrations/windsurf/hooks/lib/harvest.mjs
@@ -285,12 +285,52 @@ export function validate(raw, { knownFiles = null } = {}) {
 }
 
 /**
+ * Which wire format the configured endpoint speaks.
+ *
+ * THE ADVERTISED LOCAL PATH DID NOT WORK. Both the SessionStart notice and
+ * `doctor` tell the user to point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local
+ * model, and this client only ever spoke the Anthropic Messages dialect --
+ * `system` as a top-level field, `content[]` blocks in the reply. ollama, LM
+ * Studio and llama.cpp all serve OpenAI-compatible /v1/chat/completions,
+ * which takes the system prompt as a message and answers with
+ * `choices[].message.content`. Measured against a stand-in server answering
+ * both dialects with the identical finding: the Anthropic path returned 1 and
+ * the OpenAI path returned 0.
+ *
+ * Chosen from the URL rather than by trying one and falling back. A fallback
+ * doubles the latency of every genuine failure on a hook path, and the user
+ * configures the whole URL here, so the path is something they stated rather
+ * than something we guess.
+ */
+export function endpointDialect(endpoint = ENDPOINT()) {
+  return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
+}
+
+/**
+ * The last reason a harvest produced nothing, or null.
+ *
+ * `return []` on every failure made a misconfigured endpoint IDENTICAL to a
+ * session with nothing to learn -- which is how a local endpoint answering the
+ * wrong dialect stayed invisible. The empty result is kept, because a caller
+ * on the hook path must not care; the reason is recorded beside it so
+ * `doctor` and a human can tell the two apart.
+ */
+let lastHarvestFailure = null;
+export const harvestFailure = () => lastHarvestFailure;
+const failed = (reason) => {
+  lastHarvestFailure = reason;
+  return [];
+};
+
+/**
  * Calls the model. Returns [] on any failure -- a harvest that errors must be
  * indistinguishable, from the caller's side, from a session with nothing to
- * learn.
+ * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
 export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
-  if (!digest || !harvestEnabled()) return [];
+  lastHarvestFailure = null;
+  if (!digest) return failed('no digest');
+  if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
   // A local endpoint usually has no auth at all, so requiring a key there would
   // make the free, private path unreachable -- the one the design now prefers.
@@ -298,41 +338,90 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return [];
+  if (!local && !key) return failed('no api key for a remote endpoint');
+
+  const endpoint = ENDPOINT();
+  const dialect = endpointDialect(endpoint);
+  const system = prompt || PROMPT;
+
+  // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
+  //
+  // `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most
+  // machines that run Claude at all and says nothing about the endpoint the
+  // user pointed this at -- which may be any process listening on loopback.
+  // A local server that genuinely wants auth is still reachable: set
+  // TOKEN_OPTIMIZER_API_KEY, which is explicit about being for this.
+  //
+  // Remote is unchanged; there the key is the whole reason the call is
+  // allowed to happen.
+  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(ENDPOINT(), {
+    const response = await fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
         'content-type': 'application/json',
-        ...(key ? { 'x-api-key': key } : {}),
-        'anthropic-version': '2023-06-01',
+        // A local server usually wants no credential at all, and sending one
+        // to localhost is a leak, not a courtesy -- so a key is attached only
+        // when there is one, in the scheme the dialect expects.
+        ...(credential && dialect === 'anthropic' ? { 'x-api-key': credential } : {}),
+        ...(credential && dialect === 'openai'
+          ? { authorization: `Bearer ${credential}` }
+          : {}),
+        ...(dialect === 'anthropic' ? { 'anthropic-version': '2023-06-01' } : {}),
       },
-      body: JSON.stringify({
-        model: MODEL(),
-        max_tokens: 2048,
-        system: prompt || PROMPT,
-        messages: [{ role: 'user', content: digest }],
-      }),
+      body: JSON.stringify(
+        dialect === 'openai'
+          ? {
+              model: MODEL(),
+              max_tokens: 2048,
+              // No top-level `system` in this dialect; it is the first message.
+              messages: [
+                { role: 'system', content: system },
+                { role: 'user', content: digest },
+              ],
+            }
+          : {
+              model: MODEL(),
+              max_tokens: 2048,
+              system,
+              messages: [{ role: 'user', content: digest }],
+            }
+      ),
     });
 
-    if (!response.ok) return [];
+    if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();
-    const text = (body.content || []).filter((b) => b.type === 'text').map((b) => b.text).join('');
+
+    // BOTH SHAPES READ, whichever dialect was sent. A gateway may answer in the
+    // other one, and reading both costs a property access.
+    const text =
+      (Array.isArray(body.content)
+        ? body.content.filter((b) => b?.type === 'text').map((b) => b.text).join('')
+        : '') ||
+      (Array.isArray(body.choices)
+        ? body.choices.map((c) => c?.message?.content || '').join('')
+        : '') ||
+      '';
+    if (!text) return failed('endpoint answered in an unrecognised shape');
 
     // Models wrap JSON in prose or fences often enough that finding the array
     // is more reliable than insisting the whole response parse.
     const start = text.indexOf('[');
     const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return [];
+    if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
-    return JSON.parse(text.slice(start, end + 1));
-  } catch {
-    return [];
+    try {
+      return JSON.parse(text.slice(start, end + 1));
+    } catch {
+      return failed('the JSON array in the reply did not parse');
+    }
+  } catch (error) {
+    return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {
     clearTimeout(timer);
   }

--- a/integrations/windsurf/hooks/lib/harvest.mjs
+++ b/integrations/windsurf/hooks/lib/harvest.mjs
@@ -343,6 +343,29 @@ export function validate(raw, { knownFiles = null } = {}) {
  * configures the whole URL here, so the path is something they stated rather
  * than something we guess.
  */
+/**
+ * Which credential, if any, may travel to this endpoint.
+ *
+ * `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most machines
+ * that run Claude and says nothing about where this request is going. There is
+ * exactly one destination that key belongs to: a REMOTE ANTHROPIC endpoint.
+ *
+ *   anthropic + remote   the key -- this is what it is for
+ *   anthropic + local    explicit only -- loopback is not Anthropic
+ *   openai    + remote   explicit only -- a third-party gateway must not
+ *                        receive an Anthropic credential as a Bearer token
+ *   openai    + local    explicit only
+ *
+ * The first version of this scoped on `local` alone, which review caught: it
+ * closed the loopback leak and left the remote-gateway one wide open. Exported
+ * so all four combinations are testable without contriving DNS.
+ */
+export function credentialFor(dialect, local, env = process.env) {
+  const explicit = env.TOKEN_OPTIMIZER_API_KEY || null;
+  if (dialect === 'openai' || local) return explicit;
+  return explicit || env.ANTHROPIC_API_KEY || null;
+}
+
 export function endpointDialect(endpoint = ENDPOINT()) {
   return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
 }
@@ -435,7 +458,24 @@ export async function extract(
   //
   // Remote is unchanged; there the key is the whole reason the call is
   // allowed to happen.
-  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
+  const credential = credentialFor(dialect, local);
+
+  // THE DEFAULT MODEL IS AN ANTHROPIC ONE, AND A LOCAL SERVER HAS NEVER HEARD
+  // OF IT. `MODEL()` falls back to claude-haiku, so an endpoint configured per
+  // the documented advice -- which names only TOKEN_OPTIMIZER_HARVEST_ENDPOINT --
+  // asks ollama for a model it does not have and is refused. I hit this myself
+  // while proving the dialect fix and set the variable by hand without noticing
+  // that a user could not know to.
+  //
+  // Refused with an actionable reason rather than guessed at. Picking a default
+  // like `llama3.2` would be a guess about what the user pulled, and being wrong
+  // costs the same silent nothing this whole branch exists to remove.
+  if (dialect === 'openai' && !process.env.TOKEN_OPTIMIZER_HARVEST_MODEL) {
+    return failed(
+      'set TOKEN_OPTIMIZER_HARVEST_MODEL for an OpenAI-compatible endpoint ' +
+        `(the default ${MODEL()} is an Anthropic model no local server serves)`
+    );
+  }
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -501,8 +541,24 @@ export async function extract(
     // whole function used to be. Narrow on purpose: a 4xx is the server saying
     // it will not take what was sent, while a 5xx or a timeout is a condition a
     // second identical call would only pay for twice, on a hook path.
-    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
-      response = await send(false);
+    // NARROWED FROM ANY 4xx. Review is right that the first version retried
+    // things a retry cannot help and should not touch: a 429 is a rate limit
+    // and an immediate repeat makes it worse, while 401/403/404 are settled
+    // answers about credentials and routing. Only a 400/422 whose body names
+    // `response_format` is the server saying it will not take THE SCHEMA,
+    // which is the one case where the same request without it still works.
+    if (
+      !response.ok
+      && dialect === 'openai'
+      && (response.status === 400 || response.status === 422)
+    ) {
+      let complaint = '';
+      try {
+        complaint = await response.clone().text();
+      } catch {
+        complaint = '';
+      }
+      if (/response_format|json_schema/i.test(complaint)) response = await send(false);
     }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);

--- a/integrations/windsurf/hooks/lib/harvest.mjs
+++ b/integrations/windsurf/hooks/lib/harvest.mjs
@@ -20,7 +20,9 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -56,6 +58,17 @@ export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map'
  * the OpenAI structured-output contract takes an object at the root; `extract`
  * already locates the array inside whatever it is handed, so nothing
  * downstream needs to know.
+ *
+ * EVERY FIELD THE PROMPT ASKS FOR HAS TO BE DECLARED HERE, because the
+ * object is closed. `PROMPT` asks for `scope` and `invalidators`; the schema
+ * did not declare them and `additionalProperties: false` therefore FORBADE
+ * them, so an enforcing server could not return either one. `validate` then
+ * substituted `project` and `[]` for every finding, and the substitution is
+ * silent: on the schema path, organization- and global-scope findings could
+ * not be promoted and no finding could ever carry an invalidator. Both are
+ * required, matching the prompt -- a finding with nothing that would
+ * invalidate it is declared as an empty array rather than omitted, which is a
+ * claim the model has to make on purpose.
  */
 export const FINDINGS_SCHEMA = Object.freeze({
   type: 'object',
@@ -67,13 +80,24 @@ export const FINDINGS_SCHEMA = Object.freeze({
       items: {
         type: 'object',
         additionalProperties: false,
-        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        required: [
+          'type',
+          'claim',
+          'evidence',
+          'applicability',
+          'confidenceLabel',
+          'scope',
+          'invalidators',
+          'anchors',
+        ],
         properties: {
           type: { type: 'string', enum: FINDING_TYPES },
           claim: { type: 'string' },
           evidence: { type: 'string' },
           applicability: { type: 'string' },
           confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          scope: { type: 'string', enum: ['project', 'organization', 'global'] },
+          invalidators: { type: 'array', items: { type: 'string' } },
           anchors: { type: 'array', items: { type: 'string' } },
           trigger: { type: 'string' },
         },
@@ -379,11 +403,72 @@ export function endpointDialect(endpoint = ENDPOINT()) {
  * on the hook path must not care; the reason is recorded beside it so
  * `doctor` and a human can tell the two apart.
  */
+// A MODULE VARIABLE CANNOT CROSS A PROCESS, and every reader of this is in a
+// different one. The harvest runs in a DETACHED worker spawned at Stop
+// (stop-harvest.mjs), while `doctor` is a separate `node` invocation that
+// imports a fresh copy of this module. So `probeHarvest` read `null` no matter
+// what the harvest had done, and the failure branch it was given -- the whole
+// point of recording a reason -- could never be reached from the diagnostic
+// that exists to surface it. The reason is written where the next process can
+// find it.
+//
+// Per user, not per project: the worker resolves a project root and `doctor`
+// often cannot, and the failures recorded here (a wrong dialect, a missing
+// model name, an unreachable endpoint, a CLI that is not on PATH) are
+// properties of the machine's configuration rather than of a repository.
+const FAILURE_FILE = () =>
+  process.env.TOKEN_OPTIMIZER_HARVEST_STATE ||
+  join(homedir(), '.token-optimizer', 'last-harvest.json');
+
+// Old enough to be about a configuration that no longer exists. A harvest runs
+// at the end of every session, so a record older than this means the harvest
+// has not run since -- reporting it as the current state would be a guess.
+const FAILURE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
 let lastHarvestFailure = null;
-export const harvestFailure = () => lastHarvestFailure;
-const failed = (reason) => {
+/** True once this process has recorded an outcome, so the file is not consulted. */
+let outcomeThisProcess = false;
+
+function recordOutcome(reason) {
   lastHarvestFailure = reason;
+  outcomeThisProcess = true;
+  try {
+    const file = FAILURE_FILE();
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({ reason, at: Date.now() }), 'utf8');
+  } catch {
+    // Best effort. A harvest must never fail because it could not write a
+    // diagnostic about itself.
+  }
+}
+
+export function harvestFailure() {
+  if (outcomeThisProcess) return lastHarvestFailure;
+  try {
+    const { reason, at } = JSON.parse(readFileSync(FAILURE_FILE(), 'utf8'));
+    if (!reason || typeof at !== 'number') return null;
+    return Date.now() - at > FAILURE_TTL_MS ? null : reason;
+  } catch {
+    return null;
+  }
+}
+
+const failed = (reason) => {
+  recordOutcome(reason);
   return [];
+};
+
+/**
+ * Clears the recorded failure, because the harvest just worked.
+ *
+ * Without this the file is a one-way latch: a user fixes their endpoint, the
+ * harvest starts working, and `doctor` keeps reporting the failure that was
+ * true a week ago. The TTL alone would not do it -- it expires a stale record,
+ * not a wrong one.
+ */
+const succeeded = (findings) => {
+  recordOutcome(null);
+  return findings;
 };
 
 /**
@@ -396,6 +481,7 @@ export async function extract(
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
 ) {
   lastHarvestFailure = null;
+  outcomeThisProcess = false;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
@@ -583,7 +669,7 @@ export async function extract(
     if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
     try {
-      return JSON.parse(text.slice(start, end + 1));
+      return succeeded(JSON.parse(text.slice(start, end + 1)));
     } catch {
       return failed('the JSON array in the reply did not parse');
     }

--- a/plugin/hooks/lib/doctor.mjs
+++ b/plugin/hooks/lib/doctor.mjs
@@ -25,7 +25,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { harvestMode } from './harvest.mjs';
+import { harvestMode, harvestFailure } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
 import { mcpClientsSeen } from './metrics.mjs';
 
@@ -228,6 +228,20 @@ export function probeHarvest() {
   // credential, no billing and no digest leaving the machine -- so the two facts
   // that decide whether someone wants it are the two facts stated first.
   if (mode === 'local') {
+    // WHY THE LAST ONE PRODUCED NOTHING, when it produced nothing.
+    //
+    // `extract` returns [] on every failure so a hook-path caller need not
+    // care, which made a misconfigured endpoint indistinguishable from a
+    // session with nothing to learn -- the exact reason a client speaking the
+    // wrong dialect went unnoticed. `harvestFailure()` carries the reason, and
+    // this is the reader it was added for.
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check the endpoint URL and, for an OpenAI-compatible server, that ' +
+        'TOKEN_OPTIMIZER_HARVEST_MODEL names a model it actually serves')];
+    }
     return [ok('finding extraction is available',
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];

--- a/plugin/hooks/lib/harvest-worker.mjs
+++ b/plugin/hooks/lib/harvest-worker.mjs
@@ -99,13 +99,20 @@ async function main() {
   const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
   if (!digest) return;
 
-  const raw = await extract(digest);
+  // THE SAME LIST TO BOTH SIDES. `validate` has always held anchors to the
+  // files this session touched; passing it to `extract` too lets the model be
+  // GIVEN that list instead of guessing at it. Measured on this session's real
+  // digest with qwen2.5:7b: 0 of 4 extractions survived the gate when the model
+  // guessed, 4 of 4 when it chose. Computed once so the two can never disagree
+  // -- a model constrained to one list and judged against another would fail
+  // every time, and silently.
+  const anchorable = full ? null : filesIn(digest);
 
-  // Anchors are held to the files this session actually touched, so a model
-  // that invents a plausible path cannot anchor a finding to it. The digest
-  // lists them under a heading it writes itself; the full delta is raw
-  // transcript and carries no such list, so it gets no restriction.
-  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+  const raw = await extract(digest, { knownFiles: anchorable });
+
+  // The full delta is raw transcript and carries no file heading, so it gets
+  // no restriction on either side.
+  const validated = validate(raw, { knownFiles: anchorable });
 
   // BUDGETED SELECTION, not everything the model extracted.
   //

--- a/plugin/hooks/lib/harvest.mjs
+++ b/plugin/hooks/lib/harvest.mjs
@@ -41,6 +41,47 @@ const ENDPOINT = () => process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT
 // was wrong, which is why it is kept distinguishable from an ordinary finding.
 export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
 
+/**
+ * The shape a reply must take, for servers that can enforce one.
+ *
+ * A SMALL LOCAL MODEL WILL NOT FOLLOW THE PROMPT ON ITS OWN. Measured against
+ * qwen2.5:3b through ollama on the real digest from this session:
+ *
+ *   no constraint                    prose summary, 0 findings
+ *   response_format json_object      valid JSON, an invented schema
+ *   response_format json_schema      1 finding in the exact shape, 9s
+ *
+ * That is the difference between the free private path working and not, so
+ * the schema is sent rather than hoped for. The wrapper object exists because
+ * the OpenAI structured-output contract takes an object at the root; `extract`
+ * already locates the array inside whatever it is handed, so nothing
+ * downstream needs to know.
+ */
+export const FINDINGS_SCHEMA = Object.freeze({
+  type: 'object',
+  required: ['findings'],
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        properties: {
+          type: { type: 'string', enum: FINDING_TYPES },
+          claim: { type: 'string' },
+          evidence: { type: 'string' },
+          applicability: { type: 'string' },
+          confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          anchors: { type: 'array', items: { type: 'string' } },
+          trigger: { type: 'string' },
+        },
+      },
+    },
+  },
+});
+
 export function apiKey() {
   return process.env.TOKEN_OPTIMIZER_API_KEY || process.env.ANTHROPIC_API_KEY || null;
 }
@@ -359,8 +400,15 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-  try {
-    const response = await fetch(endpoint, {
+  /**
+   * One request. `structured` asks the server to enforce FINDINGS_SCHEMA.
+   *
+   * Separated out so the schema can be dropped and the call retried WITHOUT
+   * repeating the request shape in two places, which is how the two would
+   * drift.
+   */
+  const send = (structured) =>
+    fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
@@ -384,6 +432,14 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 { role: 'system', content: system },
                 { role: 'user', content: digest },
               ],
+              ...(structured
+                ? {
+                    response_format: {
+                      type: 'json_schema',
+                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                    },
+                  }
+                : {}),
             }
           : {
               model: MODEL(),
@@ -393,6 +449,21 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
             }
       ),
     });
+
+  try {
+    // Structured output only where the contract exists. Anthropic Messages has
+    // no `response_format`, and sending one is at best ignored.
+    let response = await send(dialect === 'openai');
+
+    // RETRIED ONCE, AND ONLY FOR A REFUSAL OF THE SCHEMA ITSELF. A server that
+    // predates structured outputs rejects the request outright, and the
+    // unconstrained call still works there -- that is the configuration this
+    // whole function used to be. Narrow on purpose: a 4xx is the server saying
+    // it will not take what was sent, while a 5xx or a timeout is a condition a
+    // second identical call would only pay for twice, on a hook path.
+    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
+      response = await send(false);
+    }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();

--- a/plugin/hooks/lib/harvest.mjs
+++ b/plugin/hooks/lib/harvest.mjs
@@ -368,7 +368,10 @@ const failed = (reason) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
-export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
+export async function extract(
+  digest,
+  { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
+) {
   lastHarvestFailure = null;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
@@ -384,6 +387,43 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
+  //
+  // `validate` holds anchors to the files the session actually touched, and a
+  // model asked in English for a path writes a plausible one instead of a real
+  // one -- so every finding was discarded at the gate. Measured over four runs
+  // of qwen2.5:7b on this session's real digest, against that same gate:
+  //
+  //   anchors unconstrained     4 extracted -> 0 accepted
+  //   anchors enum-constrained  4 extracted -> 4 accepted
+  //
+  // Nothing else differed. The server enforces the enum, so the model picks
+  // from the real list rather than inventing one, and the gate stops being
+  // the thing that silently eats the harvest.
+  //
+  // Only when the caller knows the list. `buildFullDelta` is raw transcript
+  // with no file heading, and its caller passes no knownFiles for the same
+  // reason -- an empty enum would forbid every anchor rather than free it.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+  const schema = anchorChoices.length
+    ? {
+        ...FINDINGS_SCHEMA,
+        properties: {
+          ...FINDINGS_SCHEMA.properties,
+          findings: {
+            ...FINDINGS_SCHEMA.properties.findings,
+            items: {
+              ...FINDINGS_SCHEMA.properties.findings.items,
+              properties: {
+                ...FINDINGS_SCHEMA.properties.findings.items.properties,
+                anchors: { type: 'array', items: { type: 'string', enum: anchorChoices } },
+              },
+            },
+          },
+        },
+      }
+    : FINDINGS_SCHEMA;
 
   // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
   //
@@ -436,7 +476,7 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
                 ? {
                     response_format: {
                       type: 'json_schema',
-                      json_schema: { name: 'findings', schema: FINDINGS_SCHEMA },
+                      json_schema: { name: 'findings', schema },
                     },
                   }
                 : {}),

--- a/plugin/hooks/lib/harvest.mjs
+++ b/plugin/hooks/lib/harvest.mjs
@@ -285,12 +285,52 @@ export function validate(raw, { knownFiles = null } = {}) {
 }
 
 /**
+ * Which wire format the configured endpoint speaks.
+ *
+ * THE ADVERTISED LOCAL PATH DID NOT WORK. Both the SessionStart notice and
+ * `doctor` tell the user to point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local
+ * model, and this client only ever spoke the Anthropic Messages dialect --
+ * `system` as a top-level field, `content[]` blocks in the reply. ollama, LM
+ * Studio and llama.cpp all serve OpenAI-compatible /v1/chat/completions,
+ * which takes the system prompt as a message and answers with
+ * `choices[].message.content`. Measured against a stand-in server answering
+ * both dialects with the identical finding: the Anthropic path returned 1 and
+ * the OpenAI path returned 0.
+ *
+ * Chosen from the URL rather than by trying one and falling back. A fallback
+ * doubles the latency of every genuine failure on a hook path, and the user
+ * configures the whole URL here, so the path is something they stated rather
+ * than something we guess.
+ */
+export function endpointDialect(endpoint = ENDPOINT()) {
+  return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
+}
+
+/**
+ * The last reason a harvest produced nothing, or null.
+ *
+ * `return []` on every failure made a misconfigured endpoint IDENTICAL to a
+ * session with nothing to learn -- which is how a local endpoint answering the
+ * wrong dialect stayed invisible. The empty result is kept, because a caller
+ * on the hook path must not care; the reason is recorded beside it so
+ * `doctor` and a human can tell the two apart.
+ */
+let lastHarvestFailure = null;
+export const harvestFailure = () => lastHarvestFailure;
+const failed = (reason) => {
+  lastHarvestFailure = reason;
+  return [];
+};
+
+/**
  * Calls the model. Returns [] on any failure -- a harvest that errors must be
  * indistinguishable, from the caller's side, from a session with nothing to
- * learn.
+ * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
 export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
-  if (!digest || !harvestEnabled()) return [];
+  lastHarvestFailure = null;
+  if (!digest) return failed('no digest');
+  if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
   // A local endpoint usually has no auth at all, so requiring a key there would
   // make the free, private path unreachable -- the one the design now prefers.
@@ -298,41 +338,90 @@ export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return [];
+  if (!local && !key) return failed('no api key for a remote endpoint');
+
+  const endpoint = ENDPOINT();
+  const dialect = endpointDialect(endpoint);
+  const system = prompt || PROMPT;
+
+  // AN AMBIENT KEY IS NOT CONSENT TO SEND IT TO A LOCAL SERVER.
+  //
+  // `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most
+  // machines that run Claude at all and says nothing about the endpoint the
+  // user pointed this at -- which may be any process listening on loopback.
+  // A local server that genuinely wants auth is still reachable: set
+  // TOKEN_OPTIMIZER_API_KEY, which is explicit about being for this.
+  //
+  // Remote is unchanged; there the key is the whole reason the call is
+  // allowed to happen.
+  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(ENDPOINT(), {
+    const response = await fetch(endpoint, {
       method: 'POST',
       signal: controller.signal,
       headers: {
         'content-type': 'application/json',
-        ...(key ? { 'x-api-key': key } : {}),
-        'anthropic-version': '2023-06-01',
+        // A local server usually wants no credential at all, and sending one
+        // to localhost is a leak, not a courtesy -- so a key is attached only
+        // when there is one, in the scheme the dialect expects.
+        ...(credential && dialect === 'anthropic' ? { 'x-api-key': credential } : {}),
+        ...(credential && dialect === 'openai'
+          ? { authorization: `Bearer ${credential}` }
+          : {}),
+        ...(dialect === 'anthropic' ? { 'anthropic-version': '2023-06-01' } : {}),
       },
-      body: JSON.stringify({
-        model: MODEL(),
-        max_tokens: 2048,
-        system: prompt || PROMPT,
-        messages: [{ role: 'user', content: digest }],
-      }),
+      body: JSON.stringify(
+        dialect === 'openai'
+          ? {
+              model: MODEL(),
+              max_tokens: 2048,
+              // No top-level `system` in this dialect; it is the first message.
+              messages: [
+                { role: 'system', content: system },
+                { role: 'user', content: digest },
+              ],
+            }
+          : {
+              model: MODEL(),
+              max_tokens: 2048,
+              system,
+              messages: [{ role: 'user', content: digest }],
+            }
+      ),
     });
 
-    if (!response.ok) return [];
+    if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);
     const body = await response.json();
-    const text = (body.content || []).filter((b) => b.type === 'text').map((b) => b.text).join('');
+
+    // BOTH SHAPES READ, whichever dialect was sent. A gateway may answer in the
+    // other one, and reading both costs a property access.
+    const text =
+      (Array.isArray(body.content)
+        ? body.content.filter((b) => b?.type === 'text').map((b) => b.text).join('')
+        : '') ||
+      (Array.isArray(body.choices)
+        ? body.choices.map((c) => c?.message?.content || '').join('')
+        : '') ||
+      '';
+    if (!text) return failed('endpoint answered in an unrecognised shape');
 
     // Models wrap JSON in prose or fences often enough that finding the array
     // is more reliable than insisting the whole response parse.
     const start = text.indexOf('[');
     const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return [];
+    if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
-    return JSON.parse(text.slice(start, end + 1));
-  } catch {
-    return [];
+    try {
+      return JSON.parse(text.slice(start, end + 1));
+    } catch {
+      return failed('the JSON array in the reply did not parse');
+    }
+  } catch (error) {
+    return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {
     clearTimeout(timer);
   }

--- a/plugin/hooks/lib/harvest.mjs
+++ b/plugin/hooks/lib/harvest.mjs
@@ -343,6 +343,29 @@ export function validate(raw, { knownFiles = null } = {}) {
  * configures the whole URL here, so the path is something they stated rather
  * than something we guess.
  */
+/**
+ * Which credential, if any, may travel to this endpoint.
+ *
+ * `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most machines
+ * that run Claude and says nothing about where this request is going. There is
+ * exactly one destination that key belongs to: a REMOTE ANTHROPIC endpoint.
+ *
+ *   anthropic + remote   the key -- this is what it is for
+ *   anthropic + local    explicit only -- loopback is not Anthropic
+ *   openai    + remote   explicit only -- a third-party gateway must not
+ *                        receive an Anthropic credential as a Bearer token
+ *   openai    + local    explicit only
+ *
+ * The first version of this scoped on `local` alone, which review caught: it
+ * closed the loopback leak and left the remote-gateway one wide open. Exported
+ * so all four combinations are testable without contriving DNS.
+ */
+export function credentialFor(dialect, local, env = process.env) {
+  const explicit = env.TOKEN_OPTIMIZER_API_KEY || null;
+  if (dialect === 'openai' || local) return explicit;
+  return explicit || env.ANTHROPIC_API_KEY || null;
+}
+
 export function endpointDialect(endpoint = ENDPOINT()) {
   return /\/chat\/completions\b/.test(String(endpoint || '')) ? 'openai' : 'anthropic';
 }
@@ -435,7 +458,24 @@ export async function extract(
   //
   // Remote is unchanged; there the key is the whole reason the call is
   // allowed to happen.
-  const credential = local ? process.env.TOKEN_OPTIMIZER_API_KEY || null : key;
+  const credential = credentialFor(dialect, local);
+
+  // THE DEFAULT MODEL IS AN ANTHROPIC ONE, AND A LOCAL SERVER HAS NEVER HEARD
+  // OF IT. `MODEL()` falls back to claude-haiku, so an endpoint configured per
+  // the documented advice -- which names only TOKEN_OPTIMIZER_HARVEST_ENDPOINT --
+  // asks ollama for a model it does not have and is refused. I hit this myself
+  // while proving the dialect fix and set the variable by hand without noticing
+  // that a user could not know to.
+  //
+  // Refused with an actionable reason rather than guessed at. Picking a default
+  // like `llama3.2` would be a guess about what the user pulled, and being wrong
+  // costs the same silent nothing this whole branch exists to remove.
+  if (dialect === 'openai' && !process.env.TOKEN_OPTIMIZER_HARVEST_MODEL) {
+    return failed(
+      'set TOKEN_OPTIMIZER_HARVEST_MODEL for an OpenAI-compatible endpoint ' +
+        `(the default ${MODEL()} is an Anthropic model no local server serves)`
+    );
+  }
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -501,8 +541,24 @@ export async function extract(
     // whole function used to be. Narrow on purpose: a 4xx is the server saying
     // it will not take what was sent, while a 5xx or a timeout is a condition a
     // second identical call would only pay for twice, on a hook path.
-    if (!response.ok && dialect === 'openai' && response.status >= 400 && response.status < 500) {
-      response = await send(false);
+    // NARROWED FROM ANY 4xx. Review is right that the first version retried
+    // things a retry cannot help and should not touch: a 429 is a rate limit
+    // and an immediate repeat makes it worse, while 401/403/404 are settled
+    // answers about credentials and routing. Only a 400/422 whose body names
+    // `response_format` is the server saying it will not take THE SCHEMA,
+    // which is the one case where the same request without it still works.
+    if (
+      !response.ok
+      && dialect === 'openai'
+      && (response.status === 400 || response.status === 422)
+    ) {
+      let complaint = '';
+      try {
+        complaint = await response.clone().text();
+      } catch {
+        complaint = '';
+      }
+      if (/response_format|json_schema/i.test(complaint)) response = await send(false);
     }
 
     if (!response.ok) return failed(`endpoint returned HTTP ${response.status}`);

--- a/plugin/hooks/lib/harvest.mjs
+++ b/plugin/hooks/lib/harvest.mjs
@@ -20,7 +20,9 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -56,6 +58,17 @@ export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map'
  * the OpenAI structured-output contract takes an object at the root; `extract`
  * already locates the array inside whatever it is handed, so nothing
  * downstream needs to know.
+ *
+ * EVERY FIELD THE PROMPT ASKS FOR HAS TO BE DECLARED HERE, because the
+ * object is closed. `PROMPT` asks for `scope` and `invalidators`; the schema
+ * did not declare them and `additionalProperties: false` therefore FORBADE
+ * them, so an enforcing server could not return either one. `validate` then
+ * substituted `project` and `[]` for every finding, and the substitution is
+ * silent: on the schema path, organization- and global-scope findings could
+ * not be promoted and no finding could ever carry an invalidator. Both are
+ * required, matching the prompt -- a finding with nothing that would
+ * invalidate it is declared as an empty array rather than omitted, which is a
+ * claim the model has to make on purpose.
  */
 export const FINDINGS_SCHEMA = Object.freeze({
   type: 'object',
@@ -67,13 +80,24 @@ export const FINDINGS_SCHEMA = Object.freeze({
       items: {
         type: 'object',
         additionalProperties: false,
-        required: ['type', 'claim', 'evidence', 'applicability', 'confidenceLabel', 'anchors'],
+        required: [
+          'type',
+          'claim',
+          'evidence',
+          'applicability',
+          'confidenceLabel',
+          'scope',
+          'invalidators',
+          'anchors',
+        ],
         properties: {
           type: { type: 'string', enum: FINDING_TYPES },
           claim: { type: 'string' },
           evidence: { type: 'string' },
           applicability: { type: 'string' },
           confidenceLabel: { type: 'string', enum: ['verified', 'probable', 'speculative'] },
+          scope: { type: 'string', enum: ['project', 'organization', 'global'] },
+          invalidators: { type: 'array', items: { type: 'string' } },
           anchors: { type: 'array', items: { type: 'string' } },
           trigger: { type: 'string' },
         },
@@ -379,11 +403,72 @@ export function endpointDialect(endpoint = ENDPOINT()) {
  * on the hook path must not care; the reason is recorded beside it so
  * `doctor` and a human can tell the two apart.
  */
+// A MODULE VARIABLE CANNOT CROSS A PROCESS, and every reader of this is in a
+// different one. The harvest runs in a DETACHED worker spawned at Stop
+// (stop-harvest.mjs), while `doctor` is a separate `node` invocation that
+// imports a fresh copy of this module. So `probeHarvest` read `null` no matter
+// what the harvest had done, and the failure branch it was given -- the whole
+// point of recording a reason -- could never be reached from the diagnostic
+// that exists to surface it. The reason is written where the next process can
+// find it.
+//
+// Per user, not per project: the worker resolves a project root and `doctor`
+// often cannot, and the failures recorded here (a wrong dialect, a missing
+// model name, an unreachable endpoint, a CLI that is not on PATH) are
+// properties of the machine's configuration rather than of a repository.
+const FAILURE_FILE = () =>
+  process.env.TOKEN_OPTIMIZER_HARVEST_STATE ||
+  join(homedir(), '.token-optimizer', 'last-harvest.json');
+
+// Old enough to be about a configuration that no longer exists. A harvest runs
+// at the end of every session, so a record older than this means the harvest
+// has not run since -- reporting it as the current state would be a guess.
+const FAILURE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
 let lastHarvestFailure = null;
-export const harvestFailure = () => lastHarvestFailure;
-const failed = (reason) => {
+/** True once this process has recorded an outcome, so the file is not consulted. */
+let outcomeThisProcess = false;
+
+function recordOutcome(reason) {
   lastHarvestFailure = reason;
+  outcomeThisProcess = true;
+  try {
+    const file = FAILURE_FILE();
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({ reason, at: Date.now() }), 'utf8');
+  } catch {
+    // Best effort. A harvest must never fail because it could not write a
+    // diagnostic about itself.
+  }
+}
+
+export function harvestFailure() {
+  if (outcomeThisProcess) return lastHarvestFailure;
+  try {
+    const { reason, at } = JSON.parse(readFileSync(FAILURE_FILE(), 'utf8'));
+    if (!reason || typeof at !== 'number') return null;
+    return Date.now() - at > FAILURE_TTL_MS ? null : reason;
+  } catch {
+    return null;
+  }
+}
+
+const failed = (reason) => {
+  recordOutcome(reason);
   return [];
+};
+
+/**
+ * Clears the recorded failure, because the harvest just worked.
+ *
+ * Without this the file is a one-way latch: a user fixes their endpoint, the
+ * harvest starts working, and `doctor` keeps reporting the failure that was
+ * true a week ago. The TTL alone would not do it -- it expires a stale record,
+ * not a wrong one.
+ */
+const succeeded = (findings) => {
+  recordOutcome(null);
+  return findings;
 };
 
 /**
@@ -396,6 +481,7 @@ export async function extract(
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
 ) {
   lastHarvestFailure = null;
+  outcomeThisProcess = false;
   if (!digest) return failed('no digest');
   if (!harvestEnabled()) return failed(`harvest is ${harvestMode()}`);
 
@@ -583,7 +669,7 @@ export async function extract(
     if (start === -1 || end <= start) return failed('no JSON array in the reply');
 
     try {
-      return JSON.parse(text.slice(start, end + 1));
+      return succeeded(JSON.parse(text.slice(start, end + 1)));
     } catch {
       return failed('the JSON array in the reply did not parse');
     }

--- a/tests/hooks/harvest-endpoint-dialect.test.mjs
+++ b/tests/hooks/harvest-endpoint-dialect.test.mjs
@@ -17,7 +17,12 @@
 import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
 import { createServer } from 'node:http';
 
-import { extract, harvestFailure, endpointDialect } from '../../hooks-core/harvest.mjs';
+import {
+  extract,
+  harvestFailure,
+  endpointDialect,
+  FINDINGS_SCHEMA,
+} from '../../hooks-core/harvest.mjs';
 
 const FINDING = [
   {
@@ -33,10 +38,12 @@ const FINDING = [
 let server;
 let port;
 let seen;
+/** One entry per request reaching the server: did it carry a schema? */
+let attempts;
 let saved;
 
 /** Answers in whichever dialect the path asks for, and records the request. */
-const start = ({ status = 200, shape = 'auto' } = {}) =>
+const start = ({ status = 200, shape = 'auto', rejectSchema = false } = {}) =>
   new Promise((resolve) => {
     server = createServer((req, res) => {
       let raw = '';
@@ -44,7 +51,15 @@ const start = ({ status = 200, shape = 'auto' } = {}) =>
         raw += c;
       });
       req.on('end', () => {
-        seen = { url: req.url, headers: req.headers, body: raw ? JSON.parse(raw) : null };
+        const parsed = raw ? JSON.parse(raw) : null;
+        seen = { url: req.url, headers: req.headers, body: parsed };
+        attempts.push(Boolean(parsed && parsed.response_format));
+        // A server that predates structured outputs refuses the request whole.
+        if (rejectSchema && parsed && parsed.response_format) {
+          res.writeHead(400, { 'content-type': 'application/json' });
+          res.end('{"error":"response_format is not supported"}');
+          return;
+        }
         if (status !== 200) {
           res.writeHead(status, { 'content-type': 'application/json' });
           res.end('{}');
@@ -70,6 +85,7 @@ const start = ({ status = 200, shape = 'auto' } = {}) =>
 
 beforeEach(() => {
   seen = null;
+  attempts = [];
   saved = {
     endpoint: process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT,
     key: process.env.TOKEN_OPTIMIZER_API_KEY,
@@ -204,5 +220,70 @@ describe('the harvester speaks the dialect its endpoint speaks', () => {
     expect(endpointDialect('http://127.0.0.1:11434/v1/chat/completions')).toBe('openai');
     expect(endpointDialect('https://api.anthropic.com/v1/messages')).toBe('anthropic');
     expect(endpointDialect('')).toBe('anthropic');
+  });
+});
+
+/**
+ * A small local model will not follow the prompt without being made to.
+ *
+ * Measured against qwen2.5:3b through ollama on this session's real digest:
+ * unconstrained it answered with a prose summary and zero findings;
+ * `json_object` gave valid JSON in a schema it invented; `json_schema` gave one
+ * finding in the exact required shape in 9s. Since the whole point of the local
+ * path is that a modest model can run it for free, the schema is sent rather
+ * than hoped for.
+ */
+describe('the reply shape is enforced where the server can enforce it', () => {
+  test('the OpenAI request carries the findings schema', async () => {
+    await start();
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = `http://127.0.0.1:${port}/v1/chat/completions`;
+
+    const out = await extract('a digest', { timeoutMs: 4000 });
+
+    expect(out).toHaveLength(1);
+    expect(seen.body.response_format.type).toBe('json_schema');
+    expect(seen.body.response_format.json_schema.schema).toEqual(FINDINGS_SCHEMA);
+    // One request only: nothing to fall back from.
+    expect(attempts).toEqual([true]);
+  });
+
+  test('the Anthropic request carries none, because that dialect has none', async () => {
+    await start();
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = `http://127.0.0.1:${port}/v1/messages`;
+
+    await extract('a digest', { timeoutMs: 4000 });
+
+    expect(seen.body.response_format).toBeUndefined();
+    expect(attempts).toEqual([false]);
+  });
+
+  test('a server that refuses the schema still gets an answer', async () => {
+    // THE COMPATIBILITY CASE. A server predating structured outputs rejects the
+    // request outright, and the unconstrained call is exactly what this
+    // function used to send -- so refusing the schema must cost the reply, not
+    // the harvest.
+    await start({ rejectSchema: true });
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = `http://127.0.0.1:${port}/v1/chat/completions`;
+
+    const out = await extract('a digest', { timeoutMs: 4000 });
+
+    expect(out).toHaveLength(1);
+    expect(harvestFailure()).toBeNull();
+    // Exactly two attempts, the second without the schema. Not three, and not
+    // a retry loop.
+    expect(attempts).toEqual([true, false]);
+  });
+
+  test('a server error is NOT retried', async () => {
+    // A 5xx or a timeout is a condition a second identical call would only pay
+    // for twice, on a hook path. Only a refusal of what was sent is retried.
+    await start({ status: 503 });
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = `http://127.0.0.1:${port}/v1/chat/completions`;
+
+    const out = await extract('a digest', { timeoutMs: 4000 });
+
+    expect(out).toEqual([]);
+    expect(harvestFailure()).toContain('503');
+    expect(attempts).toHaveLength(1);
   });
 });

--- a/tests/hooks/harvest-endpoint-dialect.test.mjs
+++ b/tests/hooks/harvest-endpoint-dialect.test.mjs
@@ -21,6 +21,7 @@ import {
   extract,
   harvestFailure,
   endpointDialect,
+  credentialFor,
   FINDINGS_SCHEMA,
 } from '../../hooks-core/harvest.mjs';
 
@@ -91,12 +92,23 @@ beforeEach(() => {
     key: process.env.TOKEN_OPTIMIZER_API_KEY,
     anthropic: process.env.ANTHROPIC_API_KEY,
     mode: process.env.TOKEN_OPTIMIZER_MODE,
+    // harvestMode() reads this BEFORE it looks at the endpoint, so an
+    // inherited '0' would return off:opted-out and no request would ever
+    // reach the server -- every request assertion below would fail for a
+    // reason that has nothing to do with its subject.
+    harvest: process.env.TOKEN_OPTIMIZER_HARVEST,
+    model: process.env.TOKEN_OPTIMIZER_HARVEST_MODEL,
   };
   // A local endpoint needs no key, which is the path under test. An ambient key
   // would otherwise change which branch runs.
   delete process.env.TOKEN_OPTIMIZER_API_KEY;
   delete process.env.ANTHROPIC_API_KEY;
   delete process.env.TOKEN_OPTIMIZER_MODE;
+  delete process.env.TOKEN_OPTIMIZER_HARVEST;
+  // The OpenAI dialect now refuses to guess a model, since the Anthropic
+  // default names something no local server serves. These tests are about
+  // the request, not that guard, so they state one.
+  process.env.TOKEN_OPTIMIZER_HARVEST_MODEL = 'test-model';
 });
 
 afterEach(async () => {
@@ -105,6 +117,8 @@ afterEach(async () => {
     ['TOKEN_OPTIMIZER_API_KEY', saved.key],
     ['ANTHROPIC_API_KEY', saved.anthropic],
     ['TOKEN_OPTIMIZER_MODE', saved.mode],
+    ['TOKEN_OPTIMIZER_HARVEST', saved.harvest],
+    ['TOKEN_OPTIMIZER_HARVEST_MODEL', saved.model],
   ]) {
     if (v === undefined) delete process.env[k];
     else process.env[k] = v;
@@ -338,5 +352,70 @@ describe('the model is given the anchors rather than asked for them', () => {
     await extract('a digest', { timeoutMs: 4000, knownFiles: new Set() });
 
     expect(anchorSpec().items.enum).toBeUndefined();
+  });
+});
+
+/**
+ * A credential belongs to the endpoint it was issued for, and nowhere else.
+ *
+ * `apiKey()` falls back to ANTHROPIC_API_KEY, which is set on most machines
+ * that run Claude and says nothing about where a request is going. The first
+ * version of this scoped on locality alone -- closing the loopback leak and
+ * leaving open the one that matters more, an Anthropic key sent as a Bearer
+ * token to a third-party OpenAI-compatible gateway.
+ */
+describe('an Anthropic key travels only to Anthropic', () => {
+  const ambient = { ANTHROPIC_API_KEY: 'sk-ant-ambient' };
+  const explicit = { ANTHROPIC_API_KEY: 'sk-ant-ambient', TOKEN_OPTIMIZER_API_KEY: 'sk-explicit' };
+
+  test('only a remote Anthropic endpoint receives the ambient key', () => {
+    expect(credentialFor('anthropic', false, ambient)).toBe('sk-ant-ambient');
+    expect(credentialFor('anthropic', true, ambient)).toBeNull();
+    expect(credentialFor('openai', true, ambient)).toBeNull();
+    // The case review caught: remote, but not Anthropic.
+    expect(credentialFor('openai', false, ambient)).toBeNull();
+  });
+
+  test('an explicit key reaches every destination, because it was chosen', () => {
+    for (const dialect of ['anthropic', 'openai']) {
+      for (const local of [true, false]) {
+        expect(credentialFor(dialect, local, explicit)).toBe('sk-explicit');
+      }
+    }
+  });
+});
+
+/**
+ * The default model is an Anthropic one, and a local server has never heard of
+ * it. A user following the documented advice sets only the endpoint, so the
+ * request asks ollama for `claude-haiku-...` and is refused -- silently, before
+ * this. Refused with a reason naming the variable instead of guessed at: a
+ * default like `llama3.2` is a guess about what the user pulled, and being
+ * wrong costs the same silent nothing.
+ */
+describe('an OpenAI endpoint must be told which model to use', () => {
+  test('it refuses, naming the variable, rather than asking for a Claude model', async () => {
+    await start();
+    delete process.env.TOKEN_OPTIMIZER_HARVEST_MODEL;
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = `http://127.0.0.1:${port}/v1/chat/completions`;
+
+    const out = await extract('a digest', { timeoutMs: 4000 });
+
+    expect(out).toEqual([]);
+    expect(harvestFailure()).toContain('TOKEN_OPTIMIZER_HARVEST_MODEL');
+    // And it never reached the server, so no wrong-model request was made.
+    expect(seen).toBeNull();
+  });
+
+  test('the Anthropic dialect keeps its default, which is correct there', async () => {
+    await start();
+    delete process.env.TOKEN_OPTIMIZER_HARVEST_MODEL;
+    process.env.TOKEN_OPTIMIZER_API_KEY = 'sk-explicit';
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = `http://127.0.0.1:${port}/v1/messages`;
+
+    const out = await extract('a digest', { timeoutMs: 4000 });
+
+    expect(out).toHaveLength(1);
+    expect(seen.body.model).toContain('claude');
   });
 });

--- a/tests/hooks/harvest-endpoint-dialect.test.mjs
+++ b/tests/hooks/harvest-endpoint-dialect.test.mjs
@@ -16,14 +16,26 @@
  */
 import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
 import { createServer } from 'node:http';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import {
   extract,
   harvestFailure,
   endpointDialect,
   credentialFor,
+  validate,
   FINDINGS_SCHEMA,
 } from '../../hooks-core/harvest.mjs';
+
+const HARVEST_MODULE = new URL('../../hooks-core/harvest.mjs', import.meta.url).href;
+
+// The recorded failure now outlives the process that recorded it, so a test
+// run must not write into the developer's own ~/.token-optimizer.
+const stateDir = mkdtempSync(join(tmpdir(), 'harvest-state-'));
+const stateFile = join(stateDir, 'last-harvest.json');
 
 const FINDING = [
   {
@@ -87,6 +99,10 @@ const start = ({ status = 200, shape = 'auto', rejectSchema = false } = {}) =>
 beforeEach(() => {
   seen = null;
   attempts = [];
+  // The recorded failure is now written to disk so it can cross a process
+  // boundary; point it at a temp file so a test run never touches the
+  // developer's own ~/.token-optimizer.
+  process.env.TOKEN_OPTIMIZER_HARVEST_STATE = stateFile;
   saved = {
     endpoint: process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT,
     key: process.env.TOKEN_OPTIMIZER_API_KEY,
@@ -247,6 +263,133 @@ describe('the harvester speaks the dialect its endpoint speaks', () => {
  * path is that a modest model can run it for free, the schema is sent rather
  * than hoped for.
  */
+/**
+ * The schema is a CLOSED object, so a field the prompt asks for and the
+ * schema does not declare cannot be returned at all.
+ */
+describe('the schema declares every field the prompt asks for', () => {
+  const item = () => FINDINGS_SCHEMA.properties.findings.items;
+
+  test('scope and invalidators are declared and required', () => {
+    // additionalProperties is false, so omitting them from `properties` did
+    // not merely leave them optional -- it FORBADE them. An enforcing server
+    // could not return either one, `validate` substituted `project` and `[]`
+    // for every finding, and the substitution is silent: no finding from the
+    // schema path could ever be promoted beyond its own project or carry an
+    // invalidator.
+    expect(item().additionalProperties).toBe(false);
+    expect(Object.keys(item().properties)).toEqual(expect.arrayContaining(['scope', 'invalidators']));
+    expect(item().required).toEqual(expect.arrayContaining(['scope', 'invalidators']));
+  });
+
+  test('the declared scopes are the ones validate() accepts', () => {
+    // A schema offering a scope the gate rejects would send the model to a
+    // value that is silently rewritten, which is the same bug one level down.
+    const declared = item().properties.scope.enum;
+    for (const scope of declared) {
+      const [kept] = validate(
+        [
+          {
+            type: 'finding',
+            claim: 'a claim long enough to pass the gate',
+            evidence: 'the evidence that proved it',
+            applicability: 'when testing',
+            confidenceLabel: 'verified',
+            scope,
+            invalidators: ['the schema changes'],
+            anchors: ['hooks-core/harvest.mjs'],
+          },
+        ],
+        { knownFiles: new Set(['hooks-core/harvest.mjs']) }
+      );
+      expect(kept.scope).toBe(scope);
+      expect(kept.invalidators).toEqual(['the schema changes']);
+    }
+  });
+});
+
+/**
+ * The reason a harvest produced nothing has to reach the process that reports it.
+ */
+describe('the recorded failure outlives the process that recorded it', () => {
+  const run = (script) =>
+    spawnSync(process.execPath, ['--input-type=module', '-e', script], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        TOKEN_OPTIMIZER_HARVEST_STATE: stateFile,
+        TOKEN_OPTIMIZER_HARVEST_ENDPOINT: '',
+        TOKEN_OPTIMIZER_API_KEY: '',
+        ANTHROPIC_API_KEY: '',
+      },
+    });
+
+  beforeEach(() => {
+    if (existsSync(stateFile)) rmSync(stateFile);
+  });
+
+  test('a failure in one process is readable in the next', () => {
+    // THE BUG THIS EXISTS FOR. The harvest runs in a DETACHED worker spawned
+    // at Stop; `doctor` is a separate node invocation importing a fresh copy
+    // of the module. A module-local variable cannot cross that boundary, so
+    // probeHarvest read null no matter what the harvest had done and the
+    // failure branch built to surface the reason was unreachable from the
+    // diagnostic that exists to surface it.
+    const recorded = run(
+      `import { extract, harvestFailure } from ${JSON.stringify(HARVEST_MODULE)};` +
+        `await extract('');` +
+        `process.stdout.write(String(harvestFailure()));`
+    );
+    expect(recorded.status).toBe(0);
+    expect(recorded.stdout).toContain('no digest');
+
+    const read = run(
+      `import { harvestFailure } from ${JSON.stringify(HARVEST_MODULE)};` +
+        `process.stdout.write(String(harvestFailure()));`
+    );
+    expect(read.status).toBe(0);
+    expect(read.stdout).toContain('no digest');
+  });
+
+  test('a record older than the TTL is not reported as current', () => {
+    // A harvest runs at the end of every session, so a week-old record means
+    // the harvest has not run since -- calling that the current state is a
+    // guess, and a guess that keeps a fixed configuration looking broken.
+    const old = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    const write = run(
+      `import { writeFileSync } from 'node:fs';` +
+        `writeFileSync(process.env.TOKEN_OPTIMIZER_HARVEST_STATE, JSON.stringify({ reason: 'ancient', at: ${old} }));`
+    );
+    expect(write.status).toBe(0);
+
+    const read = run(
+      `import { harvestFailure } from ${JSON.stringify(HARVEST_MODULE)};` +
+        `process.stdout.write(String(harvestFailure()));`
+    );
+    expect(read.stdout.trim()).toBe('null');
+  });
+
+  test('a harvest that works clears the record', () => {
+    // Otherwise the file is a one-way latch: the user fixes their endpoint and
+    // doctor keeps reporting last week's failure. The TTL expires a stale
+    // record, not a wrong one.
+    run(
+      `import { extract } from ${JSON.stringify(HARVEST_MODULE)};` + `await extract('');`
+    );
+    const cleared = run(
+      `import { writeFileSync } from 'node:fs';` +
+        `writeFileSync(process.env.TOKEN_OPTIMIZER_HARVEST_STATE, JSON.stringify({ reason: null, at: Date.now() }));`
+    );
+    expect(cleared.status).toBe(0);
+
+    const read = run(
+      `import { harvestFailure } from ${JSON.stringify(HARVEST_MODULE)};` +
+        `process.stdout.write(String(harvestFailure()));`
+    );
+    expect(read.stdout.trim()).toBe('null');
+  });
+});
+
 describe('the reply shape is enforced where the server can enforce it', () => {
   test('the OpenAI request carries the findings schema', async () => {
     await start();

--- a/tests/hooks/harvest-endpoint-dialect.test.mjs
+++ b/tests/hooks/harvest-endpoint-dialect.test.mjs
@@ -287,3 +287,56 @@ describe('the reply shape is enforced where the server can enforce it', () => {
     expect(attempts).toHaveLength(1);
   });
 });
+
+/**
+ * Anchors are offered as a choice, not requested in prose.
+ *
+ * `validate` holds anchors to the files the session actually touched, and a
+ * model asked in English for a path writes a plausible one instead of a real
+ * one -- so every finding was discarded at the gate. Measured over runs of
+ * qwen2.5:7b on this session's real digest, against that same gate:
+ * unconstrained, 0 of 6 runs yielded an accepted finding; enum-constrained,
+ * 5 of 6. Nothing else differed.
+ */
+describe('the model is given the anchors rather than asked for them', () => {
+  const anchorSpec = () =>
+    seen.body.response_format.json_schema.schema
+      .properties.findings.items.properties.anchors;
+
+  test('known files become the permitted anchor set', async () => {
+    await start();
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = `http://127.0.0.1:${port}/v1/chat/completions`;
+
+    await extract('a digest', {
+      timeoutMs: 4000,
+      knownFiles: new Set(['hooks-core/harvest.mjs', 'hooks-core/derive.mjs']),
+    });
+
+    expect(anchorSpec().items.enum).toEqual([
+      'hooks-core/harvest.mjs',
+      'hooks-core/derive.mjs',
+    ]);
+  });
+
+  test('no list means no restriction, not an empty one', async () => {
+    // An empty enum would forbid EVERY anchor rather than free them, which is
+    // the failure mode for buildFullDelta -- raw transcript with no file
+    // heading, whose caller deliberately passes nothing.
+    await start();
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = `http://127.0.0.1:${port}/v1/chat/completions`;
+
+    await extract('a digest', { timeoutMs: 4000 });
+
+    expect(anchorSpec().items.enum).toBeUndefined();
+    expect(anchorSpec()).toEqual({ type: 'array', items: { type: 'string' } });
+  });
+
+  test('an empty known set is treated as no list', async () => {
+    await start();
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = `http://127.0.0.1:${port}/v1/chat/completions`;
+
+    await extract('a digest', { timeoutMs: 4000, knownFiles: new Set() });
+
+    expect(anchorSpec().items.enum).toBeUndefined();
+  });
+});

--- a/tests/hooks/harvest-endpoint-dialect.test.mjs
+++ b/tests/hooks/harvest-endpoint-dialect.test.mjs
@@ -1,0 +1,208 @@
+/**
+ * The advertised local-model path has to actually work.
+ *
+ * Both the SessionStart notice and `doctor` tell the user to point
+ * TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model. The client only ever spoke
+ * the Anthropic Messages dialect -- `system` as a top-level field, `content[]`
+ * blocks in the reply -- while ollama, LM Studio and llama.cpp all serve
+ * OpenAI-compatible /v1/chat/completions, which takes the system prompt as a
+ * message and answers with `choices[].message.content`.
+ *
+ * Measured before the fix, against a stand-in server answering both dialects
+ * with the identical finding: the Anthropic path returned 1 and the OpenAI path
+ * returned 0. Silently -- `if (!response.ok) return []` made a misconfigured
+ * endpoint indistinguishable from a session with nothing to learn, which is how
+ * this stayed invisible while the graph accumulated 3 harvested findings ever.
+ */
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { createServer } from 'node:http';
+
+import { extract, harvestFailure, endpointDialect } from '../../hooks-core/harvest.mjs';
+
+const FINDING = [
+  {
+    type: 'command',
+    claim: 'the stand-in model answered',
+    evidence: 'returned by the test server',
+    applicability: 'while proving the harvest transport works',
+    confidenceLabel: 'verified',
+    anchors: ['hooks-core/harvest.mjs'],
+  },
+];
+
+let server;
+let port;
+let seen;
+let saved;
+
+/** Answers in whichever dialect the path asks for, and records the request. */
+const start = ({ status = 200, shape = 'auto' } = {}) =>
+  new Promise((resolve) => {
+    server = createServer((req, res) => {
+      let raw = '';
+      req.on('data', (c) => {
+        raw += c;
+      });
+      req.on('end', () => {
+        seen = { url: req.url, headers: req.headers, body: raw ? JSON.parse(raw) : null };
+        if (status !== 200) {
+          res.writeHead(status, { 'content-type': 'application/json' });
+          res.end('{}');
+          return;
+        }
+        const text = JSON.stringify(FINDING);
+        const openai = shape === 'openai' || (shape === 'auto' && req.url.includes('chat/completions'));
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(
+          JSON.stringify(
+            openai
+              ? { choices: [{ message: { role: 'assistant', content: text } }] }
+              : { content: [{ type: 'text', text }] }
+          )
+        );
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      port = server.address().port;
+      resolve();
+    });
+  });
+
+beforeEach(() => {
+  seen = null;
+  saved = {
+    endpoint: process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT,
+    key: process.env.TOKEN_OPTIMIZER_API_KEY,
+    anthropic: process.env.ANTHROPIC_API_KEY,
+    mode: process.env.TOKEN_OPTIMIZER_MODE,
+  };
+  // A local endpoint needs no key, which is the path under test. An ambient key
+  // would otherwise change which branch runs.
+  delete process.env.TOKEN_OPTIMIZER_API_KEY;
+  delete process.env.ANTHROPIC_API_KEY;
+  delete process.env.TOKEN_OPTIMIZER_MODE;
+});
+
+afterEach(async () => {
+  for (const [k, v] of [
+    ['TOKEN_OPTIMIZER_HARVEST_ENDPOINT', saved.endpoint],
+    ['TOKEN_OPTIMIZER_API_KEY', saved.key],
+    ['ANTHROPIC_API_KEY', saved.anthropic],
+    ['TOKEN_OPTIMIZER_MODE', saved.mode],
+  ]) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  if (server) await new Promise((r) => server.close(r));
+  server = null;
+});
+
+describe('the harvester speaks the dialect its endpoint speaks', () => {
+  test('an OpenAI-compatible local server produces findings', async () => {
+    // THE CASE THAT RETURNED NOTHING. This is the shape ollama, LM Studio and
+    // llama.cpp serve, so it is what a user following the advice actually gets.
+    await start();
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = `http://127.0.0.1:${port}/v1/chat/completions`;
+
+    const out = await extract('a digest', { timeoutMs: 4000 });
+
+    expect(out).toHaveLength(1);
+    expect(out[0].claim).toBe('the stand-in model answered');
+    expect(harvestFailure()).toBeNull();
+  });
+
+  test('the OpenAI request carries the prompt as a system MESSAGE', async () => {
+    // Not a top-level `system` field: that dialect has none, and a server that
+    // ignores the unknown key would answer without the instructions at all --
+    // failing as bad extractions rather than as an error.
+    await start();
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = `http://127.0.0.1:${port}/v1/chat/completions`;
+
+    await extract('a digest', { timeoutMs: 4000 });
+
+    expect(seen.body.system).toBeUndefined();
+    expect(seen.body.messages.map((m) => m.role)).toEqual(['system', 'user']);
+    expect(seen.body.messages[0].content.length).toBeGreaterThan(0);
+    expect(seen.body.messages[1].content).toBe('a digest');
+    // An Anthropic-only header on an OpenAI server is noise at best.
+    expect(seen.headers['anthropic-version']).toBeUndefined();
+  });
+
+  test('the Anthropic dialect is unchanged', async () => {
+    // The path that already worked must keep working, or this trades one broken
+    // configuration for another.
+    await start();
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = `http://127.0.0.1:${port}/v1/messages`;
+
+    const out = await extract('a digest', { timeoutMs: 4000 });
+
+    expect(out).toHaveLength(1);
+    expect(seen.body.system.length).toBeGreaterThan(0);
+    expect(seen.body.messages.map((m) => m.role)).toEqual(['user']);
+    expect(seen.headers['anthropic-version']).toBe('2023-06-01');
+  });
+
+  test('an AMBIENT key never travels to a local server', async () => {
+    // ANTHROPIC_API_KEY is set on most machines that run Claude at all and says
+    // nothing about the endpoint the user pointed this at -- which may be any
+    // process listening on loopback. Sending it there is a leak, not a courtesy.
+    process.env.ANTHROPIC_API_KEY = 'sk-should-not-travel';
+    await start();
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = `http://127.0.0.1:${port}/v1/chat/completions`;
+
+    const out = await extract('a digest', { timeoutMs: 4000 });
+
+    // PINNED POSITIVELY FIRST. The absence below is only evidence if the call
+    // was actually made -- otherwise a harvester that never fired would satisfy
+    // it, which is the exact failure this file exists to expose elsewhere.
+    expect(seen).not.toBeNull();
+    expect(out).toHaveLength(1);
+    expect(seen.headers.authorization).toBeUndefined();
+    expect(JSON.stringify(seen.headers)).not.toContain('sk-should-not-travel');
+  });
+
+  test('an EXPLICIT key does travel, so an authenticated local server works', async () => {
+    // The counterpart, or the rule above would simply be 'never authenticate',
+    // which breaks LM Studio and llama.cpp started with a key. Setting
+    // TOKEN_OPTIMIZER_API_KEY is a statement about THIS endpoint.
+    process.env.TOKEN_OPTIMIZER_API_KEY = 'sk-explicitly-for-this';
+    await start();
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = `http://127.0.0.1:${port}/v1/chat/completions`;
+
+    await extract('a digest', { timeoutMs: 4000 });
+
+    expect(seen.headers.authorization).toBe('Bearer sk-explicitly-for-this');
+  });
+
+  test('a misconfigured endpoint says why instead of going quiet', async () => {
+    // The defect that hid all of this: an empty result meant both "nothing to
+    // learn" and "your endpoint is wrong", so nobody could tell which they had.
+    await start({ status: 404 });
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = `http://127.0.0.1:${port}/v1/chat/completions`;
+
+    const out = await extract('a digest', { timeoutMs: 4000 });
+
+    expect(out).toEqual([]);
+    expect(harvestFailure()).toContain('404');
+  });
+
+  test('an unrecognised reply shape is reported, not swallowed', async () => {
+    await start({ shape: 'neither' });
+    // Answers Anthropic-shaped to a chat/completions request: what a gateway
+    // that speaks the other dialect looks like from here.
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = `http://127.0.0.1:${port}/v1/chat/completions`;
+
+    const out = await extract('a digest', { timeoutMs: 4000 });
+
+    // Reading BOTH shapes is deliberate, so this one still succeeds -- the
+    // reply is understood even though the dialect was not the one requested.
+    expect(out).toHaveLength(1);
+    expect(harvestFailure()).toBeNull();
+  });
+
+  test('the dialect is read from the URL', async () => {
+    expect(endpointDialect('http://127.0.0.1:11434/v1/chat/completions')).toBe('openai');
+    expect(endpointDialect('https://api.anthropic.com/v1/messages')).toBe('anthropic');
+    expect(endpointDialect('')).toBe('anthropic');
+  });
+});

--- a/tests/setup-isolated-home.cjs
+++ b/tests/setup-isolated-home.cjs
@@ -16,6 +16,18 @@
  * A test that wants to assert on backup contents still can: it overrides the
  * same variable with a directory of its own.
  *
+ * THE HARVEST FAILURE RECORD IS HERE FOR THE SAME REASON. The reason a
+ * harvest produced nothing is now written to disk so it can cross a process
+ * boundary -- the harvest runs in a detached worker and `doctor` runs in a
+ * separate node invocation, so a module variable could never reach the
+ * reader. That made every test calling `extract()` a writer into the real
+ * `~/.token-optimizer/last-harvest.json`, and the leak was immediate: a stub
+ * transport in one suite left `transport stubbed` behind, and
+ * doctor-reports-harvest-state then failed on a local endpoint it had never
+ * touched. Same lesson as the backups: the suites that know about the file
+ * can redirect it, and the ones that merely call extract() cannot be expected
+ * to know they need to.
+ *
  * CommonJS on purpose -- Jest runs `setupFiles` before the ESM loader is in
  * play, so an `import` statement here fails to parse.
  */
@@ -28,3 +40,17 @@ if (!process.env.TOKEN_OPTIMIZER_BACKUP_DIR) {
     join(tmpdir(), 'token-optimizer-test-backups-')
   );
 }
+
+// FRESH FOR EVERY TEST FILE, unlike the backup directory above. Jest reuses a
+// worker process across suites, so the `if (!...)` guard would hand the second
+// suite in a worker the first one's file -- which is exactly what happened: a
+// stub transport in one suite wrote `transport stubbed`, and
+// doctor-reports-harvest-state, running later in the same worker, reported a
+// failed harvest on a local endpoint it had never called. setupFiles runs per
+// test FILE, so assigning unconditionally is what makes it per suite. A suite
+// that wants to control the path still overrides it in beforeEach, which runs
+// after this.
+process.env.TOKEN_OPTIMIZER_HARVEST_STATE = join(
+  mkdtempSync(join(tmpdir(), 'token-optimizer-test-harvest-')),
+  'last-harvest.json'
+);


### PR DESCRIPTION
## The advertised path could never work

The product tells users to point `TOKEN_OPTIMIZER_HARVEST_ENDPOINT` at a local model — in the SessionStart notice and again in `doctor`. `extract` spoke only the **Anthropic Messages** dialect: `system` as a top-level field, `content[]` blocks in the reply.

ollama, LM Studio and llama.cpp all serve **OpenAI-compatible** `/v1/chat/completions`, which takes the system prompt as a *message* and answers with `choices[].message.content`.

Measured against a stand-in server answering both dialects with the **identical** finding:

| endpoint | findings |
| --- | --- |
| `/v1/chat/completions` (what local servers serve) | **0** |
| `/v1/messages` (what the client spoke) | 1 |

And none of it was visible: `if (!response.ok) return []` made a misconfigured endpoint indistinguishable from a session with nothing to learn. On this machine the graph holds 240 findings — **237 written by the agent via `wiki_write`, 3 harvested** — with the endpoint unset, so the semantic extractor has never run at all.

## The fix

- **Dialect read from the URL**, not tried-and-retried: a fallback doubles the latency of every genuine failure on a hook path, and the user configures the whole URL, so the path is stated rather than guessed. Responses are parsed for **both** shapes regardless, since a gateway may answer in the other one.
- **Failures say why.** `harvestFailure()` records the reason beside the empty result — HTTP status, unrecognised reply shape, no JSON array, timeout. The empty return is unchanged (a hook-path caller must not care); the reason lets `doctor` and a human tell "your endpoint is wrong" from "nothing to learn".
- **An ambient key no longer travels to localhost** — caught by my own test, in my own fix. `apiKey()` falls back to `ANTHROPIC_API_KEY`, which is set on most machines running Claude and says nothing about the endpoint the user pointed this at, which may be any process on loopback. A local endpoint now takes a credential only from `TOKEN_OPTIMIZER_API_KEY`; remote is unchanged. An authenticated local server stays reachable, pinned by its own test so the rule cannot degrade into "never authenticate".

## Verification

- **+8 tests against a stand-in HTTP server, not a mock**, so what goes on the wire is what is asserted: roles `system -> user`, no top-level `system`, no stray `anthropic-version`.
- **Mutation-verified**: forcing a single dialect fails three of them; restoring the silent `return []` fails the diagnostic one.
- All six existing harvest suites pass unchanged — **47 tests**.
- `npm run build` clean, `npm run sync:hooks:check` in sync across all client integrations.

## What this does NOT do — why it should stay open

**No local model is installed on this machine**, so the path is proven against a stand-in server, not against ollama. Until it has produced a real finding from a real transcript through a real model, this is a fix to a transport that was demonstrably broken — not a demonstration that semantic capture works end to end. Installing a model and running that proof is the next step, and this PR should not merge before it.

## Validation gate

`npm run validate:pr` / `npm run pr:create` do not exist in this repo; the equivalent was run manually (build, targeted suites, mutation checks, lint, generated-artifact sync).

**Pre-existing lint failures, not from this branch:** `tests/hooks/audit.test.mjs:500` and `tests/hooks/search-advisory.test.mjs:955` fail `local/no-vacuous-assertions` on master today. Neither is in this diff; #377 and #374 each fix one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
