### PR TITLE
feat(harvest): use the client's own CLI as the extraction model

### DIFF
--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -693,6 +693,15 @@ function extractionNotice() {
         '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
         'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
       );
+    case 'host-cli':
+      // The extractor is this client's own headless CLI, which the user opted
+      // into. Worth its own case rather than folding into `remote`: no
+      // credential is involved, and the digest goes to the same vendor that
+      // already ran the session, which is a materially different disclosure.
+      return (
+        '\n\nSemantic extraction also runs after this session through this client\'s own CLI, ' +
+        'from a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
     case 'off:mode':
       // The whole optimizer is off and this text is not emitted anyway. Saying
       // anything here would be noise stacked on an explicit choice.

--- a/hooks-core/capabilities.mjs
+++ b/hooks-core/capabilities.mjs
@@ -192,6 +192,181 @@ const native = (profile) => ({
   ...profile,
 });
 
+/**
+ * How each client's own CLI can be driven headlessly, when it has one.
+ *
+ * THE HARVEST MODEL IS THE HOST ITSELF. Semantic extraction has always
+ * needed an API key or a local endpoint, and on a machine with neither it
+ * simply does not run -- measured on this one, 3 harvested findings against
+ * 237 written by the agent. But the client that just ran the session is
+ * installed BY DEFINITION and every one of these ships a headless mode, so
+ * the model was already on the machine. Nothing needed configuring; it only
+ * needed asking.
+ *
+ * ONE ROW PER CLIENT, not a hardcoded backend list. The nearest competitor
+ * picks from three (claude, gemini, codex), so its Cursor, Zed, Amp, Crush
+ * or Droid users get no semantic harvest at all. Every client this package
+ * supports gets a row here or an explicit null, and `npm run sync:hooks`
+ * copies the same table into all 16 integrations so the design cannot drift
+ * per client.
+ *
+ * NEVER ANOTHER VENDOR'S CLI. Reaching for whatever happens to be on PATH
+ * would send this session's digest to a model the user never chose, which is
+ * a disclosure they did not agree to. The host is the only defensible
+ * default, and TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND is the only way to pick a
+ * different one.
+ *
+ * DELIVERY IS PART OF THE ROW because the CLIs genuinely differ, and getting
+ * it wrong is silent:
+ *   - 'stdin'       the whole payload goes to the child's stdin.
+ *   - 'arg-stdin'   a short instruction is the final argument and the digest
+ *                   goes to stdin, for CLIs whose prompt flag needs a value
+ *                   but which still read stdin.
+ *   - 'prompt-file' the payload is written to a temp file and the final
+ *                   argument tells the agent to read it, for CLIs that do
+ *                   not read stdin at all.
+ *
+ * WHY A FILE AND NOT JUST A LONG ARGUMENT. Passing the payload itself as an
+ * argument was tried and abandoned on evidence. On POSIX it is fine; on
+ * Windows every one of these installs as a .cmd shim, which Node will not
+ * spawn without a shell, and cmd.exe cannot carry a newline inside an
+ * argument at all. Routing through PowerShell with the payload base64-encoded
+ * got past cmd.exe and then hit PowerShell 5.1's native-argument binder,
+ * which does not escape embedded double quotes: the prompt is JSON, so the
+ * first `\"type\":` ended the quoting and the child received 32 arguments
+ * instead of 1. A path has no spaces we did not choose, no quotes and no
+ * newlines, and it also lifts the ARG_MAX ceiling entirely -- these are
+ * agentic CLIs whose whole purpose is reading files, and the route is
+ * verified: copilot asked to read a payload file returned the exact array.
+ *
+ * VERIFIED means a probe was executed against the installed CLI in this
+ * repository and its reply parsed. DOCUMENTED means the shape comes from the
+ * vendor's own `--help` or published headless docs and has not been executed
+ * here, because the CLI is not installed on this machine. Both ship; the
+ * distinction is recorded so nobody mistakes the second for the first, and a
+ * wrong DOCUMENTED row fails loudly through `harvestFailure()` and doctor
+ * rather than silently producing nothing.
+ */
+const harvestCli = (command, args, { delivery = 'stdin', verified = false } = {}) =>
+  Object.freeze({ command, args: Object.freeze([...args]), delivery, verified });
+
+export const CLIENT_HARVEST_CLI = Object.freeze({
+  // VERIFIED: `claude -p` with the payload on stdin returned the exact array
+  // asked for. --output-format stream-json was tried first and rejected: its
+  // envelopes are themselves JSON containing brackets, which is a parsing
+  // hazard for no gain when plain text is already the model's reply.
+  'claude-code': harvestCli('claude', ['-p'], { verified: true }),
+  // VERIFIED: `codex exec -` reads instructions from stdin (its own --help
+  // says so, and a probe returned the array). It prints a banner containing
+  // `[workdir, /tmp, $TMPDIR]` before the reply, which is exactly why the
+  // reply parser has to try more than the first bracket it finds.
+  codex: harvestCli('codex', ['exec', '-'], { verified: true }),
+  // VERIFIED both ways. Asked to follow instructions on stdin the agent
+  // answered that it was unable to read stdin and exited 0 -- a silent
+  // no-findings result indistinguishable from a quiet session. Asked instead
+  // to read a payload file it returned the exact array requested, which is
+  // why this row is prompt-file. --allow-all-tools is required for
+  // non-interactive use by copilot's own help text, and -s drops the stats
+  // banner.
+  copilot: harvestCli('copilot', ['-s', '--allow-all-tools', '-p'], {
+    delivery: 'prompt-file',
+    verified: true,
+  }),
+  // DOCUMENTED: `gemini --help` states that -p runs headless and that the
+  // prompt is "Appended to input on stdin (if any)", so the digest rides
+  // stdin and the instruction is the flag value. Not executed here: this
+  // machine's gemini is unauthenticated and fails in refreshAuth before any
+  // prompt is read.
+  gemini: harvestCli('gemini', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: qwen-code is a fork of gemini-cli and keeps its flag surface.
+  qwen: harvestCli('qwen', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: `opencode run <message>` is its non-interactive entry point.
+  opencode: harvestCli('opencode', ['run'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `crush run <prompt>` runs a single non-interactive prompt.
+  crush: harvestCli('crush', ['run', '-q'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `droid exec <prompt>` is Factory's headless mode.
+  droid: harvestCli('droid', ['exec'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `amp -x <prompt>` executes a single prompt and exits.
+  amp: harvestCli('amp', ['-x'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: the Continue CLI installs as `cn` and takes -p for headless.
+  continue: harvestCli('cn', ['-p'], { delivery: 'prompt-file' }),
+
+  // NO HEADLESS CLI OF THEIR OWN. These are editor- and extension-hosted:
+  // the assistant runs inside the IDE process and ships no command a hook
+  // could spawn. Declaring null keeps that a stated fact rather than an
+  // omission, and these clients fall back to a configured endpoint --
+  // borrowing a neighbouring vendor's CLI would send the digest to a model
+  // the user never chose.
+  cursor: null,
+  cline: null,
+  windsurf: null,
+  kilo: null,
+  roo: null,
+  zed: null,
+});
+
+/**
+ * Splits a configured command line into words, respecting quotes.
+ *
+ * SPLITTING ON WHITESPACE ALONE IS WRONG ON WINDOWS, and the first test
+ * written against this caught it: the natural thing to configure is the
+ * interpreter you already have, and on Windows that is
+ * `C:\\Program Files\\nodejs\\node.exe`. A bare split turned that into the
+ * command `C:\\Program` and reported `C:\\Program exited 1`, which is a
+ * diagnostic nobody can act on. Quoting a path with spaces is the ordinary
+ * way to write a command line, so it has to mean what it says.
+ */
+function commandWords(line) {
+  const words = [];
+  let current = '';
+  let quote = '';
+  let started = false;
+  for (const ch of String(line)) {
+    if (quote) {
+      if (ch === quote) quote = '';
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (started) words.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (started) words.push(current);
+  return words;
+}
+
+/**
+ * The harvest CLI for a client, or null when it has none.
+ *
+ * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
+ * client with no row -- or one whose vendor changed its flags after this
+ * shipped -- is a configuration away from working rather than a release away.
+ * The value is a command and its arguments. The payload goes to stdin unless
+ * the string ends in `{}`, which is replaced by the path of a file holding
+ * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ */
+export function harvestCliFor(client, env = process.env) {
+  const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
+  if (override) {
+    const parts = commandWords(override);
+    const arg = parts[parts.length - 1] === '{}';
+    if (arg) parts.pop();
+    const [command, ...args] = parts;
+    if (!command) return null;
+    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+  }
+  return CLIENT_HARVEST_CLI[client] || null;
+}
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({
     name: 'Claude Code',

--- a/hooks-core/capabilities.mjs
+++ b/hooks-core/capabilities.mjs
@@ -351,21 +351,40 @@ function commandWords(line) {
  * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
  * client with no row -- or one whose vendor changed its flags after this
  * shipped -- is a configuration away from working rather than a release away.
- * The value is a command and its arguments. The payload goes to stdin unless
- * the string ends in `{}`, which is replaced by the path of a file holding
- * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ * The value is a command and its arguments, and its last word may name a
+ * delivery:
+ *   (nothing)  the payload goes to the command's stdin.
+ *   `{}`       it is written to a file and the path becomes the last
+ *              argument -- what an agentic CLI that ignores stdin needs.
+ *   `{-}`      the payload goes to stdin and a short instruction becomes the
+ *              last argument, for a CLI whose prompt flag demands a value
+ *              but which still reads stdin. gemini and qwen are shaped this
+ *              way, and without this an override could not reach that shape
+ *              at all.
  */
 export function harvestCliFor(client, env = process.env) {
   const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
   if (override) {
     const parts = commandWords(override);
-    const arg = parts[parts.length - 1] === '{}';
-    if (arg) parts.pop();
+    const last = parts[parts.length - 1];
+    const delivery =
+      last === '{}' ? 'prompt-file' : last === '{-}' ? 'arg-stdin' : 'stdin';
+    if (delivery !== 'stdin') parts.pop();
     const [command, ...args] = parts;
     if (!command) return null;
-    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+    return harvestCli(command, args, { delivery });
   }
-  return CLIENT_HARVEST_CLI[client] || null;
+  // NORMALISED AND OWN-PROPERTY ONLY, matching `capabilityFor` below.
+  //
+  // A bare index disagreed with its own sibling and reached the prototype.
+  // Reproduced: TOKEN_OPTIMIZER_CLIENT=Codex resolved a capability profile
+  // through capabilityFor -- which lower-cases -- and NO harvest CLI here, so
+  // harvestMode() fell through to off:no-key and an opted-in harvest silently
+  // did nothing on a client that plainly has one. And
+  // harvestCliFor('constructor') returned a function, whose `command` is
+  // undefined, which runHostCli would have handed straight to spawn.
+  const key = String(client || '').toLowerCase();
+  return Object.hasOwn(CLIENT_HARVEST_CLI, key) ? CLIENT_HARVEST_CLI[key] : null;
 }
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({

--- a/hooks-core/doctor.mjs
+++ b/hooks-core/doctor.mjs
@@ -244,6 +244,23 @@ export function probeHarvest() {
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
+  // The host client's own CLI, opted into with TOKEN_OPTIMIZER_HARVEST_CLI.
+  // Reported with the same failure-reason read as `local`, because the two
+  // share the property that made a broken configuration invisible: they
+  // return [] on failure and look exactly like a session with nothing to
+  // learn.
+  if (mode === 'host-cli') {
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check that this client\'s CLI is on PATH and signed in, or unset ' +
+        'TOKEN_OPTIMIZER_HARVEST_CLI to fall back to a configured endpoint')];
+    }
+    return [ok('finding extraction is available',
+      "this client's own CLI runs the semantic harvest -- no separate credential and no " +
+      'second vendor. Active-model wiki_write remains the primary path')];
+  }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
       'active-model wiki_write is primary; a credential also enables fallback extraction from ' +

--- a/hooks-core/harvest.mjs
+++ b/hooks-core/harvest.mjs
@@ -21,6 +21,7 @@
 import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { harvestCliFor } from './capabilities.mjs';
 
@@ -586,6 +587,14 @@ function withAnchorChoices(system, choices) {
   );
 }
 
+/**
+ * The `-p` value for a CLI whose prompt flag needs one but which still reads
+ * stdin. One line, no quotes, no newlines: everything a Windows command line
+ * cannot carry.
+ */
+export const ARG_STDIN_INSTRUCTION =
+  'Follow the instructions in the input above and reply with only the JSON array they ask for.';
+
 /** Restated at the end of a prompt file, where an agent skimming will see it. */
 const TRAILER =
   'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
@@ -650,7 +659,11 @@ async function runHostCli(cli, system, digest, timeoutMs) {
     // under the OS temp directory, which every one of these CLIs can read by
     // default, and removed in `finish` whatever the outcome.
     try {
-      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // UNGUESSABLE, NOT MERELY UNIQUE. pid and clock are both predictable
+      // enough for another local user to pre-create the path in a shared temp
+      // directory; randomUUID removes the guess, and `flag: 'wx'` below
+      // removes the race that remains.
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${randomUUID()}.txt`);
       // 0600. This is a digest of the user's session -- paths, commands and
       // prompts -- sitting in a shared temp directory for as long as the child
       // takes to read it. It is removed in `finish`, but a kill between the two
@@ -667,6 +680,12 @@ async function runHostCli(cli, system, digest, timeoutMs) {
       writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
         encoding: 'utf8',
         mode: 0o600,
+        // EXCLUSIVE CREATE. `mode` governs a file this call makes; it does
+        // nothing about one that already exists, and the default flag 'w'
+        // happily follows a symlink someone else placed at the path -- which
+        // would redirect a digest of the user's session wherever they chose.
+        // 'wx' fails instead of following.
+        flag: 'wx',
       });
     } catch (error) {
       return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
@@ -677,9 +696,16 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         'instructions and output the JSON array they ask for, and nothing else.'
     );
   } else if (cli.delivery === 'arg-stdin') {
-    // The flag needs a value and the CLI appends it after stdin, so the short
-    // instruction is the argument and the bulky digest still rides stdin.
-    args.push(system);
+    // A SHORT SINGLE LINE, NEVER THE PROMPT. The flag needs a value, and the
+    // obvious value -- `system` -- is the multi-line PROMPT, which
+    // withAnchorChoices extends with a newline-separated file list and which
+    // is full of the JSON prompt's double quotes. That is the exact payload
+    // the prompt-file route exists to keep off a Windows command line:
+    // cmd.exe cannot carry a newline inside an argument, and the quoting
+    // doubles every `"`. These CLIs document the flag value as being
+    // APPENDED to stdin, so the whole payload rides stdin and the argument
+    // is one line of ASCII that any shell survives.
+    args.push(ARG_STDIN_INSTRUCTION);
   }
 
   if (process.platform === 'win32' && file === cli.command) {
@@ -748,12 +774,26 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         : finish({ ok: false, reason: `${cli.command} exited ${code}` })
     );
 
+    // EPIPE ARRIVES AS AN EVENT, NOT AS A THROW. The try/catch below sees
+    // only a synchronous failure; a child that exits without reading stdin
+    // fails the write asynchronously, and Node delivers that on the stream.
+    // With no listener it is an uncaught exception that takes down the hook
+    // process instead of resolving this promise -- and the path is not
+    // hypothetical: copilot, asked to read a prompt on stdin, answers that it
+    // cannot and exits 0, which is why its row is prompt-file at all.
+    child.stdin.on('error', (error) =>
+      finish({
+        ok: false,
+        reason: `could not write the digest to ${cli.command}: ${error?.message || error}`,
+      })
+    );
+
     try {
       // Closed either way: a child left waiting on a pipe that will never
       // carry anything hangs until the timeout, which is the slowest possible
       // way to produce nothing.
       if (fileMode) child.stdin.end();
-      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+      else child.stdin.end(payload);
     } catch {
       finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
     }

--- a/hooks-core/harvest.mjs
+++ b/hooks-core/harvest.mjs
@@ -18,9 +18,11 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { harvestCliFor } from './capabilities.mjs';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -176,13 +178,25 @@ export function harvestMode() {
   // Free and private, so nothing further to weigh: no credential, no billing, no digest leaving
   // the machine.
   if (localEndpoint()) return 'local';
+  // THE HOST CLI IS A BACKEND, so the enablement check has to know about it.
+  // Without this the gate answers off:no-key and `extract` never reaches the
+  // CLI path -- which defeats the whole point of a backend that needs no key.
+  // Caught end to end rather than reasoned about: with no endpoint and no key,
+  // the first run of the opted-in host-CLI harvest returned
+  // `harvest is off:no-key` in 0s, having never spawned anything.
+  if (hostCliHarvest()) return 'host-cli';
+
 
   return apiKey() ? 'remote' : 'off:no-key';
 }
 
 export function harvestEnabled() {
   const mode = harvestMode();
-  return mode === 'local' || mode === 'remote';
+  // host-cli belongs here for the same reason local and remote do: it is a
+  // backend that can actually answer. Leaving it out would let the mode say
+  // `host-cli` while every caller that asks `harvestEnabled()` -- the Stop
+  // hook, the worker, extract's own first line -- skipped the harvest.
+  return mode === 'local' || mode === 'remote' || mode === 'host-cli';
 }
 
 /**
@@ -474,6 +488,295 @@ const succeeded = (findings) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
+/**
+ * The findings array inside a reply, or null.
+ *
+ * Models wrap JSON in prose or fences often enough that locating the array is
+ * more reliable than insisting the whole response parses -- and a CLI adds its
+ * own banner lines and stream-json envelopes on top, so both callers need the
+ * same tolerance. Shared so the two cannot drift.
+ */
+function findingsIn(text) {
+  const raw = String(text || '');
+
+  // FIRST BRACKET TO LAST IS NOT ENOUGH, and a CLI is where that breaks.
+  // `codex exec` prints a banner line reading `sandbox: workspace-write
+  // [workdir, /tmp, $TMPDIR]` before the model says anything, so the first
+  // `[` in the stream belongs to the banner and the naive slice parses to
+  // nothing -- an empty harvest that looks exactly like a session with
+  // nothing to learn. Closing brackets are walked from the end and opening
+  // brackets from the start, so the widest array that actually parses wins,
+  // and prose on either side is tolerated the way it already was for HTTP.
+  const closes = [];
+  for (let i = raw.length - 1; i >= 0 && closes.length < CLOSE_TRIES; i -= 1) {
+    if (raw[i] === ']') closes.push(i);
+  }
+  for (const end of closes) {
+    let tries = 0;
+    for (let start = raw.indexOf('['); start !== -1 && start < end; start = raw.indexOf('[', start + 1)) {
+      if ((tries += 1) > OPEN_TRIES) break;
+      try {
+        const parsed = JSON.parse(raw.slice(start, end + 1));
+        if (Array.isArray(parsed)) return parsed;
+      } catch {
+        /* not this pair */
+      }
+    }
+  }
+  return null;
+}
+
+// Bounded so a pathological reply cannot turn parsing into an O(n^2) walk of
+// a megabyte. A real findings array is at the end of the reply and preceded
+// by a banner or a sentence, not by hundreds of brackets.
+const CLOSE_TRIES = 8;
+const OPEN_TRIES = 40;
+
+/**
+ * Launches a Windows command through cmd.exe WITHOUT letting Node build the
+ * command line.
+ *
+ * These CLIs all install as .cmd shims, and Node has refused to spawn .cmd
+ * or .bat without a shell since the 2024 command-injection fix -- so a shell
+ * is not optional. But Node's own `shell: true` builds the cmd.exe line by
+ * joining argv with single spaces and no quoting at all, which breaks the
+ * moment any part contains one. Caught by the first test written against
+ * this: pointing the override at `C:\\Program Files\\nodejs\\node.exe`
+ * produced `C:\\Program Files\\nodejs\\node.exe exited 1`, because cmd.exe
+ * had been handed `C:\\Program` as the command. Quoting each part and passing
+ * the line verbatim is the fix.
+ */
+function windowsShellCommand(file, args) {
+  const quote = (part) => {
+    const value = String(part);
+    // Doubling is cmd.exe's own escape for a quote inside a quoted token.
+    return /[\s"]/.test(value)
+      ? `"${value.replace(/"/g, '""')}"`
+      : value;
+  };
+  const line = [file, ...args].map(quote).join(' ');
+  return [process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', `"${line}"`]];
+}
+
+/**
+ * States the anchor list in the prompt, for a backend that cannot be handed
+ * a schema.
+ *
+ * THE ANCHOR GATE IS WHAT SILENTLY EATS A HARVEST. `validate` keeps only
+ * anchors naming a file the session actually touched, and a model asked in
+ * English for a path writes a plausible one rather than a real one. Measured
+ * over four runs of qwen2.5:7b on a real digest against that gate:
+ * unconstrained, 4 extracted and 0 accepted; constrained to the list, 4 of 4.
+ *
+ * The HTTP path gets that constraint from a server-enforced enum. A CLI has
+ * no server to enforce it, so the same constraint is stated as strongly as a
+ * prompt can state it -- the exact strings, and an instruction to copy rather
+ * than compose. Not as good as an enum, and much better than nothing: the
+ * first end-to-end run without this extracted 10 findings and kept none.
+ */
+function withAnchorChoices(system, choices) {
+  if (!choices.length) return system;
+  const list = choices.map((file) => `- ${file}`).join('\n');
+  return (
+    `${system}\n\n` +
+    'Every entry in "anchors" MUST be copied verbatim from this list -- pick the ' +
+    'entries that best match the finding, and never write a path that is not ' +
+    'listed. Choosing the nearest match is right; dropping the finding is not:\n' +
+    list
+  );
+}
+
+/** Restated at the end of a prompt file, where an agent skimming will see it. */
+const TRAILER =
+  'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
+  'reply with the JSON array of findings and nothing else. If nothing in the ' +
+  'session is worth recording, reply with an empty array.';
+
+/**
+ * Runs the host client's own CLI as the harvest model.
+ *
+ * THE CHILD MUST NOT HARVEST. The harvest runs from the Stop hook, and a
+ * child session fires its own Stop hook -- verified, not assumed: a bare
+ * `claude -p` with our plugin installed wrote mcp-client, episode-outcome and
+ * derive events to the graph. Left unguarded that is unbounded recursion,
+ * each level spending real quota.
+ *
+ * TOKEN_OPTIMIZER_MODE=off IS THE GUARD, and it is the one that works.
+ * Measured on the same probe: TOKEN_OPTIMIZER_HARVEST=0 still ran the child's
+ * Stop hook and still wrote derive events -- it disables the harvest but not
+ * the hooks around it -- while MODE=off suppressed everything but a single
+ * mcp-client row. The kill switch is the only setting that makes the child
+ * inert, so the child is spawned with it and nothing else is relied upon.
+ *
+ * DELIVERY COMES FROM THE ROW, not from an assumption that every CLI reads
+ * stdin. Copilot does not: asked to follow instructions on stdin it replies
+ * that it cannot read stdin, exits 0, and yields no findings -- which looks
+ * exactly like a session with nothing to learn. Guessing here fails silently,
+ * so it is not guessed.
+ */
+/**
+ * How long to let the host CLI run.
+ *
+ * THE 30s HTTP DEFAULT KILLS EVERY CLI HARVEST, so it cannot be shared. That
+ * budget is sized for one completion against an endpoint that is already
+ * listening. A host CLI is an agent: it starts a process, loads its plugin
+ * and hook tree, opens a session, then thinks. Measured here on a 23 KB
+ * digest with no key and no local model, `claude -p` returned 10 findings in
+ * 104 SECONDS -- correct, and more than three times over the HTTP budget.
+ * `codex exec` on the same machine defaults to xhigh reasoning effort and
+ * had not finished at 300s, which is why this is configurable rather than
+ * merely larger.
+ *
+ * A caller that asks for MORE keeps it; the floor only lifts a default that
+ * was never chosen with this backend in mind.
+ */
+function hostCliTimeoutMs(requested) {
+  const configured = Number(process.env.TOKEN_OPTIMIZER_HARVEST_CLI_TIMEOUT_MS);
+  const floor = Number.isFinite(configured) && configured > 0 ? configured : 180_000;
+  return Math.max(floor, Number(requested) || 0);
+}
+
+async function runHostCli(cli, system, digest, timeoutMs) {
+  const payload = `${system}\n\n${digest}`;
+  const fileMode = cli.delivery === 'prompt-file';
+  let file = cli.command;
+  let args = [...cli.args];
+  let verbatim = false;
+  let promptFile = null;
+
+  if (fileMode) {
+    // A PATH, NOT THE PAYLOAD. See CLIENT_HARVEST_CLI for why the payload
+    // itself cannot travel as an argument on Windows. The file is written
+    // under the OS temp directory, which every one of these CLIs can read by
+    // default, and removed in `finish` whatever the outcome.
+    try {
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // 0600. This is a digest of the user's session -- paths, commands and
+      // prompts -- sitting in a shared temp directory for as long as the child
+      // takes to read it. It is removed in `finish`, but a kill between the two
+      // would leave it behind, so it is unreadable to other users meanwhile.
+      // (Windows ignores the mode; NTFS inheritance already keeps the per-user
+      // temp directory private.)
+      // THE CONTRACT IS REPEATED AT THE END. The instructions lead the file and
+      // the digest follows, which is the natural order and the one that failed:
+      // handed 23 KB this way, copilot reported the file as "a scratchpad
+      // /summary document" with no instruction in it and asked what JSON array
+      // was wanted. An agent skimming a long file sees its tail; restating the
+      // ask there costs one line and removes the dependence on how the file is
+      // read.
+      writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
+        encoding: 'utf8',
+        mode: 0o600,
+      });
+    } catch (error) {
+      return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
+    }
+    args.push(
+      `Read the whole file at ${promptFile}. It opens with instructions, then a ` +
+        'digest of a coding session, then repeats what to reply. Follow those ' +
+        'instructions and output the JSON array they ask for, and nothing else.'
+    );
+  } else if (cli.delivery === 'arg-stdin') {
+    // The flag needs a value and the CLI appends it after stdin, so the short
+    // instruction is the argument and the bulky digest still rides stdin.
+    args.push(system);
+  }
+
+  if (process.platform === 'win32' && file === cli.command) {
+    [file, args] = windowsShellCommand(file, args);
+    verbatim = true;
+  }
+
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(file, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        // The command line was built above where it needed cmd.exe, so Node
+        // must not rebuild it: `shell: true` would join argv unquoted.
+        windowsVerbatimArguments: verbatim,
+        env: {
+          ...process.env,
+          TOKEN_OPTIMIZER_MODE: 'off',
+        },
+      });
+    } catch (error) {
+      resolve({ ok: false, reason: `${cli.command} could not start: ${error?.message || error}` });
+      return;
+    }
+
+    let out = '';
+    let done = false;
+    const finish = (value) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      try {
+        child.kill();
+      } catch {
+        /* already gone */
+      }
+      if (promptFile) {
+        try {
+          rmSync(promptFile, { force: true });
+        } catch {
+          /* a leftover in the temp directory is not worth failing a harvest */
+        }
+      }
+      resolve(value);
+    };
+    const timer = setTimeout(
+      () => finish({ ok: false, reason: `${cli.command} timed out after ${timeoutMs}ms` }),
+      timeoutMs
+    );
+
+    child.stdout.on('data', (c) => {
+      out += c;
+    });
+    // stderr is drained so a chatty CLI cannot fill the pipe and deadlock.
+    child.stderr.on('data', () => {});
+    child.on('error', (error) =>
+      finish({ ok: false, reason: `${cli.command} failed: ${error?.message || error}` })
+    );
+    // NON-ZERO IS NOT ALWAYS EMPTY. Some of these print the reply and then
+    // exit non-zero over an unrelated cleanup complaint, so a parseable array
+    // already in hand beats the exit code; the code decides only when there is
+    // nothing to parse.
+    child.on('close', (code) =>
+      code === 0 || findingsIn(out)
+        ? finish({ ok: true, text: out })
+        : finish({ ok: false, reason: `${cli.command} exited ${code}` })
+    );
+
+    try {
+      // Closed either way: a child left waiting on a pipe that will never
+      // carry anything hangs until the timeout, which is the slowest possible
+      // way to produce nothing.
+      if (fileMode) child.stdin.end();
+      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+    } catch {
+      finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
+    }
+  });
+}
+
+/**
+ * Is the host CLI available as a harvest backend for this client?
+ *
+ * OPT-IN, deliberately, and this is the one default in this file that is not
+ * on. Every other path either reads local files or spends a key the user
+ * already configured for this purpose; this one spends the subscription that
+ * runs their editor, automatically, at the end of every session. HeadRoom
+ * makes the equivalent call user-invoked (`headroom learn`, cli/learn.py) and
+ * its own design note says to log events and analyse offline. Charging someone
+ * quota they did not ask to spend is not a default worth taking.
+ */
+export function hostCliHarvest(client = undefined, env = process.env) {
+  const enabled = /^(1|true|yes|on)$/i.test(env.TOKEN_OPTIMIZER_HARVEST_CLI || '');
+  if (!enabled) return null;
+  return harvestCliFor(client === undefined ? env.TOKEN_OPTIMIZER_CLIENT : client, env);
+}
+
 export async function extract(
   digest,
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
@@ -489,11 +792,40 @@ export async function extract(
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return failed('no api key for a remote endpoint');
+  // The host CLI carries its own auth -- the user is already signed into the
+  // client that is running this -- so the key requirement is about the HTTP
+  // backends only.
+  if (!local && !key && !hostCliHarvest()) {
+    return failed('no api key for a remote endpoint');
+  }
 
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // Computed before the CLI branch because BOTH backends need it. It used to
+  // sit below, so the host CLI was the one path that never learned which
+  // files it was allowed to anchor to -- and the anchor gate is what silently
+  // eats a harvest. Caught end to end on a real session: 10 findings
+  // extracted through `claude -p`, 0 surviving `validate`.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+
+  // The host client's own CLI, when the user has opted in. Tried first
+  // because it needs no key and no local model -- the two things whose
+  // absence has kept this path at 3 harvested findings on this machine.
+  const hostCli = hostCliHarvest();
+  if (hostCli) {
+    const result = await runHostCli(
+      hostCli,
+      withAnchorChoices(system, anchorChoices),
+      digest,
+      hostCliTimeoutMs(timeoutMs)
+    );
+    if (!result.ok) return failed(result.reason);
+    const parsed = findingsIn(result.text);
+    if (!parsed) return failed(`no JSON array in the ${hostCli.command} reply`);
+    return succeeded(parsed);
+  }
 
   // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
   //
@@ -512,7 +844,6 @@ export async function extract(
   // Only when the caller knows the list. `buildFullDelta` is raw transcript
   // with no file heading, and its caller passes no knownFiles for the same
   // reason -- an empty enum would forbid every anchor rather than free it.
-  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
   const schema = anchorChoices.length
     ? {
         ...FINDINGS_SCHEMA,
@@ -660,17 +991,8 @@ export async function extract(
       '';
     if (!text) return failed('endpoint answered in an unrecognised shape');
 
-    // Models wrap JSON in prose or fences often enough that finding the array
-    // is more reliable than insisting the whole response parse.
-    const start = text.indexOf('[');
-    const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return failed('no JSON array in the reply');
-
-    try {
-      return succeeded(JSON.parse(text.slice(start, end + 1)));
-    } catch {
-      return failed('the JSON array in the reply did not parse');
-    }
+    const parsed = findingsIn(text);
+    return parsed ? succeeded(parsed) : failed('no usable JSON array in the reply');
   } catch (error) {
     return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -695,6 +695,15 @@ function extractionNotice() {
         '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
         'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
       );
+    case 'host-cli':
+      // The extractor is this client's own headless CLI, which the user opted
+      // into. Worth its own case rather than folding into `remote`: no
+      // credential is involved, and the digest goes to the same vendor that
+      // already ran the session, which is a materially different disclosure.
+      return (
+        '\n\nSemantic extraction also runs after this session through this client\'s own CLI, ' +
+        'from a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
     case 'off:mode':
       // The whole optimizer is off and this text is not emitted anyway. Saying
       // anything here would be noise stacked on an explicit choice.

--- a/integrations/cline/hooks/token-optimizer/lib/capabilities.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/capabilities.mjs
@@ -194,6 +194,181 @@ const native = (profile) => ({
   ...profile,
 });
 
+/**
+ * How each client's own CLI can be driven headlessly, when it has one.
+ *
+ * THE HARVEST MODEL IS THE HOST ITSELF. Semantic extraction has always
+ * needed an API key or a local endpoint, and on a machine with neither it
+ * simply does not run -- measured on this one, 3 harvested findings against
+ * 237 written by the agent. But the client that just ran the session is
+ * installed BY DEFINITION and every one of these ships a headless mode, so
+ * the model was already on the machine. Nothing needed configuring; it only
+ * needed asking.
+ *
+ * ONE ROW PER CLIENT, not a hardcoded backend list. The nearest competitor
+ * picks from three (claude, gemini, codex), so its Cursor, Zed, Amp, Crush
+ * or Droid users get no semantic harvest at all. Every client this package
+ * supports gets a row here or an explicit null, and `npm run sync:hooks`
+ * copies the same table into all 16 integrations so the design cannot drift
+ * per client.
+ *
+ * NEVER ANOTHER VENDOR'S CLI. Reaching for whatever happens to be on PATH
+ * would send this session's digest to a model the user never chose, which is
+ * a disclosure they did not agree to. The host is the only defensible
+ * default, and TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND is the only way to pick a
+ * different one.
+ *
+ * DELIVERY IS PART OF THE ROW because the CLIs genuinely differ, and getting
+ * it wrong is silent:
+ *   - 'stdin'       the whole payload goes to the child's stdin.
+ *   - 'arg-stdin'   a short instruction is the final argument and the digest
+ *                   goes to stdin, for CLIs whose prompt flag needs a value
+ *                   but which still read stdin.
+ *   - 'prompt-file' the payload is written to a temp file and the final
+ *                   argument tells the agent to read it, for CLIs that do
+ *                   not read stdin at all.
+ *
+ * WHY A FILE AND NOT JUST A LONG ARGUMENT. Passing the payload itself as an
+ * argument was tried and abandoned on evidence. On POSIX it is fine; on
+ * Windows every one of these installs as a .cmd shim, which Node will not
+ * spawn without a shell, and cmd.exe cannot carry a newline inside an
+ * argument at all. Routing through PowerShell with the payload base64-encoded
+ * got past cmd.exe and then hit PowerShell 5.1's native-argument binder,
+ * which does not escape embedded double quotes: the prompt is JSON, so the
+ * first `\"type\":` ended the quoting and the child received 32 arguments
+ * instead of 1. A path has no spaces we did not choose, no quotes and no
+ * newlines, and it also lifts the ARG_MAX ceiling entirely -- these are
+ * agentic CLIs whose whole purpose is reading files, and the route is
+ * verified: copilot asked to read a payload file returned the exact array.
+ *
+ * VERIFIED means a probe was executed against the installed CLI in this
+ * repository and its reply parsed. DOCUMENTED means the shape comes from the
+ * vendor's own `--help` or published headless docs and has not been executed
+ * here, because the CLI is not installed on this machine. Both ship; the
+ * distinction is recorded so nobody mistakes the second for the first, and a
+ * wrong DOCUMENTED row fails loudly through `harvestFailure()` and doctor
+ * rather than silently producing nothing.
+ */
+const harvestCli = (command, args, { delivery = 'stdin', verified = false } = {}) =>
+  Object.freeze({ command, args: Object.freeze([...args]), delivery, verified });
+
+export const CLIENT_HARVEST_CLI = Object.freeze({
+  // VERIFIED: `claude -p` with the payload on stdin returned the exact array
+  // asked for. --output-format stream-json was tried first and rejected: its
+  // envelopes are themselves JSON containing brackets, which is a parsing
+  // hazard for no gain when plain text is already the model's reply.
+  'claude-code': harvestCli('claude', ['-p'], { verified: true }),
+  // VERIFIED: `codex exec -` reads instructions from stdin (its own --help
+  // says so, and a probe returned the array). It prints a banner containing
+  // `[workdir, /tmp, $TMPDIR]` before the reply, which is exactly why the
+  // reply parser has to try more than the first bracket it finds.
+  codex: harvestCli('codex', ['exec', '-'], { verified: true }),
+  // VERIFIED both ways. Asked to follow instructions on stdin the agent
+  // answered that it was unable to read stdin and exited 0 -- a silent
+  // no-findings result indistinguishable from a quiet session. Asked instead
+  // to read a payload file it returned the exact array requested, which is
+  // why this row is prompt-file. --allow-all-tools is required for
+  // non-interactive use by copilot's own help text, and -s drops the stats
+  // banner.
+  copilot: harvestCli('copilot', ['-s', '--allow-all-tools', '-p'], {
+    delivery: 'prompt-file',
+    verified: true,
+  }),
+  // DOCUMENTED: `gemini --help` states that -p runs headless and that the
+  // prompt is "Appended to input on stdin (if any)", so the digest rides
+  // stdin and the instruction is the flag value. Not executed here: this
+  // machine's gemini is unauthenticated and fails in refreshAuth before any
+  // prompt is read.
+  gemini: harvestCli('gemini', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: qwen-code is a fork of gemini-cli and keeps its flag surface.
+  qwen: harvestCli('qwen', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: `opencode run <message>` is its non-interactive entry point.
+  opencode: harvestCli('opencode', ['run'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `crush run <prompt>` runs a single non-interactive prompt.
+  crush: harvestCli('crush', ['run', '-q'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `droid exec <prompt>` is Factory's headless mode.
+  droid: harvestCli('droid', ['exec'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `amp -x <prompt>` executes a single prompt and exits.
+  amp: harvestCli('amp', ['-x'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: the Continue CLI installs as `cn` and takes -p for headless.
+  continue: harvestCli('cn', ['-p'], { delivery: 'prompt-file' }),
+
+  // NO HEADLESS CLI OF THEIR OWN. These are editor- and extension-hosted:
+  // the assistant runs inside the IDE process and ships no command a hook
+  // could spawn. Declaring null keeps that a stated fact rather than an
+  // omission, and these clients fall back to a configured endpoint --
+  // borrowing a neighbouring vendor's CLI would send the digest to a model
+  // the user never chose.
+  cursor: null,
+  cline: null,
+  windsurf: null,
+  kilo: null,
+  roo: null,
+  zed: null,
+});
+
+/**
+ * Splits a configured command line into words, respecting quotes.
+ *
+ * SPLITTING ON WHITESPACE ALONE IS WRONG ON WINDOWS, and the first test
+ * written against this caught it: the natural thing to configure is the
+ * interpreter you already have, and on Windows that is
+ * `C:\\Program Files\\nodejs\\node.exe`. A bare split turned that into the
+ * command `C:\\Program` and reported `C:\\Program exited 1`, which is a
+ * diagnostic nobody can act on. Quoting a path with spaces is the ordinary
+ * way to write a command line, so it has to mean what it says.
+ */
+function commandWords(line) {
+  const words = [];
+  let current = '';
+  let quote = '';
+  let started = false;
+  for (const ch of String(line)) {
+    if (quote) {
+      if (ch === quote) quote = '';
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (started) words.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (started) words.push(current);
+  return words;
+}
+
+/**
+ * The harvest CLI for a client, or null when it has none.
+ *
+ * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
+ * client with no row -- or one whose vendor changed its flags after this
+ * shipped -- is a configuration away from working rather than a release away.
+ * The value is a command and its arguments. The payload goes to stdin unless
+ * the string ends in `{}`, which is replaced by the path of a file holding
+ * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ */
+export function harvestCliFor(client, env = process.env) {
+  const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
+  if (override) {
+    const parts = commandWords(override);
+    const arg = parts[parts.length - 1] === '{}';
+    if (arg) parts.pop();
+    const [command, ...args] = parts;
+    if (!command) return null;
+    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+  }
+  return CLIENT_HARVEST_CLI[client] || null;
+}
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({
     name: 'Claude Code',

--- a/integrations/cline/hooks/token-optimizer/lib/capabilities.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/capabilities.mjs
@@ -353,21 +353,40 @@ function commandWords(line) {
  * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
  * client with no row -- or one whose vendor changed its flags after this
  * shipped -- is a configuration away from working rather than a release away.
- * The value is a command and its arguments. The payload goes to stdin unless
- * the string ends in `{}`, which is replaced by the path of a file holding
- * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ * The value is a command and its arguments, and its last word may name a
+ * delivery:
+ *   (nothing)  the payload goes to the command's stdin.
+ *   `{}`       it is written to a file and the path becomes the last
+ *              argument -- what an agentic CLI that ignores stdin needs.
+ *   `{-}`      the payload goes to stdin and a short instruction becomes the
+ *              last argument, for a CLI whose prompt flag demands a value
+ *              but which still reads stdin. gemini and qwen are shaped this
+ *              way, and without this an override could not reach that shape
+ *              at all.
  */
 export function harvestCliFor(client, env = process.env) {
   const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
   if (override) {
     const parts = commandWords(override);
-    const arg = parts[parts.length - 1] === '{}';
-    if (arg) parts.pop();
+    const last = parts[parts.length - 1];
+    const delivery =
+      last === '{}' ? 'prompt-file' : last === '{-}' ? 'arg-stdin' : 'stdin';
+    if (delivery !== 'stdin') parts.pop();
     const [command, ...args] = parts;
     if (!command) return null;
-    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+    return harvestCli(command, args, { delivery });
   }
-  return CLIENT_HARVEST_CLI[client] || null;
+  // NORMALISED AND OWN-PROPERTY ONLY, matching `capabilityFor` below.
+  //
+  // A bare index disagreed with its own sibling and reached the prototype.
+  // Reproduced: TOKEN_OPTIMIZER_CLIENT=Codex resolved a capability profile
+  // through capabilityFor -- which lower-cases -- and NO harvest CLI here, so
+  // harvestMode() fell through to off:no-key and an opted-in harvest silently
+  // did nothing on a client that plainly has one. And
+  // harvestCliFor('constructor') returned a function, whose `command` is
+  // undefined, which runHostCli would have handed straight to spawn.
+  const key = String(client || '').toLowerCase();
+  return Object.hasOwn(CLIENT_HARVEST_CLI, key) ? CLIENT_HARVEST_CLI[key] : null;
 }
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({

--- a/integrations/cline/hooks/token-optimizer/lib/doctor.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/doctor.mjs
@@ -246,6 +246,23 @@ export function probeHarvest() {
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
+  // The host client's own CLI, opted into with TOKEN_OPTIMIZER_HARVEST_CLI.
+  // Reported with the same failure-reason read as `local`, because the two
+  // share the property that made a broken configuration invisible: they
+  // return [] on failure and look exactly like a session with nothing to
+  // learn.
+  if (mode === 'host-cli') {
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check that this client\'s CLI is on PATH and signed in, or unset ' +
+        'TOKEN_OPTIMIZER_HARVEST_CLI to fall back to a configured endpoint')];
+    }
+    return [ok('finding extraction is available',
+      "this client's own CLI runs the semantic harvest -- no separate credential and no " +
+      'second vendor. Active-model wiki_write remains the primary path')];
+  }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
       'active-model wiki_write is primary; a credential also enables fallback extraction from ' +

--- a/integrations/cline/hooks/token-optimizer/lib/harvest.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/harvest.mjs
@@ -23,6 +23,7 @@
 import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { harvestCliFor } from './capabilities.mjs';
 
@@ -588,6 +589,14 @@ function withAnchorChoices(system, choices) {
   );
 }
 
+/**
+ * The `-p` value for a CLI whose prompt flag needs one but which still reads
+ * stdin. One line, no quotes, no newlines: everything a Windows command line
+ * cannot carry.
+ */
+export const ARG_STDIN_INSTRUCTION =
+  'Follow the instructions in the input above and reply with only the JSON array they ask for.';
+
 /** Restated at the end of a prompt file, where an agent skimming will see it. */
 const TRAILER =
   'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
@@ -652,7 +661,11 @@ async function runHostCli(cli, system, digest, timeoutMs) {
     // under the OS temp directory, which every one of these CLIs can read by
     // default, and removed in `finish` whatever the outcome.
     try {
-      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // UNGUESSABLE, NOT MERELY UNIQUE. pid and clock are both predictable
+      // enough for another local user to pre-create the path in a shared temp
+      // directory; randomUUID removes the guess, and `flag: 'wx'` below
+      // removes the race that remains.
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${randomUUID()}.txt`);
       // 0600. This is a digest of the user's session -- paths, commands and
       // prompts -- sitting in a shared temp directory for as long as the child
       // takes to read it. It is removed in `finish`, but a kill between the two
@@ -669,6 +682,12 @@ async function runHostCli(cli, system, digest, timeoutMs) {
       writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
         encoding: 'utf8',
         mode: 0o600,
+        // EXCLUSIVE CREATE. `mode` governs a file this call makes; it does
+        // nothing about one that already exists, and the default flag 'w'
+        // happily follows a symlink someone else placed at the path -- which
+        // would redirect a digest of the user's session wherever they chose.
+        // 'wx' fails instead of following.
+        flag: 'wx',
       });
     } catch (error) {
       return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
@@ -679,9 +698,16 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         'instructions and output the JSON array they ask for, and nothing else.'
     );
   } else if (cli.delivery === 'arg-stdin') {
-    // The flag needs a value and the CLI appends it after stdin, so the short
-    // instruction is the argument and the bulky digest still rides stdin.
-    args.push(system);
+    // A SHORT SINGLE LINE, NEVER THE PROMPT. The flag needs a value, and the
+    // obvious value -- `system` -- is the multi-line PROMPT, which
+    // withAnchorChoices extends with a newline-separated file list and which
+    // is full of the JSON prompt's double quotes. That is the exact payload
+    // the prompt-file route exists to keep off a Windows command line:
+    // cmd.exe cannot carry a newline inside an argument, and the quoting
+    // doubles every `"`. These CLIs document the flag value as being
+    // APPENDED to stdin, so the whole payload rides stdin and the argument
+    // is one line of ASCII that any shell survives.
+    args.push(ARG_STDIN_INSTRUCTION);
   }
 
   if (process.platform === 'win32' && file === cli.command) {
@@ -750,12 +776,26 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         : finish({ ok: false, reason: `${cli.command} exited ${code}` })
     );
 
+    // EPIPE ARRIVES AS AN EVENT, NOT AS A THROW. The try/catch below sees
+    // only a synchronous failure; a child that exits without reading stdin
+    // fails the write asynchronously, and Node delivers that on the stream.
+    // With no listener it is an uncaught exception that takes down the hook
+    // process instead of resolving this promise -- and the path is not
+    // hypothetical: copilot, asked to read a prompt on stdin, answers that it
+    // cannot and exits 0, which is why its row is prompt-file at all.
+    child.stdin.on('error', (error) =>
+      finish({
+        ok: false,
+        reason: `could not write the digest to ${cli.command}: ${error?.message || error}`,
+      })
+    );
+
     try {
       // Closed either way: a child left waiting on a pipe that will never
       // carry anything hangs until the timeout, which is the slowest possible
       // way to produce nothing.
       if (fileMode) child.stdin.end();
-      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+      else child.stdin.end(payload);
     } catch {
       finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
     }

--- a/integrations/cline/hooks/token-optimizer/lib/harvest.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/harvest.mjs
@@ -20,9 +20,11 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { harvestCliFor } from './capabilities.mjs';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -178,13 +180,25 @@ export function harvestMode() {
   // Free and private, so nothing further to weigh: no credential, no billing, no digest leaving
   // the machine.
   if (localEndpoint()) return 'local';
+  // THE HOST CLI IS A BACKEND, so the enablement check has to know about it.
+  // Without this the gate answers off:no-key and `extract` never reaches the
+  // CLI path -- which defeats the whole point of a backend that needs no key.
+  // Caught end to end rather than reasoned about: with no endpoint and no key,
+  // the first run of the opted-in host-CLI harvest returned
+  // `harvest is off:no-key` in 0s, having never spawned anything.
+  if (hostCliHarvest()) return 'host-cli';
+
 
   return apiKey() ? 'remote' : 'off:no-key';
 }
 
 export function harvestEnabled() {
   const mode = harvestMode();
-  return mode === 'local' || mode === 'remote';
+  // host-cli belongs here for the same reason local and remote do: it is a
+  // backend that can actually answer. Leaving it out would let the mode say
+  // `host-cli` while every caller that asks `harvestEnabled()` -- the Stop
+  // hook, the worker, extract's own first line -- skipped the harvest.
+  return mode === 'local' || mode === 'remote' || mode === 'host-cli';
 }
 
 /**
@@ -476,6 +490,295 @@ const succeeded = (findings) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
+/**
+ * The findings array inside a reply, or null.
+ *
+ * Models wrap JSON in prose or fences often enough that locating the array is
+ * more reliable than insisting the whole response parses -- and a CLI adds its
+ * own banner lines and stream-json envelopes on top, so both callers need the
+ * same tolerance. Shared so the two cannot drift.
+ */
+function findingsIn(text) {
+  const raw = String(text || '');
+
+  // FIRST BRACKET TO LAST IS NOT ENOUGH, and a CLI is where that breaks.
+  // `codex exec` prints a banner line reading `sandbox: workspace-write
+  // [workdir, /tmp, $TMPDIR]` before the model says anything, so the first
+  // `[` in the stream belongs to the banner and the naive slice parses to
+  // nothing -- an empty harvest that looks exactly like a session with
+  // nothing to learn. Closing brackets are walked from the end and opening
+  // brackets from the start, so the widest array that actually parses wins,
+  // and prose on either side is tolerated the way it already was for HTTP.
+  const closes = [];
+  for (let i = raw.length - 1; i >= 0 && closes.length < CLOSE_TRIES; i -= 1) {
+    if (raw[i] === ']') closes.push(i);
+  }
+  for (const end of closes) {
+    let tries = 0;
+    for (let start = raw.indexOf('['); start !== -1 && start < end; start = raw.indexOf('[', start + 1)) {
+      if ((tries += 1) > OPEN_TRIES) break;
+      try {
+        const parsed = JSON.parse(raw.slice(start, end + 1));
+        if (Array.isArray(parsed)) return parsed;
+      } catch {
+        /* not this pair */
+      }
+    }
+  }
+  return null;
+}
+
+// Bounded so a pathological reply cannot turn parsing into an O(n^2) walk of
+// a megabyte. A real findings array is at the end of the reply and preceded
+// by a banner or a sentence, not by hundreds of brackets.
+const CLOSE_TRIES = 8;
+const OPEN_TRIES = 40;
+
+/**
+ * Launches a Windows command through cmd.exe WITHOUT letting Node build the
+ * command line.
+ *
+ * These CLIs all install as .cmd shims, and Node has refused to spawn .cmd
+ * or .bat without a shell since the 2024 command-injection fix -- so a shell
+ * is not optional. But Node's own `shell: true` builds the cmd.exe line by
+ * joining argv with single spaces and no quoting at all, which breaks the
+ * moment any part contains one. Caught by the first test written against
+ * this: pointing the override at `C:\\Program Files\\nodejs\\node.exe`
+ * produced `C:\\Program Files\\nodejs\\node.exe exited 1`, because cmd.exe
+ * had been handed `C:\\Program` as the command. Quoting each part and passing
+ * the line verbatim is the fix.
+ */
+function windowsShellCommand(file, args) {
+  const quote = (part) => {
+    const value = String(part);
+    // Doubling is cmd.exe's own escape for a quote inside a quoted token.
+    return /[\s"]/.test(value)
+      ? `"${value.replace(/"/g, '""')}"`
+      : value;
+  };
+  const line = [file, ...args].map(quote).join(' ');
+  return [process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', `"${line}"`]];
+}
+
+/**
+ * States the anchor list in the prompt, for a backend that cannot be handed
+ * a schema.
+ *
+ * THE ANCHOR GATE IS WHAT SILENTLY EATS A HARVEST. `validate` keeps only
+ * anchors naming a file the session actually touched, and a model asked in
+ * English for a path writes a plausible one rather than a real one. Measured
+ * over four runs of qwen2.5:7b on a real digest against that gate:
+ * unconstrained, 4 extracted and 0 accepted; constrained to the list, 4 of 4.
+ *
+ * The HTTP path gets that constraint from a server-enforced enum. A CLI has
+ * no server to enforce it, so the same constraint is stated as strongly as a
+ * prompt can state it -- the exact strings, and an instruction to copy rather
+ * than compose. Not as good as an enum, and much better than nothing: the
+ * first end-to-end run without this extracted 10 findings and kept none.
+ */
+function withAnchorChoices(system, choices) {
+  if (!choices.length) return system;
+  const list = choices.map((file) => `- ${file}`).join('\n');
+  return (
+    `${system}\n\n` +
+    'Every entry in "anchors" MUST be copied verbatim from this list -- pick the ' +
+    'entries that best match the finding, and never write a path that is not ' +
+    'listed. Choosing the nearest match is right; dropping the finding is not:\n' +
+    list
+  );
+}
+
+/** Restated at the end of a prompt file, where an agent skimming will see it. */
+const TRAILER =
+  'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
+  'reply with the JSON array of findings and nothing else. If nothing in the ' +
+  'session is worth recording, reply with an empty array.';
+
+/**
+ * Runs the host client's own CLI as the harvest model.
+ *
+ * THE CHILD MUST NOT HARVEST. The harvest runs from the Stop hook, and a
+ * child session fires its own Stop hook -- verified, not assumed: a bare
+ * `claude -p` with our plugin installed wrote mcp-client, episode-outcome and
+ * derive events to the graph. Left unguarded that is unbounded recursion,
+ * each level spending real quota.
+ *
+ * TOKEN_OPTIMIZER_MODE=off IS THE GUARD, and it is the one that works.
+ * Measured on the same probe: TOKEN_OPTIMIZER_HARVEST=0 still ran the child's
+ * Stop hook and still wrote derive events -- it disables the harvest but not
+ * the hooks around it -- while MODE=off suppressed everything but a single
+ * mcp-client row. The kill switch is the only setting that makes the child
+ * inert, so the child is spawned with it and nothing else is relied upon.
+ *
+ * DELIVERY COMES FROM THE ROW, not from an assumption that every CLI reads
+ * stdin. Copilot does not: asked to follow instructions on stdin it replies
+ * that it cannot read stdin, exits 0, and yields no findings -- which looks
+ * exactly like a session with nothing to learn. Guessing here fails silently,
+ * so it is not guessed.
+ */
+/**
+ * How long to let the host CLI run.
+ *
+ * THE 30s HTTP DEFAULT KILLS EVERY CLI HARVEST, so it cannot be shared. That
+ * budget is sized for one completion against an endpoint that is already
+ * listening. A host CLI is an agent: it starts a process, loads its plugin
+ * and hook tree, opens a session, then thinks. Measured here on a 23 KB
+ * digest with no key and no local model, `claude -p` returned 10 findings in
+ * 104 SECONDS -- correct, and more than three times over the HTTP budget.
+ * `codex exec` on the same machine defaults to xhigh reasoning effort and
+ * had not finished at 300s, which is why this is configurable rather than
+ * merely larger.
+ *
+ * A caller that asks for MORE keeps it; the floor only lifts a default that
+ * was never chosen with this backend in mind.
+ */
+function hostCliTimeoutMs(requested) {
+  const configured = Number(process.env.TOKEN_OPTIMIZER_HARVEST_CLI_TIMEOUT_MS);
+  const floor = Number.isFinite(configured) && configured > 0 ? configured : 180_000;
+  return Math.max(floor, Number(requested) || 0);
+}
+
+async function runHostCli(cli, system, digest, timeoutMs) {
+  const payload = `${system}\n\n${digest}`;
+  const fileMode = cli.delivery === 'prompt-file';
+  let file = cli.command;
+  let args = [...cli.args];
+  let verbatim = false;
+  let promptFile = null;
+
+  if (fileMode) {
+    // A PATH, NOT THE PAYLOAD. See CLIENT_HARVEST_CLI for why the payload
+    // itself cannot travel as an argument on Windows. The file is written
+    // under the OS temp directory, which every one of these CLIs can read by
+    // default, and removed in `finish` whatever the outcome.
+    try {
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // 0600. This is a digest of the user's session -- paths, commands and
+      // prompts -- sitting in a shared temp directory for as long as the child
+      // takes to read it. It is removed in `finish`, but a kill between the two
+      // would leave it behind, so it is unreadable to other users meanwhile.
+      // (Windows ignores the mode; NTFS inheritance already keeps the per-user
+      // temp directory private.)
+      // THE CONTRACT IS REPEATED AT THE END. The instructions lead the file and
+      // the digest follows, which is the natural order and the one that failed:
+      // handed 23 KB this way, copilot reported the file as "a scratchpad
+      // /summary document" with no instruction in it and asked what JSON array
+      // was wanted. An agent skimming a long file sees its tail; restating the
+      // ask there costs one line and removes the dependence on how the file is
+      // read.
+      writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
+        encoding: 'utf8',
+        mode: 0o600,
+      });
+    } catch (error) {
+      return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
+    }
+    args.push(
+      `Read the whole file at ${promptFile}. It opens with instructions, then a ` +
+        'digest of a coding session, then repeats what to reply. Follow those ' +
+        'instructions and output the JSON array they ask for, and nothing else.'
+    );
+  } else if (cli.delivery === 'arg-stdin') {
+    // The flag needs a value and the CLI appends it after stdin, so the short
+    // instruction is the argument and the bulky digest still rides stdin.
+    args.push(system);
+  }
+
+  if (process.platform === 'win32' && file === cli.command) {
+    [file, args] = windowsShellCommand(file, args);
+    verbatim = true;
+  }
+
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(file, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        // The command line was built above where it needed cmd.exe, so Node
+        // must not rebuild it: `shell: true` would join argv unquoted.
+        windowsVerbatimArguments: verbatim,
+        env: {
+          ...process.env,
+          TOKEN_OPTIMIZER_MODE: 'off',
+        },
+      });
+    } catch (error) {
+      resolve({ ok: false, reason: `${cli.command} could not start: ${error?.message || error}` });
+      return;
+    }
+
+    let out = '';
+    let done = false;
+    const finish = (value) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      try {
+        child.kill();
+      } catch {
+        /* already gone */
+      }
+      if (promptFile) {
+        try {
+          rmSync(promptFile, { force: true });
+        } catch {
+          /* a leftover in the temp directory is not worth failing a harvest */
+        }
+      }
+      resolve(value);
+    };
+    const timer = setTimeout(
+      () => finish({ ok: false, reason: `${cli.command} timed out after ${timeoutMs}ms` }),
+      timeoutMs
+    );
+
+    child.stdout.on('data', (c) => {
+      out += c;
+    });
+    // stderr is drained so a chatty CLI cannot fill the pipe and deadlock.
+    child.stderr.on('data', () => {});
+    child.on('error', (error) =>
+      finish({ ok: false, reason: `${cli.command} failed: ${error?.message || error}` })
+    );
+    // NON-ZERO IS NOT ALWAYS EMPTY. Some of these print the reply and then
+    // exit non-zero over an unrelated cleanup complaint, so a parseable array
+    // already in hand beats the exit code; the code decides only when there is
+    // nothing to parse.
+    child.on('close', (code) =>
+      code === 0 || findingsIn(out)
+        ? finish({ ok: true, text: out })
+        : finish({ ok: false, reason: `${cli.command} exited ${code}` })
+    );
+
+    try {
+      // Closed either way: a child left waiting on a pipe that will never
+      // carry anything hangs until the timeout, which is the slowest possible
+      // way to produce nothing.
+      if (fileMode) child.stdin.end();
+      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+    } catch {
+      finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
+    }
+  });
+}
+
+/**
+ * Is the host CLI available as a harvest backend for this client?
+ *
+ * OPT-IN, deliberately, and this is the one default in this file that is not
+ * on. Every other path either reads local files or spends a key the user
+ * already configured for this purpose; this one spends the subscription that
+ * runs their editor, automatically, at the end of every session. HeadRoom
+ * makes the equivalent call user-invoked (`headroom learn`, cli/learn.py) and
+ * its own design note says to log events and analyse offline. Charging someone
+ * quota they did not ask to spend is not a default worth taking.
+ */
+export function hostCliHarvest(client = undefined, env = process.env) {
+  const enabled = /^(1|true|yes|on)$/i.test(env.TOKEN_OPTIMIZER_HARVEST_CLI || '');
+  if (!enabled) return null;
+  return harvestCliFor(client === undefined ? env.TOKEN_OPTIMIZER_CLIENT : client, env);
+}
+
 export async function extract(
   digest,
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
@@ -491,11 +794,40 @@ export async function extract(
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return failed('no api key for a remote endpoint');
+  // The host CLI carries its own auth -- the user is already signed into the
+  // client that is running this -- so the key requirement is about the HTTP
+  // backends only.
+  if (!local && !key && !hostCliHarvest()) {
+    return failed('no api key for a remote endpoint');
+  }
 
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // Computed before the CLI branch because BOTH backends need it. It used to
+  // sit below, so the host CLI was the one path that never learned which
+  // files it was allowed to anchor to -- and the anchor gate is what silently
+  // eats a harvest. Caught end to end on a real session: 10 findings
+  // extracted through `claude -p`, 0 surviving `validate`.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+
+  // The host client's own CLI, when the user has opted in. Tried first
+  // because it needs no key and no local model -- the two things whose
+  // absence has kept this path at 3 harvested findings on this machine.
+  const hostCli = hostCliHarvest();
+  if (hostCli) {
+    const result = await runHostCli(
+      hostCli,
+      withAnchorChoices(system, anchorChoices),
+      digest,
+      hostCliTimeoutMs(timeoutMs)
+    );
+    if (!result.ok) return failed(result.reason);
+    const parsed = findingsIn(result.text);
+    if (!parsed) return failed(`no JSON array in the ${hostCli.command} reply`);
+    return succeeded(parsed);
+  }
 
   // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
   //
@@ -514,7 +846,6 @@ export async function extract(
   // Only when the caller knows the list. `buildFullDelta` is raw transcript
   // with no file heading, and its caller passes no knownFiles for the same
   // reason -- an empty enum would forbid every anchor rather than free it.
-  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
   const schema = anchorChoices.length
     ? {
         ...FINDINGS_SCHEMA,
@@ -662,17 +993,8 @@ export async function extract(
       '';
     if (!text) return failed('endpoint answered in an unrecognised shape');
 
-    // Models wrap JSON in prose or fences often enough that finding the array
-    // is more reliable than insisting the whole response parse.
-    const start = text.indexOf('[');
-    const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return failed('no JSON array in the reply');
-
-    try {
-      return succeeded(JSON.parse(text.slice(start, end + 1)));
-    } catch {
-      return failed('the JSON array in the reply did not parse');
-    }
+    const parsed = findingsIn(text);
+    return parsed ? succeeded(parsed) : failed('no usable JSON array in the reply');
   } catch (error) {
     return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -695,6 +695,15 @@ function extractionNotice() {
         '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
         'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
       );
+    case 'host-cli':
+      // The extractor is this client's own headless CLI, which the user opted
+      // into. Worth its own case rather than folding into `remote`: no
+      // credential is involved, and the digest goes to the same vendor that
+      // already ran the session, which is a materially different disclosure.
+      return (
+        '\n\nSemantic extraction also runs after this session through this client\'s own CLI, ' +
+        'from a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
     case 'off:mode':
       // The whole optimizer is off and this text is not emitted anyway. Saying
       // anything here would be noise stacked on an explicit choice.

--- a/integrations/codex/hooks/lib/capabilities.mjs
+++ b/integrations/codex/hooks/lib/capabilities.mjs
@@ -194,6 +194,181 @@ const native = (profile) => ({
   ...profile,
 });
 
+/**
+ * How each client's own CLI can be driven headlessly, when it has one.
+ *
+ * THE HARVEST MODEL IS THE HOST ITSELF. Semantic extraction has always
+ * needed an API key or a local endpoint, and on a machine with neither it
+ * simply does not run -- measured on this one, 3 harvested findings against
+ * 237 written by the agent. But the client that just ran the session is
+ * installed BY DEFINITION and every one of these ships a headless mode, so
+ * the model was already on the machine. Nothing needed configuring; it only
+ * needed asking.
+ *
+ * ONE ROW PER CLIENT, not a hardcoded backend list. The nearest competitor
+ * picks from three (claude, gemini, codex), so its Cursor, Zed, Amp, Crush
+ * or Droid users get no semantic harvest at all. Every client this package
+ * supports gets a row here or an explicit null, and `npm run sync:hooks`
+ * copies the same table into all 16 integrations so the design cannot drift
+ * per client.
+ *
+ * NEVER ANOTHER VENDOR'S CLI. Reaching for whatever happens to be on PATH
+ * would send this session's digest to a model the user never chose, which is
+ * a disclosure they did not agree to. The host is the only defensible
+ * default, and TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND is the only way to pick a
+ * different one.
+ *
+ * DELIVERY IS PART OF THE ROW because the CLIs genuinely differ, and getting
+ * it wrong is silent:
+ *   - 'stdin'       the whole payload goes to the child's stdin.
+ *   - 'arg-stdin'   a short instruction is the final argument and the digest
+ *                   goes to stdin, for CLIs whose prompt flag needs a value
+ *                   but which still read stdin.
+ *   - 'prompt-file' the payload is written to a temp file and the final
+ *                   argument tells the agent to read it, for CLIs that do
+ *                   not read stdin at all.
+ *
+ * WHY A FILE AND NOT JUST A LONG ARGUMENT. Passing the payload itself as an
+ * argument was tried and abandoned on evidence. On POSIX it is fine; on
+ * Windows every one of these installs as a .cmd shim, which Node will not
+ * spawn without a shell, and cmd.exe cannot carry a newline inside an
+ * argument at all. Routing through PowerShell with the payload base64-encoded
+ * got past cmd.exe and then hit PowerShell 5.1's native-argument binder,
+ * which does not escape embedded double quotes: the prompt is JSON, so the
+ * first `\"type\":` ended the quoting and the child received 32 arguments
+ * instead of 1. A path has no spaces we did not choose, no quotes and no
+ * newlines, and it also lifts the ARG_MAX ceiling entirely -- these are
+ * agentic CLIs whose whole purpose is reading files, and the route is
+ * verified: copilot asked to read a payload file returned the exact array.
+ *
+ * VERIFIED means a probe was executed against the installed CLI in this
+ * repository and its reply parsed. DOCUMENTED means the shape comes from the
+ * vendor's own `--help` or published headless docs and has not been executed
+ * here, because the CLI is not installed on this machine. Both ship; the
+ * distinction is recorded so nobody mistakes the second for the first, and a
+ * wrong DOCUMENTED row fails loudly through `harvestFailure()` and doctor
+ * rather than silently producing nothing.
+ */
+const harvestCli = (command, args, { delivery = 'stdin', verified = false } = {}) =>
+  Object.freeze({ command, args: Object.freeze([...args]), delivery, verified });
+
+export const CLIENT_HARVEST_CLI = Object.freeze({
+  // VERIFIED: `claude -p` with the payload on stdin returned the exact array
+  // asked for. --output-format stream-json was tried first and rejected: its
+  // envelopes are themselves JSON containing brackets, which is a parsing
+  // hazard for no gain when plain text is already the model's reply.
+  'claude-code': harvestCli('claude', ['-p'], { verified: true }),
+  // VERIFIED: `codex exec -` reads instructions from stdin (its own --help
+  // says so, and a probe returned the array). It prints a banner containing
+  // `[workdir, /tmp, $TMPDIR]` before the reply, which is exactly why the
+  // reply parser has to try more than the first bracket it finds.
+  codex: harvestCli('codex', ['exec', '-'], { verified: true }),
+  // VERIFIED both ways. Asked to follow instructions on stdin the agent
+  // answered that it was unable to read stdin and exited 0 -- a silent
+  // no-findings result indistinguishable from a quiet session. Asked instead
+  // to read a payload file it returned the exact array requested, which is
+  // why this row is prompt-file. --allow-all-tools is required for
+  // non-interactive use by copilot's own help text, and -s drops the stats
+  // banner.
+  copilot: harvestCli('copilot', ['-s', '--allow-all-tools', '-p'], {
+    delivery: 'prompt-file',
+    verified: true,
+  }),
+  // DOCUMENTED: `gemini --help` states that -p runs headless and that the
+  // prompt is "Appended to input on stdin (if any)", so the digest rides
+  // stdin and the instruction is the flag value. Not executed here: this
+  // machine's gemini is unauthenticated and fails in refreshAuth before any
+  // prompt is read.
+  gemini: harvestCli('gemini', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: qwen-code is a fork of gemini-cli and keeps its flag surface.
+  qwen: harvestCli('qwen', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: `opencode run <message>` is its non-interactive entry point.
+  opencode: harvestCli('opencode', ['run'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `crush run <prompt>` runs a single non-interactive prompt.
+  crush: harvestCli('crush', ['run', '-q'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `droid exec <prompt>` is Factory's headless mode.
+  droid: harvestCli('droid', ['exec'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `amp -x <prompt>` executes a single prompt and exits.
+  amp: harvestCli('amp', ['-x'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: the Continue CLI installs as `cn` and takes -p for headless.
+  continue: harvestCli('cn', ['-p'], { delivery: 'prompt-file' }),
+
+  // NO HEADLESS CLI OF THEIR OWN. These are editor- and extension-hosted:
+  // the assistant runs inside the IDE process and ships no command a hook
+  // could spawn. Declaring null keeps that a stated fact rather than an
+  // omission, and these clients fall back to a configured endpoint --
+  // borrowing a neighbouring vendor's CLI would send the digest to a model
+  // the user never chose.
+  cursor: null,
+  cline: null,
+  windsurf: null,
+  kilo: null,
+  roo: null,
+  zed: null,
+});
+
+/**
+ * Splits a configured command line into words, respecting quotes.
+ *
+ * SPLITTING ON WHITESPACE ALONE IS WRONG ON WINDOWS, and the first test
+ * written against this caught it: the natural thing to configure is the
+ * interpreter you already have, and on Windows that is
+ * `C:\\Program Files\\nodejs\\node.exe`. A bare split turned that into the
+ * command `C:\\Program` and reported `C:\\Program exited 1`, which is a
+ * diagnostic nobody can act on. Quoting a path with spaces is the ordinary
+ * way to write a command line, so it has to mean what it says.
+ */
+function commandWords(line) {
+  const words = [];
+  let current = '';
+  let quote = '';
+  let started = false;
+  for (const ch of String(line)) {
+    if (quote) {
+      if (ch === quote) quote = '';
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (started) words.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (started) words.push(current);
+  return words;
+}
+
+/**
+ * The harvest CLI for a client, or null when it has none.
+ *
+ * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
+ * client with no row -- or one whose vendor changed its flags after this
+ * shipped -- is a configuration away from working rather than a release away.
+ * The value is a command and its arguments. The payload goes to stdin unless
+ * the string ends in `{}`, which is replaced by the path of a file holding
+ * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ */
+export function harvestCliFor(client, env = process.env) {
+  const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
+  if (override) {
+    const parts = commandWords(override);
+    const arg = parts[parts.length - 1] === '{}';
+    if (arg) parts.pop();
+    const [command, ...args] = parts;
+    if (!command) return null;
+    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+  }
+  return CLIENT_HARVEST_CLI[client] || null;
+}
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({
     name: 'Claude Code',

--- a/integrations/codex/hooks/lib/capabilities.mjs
+++ b/integrations/codex/hooks/lib/capabilities.mjs
@@ -353,21 +353,40 @@ function commandWords(line) {
  * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
  * client with no row -- or one whose vendor changed its flags after this
  * shipped -- is a configuration away from working rather than a release away.
- * The value is a command and its arguments. The payload goes to stdin unless
- * the string ends in `{}`, which is replaced by the path of a file holding
- * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ * The value is a command and its arguments, and its last word may name a
+ * delivery:
+ *   (nothing)  the payload goes to the command's stdin.
+ *   `{}`       it is written to a file and the path becomes the last
+ *              argument -- what an agentic CLI that ignores stdin needs.
+ *   `{-}`      the payload goes to stdin and a short instruction becomes the
+ *              last argument, for a CLI whose prompt flag demands a value
+ *              but which still reads stdin. gemini and qwen are shaped this
+ *              way, and without this an override could not reach that shape
+ *              at all.
  */
 export function harvestCliFor(client, env = process.env) {
   const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
   if (override) {
     const parts = commandWords(override);
-    const arg = parts[parts.length - 1] === '{}';
-    if (arg) parts.pop();
+    const last = parts[parts.length - 1];
+    const delivery =
+      last === '{}' ? 'prompt-file' : last === '{-}' ? 'arg-stdin' : 'stdin';
+    if (delivery !== 'stdin') parts.pop();
     const [command, ...args] = parts;
     if (!command) return null;
-    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+    return harvestCli(command, args, { delivery });
   }
-  return CLIENT_HARVEST_CLI[client] || null;
+  // NORMALISED AND OWN-PROPERTY ONLY, matching `capabilityFor` below.
+  //
+  // A bare index disagreed with its own sibling and reached the prototype.
+  // Reproduced: TOKEN_OPTIMIZER_CLIENT=Codex resolved a capability profile
+  // through capabilityFor -- which lower-cases -- and NO harvest CLI here, so
+  // harvestMode() fell through to off:no-key and an opted-in harvest silently
+  // did nothing on a client that plainly has one. And
+  // harvestCliFor('constructor') returned a function, whose `command` is
+  // undefined, which runHostCli would have handed straight to spawn.
+  const key = String(client || '').toLowerCase();
+  return Object.hasOwn(CLIENT_HARVEST_CLI, key) ? CLIENT_HARVEST_CLI[key] : null;
 }
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({

--- a/integrations/codex/hooks/lib/doctor.mjs
+++ b/integrations/codex/hooks/lib/doctor.mjs
@@ -246,6 +246,23 @@ export function probeHarvest() {
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
+  // The host client's own CLI, opted into with TOKEN_OPTIMIZER_HARVEST_CLI.
+  // Reported with the same failure-reason read as `local`, because the two
+  // share the property that made a broken configuration invisible: they
+  // return [] on failure and look exactly like a session with nothing to
+  // learn.
+  if (mode === 'host-cli') {
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check that this client\'s CLI is on PATH and signed in, or unset ' +
+        'TOKEN_OPTIMIZER_HARVEST_CLI to fall back to a configured endpoint')];
+    }
+    return [ok('finding extraction is available',
+      "this client's own CLI runs the semantic harvest -- no separate credential and no " +
+      'second vendor. Active-model wiki_write remains the primary path')];
+  }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
       'active-model wiki_write is primary; a credential also enables fallback extraction from ' +

--- a/integrations/codex/hooks/lib/harvest.mjs
+++ b/integrations/codex/hooks/lib/harvest.mjs
@@ -23,6 +23,7 @@
 import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { harvestCliFor } from './capabilities.mjs';
 
@@ -588,6 +589,14 @@ function withAnchorChoices(system, choices) {
   );
 }
 
+/**
+ * The `-p` value for a CLI whose prompt flag needs one but which still reads
+ * stdin. One line, no quotes, no newlines: everything a Windows command line
+ * cannot carry.
+ */
+export const ARG_STDIN_INSTRUCTION =
+  'Follow the instructions in the input above and reply with only the JSON array they ask for.';
+
 /** Restated at the end of a prompt file, where an agent skimming will see it. */
 const TRAILER =
   'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
@@ -652,7 +661,11 @@ async function runHostCli(cli, system, digest, timeoutMs) {
     // under the OS temp directory, which every one of these CLIs can read by
     // default, and removed in `finish` whatever the outcome.
     try {
-      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // UNGUESSABLE, NOT MERELY UNIQUE. pid and clock are both predictable
+      // enough for another local user to pre-create the path in a shared temp
+      // directory; randomUUID removes the guess, and `flag: 'wx'` below
+      // removes the race that remains.
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${randomUUID()}.txt`);
       // 0600. This is a digest of the user's session -- paths, commands and
       // prompts -- sitting in a shared temp directory for as long as the child
       // takes to read it. It is removed in `finish`, but a kill between the two
@@ -669,6 +682,12 @@ async function runHostCli(cli, system, digest, timeoutMs) {
       writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
         encoding: 'utf8',
         mode: 0o600,
+        // EXCLUSIVE CREATE. `mode` governs a file this call makes; it does
+        // nothing about one that already exists, and the default flag 'w'
+        // happily follows a symlink someone else placed at the path -- which
+        // would redirect a digest of the user's session wherever they chose.
+        // 'wx' fails instead of following.
+        flag: 'wx',
       });
     } catch (error) {
       return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
@@ -679,9 +698,16 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         'instructions and output the JSON array they ask for, and nothing else.'
     );
   } else if (cli.delivery === 'arg-stdin') {
-    // The flag needs a value and the CLI appends it after stdin, so the short
-    // instruction is the argument and the bulky digest still rides stdin.
-    args.push(system);
+    // A SHORT SINGLE LINE, NEVER THE PROMPT. The flag needs a value, and the
+    // obvious value -- `system` -- is the multi-line PROMPT, which
+    // withAnchorChoices extends with a newline-separated file list and which
+    // is full of the JSON prompt's double quotes. That is the exact payload
+    // the prompt-file route exists to keep off a Windows command line:
+    // cmd.exe cannot carry a newline inside an argument, and the quoting
+    // doubles every `"`. These CLIs document the flag value as being
+    // APPENDED to stdin, so the whole payload rides stdin and the argument
+    // is one line of ASCII that any shell survives.
+    args.push(ARG_STDIN_INSTRUCTION);
   }
 
   if (process.platform === 'win32' && file === cli.command) {
@@ -750,12 +776,26 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         : finish({ ok: false, reason: `${cli.command} exited ${code}` })
     );
 
+    // EPIPE ARRIVES AS AN EVENT, NOT AS A THROW. The try/catch below sees
+    // only a synchronous failure; a child that exits without reading stdin
+    // fails the write asynchronously, and Node delivers that on the stream.
+    // With no listener it is an uncaught exception that takes down the hook
+    // process instead of resolving this promise -- and the path is not
+    // hypothetical: copilot, asked to read a prompt on stdin, answers that it
+    // cannot and exits 0, which is why its row is prompt-file at all.
+    child.stdin.on('error', (error) =>
+      finish({
+        ok: false,
+        reason: `could not write the digest to ${cli.command}: ${error?.message || error}`,
+      })
+    );
+
     try {
       // Closed either way: a child left waiting on a pipe that will never
       // carry anything hangs until the timeout, which is the slowest possible
       // way to produce nothing.
       if (fileMode) child.stdin.end();
-      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+      else child.stdin.end(payload);
     } catch {
       finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
     }

--- a/integrations/codex/hooks/lib/harvest.mjs
+++ b/integrations/codex/hooks/lib/harvest.mjs
@@ -20,9 +20,11 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { harvestCliFor } from './capabilities.mjs';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -178,13 +180,25 @@ export function harvestMode() {
   // Free and private, so nothing further to weigh: no credential, no billing, no digest leaving
   // the machine.
   if (localEndpoint()) return 'local';
+  // THE HOST CLI IS A BACKEND, so the enablement check has to know about it.
+  // Without this the gate answers off:no-key and `extract` never reaches the
+  // CLI path -- which defeats the whole point of a backend that needs no key.
+  // Caught end to end rather than reasoned about: with no endpoint and no key,
+  // the first run of the opted-in host-CLI harvest returned
+  // `harvest is off:no-key` in 0s, having never spawned anything.
+  if (hostCliHarvest()) return 'host-cli';
+
 
   return apiKey() ? 'remote' : 'off:no-key';
 }
 
 export function harvestEnabled() {
   const mode = harvestMode();
-  return mode === 'local' || mode === 'remote';
+  // host-cli belongs here for the same reason local and remote do: it is a
+  // backend that can actually answer. Leaving it out would let the mode say
+  // `host-cli` while every caller that asks `harvestEnabled()` -- the Stop
+  // hook, the worker, extract's own first line -- skipped the harvest.
+  return mode === 'local' || mode === 'remote' || mode === 'host-cli';
 }
 
 /**
@@ -476,6 +490,295 @@ const succeeded = (findings) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
+/**
+ * The findings array inside a reply, or null.
+ *
+ * Models wrap JSON in prose or fences often enough that locating the array is
+ * more reliable than insisting the whole response parses -- and a CLI adds its
+ * own banner lines and stream-json envelopes on top, so both callers need the
+ * same tolerance. Shared so the two cannot drift.
+ */
+function findingsIn(text) {
+  const raw = String(text || '');
+
+  // FIRST BRACKET TO LAST IS NOT ENOUGH, and a CLI is where that breaks.
+  // `codex exec` prints a banner line reading `sandbox: workspace-write
+  // [workdir, /tmp, $TMPDIR]` before the model says anything, so the first
+  // `[` in the stream belongs to the banner and the naive slice parses to
+  // nothing -- an empty harvest that looks exactly like a session with
+  // nothing to learn. Closing brackets are walked from the end and opening
+  // brackets from the start, so the widest array that actually parses wins,
+  // and prose on either side is tolerated the way it already was for HTTP.
+  const closes = [];
+  for (let i = raw.length - 1; i >= 0 && closes.length < CLOSE_TRIES; i -= 1) {
+    if (raw[i] === ']') closes.push(i);
+  }
+  for (const end of closes) {
+    let tries = 0;
+    for (let start = raw.indexOf('['); start !== -1 && start < end; start = raw.indexOf('[', start + 1)) {
+      if ((tries += 1) > OPEN_TRIES) break;
+      try {
+        const parsed = JSON.parse(raw.slice(start, end + 1));
+        if (Array.isArray(parsed)) return parsed;
+      } catch {
+        /* not this pair */
+      }
+    }
+  }
+  return null;
+}
+
+// Bounded so a pathological reply cannot turn parsing into an O(n^2) walk of
+// a megabyte. A real findings array is at the end of the reply and preceded
+// by a banner or a sentence, not by hundreds of brackets.
+const CLOSE_TRIES = 8;
+const OPEN_TRIES = 40;
+
+/**
+ * Launches a Windows command through cmd.exe WITHOUT letting Node build the
+ * command line.
+ *
+ * These CLIs all install as .cmd shims, and Node has refused to spawn .cmd
+ * or .bat without a shell since the 2024 command-injection fix -- so a shell
+ * is not optional. But Node's own `shell: true` builds the cmd.exe line by
+ * joining argv with single spaces and no quoting at all, which breaks the
+ * moment any part contains one. Caught by the first test written against
+ * this: pointing the override at `C:\\Program Files\\nodejs\\node.exe`
+ * produced `C:\\Program Files\\nodejs\\node.exe exited 1`, because cmd.exe
+ * had been handed `C:\\Program` as the command. Quoting each part and passing
+ * the line verbatim is the fix.
+ */
+function windowsShellCommand(file, args) {
+  const quote = (part) => {
+    const value = String(part);
+    // Doubling is cmd.exe's own escape for a quote inside a quoted token.
+    return /[\s"]/.test(value)
+      ? `"${value.replace(/"/g, '""')}"`
+      : value;
+  };
+  const line = [file, ...args].map(quote).join(' ');
+  return [process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', `"${line}"`]];
+}
+
+/**
+ * States the anchor list in the prompt, for a backend that cannot be handed
+ * a schema.
+ *
+ * THE ANCHOR GATE IS WHAT SILENTLY EATS A HARVEST. `validate` keeps only
+ * anchors naming a file the session actually touched, and a model asked in
+ * English for a path writes a plausible one rather than a real one. Measured
+ * over four runs of qwen2.5:7b on a real digest against that gate:
+ * unconstrained, 4 extracted and 0 accepted; constrained to the list, 4 of 4.
+ *
+ * The HTTP path gets that constraint from a server-enforced enum. A CLI has
+ * no server to enforce it, so the same constraint is stated as strongly as a
+ * prompt can state it -- the exact strings, and an instruction to copy rather
+ * than compose. Not as good as an enum, and much better than nothing: the
+ * first end-to-end run without this extracted 10 findings and kept none.
+ */
+function withAnchorChoices(system, choices) {
+  if (!choices.length) return system;
+  const list = choices.map((file) => `- ${file}`).join('\n');
+  return (
+    `${system}\n\n` +
+    'Every entry in "anchors" MUST be copied verbatim from this list -- pick the ' +
+    'entries that best match the finding, and never write a path that is not ' +
+    'listed. Choosing the nearest match is right; dropping the finding is not:\n' +
+    list
+  );
+}
+
+/** Restated at the end of a prompt file, where an agent skimming will see it. */
+const TRAILER =
+  'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
+  'reply with the JSON array of findings and nothing else. If nothing in the ' +
+  'session is worth recording, reply with an empty array.';
+
+/**
+ * Runs the host client's own CLI as the harvest model.
+ *
+ * THE CHILD MUST NOT HARVEST. The harvest runs from the Stop hook, and a
+ * child session fires its own Stop hook -- verified, not assumed: a bare
+ * `claude -p` with our plugin installed wrote mcp-client, episode-outcome and
+ * derive events to the graph. Left unguarded that is unbounded recursion,
+ * each level spending real quota.
+ *
+ * TOKEN_OPTIMIZER_MODE=off IS THE GUARD, and it is the one that works.
+ * Measured on the same probe: TOKEN_OPTIMIZER_HARVEST=0 still ran the child's
+ * Stop hook and still wrote derive events -- it disables the harvest but not
+ * the hooks around it -- while MODE=off suppressed everything but a single
+ * mcp-client row. The kill switch is the only setting that makes the child
+ * inert, so the child is spawned with it and nothing else is relied upon.
+ *
+ * DELIVERY COMES FROM THE ROW, not from an assumption that every CLI reads
+ * stdin. Copilot does not: asked to follow instructions on stdin it replies
+ * that it cannot read stdin, exits 0, and yields no findings -- which looks
+ * exactly like a session with nothing to learn. Guessing here fails silently,
+ * so it is not guessed.
+ */
+/**
+ * How long to let the host CLI run.
+ *
+ * THE 30s HTTP DEFAULT KILLS EVERY CLI HARVEST, so it cannot be shared. That
+ * budget is sized for one completion against an endpoint that is already
+ * listening. A host CLI is an agent: it starts a process, loads its plugin
+ * and hook tree, opens a session, then thinks. Measured here on a 23 KB
+ * digest with no key and no local model, `claude -p` returned 10 findings in
+ * 104 SECONDS -- correct, and more than three times over the HTTP budget.
+ * `codex exec` on the same machine defaults to xhigh reasoning effort and
+ * had not finished at 300s, which is why this is configurable rather than
+ * merely larger.
+ *
+ * A caller that asks for MORE keeps it; the floor only lifts a default that
+ * was never chosen with this backend in mind.
+ */
+function hostCliTimeoutMs(requested) {
+  const configured = Number(process.env.TOKEN_OPTIMIZER_HARVEST_CLI_TIMEOUT_MS);
+  const floor = Number.isFinite(configured) && configured > 0 ? configured : 180_000;
+  return Math.max(floor, Number(requested) || 0);
+}
+
+async function runHostCli(cli, system, digest, timeoutMs) {
+  const payload = `${system}\n\n${digest}`;
+  const fileMode = cli.delivery === 'prompt-file';
+  let file = cli.command;
+  let args = [...cli.args];
+  let verbatim = false;
+  let promptFile = null;
+
+  if (fileMode) {
+    // A PATH, NOT THE PAYLOAD. See CLIENT_HARVEST_CLI for why the payload
+    // itself cannot travel as an argument on Windows. The file is written
+    // under the OS temp directory, which every one of these CLIs can read by
+    // default, and removed in `finish` whatever the outcome.
+    try {
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // 0600. This is a digest of the user's session -- paths, commands and
+      // prompts -- sitting in a shared temp directory for as long as the child
+      // takes to read it. It is removed in `finish`, but a kill between the two
+      // would leave it behind, so it is unreadable to other users meanwhile.
+      // (Windows ignores the mode; NTFS inheritance already keeps the per-user
+      // temp directory private.)
+      // THE CONTRACT IS REPEATED AT THE END. The instructions lead the file and
+      // the digest follows, which is the natural order and the one that failed:
+      // handed 23 KB this way, copilot reported the file as "a scratchpad
+      // /summary document" with no instruction in it and asked what JSON array
+      // was wanted. An agent skimming a long file sees its tail; restating the
+      // ask there costs one line and removes the dependence on how the file is
+      // read.
+      writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
+        encoding: 'utf8',
+        mode: 0o600,
+      });
+    } catch (error) {
+      return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
+    }
+    args.push(
+      `Read the whole file at ${promptFile}. It opens with instructions, then a ` +
+        'digest of a coding session, then repeats what to reply. Follow those ' +
+        'instructions and output the JSON array they ask for, and nothing else.'
+    );
+  } else if (cli.delivery === 'arg-stdin') {
+    // The flag needs a value and the CLI appends it after stdin, so the short
+    // instruction is the argument and the bulky digest still rides stdin.
+    args.push(system);
+  }
+
+  if (process.platform === 'win32' && file === cli.command) {
+    [file, args] = windowsShellCommand(file, args);
+    verbatim = true;
+  }
+
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(file, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        // The command line was built above where it needed cmd.exe, so Node
+        // must not rebuild it: `shell: true` would join argv unquoted.
+        windowsVerbatimArguments: verbatim,
+        env: {
+          ...process.env,
+          TOKEN_OPTIMIZER_MODE: 'off',
+        },
+      });
+    } catch (error) {
+      resolve({ ok: false, reason: `${cli.command} could not start: ${error?.message || error}` });
+      return;
+    }
+
+    let out = '';
+    let done = false;
+    const finish = (value) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      try {
+        child.kill();
+      } catch {
+        /* already gone */
+      }
+      if (promptFile) {
+        try {
+          rmSync(promptFile, { force: true });
+        } catch {
+          /* a leftover in the temp directory is not worth failing a harvest */
+        }
+      }
+      resolve(value);
+    };
+    const timer = setTimeout(
+      () => finish({ ok: false, reason: `${cli.command} timed out after ${timeoutMs}ms` }),
+      timeoutMs
+    );
+
+    child.stdout.on('data', (c) => {
+      out += c;
+    });
+    // stderr is drained so a chatty CLI cannot fill the pipe and deadlock.
+    child.stderr.on('data', () => {});
+    child.on('error', (error) =>
+      finish({ ok: false, reason: `${cli.command} failed: ${error?.message || error}` })
+    );
+    // NON-ZERO IS NOT ALWAYS EMPTY. Some of these print the reply and then
+    // exit non-zero over an unrelated cleanup complaint, so a parseable array
+    // already in hand beats the exit code; the code decides only when there is
+    // nothing to parse.
+    child.on('close', (code) =>
+      code === 0 || findingsIn(out)
+        ? finish({ ok: true, text: out })
+        : finish({ ok: false, reason: `${cli.command} exited ${code}` })
+    );
+
+    try {
+      // Closed either way: a child left waiting on a pipe that will never
+      // carry anything hangs until the timeout, which is the slowest possible
+      // way to produce nothing.
+      if (fileMode) child.stdin.end();
+      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+    } catch {
+      finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
+    }
+  });
+}
+
+/**
+ * Is the host CLI available as a harvest backend for this client?
+ *
+ * OPT-IN, deliberately, and this is the one default in this file that is not
+ * on. Every other path either reads local files or spends a key the user
+ * already configured for this purpose; this one spends the subscription that
+ * runs their editor, automatically, at the end of every session. HeadRoom
+ * makes the equivalent call user-invoked (`headroom learn`, cli/learn.py) and
+ * its own design note says to log events and analyse offline. Charging someone
+ * quota they did not ask to spend is not a default worth taking.
+ */
+export function hostCliHarvest(client = undefined, env = process.env) {
+  const enabled = /^(1|true|yes|on)$/i.test(env.TOKEN_OPTIMIZER_HARVEST_CLI || '');
+  if (!enabled) return null;
+  return harvestCliFor(client === undefined ? env.TOKEN_OPTIMIZER_CLIENT : client, env);
+}
+
 export async function extract(
   digest,
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
@@ -491,11 +794,40 @@ export async function extract(
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return failed('no api key for a remote endpoint');
+  // The host CLI carries its own auth -- the user is already signed into the
+  // client that is running this -- so the key requirement is about the HTTP
+  // backends only.
+  if (!local && !key && !hostCliHarvest()) {
+    return failed('no api key for a remote endpoint');
+  }
 
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // Computed before the CLI branch because BOTH backends need it. It used to
+  // sit below, so the host CLI was the one path that never learned which
+  // files it was allowed to anchor to -- and the anchor gate is what silently
+  // eats a harvest. Caught end to end on a real session: 10 findings
+  // extracted through `claude -p`, 0 surviving `validate`.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+
+  // The host client's own CLI, when the user has opted in. Tried first
+  // because it needs no key and no local model -- the two things whose
+  // absence has kept this path at 3 harvested findings on this machine.
+  const hostCli = hostCliHarvest();
+  if (hostCli) {
+    const result = await runHostCli(
+      hostCli,
+      withAnchorChoices(system, anchorChoices),
+      digest,
+      hostCliTimeoutMs(timeoutMs)
+    );
+    if (!result.ok) return failed(result.reason);
+    const parsed = findingsIn(result.text);
+    if (!parsed) return failed(`no JSON array in the ${hostCli.command} reply`);
+    return succeeded(parsed);
+  }
 
   // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
   //
@@ -514,7 +846,6 @@ export async function extract(
   // Only when the caller knows the list. `buildFullDelta` is raw transcript
   // with no file heading, and its caller passes no knownFiles for the same
   // reason -- an empty enum would forbid every anchor rather than free it.
-  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
   const schema = anchorChoices.length
     ? {
         ...FINDINGS_SCHEMA,
@@ -662,17 +993,8 @@ export async function extract(
       '';
     if (!text) return failed('endpoint answered in an unrecognised shape');
 
-    // Models wrap JSON in prose or fences often enough that finding the array
-    // is more reliable than insisting the whole response parse.
-    const start = text.indexOf('[');
-    const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return failed('no JSON array in the reply');
-
-    try {
-      return succeeded(JSON.parse(text.slice(start, end + 1)));
-    } catch {
-      return failed('the JSON array in the reply did not parse');
-    }
+    const parsed = findingsIn(text);
+    return parsed ? succeeded(parsed) : failed('no usable JSON array in the reply');
   } catch (error) {
     return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -695,6 +695,15 @@ function extractionNotice() {
         '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
         'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
       );
+    case 'host-cli':
+      // The extractor is this client's own headless CLI, which the user opted
+      // into. Worth its own case rather than folding into `remote`: no
+      // credential is involved, and the digest goes to the same vendor that
+      // already ran the session, which is a materially different disclosure.
+      return (
+        '\n\nSemantic extraction also runs after this session through this client\'s own CLI, ' +
+        'from a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
     case 'off:mode':
       // The whole optimizer is off and this text is not emitted anyway. Saying
       // anything here would be noise stacked on an explicit choice.

--- a/integrations/codex/plugin/hooks/lib/capabilities.mjs
+++ b/integrations/codex/plugin/hooks/lib/capabilities.mjs
@@ -194,6 +194,181 @@ const native = (profile) => ({
   ...profile,
 });
 
+/**
+ * How each client's own CLI can be driven headlessly, when it has one.
+ *
+ * THE HARVEST MODEL IS THE HOST ITSELF. Semantic extraction has always
+ * needed an API key or a local endpoint, and on a machine with neither it
+ * simply does not run -- measured on this one, 3 harvested findings against
+ * 237 written by the agent. But the client that just ran the session is
+ * installed BY DEFINITION and every one of these ships a headless mode, so
+ * the model was already on the machine. Nothing needed configuring; it only
+ * needed asking.
+ *
+ * ONE ROW PER CLIENT, not a hardcoded backend list. The nearest competitor
+ * picks from three (claude, gemini, codex), so its Cursor, Zed, Amp, Crush
+ * or Droid users get no semantic harvest at all. Every client this package
+ * supports gets a row here or an explicit null, and `npm run sync:hooks`
+ * copies the same table into all 16 integrations so the design cannot drift
+ * per client.
+ *
+ * NEVER ANOTHER VENDOR'S CLI. Reaching for whatever happens to be on PATH
+ * would send this session's digest to a model the user never chose, which is
+ * a disclosure they did not agree to. The host is the only defensible
+ * default, and TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND is the only way to pick a
+ * different one.
+ *
+ * DELIVERY IS PART OF THE ROW because the CLIs genuinely differ, and getting
+ * it wrong is silent:
+ *   - 'stdin'       the whole payload goes to the child's stdin.
+ *   - 'arg-stdin'   a short instruction is the final argument and the digest
+ *                   goes to stdin, for CLIs whose prompt flag needs a value
+ *                   but which still read stdin.
+ *   - 'prompt-file' the payload is written to a temp file and the final
+ *                   argument tells the agent to read it, for CLIs that do
+ *                   not read stdin at all.
+ *
+ * WHY A FILE AND NOT JUST A LONG ARGUMENT. Passing the payload itself as an
+ * argument was tried and abandoned on evidence. On POSIX it is fine; on
+ * Windows every one of these installs as a .cmd shim, which Node will not
+ * spawn without a shell, and cmd.exe cannot carry a newline inside an
+ * argument at all. Routing through PowerShell with the payload base64-encoded
+ * got past cmd.exe and then hit PowerShell 5.1's native-argument binder,
+ * which does not escape embedded double quotes: the prompt is JSON, so the
+ * first `\"type\":` ended the quoting and the child received 32 arguments
+ * instead of 1. A path has no spaces we did not choose, no quotes and no
+ * newlines, and it also lifts the ARG_MAX ceiling entirely -- these are
+ * agentic CLIs whose whole purpose is reading files, and the route is
+ * verified: copilot asked to read a payload file returned the exact array.
+ *
+ * VERIFIED means a probe was executed against the installed CLI in this
+ * repository and its reply parsed. DOCUMENTED means the shape comes from the
+ * vendor's own `--help` or published headless docs and has not been executed
+ * here, because the CLI is not installed on this machine. Both ship; the
+ * distinction is recorded so nobody mistakes the second for the first, and a
+ * wrong DOCUMENTED row fails loudly through `harvestFailure()` and doctor
+ * rather than silently producing nothing.
+ */
+const harvestCli = (command, args, { delivery = 'stdin', verified = false } = {}) =>
+  Object.freeze({ command, args: Object.freeze([...args]), delivery, verified });
+
+export const CLIENT_HARVEST_CLI = Object.freeze({
+  // VERIFIED: `claude -p` with the payload on stdin returned the exact array
+  // asked for. --output-format stream-json was tried first and rejected: its
+  // envelopes are themselves JSON containing brackets, which is a parsing
+  // hazard for no gain when plain text is already the model's reply.
+  'claude-code': harvestCli('claude', ['-p'], { verified: true }),
+  // VERIFIED: `codex exec -` reads instructions from stdin (its own --help
+  // says so, and a probe returned the array). It prints a banner containing
+  // `[workdir, /tmp, $TMPDIR]` before the reply, which is exactly why the
+  // reply parser has to try more than the first bracket it finds.
+  codex: harvestCli('codex', ['exec', '-'], { verified: true }),
+  // VERIFIED both ways. Asked to follow instructions on stdin the agent
+  // answered that it was unable to read stdin and exited 0 -- a silent
+  // no-findings result indistinguishable from a quiet session. Asked instead
+  // to read a payload file it returned the exact array requested, which is
+  // why this row is prompt-file. --allow-all-tools is required for
+  // non-interactive use by copilot's own help text, and -s drops the stats
+  // banner.
+  copilot: harvestCli('copilot', ['-s', '--allow-all-tools', '-p'], {
+    delivery: 'prompt-file',
+    verified: true,
+  }),
+  // DOCUMENTED: `gemini --help` states that -p runs headless and that the
+  // prompt is "Appended to input on stdin (if any)", so the digest rides
+  // stdin and the instruction is the flag value. Not executed here: this
+  // machine's gemini is unauthenticated and fails in refreshAuth before any
+  // prompt is read.
+  gemini: harvestCli('gemini', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: qwen-code is a fork of gemini-cli and keeps its flag surface.
+  qwen: harvestCli('qwen', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: `opencode run <message>` is its non-interactive entry point.
+  opencode: harvestCli('opencode', ['run'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `crush run <prompt>` runs a single non-interactive prompt.
+  crush: harvestCli('crush', ['run', '-q'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `droid exec <prompt>` is Factory's headless mode.
+  droid: harvestCli('droid', ['exec'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `amp -x <prompt>` executes a single prompt and exits.
+  amp: harvestCli('amp', ['-x'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: the Continue CLI installs as `cn` and takes -p for headless.
+  continue: harvestCli('cn', ['-p'], { delivery: 'prompt-file' }),
+
+  // NO HEADLESS CLI OF THEIR OWN. These are editor- and extension-hosted:
+  // the assistant runs inside the IDE process and ships no command a hook
+  // could spawn. Declaring null keeps that a stated fact rather than an
+  // omission, and these clients fall back to a configured endpoint --
+  // borrowing a neighbouring vendor's CLI would send the digest to a model
+  // the user never chose.
+  cursor: null,
+  cline: null,
+  windsurf: null,
+  kilo: null,
+  roo: null,
+  zed: null,
+});
+
+/**
+ * Splits a configured command line into words, respecting quotes.
+ *
+ * SPLITTING ON WHITESPACE ALONE IS WRONG ON WINDOWS, and the first test
+ * written against this caught it: the natural thing to configure is the
+ * interpreter you already have, and on Windows that is
+ * `C:\\Program Files\\nodejs\\node.exe`. A bare split turned that into the
+ * command `C:\\Program` and reported `C:\\Program exited 1`, which is a
+ * diagnostic nobody can act on. Quoting a path with spaces is the ordinary
+ * way to write a command line, so it has to mean what it says.
+ */
+function commandWords(line) {
+  const words = [];
+  let current = '';
+  let quote = '';
+  let started = false;
+  for (const ch of String(line)) {
+    if (quote) {
+      if (ch === quote) quote = '';
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (started) words.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (started) words.push(current);
+  return words;
+}
+
+/**
+ * The harvest CLI for a client, or null when it has none.
+ *
+ * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
+ * client with no row -- or one whose vendor changed its flags after this
+ * shipped -- is a configuration away from working rather than a release away.
+ * The value is a command and its arguments. The payload goes to stdin unless
+ * the string ends in `{}`, which is replaced by the path of a file holding
+ * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ */
+export function harvestCliFor(client, env = process.env) {
+  const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
+  if (override) {
+    const parts = commandWords(override);
+    const arg = parts[parts.length - 1] === '{}';
+    if (arg) parts.pop();
+    const [command, ...args] = parts;
+    if (!command) return null;
+    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+  }
+  return CLIENT_HARVEST_CLI[client] || null;
+}
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({
     name: 'Claude Code',

--- a/integrations/codex/plugin/hooks/lib/capabilities.mjs
+++ b/integrations/codex/plugin/hooks/lib/capabilities.mjs
@@ -353,21 +353,40 @@ function commandWords(line) {
  * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
  * client with no row -- or one whose vendor changed its flags after this
  * shipped -- is a configuration away from working rather than a release away.
- * The value is a command and its arguments. The payload goes to stdin unless
- * the string ends in `{}`, which is replaced by the path of a file holding
- * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ * The value is a command and its arguments, and its last word may name a
+ * delivery:
+ *   (nothing)  the payload goes to the command's stdin.
+ *   `{}`       it is written to a file and the path becomes the last
+ *              argument -- what an agentic CLI that ignores stdin needs.
+ *   `{-}`      the payload goes to stdin and a short instruction becomes the
+ *              last argument, for a CLI whose prompt flag demands a value
+ *              but which still reads stdin. gemini and qwen are shaped this
+ *              way, and without this an override could not reach that shape
+ *              at all.
  */
 export function harvestCliFor(client, env = process.env) {
   const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
   if (override) {
     const parts = commandWords(override);
-    const arg = parts[parts.length - 1] === '{}';
-    if (arg) parts.pop();
+    const last = parts[parts.length - 1];
+    const delivery =
+      last === '{}' ? 'prompt-file' : last === '{-}' ? 'arg-stdin' : 'stdin';
+    if (delivery !== 'stdin') parts.pop();
     const [command, ...args] = parts;
     if (!command) return null;
-    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+    return harvestCli(command, args, { delivery });
   }
-  return CLIENT_HARVEST_CLI[client] || null;
+  // NORMALISED AND OWN-PROPERTY ONLY, matching `capabilityFor` below.
+  //
+  // A bare index disagreed with its own sibling and reached the prototype.
+  // Reproduced: TOKEN_OPTIMIZER_CLIENT=Codex resolved a capability profile
+  // through capabilityFor -- which lower-cases -- and NO harvest CLI here, so
+  // harvestMode() fell through to off:no-key and an opted-in harvest silently
+  // did nothing on a client that plainly has one. And
+  // harvestCliFor('constructor') returned a function, whose `command` is
+  // undefined, which runHostCli would have handed straight to spawn.
+  const key = String(client || '').toLowerCase();
+  return Object.hasOwn(CLIENT_HARVEST_CLI, key) ? CLIENT_HARVEST_CLI[key] : null;
 }
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({

--- a/integrations/codex/plugin/hooks/lib/doctor.mjs
+++ b/integrations/codex/plugin/hooks/lib/doctor.mjs
@@ -246,6 +246,23 @@ export function probeHarvest() {
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
+  // The host client's own CLI, opted into with TOKEN_OPTIMIZER_HARVEST_CLI.
+  // Reported with the same failure-reason read as `local`, because the two
+  // share the property that made a broken configuration invisible: they
+  // return [] on failure and look exactly like a session with nothing to
+  // learn.
+  if (mode === 'host-cli') {
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check that this client\'s CLI is on PATH and signed in, or unset ' +
+        'TOKEN_OPTIMIZER_HARVEST_CLI to fall back to a configured endpoint')];
+    }
+    return [ok('finding extraction is available',
+      "this client's own CLI runs the semantic harvest -- no separate credential and no " +
+      'second vendor. Active-model wiki_write remains the primary path')];
+  }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
       'active-model wiki_write is primary; a credential also enables fallback extraction from ' +

--- a/integrations/codex/plugin/hooks/lib/harvest.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest.mjs
@@ -23,6 +23,7 @@
 import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { harvestCliFor } from './capabilities.mjs';
 
@@ -588,6 +589,14 @@ function withAnchorChoices(system, choices) {
   );
 }
 
+/**
+ * The `-p` value for a CLI whose prompt flag needs one but which still reads
+ * stdin. One line, no quotes, no newlines: everything a Windows command line
+ * cannot carry.
+ */
+export const ARG_STDIN_INSTRUCTION =
+  'Follow the instructions in the input above and reply with only the JSON array they ask for.';
+
 /** Restated at the end of a prompt file, where an agent skimming will see it. */
 const TRAILER =
   'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
@@ -652,7 +661,11 @@ async function runHostCli(cli, system, digest, timeoutMs) {
     // under the OS temp directory, which every one of these CLIs can read by
     // default, and removed in `finish` whatever the outcome.
     try {
-      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // UNGUESSABLE, NOT MERELY UNIQUE. pid and clock are both predictable
+      // enough for another local user to pre-create the path in a shared temp
+      // directory; randomUUID removes the guess, and `flag: 'wx'` below
+      // removes the race that remains.
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${randomUUID()}.txt`);
       // 0600. This is a digest of the user's session -- paths, commands and
       // prompts -- sitting in a shared temp directory for as long as the child
       // takes to read it. It is removed in `finish`, but a kill between the two
@@ -669,6 +682,12 @@ async function runHostCli(cli, system, digest, timeoutMs) {
       writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
         encoding: 'utf8',
         mode: 0o600,
+        // EXCLUSIVE CREATE. `mode` governs a file this call makes; it does
+        // nothing about one that already exists, and the default flag 'w'
+        // happily follows a symlink someone else placed at the path -- which
+        // would redirect a digest of the user's session wherever they chose.
+        // 'wx' fails instead of following.
+        flag: 'wx',
       });
     } catch (error) {
       return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
@@ -679,9 +698,16 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         'instructions and output the JSON array they ask for, and nothing else.'
     );
   } else if (cli.delivery === 'arg-stdin') {
-    // The flag needs a value and the CLI appends it after stdin, so the short
-    // instruction is the argument and the bulky digest still rides stdin.
-    args.push(system);
+    // A SHORT SINGLE LINE, NEVER THE PROMPT. The flag needs a value, and the
+    // obvious value -- `system` -- is the multi-line PROMPT, which
+    // withAnchorChoices extends with a newline-separated file list and which
+    // is full of the JSON prompt's double quotes. That is the exact payload
+    // the prompt-file route exists to keep off a Windows command line:
+    // cmd.exe cannot carry a newline inside an argument, and the quoting
+    // doubles every `"`. These CLIs document the flag value as being
+    // APPENDED to stdin, so the whole payload rides stdin and the argument
+    // is one line of ASCII that any shell survives.
+    args.push(ARG_STDIN_INSTRUCTION);
   }
 
   if (process.platform === 'win32' && file === cli.command) {
@@ -750,12 +776,26 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         : finish({ ok: false, reason: `${cli.command} exited ${code}` })
     );
 
+    // EPIPE ARRIVES AS AN EVENT, NOT AS A THROW. The try/catch below sees
+    // only a synchronous failure; a child that exits without reading stdin
+    // fails the write asynchronously, and Node delivers that on the stream.
+    // With no listener it is an uncaught exception that takes down the hook
+    // process instead of resolving this promise -- and the path is not
+    // hypothetical: copilot, asked to read a prompt on stdin, answers that it
+    // cannot and exits 0, which is why its row is prompt-file at all.
+    child.stdin.on('error', (error) =>
+      finish({
+        ok: false,
+        reason: `could not write the digest to ${cli.command}: ${error?.message || error}`,
+      })
+    );
+
     try {
       // Closed either way: a child left waiting on a pipe that will never
       // carry anything hangs until the timeout, which is the slowest possible
       // way to produce nothing.
       if (fileMode) child.stdin.end();
-      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+      else child.stdin.end(payload);
     } catch {
       finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
     }

--- a/integrations/codex/plugin/hooks/lib/harvest.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest.mjs
@@ -20,9 +20,11 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { harvestCliFor } from './capabilities.mjs';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -178,13 +180,25 @@ export function harvestMode() {
   // Free and private, so nothing further to weigh: no credential, no billing, no digest leaving
   // the machine.
   if (localEndpoint()) return 'local';
+  // THE HOST CLI IS A BACKEND, so the enablement check has to know about it.
+  // Without this the gate answers off:no-key and `extract` never reaches the
+  // CLI path -- which defeats the whole point of a backend that needs no key.
+  // Caught end to end rather than reasoned about: with no endpoint and no key,
+  // the first run of the opted-in host-CLI harvest returned
+  // `harvest is off:no-key` in 0s, having never spawned anything.
+  if (hostCliHarvest()) return 'host-cli';
+
 
   return apiKey() ? 'remote' : 'off:no-key';
 }
 
 export function harvestEnabled() {
   const mode = harvestMode();
-  return mode === 'local' || mode === 'remote';
+  // host-cli belongs here for the same reason local and remote do: it is a
+  // backend that can actually answer. Leaving it out would let the mode say
+  // `host-cli` while every caller that asks `harvestEnabled()` -- the Stop
+  // hook, the worker, extract's own first line -- skipped the harvest.
+  return mode === 'local' || mode === 'remote' || mode === 'host-cli';
 }
 
 /**
@@ -476,6 +490,295 @@ const succeeded = (findings) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
+/**
+ * The findings array inside a reply, or null.
+ *
+ * Models wrap JSON in prose or fences often enough that locating the array is
+ * more reliable than insisting the whole response parses -- and a CLI adds its
+ * own banner lines and stream-json envelopes on top, so both callers need the
+ * same tolerance. Shared so the two cannot drift.
+ */
+function findingsIn(text) {
+  const raw = String(text || '');
+
+  // FIRST BRACKET TO LAST IS NOT ENOUGH, and a CLI is where that breaks.
+  // `codex exec` prints a banner line reading `sandbox: workspace-write
+  // [workdir, /tmp, $TMPDIR]` before the model says anything, so the first
+  // `[` in the stream belongs to the banner and the naive slice parses to
+  // nothing -- an empty harvest that looks exactly like a session with
+  // nothing to learn. Closing brackets are walked from the end and opening
+  // brackets from the start, so the widest array that actually parses wins,
+  // and prose on either side is tolerated the way it already was for HTTP.
+  const closes = [];
+  for (let i = raw.length - 1; i >= 0 && closes.length < CLOSE_TRIES; i -= 1) {
+    if (raw[i] === ']') closes.push(i);
+  }
+  for (const end of closes) {
+    let tries = 0;
+    for (let start = raw.indexOf('['); start !== -1 && start < end; start = raw.indexOf('[', start + 1)) {
+      if ((tries += 1) > OPEN_TRIES) break;
+      try {
+        const parsed = JSON.parse(raw.slice(start, end + 1));
+        if (Array.isArray(parsed)) return parsed;
+      } catch {
+        /* not this pair */
+      }
+    }
+  }
+  return null;
+}
+
+// Bounded so a pathological reply cannot turn parsing into an O(n^2) walk of
+// a megabyte. A real findings array is at the end of the reply and preceded
+// by a banner or a sentence, not by hundreds of brackets.
+const CLOSE_TRIES = 8;
+const OPEN_TRIES = 40;
+
+/**
+ * Launches a Windows command through cmd.exe WITHOUT letting Node build the
+ * command line.
+ *
+ * These CLIs all install as .cmd shims, and Node has refused to spawn .cmd
+ * or .bat without a shell since the 2024 command-injection fix -- so a shell
+ * is not optional. But Node's own `shell: true` builds the cmd.exe line by
+ * joining argv with single spaces and no quoting at all, which breaks the
+ * moment any part contains one. Caught by the first test written against
+ * this: pointing the override at `C:\\Program Files\\nodejs\\node.exe`
+ * produced `C:\\Program Files\\nodejs\\node.exe exited 1`, because cmd.exe
+ * had been handed `C:\\Program` as the command. Quoting each part and passing
+ * the line verbatim is the fix.
+ */
+function windowsShellCommand(file, args) {
+  const quote = (part) => {
+    const value = String(part);
+    // Doubling is cmd.exe's own escape for a quote inside a quoted token.
+    return /[\s"]/.test(value)
+      ? `"${value.replace(/"/g, '""')}"`
+      : value;
+  };
+  const line = [file, ...args].map(quote).join(' ');
+  return [process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', `"${line}"`]];
+}
+
+/**
+ * States the anchor list in the prompt, for a backend that cannot be handed
+ * a schema.
+ *
+ * THE ANCHOR GATE IS WHAT SILENTLY EATS A HARVEST. `validate` keeps only
+ * anchors naming a file the session actually touched, and a model asked in
+ * English for a path writes a plausible one rather than a real one. Measured
+ * over four runs of qwen2.5:7b on a real digest against that gate:
+ * unconstrained, 4 extracted and 0 accepted; constrained to the list, 4 of 4.
+ *
+ * The HTTP path gets that constraint from a server-enforced enum. A CLI has
+ * no server to enforce it, so the same constraint is stated as strongly as a
+ * prompt can state it -- the exact strings, and an instruction to copy rather
+ * than compose. Not as good as an enum, and much better than nothing: the
+ * first end-to-end run without this extracted 10 findings and kept none.
+ */
+function withAnchorChoices(system, choices) {
+  if (!choices.length) return system;
+  const list = choices.map((file) => `- ${file}`).join('\n');
+  return (
+    `${system}\n\n` +
+    'Every entry in "anchors" MUST be copied verbatim from this list -- pick the ' +
+    'entries that best match the finding, and never write a path that is not ' +
+    'listed. Choosing the nearest match is right; dropping the finding is not:\n' +
+    list
+  );
+}
+
+/** Restated at the end of a prompt file, where an agent skimming will see it. */
+const TRAILER =
+  'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
+  'reply with the JSON array of findings and nothing else. If nothing in the ' +
+  'session is worth recording, reply with an empty array.';
+
+/**
+ * Runs the host client's own CLI as the harvest model.
+ *
+ * THE CHILD MUST NOT HARVEST. The harvest runs from the Stop hook, and a
+ * child session fires its own Stop hook -- verified, not assumed: a bare
+ * `claude -p` with our plugin installed wrote mcp-client, episode-outcome and
+ * derive events to the graph. Left unguarded that is unbounded recursion,
+ * each level spending real quota.
+ *
+ * TOKEN_OPTIMIZER_MODE=off IS THE GUARD, and it is the one that works.
+ * Measured on the same probe: TOKEN_OPTIMIZER_HARVEST=0 still ran the child's
+ * Stop hook and still wrote derive events -- it disables the harvest but not
+ * the hooks around it -- while MODE=off suppressed everything but a single
+ * mcp-client row. The kill switch is the only setting that makes the child
+ * inert, so the child is spawned with it and nothing else is relied upon.
+ *
+ * DELIVERY COMES FROM THE ROW, not from an assumption that every CLI reads
+ * stdin. Copilot does not: asked to follow instructions on stdin it replies
+ * that it cannot read stdin, exits 0, and yields no findings -- which looks
+ * exactly like a session with nothing to learn. Guessing here fails silently,
+ * so it is not guessed.
+ */
+/**
+ * How long to let the host CLI run.
+ *
+ * THE 30s HTTP DEFAULT KILLS EVERY CLI HARVEST, so it cannot be shared. That
+ * budget is sized for one completion against an endpoint that is already
+ * listening. A host CLI is an agent: it starts a process, loads its plugin
+ * and hook tree, opens a session, then thinks. Measured here on a 23 KB
+ * digest with no key and no local model, `claude -p` returned 10 findings in
+ * 104 SECONDS -- correct, and more than three times over the HTTP budget.
+ * `codex exec` on the same machine defaults to xhigh reasoning effort and
+ * had not finished at 300s, which is why this is configurable rather than
+ * merely larger.
+ *
+ * A caller that asks for MORE keeps it; the floor only lifts a default that
+ * was never chosen with this backend in mind.
+ */
+function hostCliTimeoutMs(requested) {
+  const configured = Number(process.env.TOKEN_OPTIMIZER_HARVEST_CLI_TIMEOUT_MS);
+  const floor = Number.isFinite(configured) && configured > 0 ? configured : 180_000;
+  return Math.max(floor, Number(requested) || 0);
+}
+
+async function runHostCli(cli, system, digest, timeoutMs) {
+  const payload = `${system}\n\n${digest}`;
+  const fileMode = cli.delivery === 'prompt-file';
+  let file = cli.command;
+  let args = [...cli.args];
+  let verbatim = false;
+  let promptFile = null;
+
+  if (fileMode) {
+    // A PATH, NOT THE PAYLOAD. See CLIENT_HARVEST_CLI for why the payload
+    // itself cannot travel as an argument on Windows. The file is written
+    // under the OS temp directory, which every one of these CLIs can read by
+    // default, and removed in `finish` whatever the outcome.
+    try {
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // 0600. This is a digest of the user's session -- paths, commands and
+      // prompts -- sitting in a shared temp directory for as long as the child
+      // takes to read it. It is removed in `finish`, but a kill between the two
+      // would leave it behind, so it is unreadable to other users meanwhile.
+      // (Windows ignores the mode; NTFS inheritance already keeps the per-user
+      // temp directory private.)
+      // THE CONTRACT IS REPEATED AT THE END. The instructions lead the file and
+      // the digest follows, which is the natural order and the one that failed:
+      // handed 23 KB this way, copilot reported the file as "a scratchpad
+      // /summary document" with no instruction in it and asked what JSON array
+      // was wanted. An agent skimming a long file sees its tail; restating the
+      // ask there costs one line and removes the dependence on how the file is
+      // read.
+      writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
+        encoding: 'utf8',
+        mode: 0o600,
+      });
+    } catch (error) {
+      return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
+    }
+    args.push(
+      `Read the whole file at ${promptFile}. It opens with instructions, then a ` +
+        'digest of a coding session, then repeats what to reply. Follow those ' +
+        'instructions and output the JSON array they ask for, and nothing else.'
+    );
+  } else if (cli.delivery === 'arg-stdin') {
+    // The flag needs a value and the CLI appends it after stdin, so the short
+    // instruction is the argument and the bulky digest still rides stdin.
+    args.push(system);
+  }
+
+  if (process.platform === 'win32' && file === cli.command) {
+    [file, args] = windowsShellCommand(file, args);
+    verbatim = true;
+  }
+
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(file, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        // The command line was built above where it needed cmd.exe, so Node
+        // must not rebuild it: `shell: true` would join argv unquoted.
+        windowsVerbatimArguments: verbatim,
+        env: {
+          ...process.env,
+          TOKEN_OPTIMIZER_MODE: 'off',
+        },
+      });
+    } catch (error) {
+      resolve({ ok: false, reason: `${cli.command} could not start: ${error?.message || error}` });
+      return;
+    }
+
+    let out = '';
+    let done = false;
+    const finish = (value) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      try {
+        child.kill();
+      } catch {
+        /* already gone */
+      }
+      if (promptFile) {
+        try {
+          rmSync(promptFile, { force: true });
+        } catch {
+          /* a leftover in the temp directory is not worth failing a harvest */
+        }
+      }
+      resolve(value);
+    };
+    const timer = setTimeout(
+      () => finish({ ok: false, reason: `${cli.command} timed out after ${timeoutMs}ms` }),
+      timeoutMs
+    );
+
+    child.stdout.on('data', (c) => {
+      out += c;
+    });
+    // stderr is drained so a chatty CLI cannot fill the pipe and deadlock.
+    child.stderr.on('data', () => {});
+    child.on('error', (error) =>
+      finish({ ok: false, reason: `${cli.command} failed: ${error?.message || error}` })
+    );
+    // NON-ZERO IS NOT ALWAYS EMPTY. Some of these print the reply and then
+    // exit non-zero over an unrelated cleanup complaint, so a parseable array
+    // already in hand beats the exit code; the code decides only when there is
+    // nothing to parse.
+    child.on('close', (code) =>
+      code === 0 || findingsIn(out)
+        ? finish({ ok: true, text: out })
+        : finish({ ok: false, reason: `${cli.command} exited ${code}` })
+    );
+
+    try {
+      // Closed either way: a child left waiting on a pipe that will never
+      // carry anything hangs until the timeout, which is the slowest possible
+      // way to produce nothing.
+      if (fileMode) child.stdin.end();
+      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+    } catch {
+      finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
+    }
+  });
+}
+
+/**
+ * Is the host CLI available as a harvest backend for this client?
+ *
+ * OPT-IN, deliberately, and this is the one default in this file that is not
+ * on. Every other path either reads local files or spends a key the user
+ * already configured for this purpose; this one spends the subscription that
+ * runs their editor, automatically, at the end of every session. HeadRoom
+ * makes the equivalent call user-invoked (`headroom learn`, cli/learn.py) and
+ * its own design note says to log events and analyse offline. Charging someone
+ * quota they did not ask to spend is not a default worth taking.
+ */
+export function hostCliHarvest(client = undefined, env = process.env) {
+  const enabled = /^(1|true|yes|on)$/i.test(env.TOKEN_OPTIMIZER_HARVEST_CLI || '');
+  if (!enabled) return null;
+  return harvestCliFor(client === undefined ? env.TOKEN_OPTIMIZER_CLIENT : client, env);
+}
+
 export async function extract(
   digest,
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
@@ -491,11 +794,40 @@ export async function extract(
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return failed('no api key for a remote endpoint');
+  // The host CLI carries its own auth -- the user is already signed into the
+  // client that is running this -- so the key requirement is about the HTTP
+  // backends only.
+  if (!local && !key && !hostCliHarvest()) {
+    return failed('no api key for a remote endpoint');
+  }
 
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // Computed before the CLI branch because BOTH backends need it. It used to
+  // sit below, so the host CLI was the one path that never learned which
+  // files it was allowed to anchor to -- and the anchor gate is what silently
+  // eats a harvest. Caught end to end on a real session: 10 findings
+  // extracted through `claude -p`, 0 surviving `validate`.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+
+  // The host client's own CLI, when the user has opted in. Tried first
+  // because it needs no key and no local model -- the two things whose
+  // absence has kept this path at 3 harvested findings on this machine.
+  const hostCli = hostCliHarvest();
+  if (hostCli) {
+    const result = await runHostCli(
+      hostCli,
+      withAnchorChoices(system, anchorChoices),
+      digest,
+      hostCliTimeoutMs(timeoutMs)
+    );
+    if (!result.ok) return failed(result.reason);
+    const parsed = findingsIn(result.text);
+    if (!parsed) return failed(`no JSON array in the ${hostCli.command} reply`);
+    return succeeded(parsed);
+  }
 
   // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
   //
@@ -514,7 +846,6 @@ export async function extract(
   // Only when the caller knows the list. `buildFullDelta` is raw transcript
   // with no file heading, and its caller passes no knownFiles for the same
   // reason -- an empty enum would forbid every anchor rather than free it.
-  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
   const schema = anchorChoices.length
     ? {
         ...FINDINGS_SCHEMA,
@@ -662,17 +993,8 @@ export async function extract(
       '';
     if (!text) return failed('endpoint answered in an unrecognised shape');
 
-    // Models wrap JSON in prose or fences often enough that finding the array
-    // is more reliable than insisting the whole response parse.
-    const start = text.indexOf('[');
-    const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return failed('no JSON array in the reply');
-
-    try {
-      return succeeded(JSON.parse(text.slice(start, end + 1)));
-    } catch {
-      return failed('the JSON array in the reply did not parse');
-    }
+    const parsed = findingsIn(text);
+    return parsed ? succeeded(parsed) : failed('no usable JSON array in the reply');
   } catch (error) {
     return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -695,6 +695,15 @@ function extractionNotice() {
         '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
         'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
       );
+    case 'host-cli':
+      // The extractor is this client's own headless CLI, which the user opted
+      // into. Worth its own case rather than folding into `remote`: no
+      // credential is involved, and the digest goes to the same vendor that
+      // already ran the session, which is a materially different disclosure.
+      return (
+        '\n\nSemantic extraction also runs after this session through this client\'s own CLI, ' +
+        'from a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
     case 'off:mode':
       // The whole optimizer is off and this text is not emitted anyway. Saying
       // anything here would be noise stacked on an explicit choice.

--- a/integrations/copilot/.github/hooks/lib/capabilities.mjs
+++ b/integrations/copilot/.github/hooks/lib/capabilities.mjs
@@ -194,6 +194,181 @@ const native = (profile) => ({
   ...profile,
 });
 
+/**
+ * How each client's own CLI can be driven headlessly, when it has one.
+ *
+ * THE HARVEST MODEL IS THE HOST ITSELF. Semantic extraction has always
+ * needed an API key or a local endpoint, and on a machine with neither it
+ * simply does not run -- measured on this one, 3 harvested findings against
+ * 237 written by the agent. But the client that just ran the session is
+ * installed BY DEFINITION and every one of these ships a headless mode, so
+ * the model was already on the machine. Nothing needed configuring; it only
+ * needed asking.
+ *
+ * ONE ROW PER CLIENT, not a hardcoded backend list. The nearest competitor
+ * picks from three (claude, gemini, codex), so its Cursor, Zed, Amp, Crush
+ * or Droid users get no semantic harvest at all. Every client this package
+ * supports gets a row here or an explicit null, and `npm run sync:hooks`
+ * copies the same table into all 16 integrations so the design cannot drift
+ * per client.
+ *
+ * NEVER ANOTHER VENDOR'S CLI. Reaching for whatever happens to be on PATH
+ * would send this session's digest to a model the user never chose, which is
+ * a disclosure they did not agree to. The host is the only defensible
+ * default, and TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND is the only way to pick a
+ * different one.
+ *
+ * DELIVERY IS PART OF THE ROW because the CLIs genuinely differ, and getting
+ * it wrong is silent:
+ *   - 'stdin'       the whole payload goes to the child's stdin.
+ *   - 'arg-stdin'   a short instruction is the final argument and the digest
+ *                   goes to stdin, for CLIs whose prompt flag needs a value
+ *                   but which still read stdin.
+ *   - 'prompt-file' the payload is written to a temp file and the final
+ *                   argument tells the agent to read it, for CLIs that do
+ *                   not read stdin at all.
+ *
+ * WHY A FILE AND NOT JUST A LONG ARGUMENT. Passing the payload itself as an
+ * argument was tried and abandoned on evidence. On POSIX it is fine; on
+ * Windows every one of these installs as a .cmd shim, which Node will not
+ * spawn without a shell, and cmd.exe cannot carry a newline inside an
+ * argument at all. Routing through PowerShell with the payload base64-encoded
+ * got past cmd.exe and then hit PowerShell 5.1's native-argument binder,
+ * which does not escape embedded double quotes: the prompt is JSON, so the
+ * first `\"type\":` ended the quoting and the child received 32 arguments
+ * instead of 1. A path has no spaces we did not choose, no quotes and no
+ * newlines, and it also lifts the ARG_MAX ceiling entirely -- these are
+ * agentic CLIs whose whole purpose is reading files, and the route is
+ * verified: copilot asked to read a payload file returned the exact array.
+ *
+ * VERIFIED means a probe was executed against the installed CLI in this
+ * repository and its reply parsed. DOCUMENTED means the shape comes from the
+ * vendor's own `--help` or published headless docs and has not been executed
+ * here, because the CLI is not installed on this machine. Both ship; the
+ * distinction is recorded so nobody mistakes the second for the first, and a
+ * wrong DOCUMENTED row fails loudly through `harvestFailure()` and doctor
+ * rather than silently producing nothing.
+ */
+const harvestCli = (command, args, { delivery = 'stdin', verified = false } = {}) =>
+  Object.freeze({ command, args: Object.freeze([...args]), delivery, verified });
+
+export const CLIENT_HARVEST_CLI = Object.freeze({
+  // VERIFIED: `claude -p` with the payload on stdin returned the exact array
+  // asked for. --output-format stream-json was tried first and rejected: its
+  // envelopes are themselves JSON containing brackets, which is a parsing
+  // hazard for no gain when plain text is already the model's reply.
+  'claude-code': harvestCli('claude', ['-p'], { verified: true }),
+  // VERIFIED: `codex exec -` reads instructions from stdin (its own --help
+  // says so, and a probe returned the array). It prints a banner containing
+  // `[workdir, /tmp, $TMPDIR]` before the reply, which is exactly why the
+  // reply parser has to try more than the first bracket it finds.
+  codex: harvestCli('codex', ['exec', '-'], { verified: true }),
+  // VERIFIED both ways. Asked to follow instructions on stdin the agent
+  // answered that it was unable to read stdin and exited 0 -- a silent
+  // no-findings result indistinguishable from a quiet session. Asked instead
+  // to read a payload file it returned the exact array requested, which is
+  // why this row is prompt-file. --allow-all-tools is required for
+  // non-interactive use by copilot's own help text, and -s drops the stats
+  // banner.
+  copilot: harvestCli('copilot', ['-s', '--allow-all-tools', '-p'], {
+    delivery: 'prompt-file',
+    verified: true,
+  }),
+  // DOCUMENTED: `gemini --help` states that -p runs headless and that the
+  // prompt is "Appended to input on stdin (if any)", so the digest rides
+  // stdin and the instruction is the flag value. Not executed here: this
+  // machine's gemini is unauthenticated and fails in refreshAuth before any
+  // prompt is read.
+  gemini: harvestCli('gemini', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: qwen-code is a fork of gemini-cli and keeps its flag surface.
+  qwen: harvestCli('qwen', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: `opencode run <message>` is its non-interactive entry point.
+  opencode: harvestCli('opencode', ['run'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `crush run <prompt>` runs a single non-interactive prompt.
+  crush: harvestCli('crush', ['run', '-q'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `droid exec <prompt>` is Factory's headless mode.
+  droid: harvestCli('droid', ['exec'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `amp -x <prompt>` executes a single prompt and exits.
+  amp: harvestCli('amp', ['-x'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: the Continue CLI installs as `cn` and takes -p for headless.
+  continue: harvestCli('cn', ['-p'], { delivery: 'prompt-file' }),
+
+  // NO HEADLESS CLI OF THEIR OWN. These are editor- and extension-hosted:
+  // the assistant runs inside the IDE process and ships no command a hook
+  // could spawn. Declaring null keeps that a stated fact rather than an
+  // omission, and these clients fall back to a configured endpoint --
+  // borrowing a neighbouring vendor's CLI would send the digest to a model
+  // the user never chose.
+  cursor: null,
+  cline: null,
+  windsurf: null,
+  kilo: null,
+  roo: null,
+  zed: null,
+});
+
+/**
+ * Splits a configured command line into words, respecting quotes.
+ *
+ * SPLITTING ON WHITESPACE ALONE IS WRONG ON WINDOWS, and the first test
+ * written against this caught it: the natural thing to configure is the
+ * interpreter you already have, and on Windows that is
+ * `C:\\Program Files\\nodejs\\node.exe`. A bare split turned that into the
+ * command `C:\\Program` and reported `C:\\Program exited 1`, which is a
+ * diagnostic nobody can act on. Quoting a path with spaces is the ordinary
+ * way to write a command line, so it has to mean what it says.
+ */
+function commandWords(line) {
+  const words = [];
+  let current = '';
+  let quote = '';
+  let started = false;
+  for (const ch of String(line)) {
+    if (quote) {
+      if (ch === quote) quote = '';
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (started) words.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (started) words.push(current);
+  return words;
+}
+
+/**
+ * The harvest CLI for a client, or null when it has none.
+ *
+ * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
+ * client with no row -- or one whose vendor changed its flags after this
+ * shipped -- is a configuration away from working rather than a release away.
+ * The value is a command and its arguments. The payload goes to stdin unless
+ * the string ends in `{}`, which is replaced by the path of a file holding
+ * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ */
+export function harvestCliFor(client, env = process.env) {
+  const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
+  if (override) {
+    const parts = commandWords(override);
+    const arg = parts[parts.length - 1] === '{}';
+    if (arg) parts.pop();
+    const [command, ...args] = parts;
+    if (!command) return null;
+    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+  }
+  return CLIENT_HARVEST_CLI[client] || null;
+}
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({
     name: 'Claude Code',

--- a/integrations/copilot/.github/hooks/lib/capabilities.mjs
+++ b/integrations/copilot/.github/hooks/lib/capabilities.mjs
@@ -353,21 +353,40 @@ function commandWords(line) {
  * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
  * client with no row -- or one whose vendor changed its flags after this
  * shipped -- is a configuration away from working rather than a release away.
- * The value is a command and its arguments. The payload goes to stdin unless
- * the string ends in `{}`, which is replaced by the path of a file holding
- * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ * The value is a command and its arguments, and its last word may name a
+ * delivery:
+ *   (nothing)  the payload goes to the command's stdin.
+ *   `{}`       it is written to a file and the path becomes the last
+ *              argument -- what an agentic CLI that ignores stdin needs.
+ *   `{-}`      the payload goes to stdin and a short instruction becomes the
+ *              last argument, for a CLI whose prompt flag demands a value
+ *              but which still reads stdin. gemini and qwen are shaped this
+ *              way, and without this an override could not reach that shape
+ *              at all.
  */
 export function harvestCliFor(client, env = process.env) {
   const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
   if (override) {
     const parts = commandWords(override);
-    const arg = parts[parts.length - 1] === '{}';
-    if (arg) parts.pop();
+    const last = parts[parts.length - 1];
+    const delivery =
+      last === '{}' ? 'prompt-file' : last === '{-}' ? 'arg-stdin' : 'stdin';
+    if (delivery !== 'stdin') parts.pop();
     const [command, ...args] = parts;
     if (!command) return null;
-    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+    return harvestCli(command, args, { delivery });
   }
-  return CLIENT_HARVEST_CLI[client] || null;
+  // NORMALISED AND OWN-PROPERTY ONLY, matching `capabilityFor` below.
+  //
+  // A bare index disagreed with its own sibling and reached the prototype.
+  // Reproduced: TOKEN_OPTIMIZER_CLIENT=Codex resolved a capability profile
+  // through capabilityFor -- which lower-cases -- and NO harvest CLI here, so
+  // harvestMode() fell through to off:no-key and an opted-in harvest silently
+  // did nothing on a client that plainly has one. And
+  // harvestCliFor('constructor') returned a function, whose `command` is
+  // undefined, which runHostCli would have handed straight to spawn.
+  const key = String(client || '').toLowerCase();
+  return Object.hasOwn(CLIENT_HARVEST_CLI, key) ? CLIENT_HARVEST_CLI[key] : null;
 }
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({

--- a/integrations/copilot/.github/hooks/lib/doctor.mjs
+++ b/integrations/copilot/.github/hooks/lib/doctor.mjs
@@ -246,6 +246,23 @@ export function probeHarvest() {
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
+  // The host client's own CLI, opted into with TOKEN_OPTIMIZER_HARVEST_CLI.
+  // Reported with the same failure-reason read as `local`, because the two
+  // share the property that made a broken configuration invisible: they
+  // return [] on failure and look exactly like a session with nothing to
+  // learn.
+  if (mode === 'host-cli') {
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check that this client\'s CLI is on PATH and signed in, or unset ' +
+        'TOKEN_OPTIMIZER_HARVEST_CLI to fall back to a configured endpoint')];
+    }
+    return [ok('finding extraction is available',
+      "this client's own CLI runs the semantic harvest -- no separate credential and no " +
+      'second vendor. Active-model wiki_write remains the primary path')];
+  }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
       'active-model wiki_write is primary; a credential also enables fallback extraction from ' +

--- a/integrations/copilot/.github/hooks/lib/harvest.mjs
+++ b/integrations/copilot/.github/hooks/lib/harvest.mjs
@@ -23,6 +23,7 @@
 import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { harvestCliFor } from './capabilities.mjs';
 
@@ -588,6 +589,14 @@ function withAnchorChoices(system, choices) {
   );
 }
 
+/**
+ * The `-p` value for a CLI whose prompt flag needs one but which still reads
+ * stdin. One line, no quotes, no newlines: everything a Windows command line
+ * cannot carry.
+ */
+export const ARG_STDIN_INSTRUCTION =
+  'Follow the instructions in the input above and reply with only the JSON array they ask for.';
+
 /** Restated at the end of a prompt file, where an agent skimming will see it. */
 const TRAILER =
   'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
@@ -652,7 +661,11 @@ async function runHostCli(cli, system, digest, timeoutMs) {
     // under the OS temp directory, which every one of these CLIs can read by
     // default, and removed in `finish` whatever the outcome.
     try {
-      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // UNGUESSABLE, NOT MERELY UNIQUE. pid and clock are both predictable
+      // enough for another local user to pre-create the path in a shared temp
+      // directory; randomUUID removes the guess, and `flag: 'wx'` below
+      // removes the race that remains.
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${randomUUID()}.txt`);
       // 0600. This is a digest of the user's session -- paths, commands and
       // prompts -- sitting in a shared temp directory for as long as the child
       // takes to read it. It is removed in `finish`, but a kill between the two
@@ -669,6 +682,12 @@ async function runHostCli(cli, system, digest, timeoutMs) {
       writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
         encoding: 'utf8',
         mode: 0o600,
+        // EXCLUSIVE CREATE. `mode` governs a file this call makes; it does
+        // nothing about one that already exists, and the default flag 'w'
+        // happily follows a symlink someone else placed at the path -- which
+        // would redirect a digest of the user's session wherever they chose.
+        // 'wx' fails instead of following.
+        flag: 'wx',
       });
     } catch (error) {
       return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
@@ -679,9 +698,16 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         'instructions and output the JSON array they ask for, and nothing else.'
     );
   } else if (cli.delivery === 'arg-stdin') {
-    // The flag needs a value and the CLI appends it after stdin, so the short
-    // instruction is the argument and the bulky digest still rides stdin.
-    args.push(system);
+    // A SHORT SINGLE LINE, NEVER THE PROMPT. The flag needs a value, and the
+    // obvious value -- `system` -- is the multi-line PROMPT, which
+    // withAnchorChoices extends with a newline-separated file list and which
+    // is full of the JSON prompt's double quotes. That is the exact payload
+    // the prompt-file route exists to keep off a Windows command line:
+    // cmd.exe cannot carry a newline inside an argument, and the quoting
+    // doubles every `"`. These CLIs document the flag value as being
+    // APPENDED to stdin, so the whole payload rides stdin and the argument
+    // is one line of ASCII that any shell survives.
+    args.push(ARG_STDIN_INSTRUCTION);
   }
 
   if (process.platform === 'win32' && file === cli.command) {
@@ -750,12 +776,26 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         : finish({ ok: false, reason: `${cli.command} exited ${code}` })
     );
 
+    // EPIPE ARRIVES AS AN EVENT, NOT AS A THROW. The try/catch below sees
+    // only a synchronous failure; a child that exits without reading stdin
+    // fails the write asynchronously, and Node delivers that on the stream.
+    // With no listener it is an uncaught exception that takes down the hook
+    // process instead of resolving this promise -- and the path is not
+    // hypothetical: copilot, asked to read a prompt on stdin, answers that it
+    // cannot and exits 0, which is why its row is prompt-file at all.
+    child.stdin.on('error', (error) =>
+      finish({
+        ok: false,
+        reason: `could not write the digest to ${cli.command}: ${error?.message || error}`,
+      })
+    );
+
     try {
       // Closed either way: a child left waiting on a pipe that will never
       // carry anything hangs until the timeout, which is the slowest possible
       // way to produce nothing.
       if (fileMode) child.stdin.end();
-      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+      else child.stdin.end(payload);
     } catch {
       finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
     }

--- a/integrations/copilot/.github/hooks/lib/harvest.mjs
+++ b/integrations/copilot/.github/hooks/lib/harvest.mjs
@@ -20,9 +20,11 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { harvestCliFor } from './capabilities.mjs';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -178,13 +180,25 @@ export function harvestMode() {
   // Free and private, so nothing further to weigh: no credential, no billing, no digest leaving
   // the machine.
   if (localEndpoint()) return 'local';
+  // THE HOST CLI IS A BACKEND, so the enablement check has to know about it.
+  // Without this the gate answers off:no-key and `extract` never reaches the
+  // CLI path -- which defeats the whole point of a backend that needs no key.
+  // Caught end to end rather than reasoned about: with no endpoint and no key,
+  // the first run of the opted-in host-CLI harvest returned
+  // `harvest is off:no-key` in 0s, having never spawned anything.
+  if (hostCliHarvest()) return 'host-cli';
+
 
   return apiKey() ? 'remote' : 'off:no-key';
 }
 
 export function harvestEnabled() {
   const mode = harvestMode();
-  return mode === 'local' || mode === 'remote';
+  // host-cli belongs here for the same reason local and remote do: it is a
+  // backend that can actually answer. Leaving it out would let the mode say
+  // `host-cli` while every caller that asks `harvestEnabled()` -- the Stop
+  // hook, the worker, extract's own first line -- skipped the harvest.
+  return mode === 'local' || mode === 'remote' || mode === 'host-cli';
 }
 
 /**
@@ -476,6 +490,295 @@ const succeeded = (findings) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
+/**
+ * The findings array inside a reply, or null.
+ *
+ * Models wrap JSON in prose or fences often enough that locating the array is
+ * more reliable than insisting the whole response parses -- and a CLI adds its
+ * own banner lines and stream-json envelopes on top, so both callers need the
+ * same tolerance. Shared so the two cannot drift.
+ */
+function findingsIn(text) {
+  const raw = String(text || '');
+
+  // FIRST BRACKET TO LAST IS NOT ENOUGH, and a CLI is where that breaks.
+  // `codex exec` prints a banner line reading `sandbox: workspace-write
+  // [workdir, /tmp, $TMPDIR]` before the model says anything, so the first
+  // `[` in the stream belongs to the banner and the naive slice parses to
+  // nothing -- an empty harvest that looks exactly like a session with
+  // nothing to learn. Closing brackets are walked from the end and opening
+  // brackets from the start, so the widest array that actually parses wins,
+  // and prose on either side is tolerated the way it already was for HTTP.
+  const closes = [];
+  for (let i = raw.length - 1; i >= 0 && closes.length < CLOSE_TRIES; i -= 1) {
+    if (raw[i] === ']') closes.push(i);
+  }
+  for (const end of closes) {
+    let tries = 0;
+    for (let start = raw.indexOf('['); start !== -1 && start < end; start = raw.indexOf('[', start + 1)) {
+      if ((tries += 1) > OPEN_TRIES) break;
+      try {
+        const parsed = JSON.parse(raw.slice(start, end + 1));
+        if (Array.isArray(parsed)) return parsed;
+      } catch {
+        /* not this pair */
+      }
+    }
+  }
+  return null;
+}
+
+// Bounded so a pathological reply cannot turn parsing into an O(n^2) walk of
+// a megabyte. A real findings array is at the end of the reply and preceded
+// by a banner or a sentence, not by hundreds of brackets.
+const CLOSE_TRIES = 8;
+const OPEN_TRIES = 40;
+
+/**
+ * Launches a Windows command through cmd.exe WITHOUT letting Node build the
+ * command line.
+ *
+ * These CLIs all install as .cmd shims, and Node has refused to spawn .cmd
+ * or .bat without a shell since the 2024 command-injection fix -- so a shell
+ * is not optional. But Node's own `shell: true` builds the cmd.exe line by
+ * joining argv with single spaces and no quoting at all, which breaks the
+ * moment any part contains one. Caught by the first test written against
+ * this: pointing the override at `C:\\Program Files\\nodejs\\node.exe`
+ * produced `C:\\Program Files\\nodejs\\node.exe exited 1`, because cmd.exe
+ * had been handed `C:\\Program` as the command. Quoting each part and passing
+ * the line verbatim is the fix.
+ */
+function windowsShellCommand(file, args) {
+  const quote = (part) => {
+    const value = String(part);
+    // Doubling is cmd.exe's own escape for a quote inside a quoted token.
+    return /[\s"]/.test(value)
+      ? `"${value.replace(/"/g, '""')}"`
+      : value;
+  };
+  const line = [file, ...args].map(quote).join(' ');
+  return [process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', `"${line}"`]];
+}
+
+/**
+ * States the anchor list in the prompt, for a backend that cannot be handed
+ * a schema.
+ *
+ * THE ANCHOR GATE IS WHAT SILENTLY EATS A HARVEST. `validate` keeps only
+ * anchors naming a file the session actually touched, and a model asked in
+ * English for a path writes a plausible one rather than a real one. Measured
+ * over four runs of qwen2.5:7b on a real digest against that gate:
+ * unconstrained, 4 extracted and 0 accepted; constrained to the list, 4 of 4.
+ *
+ * The HTTP path gets that constraint from a server-enforced enum. A CLI has
+ * no server to enforce it, so the same constraint is stated as strongly as a
+ * prompt can state it -- the exact strings, and an instruction to copy rather
+ * than compose. Not as good as an enum, and much better than nothing: the
+ * first end-to-end run without this extracted 10 findings and kept none.
+ */
+function withAnchorChoices(system, choices) {
+  if (!choices.length) return system;
+  const list = choices.map((file) => `- ${file}`).join('\n');
+  return (
+    `${system}\n\n` +
+    'Every entry in "anchors" MUST be copied verbatim from this list -- pick the ' +
+    'entries that best match the finding, and never write a path that is not ' +
+    'listed. Choosing the nearest match is right; dropping the finding is not:\n' +
+    list
+  );
+}
+
+/** Restated at the end of a prompt file, where an agent skimming will see it. */
+const TRAILER =
+  'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
+  'reply with the JSON array of findings and nothing else. If nothing in the ' +
+  'session is worth recording, reply with an empty array.';
+
+/**
+ * Runs the host client's own CLI as the harvest model.
+ *
+ * THE CHILD MUST NOT HARVEST. The harvest runs from the Stop hook, and a
+ * child session fires its own Stop hook -- verified, not assumed: a bare
+ * `claude -p` with our plugin installed wrote mcp-client, episode-outcome and
+ * derive events to the graph. Left unguarded that is unbounded recursion,
+ * each level spending real quota.
+ *
+ * TOKEN_OPTIMIZER_MODE=off IS THE GUARD, and it is the one that works.
+ * Measured on the same probe: TOKEN_OPTIMIZER_HARVEST=0 still ran the child's
+ * Stop hook and still wrote derive events -- it disables the harvest but not
+ * the hooks around it -- while MODE=off suppressed everything but a single
+ * mcp-client row. The kill switch is the only setting that makes the child
+ * inert, so the child is spawned with it and nothing else is relied upon.
+ *
+ * DELIVERY COMES FROM THE ROW, not from an assumption that every CLI reads
+ * stdin. Copilot does not: asked to follow instructions on stdin it replies
+ * that it cannot read stdin, exits 0, and yields no findings -- which looks
+ * exactly like a session with nothing to learn. Guessing here fails silently,
+ * so it is not guessed.
+ */
+/**
+ * How long to let the host CLI run.
+ *
+ * THE 30s HTTP DEFAULT KILLS EVERY CLI HARVEST, so it cannot be shared. That
+ * budget is sized for one completion against an endpoint that is already
+ * listening. A host CLI is an agent: it starts a process, loads its plugin
+ * and hook tree, opens a session, then thinks. Measured here on a 23 KB
+ * digest with no key and no local model, `claude -p` returned 10 findings in
+ * 104 SECONDS -- correct, and more than three times over the HTTP budget.
+ * `codex exec` on the same machine defaults to xhigh reasoning effort and
+ * had not finished at 300s, which is why this is configurable rather than
+ * merely larger.
+ *
+ * A caller that asks for MORE keeps it; the floor only lifts a default that
+ * was never chosen with this backend in mind.
+ */
+function hostCliTimeoutMs(requested) {
+  const configured = Number(process.env.TOKEN_OPTIMIZER_HARVEST_CLI_TIMEOUT_MS);
+  const floor = Number.isFinite(configured) && configured > 0 ? configured : 180_000;
+  return Math.max(floor, Number(requested) || 0);
+}
+
+async function runHostCli(cli, system, digest, timeoutMs) {
+  const payload = `${system}\n\n${digest}`;
+  const fileMode = cli.delivery === 'prompt-file';
+  let file = cli.command;
+  let args = [...cli.args];
+  let verbatim = false;
+  let promptFile = null;
+
+  if (fileMode) {
+    // A PATH, NOT THE PAYLOAD. See CLIENT_HARVEST_CLI for why the payload
+    // itself cannot travel as an argument on Windows. The file is written
+    // under the OS temp directory, which every one of these CLIs can read by
+    // default, and removed in `finish` whatever the outcome.
+    try {
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // 0600. This is a digest of the user's session -- paths, commands and
+      // prompts -- sitting in a shared temp directory for as long as the child
+      // takes to read it. It is removed in `finish`, but a kill between the two
+      // would leave it behind, so it is unreadable to other users meanwhile.
+      // (Windows ignores the mode; NTFS inheritance already keeps the per-user
+      // temp directory private.)
+      // THE CONTRACT IS REPEATED AT THE END. The instructions lead the file and
+      // the digest follows, which is the natural order and the one that failed:
+      // handed 23 KB this way, copilot reported the file as "a scratchpad
+      // /summary document" with no instruction in it and asked what JSON array
+      // was wanted. An agent skimming a long file sees its tail; restating the
+      // ask there costs one line and removes the dependence on how the file is
+      // read.
+      writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
+        encoding: 'utf8',
+        mode: 0o600,
+      });
+    } catch (error) {
+      return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
+    }
+    args.push(
+      `Read the whole file at ${promptFile}. It opens with instructions, then a ` +
+        'digest of a coding session, then repeats what to reply. Follow those ' +
+        'instructions and output the JSON array they ask for, and nothing else.'
+    );
+  } else if (cli.delivery === 'arg-stdin') {
+    // The flag needs a value and the CLI appends it after stdin, so the short
+    // instruction is the argument and the bulky digest still rides stdin.
+    args.push(system);
+  }
+
+  if (process.platform === 'win32' && file === cli.command) {
+    [file, args] = windowsShellCommand(file, args);
+    verbatim = true;
+  }
+
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(file, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        // The command line was built above where it needed cmd.exe, so Node
+        // must not rebuild it: `shell: true` would join argv unquoted.
+        windowsVerbatimArguments: verbatim,
+        env: {
+          ...process.env,
+          TOKEN_OPTIMIZER_MODE: 'off',
+        },
+      });
+    } catch (error) {
+      resolve({ ok: false, reason: `${cli.command} could not start: ${error?.message || error}` });
+      return;
+    }
+
+    let out = '';
+    let done = false;
+    const finish = (value) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      try {
+        child.kill();
+      } catch {
+        /* already gone */
+      }
+      if (promptFile) {
+        try {
+          rmSync(promptFile, { force: true });
+        } catch {
+          /* a leftover in the temp directory is not worth failing a harvest */
+        }
+      }
+      resolve(value);
+    };
+    const timer = setTimeout(
+      () => finish({ ok: false, reason: `${cli.command} timed out after ${timeoutMs}ms` }),
+      timeoutMs
+    );
+
+    child.stdout.on('data', (c) => {
+      out += c;
+    });
+    // stderr is drained so a chatty CLI cannot fill the pipe and deadlock.
+    child.stderr.on('data', () => {});
+    child.on('error', (error) =>
+      finish({ ok: false, reason: `${cli.command} failed: ${error?.message || error}` })
+    );
+    // NON-ZERO IS NOT ALWAYS EMPTY. Some of these print the reply and then
+    // exit non-zero over an unrelated cleanup complaint, so a parseable array
+    // already in hand beats the exit code; the code decides only when there is
+    // nothing to parse.
+    child.on('close', (code) =>
+      code === 0 || findingsIn(out)
+        ? finish({ ok: true, text: out })
+        : finish({ ok: false, reason: `${cli.command} exited ${code}` })
+    );
+
+    try {
+      // Closed either way: a child left waiting on a pipe that will never
+      // carry anything hangs until the timeout, which is the slowest possible
+      // way to produce nothing.
+      if (fileMode) child.stdin.end();
+      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+    } catch {
+      finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
+    }
+  });
+}
+
+/**
+ * Is the host CLI available as a harvest backend for this client?
+ *
+ * OPT-IN, deliberately, and this is the one default in this file that is not
+ * on. Every other path either reads local files or spends a key the user
+ * already configured for this purpose; this one spends the subscription that
+ * runs their editor, automatically, at the end of every session. HeadRoom
+ * makes the equivalent call user-invoked (`headroom learn`, cli/learn.py) and
+ * its own design note says to log events and analyse offline. Charging someone
+ * quota they did not ask to spend is not a default worth taking.
+ */
+export function hostCliHarvest(client = undefined, env = process.env) {
+  const enabled = /^(1|true|yes|on)$/i.test(env.TOKEN_OPTIMIZER_HARVEST_CLI || '');
+  if (!enabled) return null;
+  return harvestCliFor(client === undefined ? env.TOKEN_OPTIMIZER_CLIENT : client, env);
+}
+
 export async function extract(
   digest,
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
@@ -491,11 +794,40 @@ export async function extract(
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return failed('no api key for a remote endpoint');
+  // The host CLI carries its own auth -- the user is already signed into the
+  // client that is running this -- so the key requirement is about the HTTP
+  // backends only.
+  if (!local && !key && !hostCliHarvest()) {
+    return failed('no api key for a remote endpoint');
+  }
 
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // Computed before the CLI branch because BOTH backends need it. It used to
+  // sit below, so the host CLI was the one path that never learned which
+  // files it was allowed to anchor to -- and the anchor gate is what silently
+  // eats a harvest. Caught end to end on a real session: 10 findings
+  // extracted through `claude -p`, 0 surviving `validate`.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+
+  // The host client's own CLI, when the user has opted in. Tried first
+  // because it needs no key and no local model -- the two things whose
+  // absence has kept this path at 3 harvested findings on this machine.
+  const hostCli = hostCliHarvest();
+  if (hostCli) {
+    const result = await runHostCli(
+      hostCli,
+      withAnchorChoices(system, anchorChoices),
+      digest,
+      hostCliTimeoutMs(timeoutMs)
+    );
+    if (!result.ok) return failed(result.reason);
+    const parsed = findingsIn(result.text);
+    if (!parsed) return failed(`no JSON array in the ${hostCli.command} reply`);
+    return succeeded(parsed);
+  }
 
   // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
   //
@@ -514,7 +846,6 @@ export async function extract(
   // Only when the caller knows the list. `buildFullDelta` is raw transcript
   // with no file heading, and its caller passes no knownFiles for the same
   // reason -- an empty enum would forbid every anchor rather than free it.
-  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
   const schema = anchorChoices.length
     ? {
         ...FINDINGS_SCHEMA,
@@ -662,17 +993,8 @@ export async function extract(
       '';
     if (!text) return failed('endpoint answered in an unrecognised shape');
 
-    // Models wrap JSON in prose or fences often enough that finding the array
-    // is more reliable than insisting the whole response parse.
-    const start = text.indexOf('[');
-    const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return failed('no JSON array in the reply');
-
-    try {
-      return succeeded(JSON.parse(text.slice(start, end + 1)));
-    } catch {
-      return failed('the JSON array in the reply did not parse');
-    }
+    const parsed = findingsIn(text);
+    return parsed ? succeeded(parsed) : failed('no usable JSON array in the reply');
   } catch (error) {
     return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -695,6 +695,15 @@ function extractionNotice() {
         '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
         'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
       );
+    case 'host-cli':
+      // The extractor is this client's own headless CLI, which the user opted
+      // into. Worth its own case rather than folding into `remote`: no
+      // credential is involved, and the digest goes to the same vendor that
+      // already ran the session, which is a materially different disclosure.
+      return (
+        '\n\nSemantic extraction also runs after this session through this client\'s own CLI, ' +
+        'from a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
     case 'off:mode':
       // The whole optimizer is off and this text is not emitted anyway. Saying
       // anything here would be noise stacked on an explicit choice.

--- a/integrations/cursor/hooks/lib/capabilities.mjs
+++ b/integrations/cursor/hooks/lib/capabilities.mjs
@@ -194,6 +194,181 @@ const native = (profile) => ({
   ...profile,
 });
 
+/**
+ * How each client's own CLI can be driven headlessly, when it has one.
+ *
+ * THE HARVEST MODEL IS THE HOST ITSELF. Semantic extraction has always
+ * needed an API key or a local endpoint, and on a machine with neither it
+ * simply does not run -- measured on this one, 3 harvested findings against
+ * 237 written by the agent. But the client that just ran the session is
+ * installed BY DEFINITION and every one of these ships a headless mode, so
+ * the model was already on the machine. Nothing needed configuring; it only
+ * needed asking.
+ *
+ * ONE ROW PER CLIENT, not a hardcoded backend list. The nearest competitor
+ * picks from three (claude, gemini, codex), so its Cursor, Zed, Amp, Crush
+ * or Droid users get no semantic harvest at all. Every client this package
+ * supports gets a row here or an explicit null, and `npm run sync:hooks`
+ * copies the same table into all 16 integrations so the design cannot drift
+ * per client.
+ *
+ * NEVER ANOTHER VENDOR'S CLI. Reaching for whatever happens to be on PATH
+ * would send this session's digest to a model the user never chose, which is
+ * a disclosure they did not agree to. The host is the only defensible
+ * default, and TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND is the only way to pick a
+ * different one.
+ *
+ * DELIVERY IS PART OF THE ROW because the CLIs genuinely differ, and getting
+ * it wrong is silent:
+ *   - 'stdin'       the whole payload goes to the child's stdin.
+ *   - 'arg-stdin'   a short instruction is the final argument and the digest
+ *                   goes to stdin, for CLIs whose prompt flag needs a value
+ *                   but which still read stdin.
+ *   - 'prompt-file' the payload is written to a temp file and the final
+ *                   argument tells the agent to read it, for CLIs that do
+ *                   not read stdin at all.
+ *
+ * WHY A FILE AND NOT JUST A LONG ARGUMENT. Passing the payload itself as an
+ * argument was tried and abandoned on evidence. On POSIX it is fine; on
+ * Windows every one of these installs as a .cmd shim, which Node will not
+ * spawn without a shell, and cmd.exe cannot carry a newline inside an
+ * argument at all. Routing through PowerShell with the payload base64-encoded
+ * got past cmd.exe and then hit PowerShell 5.1's native-argument binder,
+ * which does not escape embedded double quotes: the prompt is JSON, so the
+ * first `\"type\":` ended the quoting and the child received 32 arguments
+ * instead of 1. A path has no spaces we did not choose, no quotes and no
+ * newlines, and it also lifts the ARG_MAX ceiling entirely -- these are
+ * agentic CLIs whose whole purpose is reading files, and the route is
+ * verified: copilot asked to read a payload file returned the exact array.
+ *
+ * VERIFIED means a probe was executed against the installed CLI in this
+ * repository and its reply parsed. DOCUMENTED means the shape comes from the
+ * vendor's own `--help` or published headless docs and has not been executed
+ * here, because the CLI is not installed on this machine. Both ship; the
+ * distinction is recorded so nobody mistakes the second for the first, and a
+ * wrong DOCUMENTED row fails loudly through `harvestFailure()` and doctor
+ * rather than silently producing nothing.
+ */
+const harvestCli = (command, args, { delivery = 'stdin', verified = false } = {}) =>
+  Object.freeze({ command, args: Object.freeze([...args]), delivery, verified });
+
+export const CLIENT_HARVEST_CLI = Object.freeze({
+  // VERIFIED: `claude -p` with the payload on stdin returned the exact array
+  // asked for. --output-format stream-json was tried first and rejected: its
+  // envelopes are themselves JSON containing brackets, which is a parsing
+  // hazard for no gain when plain text is already the model's reply.
+  'claude-code': harvestCli('claude', ['-p'], { verified: true }),
+  // VERIFIED: `codex exec -` reads instructions from stdin (its own --help
+  // says so, and a probe returned the array). It prints a banner containing
+  // `[workdir, /tmp, $TMPDIR]` before the reply, which is exactly why the
+  // reply parser has to try more than the first bracket it finds.
+  codex: harvestCli('codex', ['exec', '-'], { verified: true }),
+  // VERIFIED both ways. Asked to follow instructions on stdin the agent
+  // answered that it was unable to read stdin and exited 0 -- a silent
+  // no-findings result indistinguishable from a quiet session. Asked instead
+  // to read a payload file it returned the exact array requested, which is
+  // why this row is prompt-file. --allow-all-tools is required for
+  // non-interactive use by copilot's own help text, and -s drops the stats
+  // banner.
+  copilot: harvestCli('copilot', ['-s', '--allow-all-tools', '-p'], {
+    delivery: 'prompt-file',
+    verified: true,
+  }),
+  // DOCUMENTED: `gemini --help` states that -p runs headless and that the
+  // prompt is "Appended to input on stdin (if any)", so the digest rides
+  // stdin and the instruction is the flag value. Not executed here: this
+  // machine's gemini is unauthenticated and fails in refreshAuth before any
+  // prompt is read.
+  gemini: harvestCli('gemini', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: qwen-code is a fork of gemini-cli and keeps its flag surface.
+  qwen: harvestCli('qwen', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: `opencode run <message>` is its non-interactive entry point.
+  opencode: harvestCli('opencode', ['run'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `crush run <prompt>` runs a single non-interactive prompt.
+  crush: harvestCli('crush', ['run', '-q'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `droid exec <prompt>` is Factory's headless mode.
+  droid: harvestCli('droid', ['exec'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `amp -x <prompt>` executes a single prompt and exits.
+  amp: harvestCli('amp', ['-x'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: the Continue CLI installs as `cn` and takes -p for headless.
+  continue: harvestCli('cn', ['-p'], { delivery: 'prompt-file' }),
+
+  // NO HEADLESS CLI OF THEIR OWN. These are editor- and extension-hosted:
+  // the assistant runs inside the IDE process and ships no command a hook
+  // could spawn. Declaring null keeps that a stated fact rather than an
+  // omission, and these clients fall back to a configured endpoint --
+  // borrowing a neighbouring vendor's CLI would send the digest to a model
+  // the user never chose.
+  cursor: null,
+  cline: null,
+  windsurf: null,
+  kilo: null,
+  roo: null,
+  zed: null,
+});
+
+/**
+ * Splits a configured command line into words, respecting quotes.
+ *
+ * SPLITTING ON WHITESPACE ALONE IS WRONG ON WINDOWS, and the first test
+ * written against this caught it: the natural thing to configure is the
+ * interpreter you already have, and on Windows that is
+ * `C:\\Program Files\\nodejs\\node.exe`. A bare split turned that into the
+ * command `C:\\Program` and reported `C:\\Program exited 1`, which is a
+ * diagnostic nobody can act on. Quoting a path with spaces is the ordinary
+ * way to write a command line, so it has to mean what it says.
+ */
+function commandWords(line) {
+  const words = [];
+  let current = '';
+  let quote = '';
+  let started = false;
+  for (const ch of String(line)) {
+    if (quote) {
+      if (ch === quote) quote = '';
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (started) words.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (started) words.push(current);
+  return words;
+}
+
+/**
+ * The harvest CLI for a client, or null when it has none.
+ *
+ * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
+ * client with no row -- or one whose vendor changed its flags after this
+ * shipped -- is a configuration away from working rather than a release away.
+ * The value is a command and its arguments. The payload goes to stdin unless
+ * the string ends in `{}`, which is replaced by the path of a file holding
+ * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ */
+export function harvestCliFor(client, env = process.env) {
+  const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
+  if (override) {
+    const parts = commandWords(override);
+    const arg = parts[parts.length - 1] === '{}';
+    if (arg) parts.pop();
+    const [command, ...args] = parts;
+    if (!command) return null;
+    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+  }
+  return CLIENT_HARVEST_CLI[client] || null;
+}
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({
     name: 'Claude Code',

--- a/integrations/cursor/hooks/lib/capabilities.mjs
+++ b/integrations/cursor/hooks/lib/capabilities.mjs
@@ -353,21 +353,40 @@ function commandWords(line) {
  * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
  * client with no row -- or one whose vendor changed its flags after this
  * shipped -- is a configuration away from working rather than a release away.
- * The value is a command and its arguments. The payload goes to stdin unless
- * the string ends in `{}`, which is replaced by the path of a file holding
- * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ * The value is a command and its arguments, and its last word may name a
+ * delivery:
+ *   (nothing)  the payload goes to the command's stdin.
+ *   `{}`       it is written to a file and the path becomes the last
+ *              argument -- what an agentic CLI that ignores stdin needs.
+ *   `{-}`      the payload goes to stdin and a short instruction becomes the
+ *              last argument, for a CLI whose prompt flag demands a value
+ *              but which still reads stdin. gemini and qwen are shaped this
+ *              way, and without this an override could not reach that shape
+ *              at all.
  */
 export function harvestCliFor(client, env = process.env) {
   const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
   if (override) {
     const parts = commandWords(override);
-    const arg = parts[parts.length - 1] === '{}';
-    if (arg) parts.pop();
+    const last = parts[parts.length - 1];
+    const delivery =
+      last === '{}' ? 'prompt-file' : last === '{-}' ? 'arg-stdin' : 'stdin';
+    if (delivery !== 'stdin') parts.pop();
     const [command, ...args] = parts;
     if (!command) return null;
-    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+    return harvestCli(command, args, { delivery });
   }
-  return CLIENT_HARVEST_CLI[client] || null;
+  // NORMALISED AND OWN-PROPERTY ONLY, matching `capabilityFor` below.
+  //
+  // A bare index disagreed with its own sibling and reached the prototype.
+  // Reproduced: TOKEN_OPTIMIZER_CLIENT=Codex resolved a capability profile
+  // through capabilityFor -- which lower-cases -- and NO harvest CLI here, so
+  // harvestMode() fell through to off:no-key and an opted-in harvest silently
+  // did nothing on a client that plainly has one. And
+  // harvestCliFor('constructor') returned a function, whose `command` is
+  // undefined, which runHostCli would have handed straight to spawn.
+  const key = String(client || '').toLowerCase();
+  return Object.hasOwn(CLIENT_HARVEST_CLI, key) ? CLIENT_HARVEST_CLI[key] : null;
 }
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({

--- a/integrations/cursor/hooks/lib/doctor.mjs
+++ b/integrations/cursor/hooks/lib/doctor.mjs
@@ -246,6 +246,23 @@ export function probeHarvest() {
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
+  // The host client's own CLI, opted into with TOKEN_OPTIMIZER_HARVEST_CLI.
+  // Reported with the same failure-reason read as `local`, because the two
+  // share the property that made a broken configuration invisible: they
+  // return [] on failure and look exactly like a session with nothing to
+  // learn.
+  if (mode === 'host-cli') {
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check that this client\'s CLI is on PATH and signed in, or unset ' +
+        'TOKEN_OPTIMIZER_HARVEST_CLI to fall back to a configured endpoint')];
+    }
+    return [ok('finding extraction is available',
+      "this client's own CLI runs the semantic harvest -- no separate credential and no " +
+      'second vendor. Active-model wiki_write remains the primary path')];
+  }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
       'active-model wiki_write is primary; a credential also enables fallback extraction from ' +

--- a/integrations/cursor/hooks/lib/harvest.mjs
+++ b/integrations/cursor/hooks/lib/harvest.mjs
@@ -23,6 +23,7 @@
 import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { harvestCliFor } from './capabilities.mjs';
 
@@ -588,6 +589,14 @@ function withAnchorChoices(system, choices) {
   );
 }
 
+/**
+ * The `-p` value for a CLI whose prompt flag needs one but which still reads
+ * stdin. One line, no quotes, no newlines: everything a Windows command line
+ * cannot carry.
+ */
+export const ARG_STDIN_INSTRUCTION =
+  'Follow the instructions in the input above and reply with only the JSON array they ask for.';
+
 /** Restated at the end of a prompt file, where an agent skimming will see it. */
 const TRAILER =
   'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
@@ -652,7 +661,11 @@ async function runHostCli(cli, system, digest, timeoutMs) {
     // under the OS temp directory, which every one of these CLIs can read by
     // default, and removed in `finish` whatever the outcome.
     try {
-      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // UNGUESSABLE, NOT MERELY UNIQUE. pid and clock are both predictable
+      // enough for another local user to pre-create the path in a shared temp
+      // directory; randomUUID removes the guess, and `flag: 'wx'` below
+      // removes the race that remains.
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${randomUUID()}.txt`);
       // 0600. This is a digest of the user's session -- paths, commands and
       // prompts -- sitting in a shared temp directory for as long as the child
       // takes to read it. It is removed in `finish`, but a kill between the two
@@ -669,6 +682,12 @@ async function runHostCli(cli, system, digest, timeoutMs) {
       writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
         encoding: 'utf8',
         mode: 0o600,
+        // EXCLUSIVE CREATE. `mode` governs a file this call makes; it does
+        // nothing about one that already exists, and the default flag 'w'
+        // happily follows a symlink someone else placed at the path -- which
+        // would redirect a digest of the user's session wherever they chose.
+        // 'wx' fails instead of following.
+        flag: 'wx',
       });
     } catch (error) {
       return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
@@ -679,9 +698,16 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         'instructions and output the JSON array they ask for, and nothing else.'
     );
   } else if (cli.delivery === 'arg-stdin') {
-    // The flag needs a value and the CLI appends it after stdin, so the short
-    // instruction is the argument and the bulky digest still rides stdin.
-    args.push(system);
+    // A SHORT SINGLE LINE, NEVER THE PROMPT. The flag needs a value, and the
+    // obvious value -- `system` -- is the multi-line PROMPT, which
+    // withAnchorChoices extends with a newline-separated file list and which
+    // is full of the JSON prompt's double quotes. That is the exact payload
+    // the prompt-file route exists to keep off a Windows command line:
+    // cmd.exe cannot carry a newline inside an argument, and the quoting
+    // doubles every `"`. These CLIs document the flag value as being
+    // APPENDED to stdin, so the whole payload rides stdin and the argument
+    // is one line of ASCII that any shell survives.
+    args.push(ARG_STDIN_INSTRUCTION);
   }
 
   if (process.platform === 'win32' && file === cli.command) {
@@ -750,12 +776,26 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         : finish({ ok: false, reason: `${cli.command} exited ${code}` })
     );
 
+    // EPIPE ARRIVES AS AN EVENT, NOT AS A THROW. The try/catch below sees
+    // only a synchronous failure; a child that exits without reading stdin
+    // fails the write asynchronously, and Node delivers that on the stream.
+    // With no listener it is an uncaught exception that takes down the hook
+    // process instead of resolving this promise -- and the path is not
+    // hypothetical: copilot, asked to read a prompt on stdin, answers that it
+    // cannot and exits 0, which is why its row is prompt-file at all.
+    child.stdin.on('error', (error) =>
+      finish({
+        ok: false,
+        reason: `could not write the digest to ${cli.command}: ${error?.message || error}`,
+      })
+    );
+
     try {
       // Closed either way: a child left waiting on a pipe that will never
       // carry anything hangs until the timeout, which is the slowest possible
       // way to produce nothing.
       if (fileMode) child.stdin.end();
-      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+      else child.stdin.end(payload);
     } catch {
       finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
     }

--- a/integrations/cursor/hooks/lib/harvest.mjs
+++ b/integrations/cursor/hooks/lib/harvest.mjs
@@ -20,9 +20,11 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { harvestCliFor } from './capabilities.mjs';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -178,13 +180,25 @@ export function harvestMode() {
   // Free and private, so nothing further to weigh: no credential, no billing, no digest leaving
   // the machine.
   if (localEndpoint()) return 'local';
+  // THE HOST CLI IS A BACKEND, so the enablement check has to know about it.
+  // Without this the gate answers off:no-key and `extract` never reaches the
+  // CLI path -- which defeats the whole point of a backend that needs no key.
+  // Caught end to end rather than reasoned about: with no endpoint and no key,
+  // the first run of the opted-in host-CLI harvest returned
+  // `harvest is off:no-key` in 0s, having never spawned anything.
+  if (hostCliHarvest()) return 'host-cli';
+
 
   return apiKey() ? 'remote' : 'off:no-key';
 }
 
 export function harvestEnabled() {
   const mode = harvestMode();
-  return mode === 'local' || mode === 'remote';
+  // host-cli belongs here for the same reason local and remote do: it is a
+  // backend that can actually answer. Leaving it out would let the mode say
+  // `host-cli` while every caller that asks `harvestEnabled()` -- the Stop
+  // hook, the worker, extract's own first line -- skipped the harvest.
+  return mode === 'local' || mode === 'remote' || mode === 'host-cli';
 }
 
 /**
@@ -476,6 +490,295 @@ const succeeded = (findings) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
+/**
+ * The findings array inside a reply, or null.
+ *
+ * Models wrap JSON in prose or fences often enough that locating the array is
+ * more reliable than insisting the whole response parses -- and a CLI adds its
+ * own banner lines and stream-json envelopes on top, so both callers need the
+ * same tolerance. Shared so the two cannot drift.
+ */
+function findingsIn(text) {
+  const raw = String(text || '');
+
+  // FIRST BRACKET TO LAST IS NOT ENOUGH, and a CLI is where that breaks.
+  // `codex exec` prints a banner line reading `sandbox: workspace-write
+  // [workdir, /tmp, $TMPDIR]` before the model says anything, so the first
+  // `[` in the stream belongs to the banner and the naive slice parses to
+  // nothing -- an empty harvest that looks exactly like a session with
+  // nothing to learn. Closing brackets are walked from the end and opening
+  // brackets from the start, so the widest array that actually parses wins,
+  // and prose on either side is tolerated the way it already was for HTTP.
+  const closes = [];
+  for (let i = raw.length - 1; i >= 0 && closes.length < CLOSE_TRIES; i -= 1) {
+    if (raw[i] === ']') closes.push(i);
+  }
+  for (const end of closes) {
+    let tries = 0;
+    for (let start = raw.indexOf('['); start !== -1 && start < end; start = raw.indexOf('[', start + 1)) {
+      if ((tries += 1) > OPEN_TRIES) break;
+      try {
+        const parsed = JSON.parse(raw.slice(start, end + 1));
+        if (Array.isArray(parsed)) return parsed;
+      } catch {
+        /* not this pair */
+      }
+    }
+  }
+  return null;
+}
+
+// Bounded so a pathological reply cannot turn parsing into an O(n^2) walk of
+// a megabyte. A real findings array is at the end of the reply and preceded
+// by a banner or a sentence, not by hundreds of brackets.
+const CLOSE_TRIES = 8;
+const OPEN_TRIES = 40;
+
+/**
+ * Launches a Windows command through cmd.exe WITHOUT letting Node build the
+ * command line.
+ *
+ * These CLIs all install as .cmd shims, and Node has refused to spawn .cmd
+ * or .bat without a shell since the 2024 command-injection fix -- so a shell
+ * is not optional. But Node's own `shell: true` builds the cmd.exe line by
+ * joining argv with single spaces and no quoting at all, which breaks the
+ * moment any part contains one. Caught by the first test written against
+ * this: pointing the override at `C:\\Program Files\\nodejs\\node.exe`
+ * produced `C:\\Program Files\\nodejs\\node.exe exited 1`, because cmd.exe
+ * had been handed `C:\\Program` as the command. Quoting each part and passing
+ * the line verbatim is the fix.
+ */
+function windowsShellCommand(file, args) {
+  const quote = (part) => {
+    const value = String(part);
+    // Doubling is cmd.exe's own escape for a quote inside a quoted token.
+    return /[\s"]/.test(value)
+      ? `"${value.replace(/"/g, '""')}"`
+      : value;
+  };
+  const line = [file, ...args].map(quote).join(' ');
+  return [process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', `"${line}"`]];
+}
+
+/**
+ * States the anchor list in the prompt, for a backend that cannot be handed
+ * a schema.
+ *
+ * THE ANCHOR GATE IS WHAT SILENTLY EATS A HARVEST. `validate` keeps only
+ * anchors naming a file the session actually touched, and a model asked in
+ * English for a path writes a plausible one rather than a real one. Measured
+ * over four runs of qwen2.5:7b on a real digest against that gate:
+ * unconstrained, 4 extracted and 0 accepted; constrained to the list, 4 of 4.
+ *
+ * The HTTP path gets that constraint from a server-enforced enum. A CLI has
+ * no server to enforce it, so the same constraint is stated as strongly as a
+ * prompt can state it -- the exact strings, and an instruction to copy rather
+ * than compose. Not as good as an enum, and much better than nothing: the
+ * first end-to-end run without this extracted 10 findings and kept none.
+ */
+function withAnchorChoices(system, choices) {
+  if (!choices.length) return system;
+  const list = choices.map((file) => `- ${file}`).join('\n');
+  return (
+    `${system}\n\n` +
+    'Every entry in "anchors" MUST be copied verbatim from this list -- pick the ' +
+    'entries that best match the finding, and never write a path that is not ' +
+    'listed. Choosing the nearest match is right; dropping the finding is not:\n' +
+    list
+  );
+}
+
+/** Restated at the end of a prompt file, where an agent skimming will see it. */
+const TRAILER =
+  'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
+  'reply with the JSON array of findings and nothing else. If nothing in the ' +
+  'session is worth recording, reply with an empty array.';
+
+/**
+ * Runs the host client's own CLI as the harvest model.
+ *
+ * THE CHILD MUST NOT HARVEST. The harvest runs from the Stop hook, and a
+ * child session fires its own Stop hook -- verified, not assumed: a bare
+ * `claude -p` with our plugin installed wrote mcp-client, episode-outcome and
+ * derive events to the graph. Left unguarded that is unbounded recursion,
+ * each level spending real quota.
+ *
+ * TOKEN_OPTIMIZER_MODE=off IS THE GUARD, and it is the one that works.
+ * Measured on the same probe: TOKEN_OPTIMIZER_HARVEST=0 still ran the child's
+ * Stop hook and still wrote derive events -- it disables the harvest but not
+ * the hooks around it -- while MODE=off suppressed everything but a single
+ * mcp-client row. The kill switch is the only setting that makes the child
+ * inert, so the child is spawned with it and nothing else is relied upon.
+ *
+ * DELIVERY COMES FROM THE ROW, not from an assumption that every CLI reads
+ * stdin. Copilot does not: asked to follow instructions on stdin it replies
+ * that it cannot read stdin, exits 0, and yields no findings -- which looks
+ * exactly like a session with nothing to learn. Guessing here fails silently,
+ * so it is not guessed.
+ */
+/**
+ * How long to let the host CLI run.
+ *
+ * THE 30s HTTP DEFAULT KILLS EVERY CLI HARVEST, so it cannot be shared. That
+ * budget is sized for one completion against an endpoint that is already
+ * listening. A host CLI is an agent: it starts a process, loads its plugin
+ * and hook tree, opens a session, then thinks. Measured here on a 23 KB
+ * digest with no key and no local model, `claude -p` returned 10 findings in
+ * 104 SECONDS -- correct, and more than three times over the HTTP budget.
+ * `codex exec` on the same machine defaults to xhigh reasoning effort and
+ * had not finished at 300s, which is why this is configurable rather than
+ * merely larger.
+ *
+ * A caller that asks for MORE keeps it; the floor only lifts a default that
+ * was never chosen with this backend in mind.
+ */
+function hostCliTimeoutMs(requested) {
+  const configured = Number(process.env.TOKEN_OPTIMIZER_HARVEST_CLI_TIMEOUT_MS);
+  const floor = Number.isFinite(configured) && configured > 0 ? configured : 180_000;
+  return Math.max(floor, Number(requested) || 0);
+}
+
+async function runHostCli(cli, system, digest, timeoutMs) {
+  const payload = `${system}\n\n${digest}`;
+  const fileMode = cli.delivery === 'prompt-file';
+  let file = cli.command;
+  let args = [...cli.args];
+  let verbatim = false;
+  let promptFile = null;
+
+  if (fileMode) {
+    // A PATH, NOT THE PAYLOAD. See CLIENT_HARVEST_CLI for why the payload
+    // itself cannot travel as an argument on Windows. The file is written
+    // under the OS temp directory, which every one of these CLIs can read by
+    // default, and removed in `finish` whatever the outcome.
+    try {
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // 0600. This is a digest of the user's session -- paths, commands and
+      // prompts -- sitting in a shared temp directory for as long as the child
+      // takes to read it. It is removed in `finish`, but a kill between the two
+      // would leave it behind, so it is unreadable to other users meanwhile.
+      // (Windows ignores the mode; NTFS inheritance already keeps the per-user
+      // temp directory private.)
+      // THE CONTRACT IS REPEATED AT THE END. The instructions lead the file and
+      // the digest follows, which is the natural order and the one that failed:
+      // handed 23 KB this way, copilot reported the file as "a scratchpad
+      // /summary document" with no instruction in it and asked what JSON array
+      // was wanted. An agent skimming a long file sees its tail; restating the
+      // ask there costs one line and removes the dependence on how the file is
+      // read.
+      writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
+        encoding: 'utf8',
+        mode: 0o600,
+      });
+    } catch (error) {
+      return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
+    }
+    args.push(
+      `Read the whole file at ${promptFile}. It opens with instructions, then a ` +
+        'digest of a coding session, then repeats what to reply. Follow those ' +
+        'instructions and output the JSON array they ask for, and nothing else.'
+    );
+  } else if (cli.delivery === 'arg-stdin') {
+    // The flag needs a value and the CLI appends it after stdin, so the short
+    // instruction is the argument and the bulky digest still rides stdin.
+    args.push(system);
+  }
+
+  if (process.platform === 'win32' && file === cli.command) {
+    [file, args] = windowsShellCommand(file, args);
+    verbatim = true;
+  }
+
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(file, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        // The command line was built above where it needed cmd.exe, so Node
+        // must not rebuild it: `shell: true` would join argv unquoted.
+        windowsVerbatimArguments: verbatim,
+        env: {
+          ...process.env,
+          TOKEN_OPTIMIZER_MODE: 'off',
+        },
+      });
+    } catch (error) {
+      resolve({ ok: false, reason: `${cli.command} could not start: ${error?.message || error}` });
+      return;
+    }
+
+    let out = '';
+    let done = false;
+    const finish = (value) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      try {
+        child.kill();
+      } catch {
+        /* already gone */
+      }
+      if (promptFile) {
+        try {
+          rmSync(promptFile, { force: true });
+        } catch {
+          /* a leftover in the temp directory is not worth failing a harvest */
+        }
+      }
+      resolve(value);
+    };
+    const timer = setTimeout(
+      () => finish({ ok: false, reason: `${cli.command} timed out after ${timeoutMs}ms` }),
+      timeoutMs
+    );
+
+    child.stdout.on('data', (c) => {
+      out += c;
+    });
+    // stderr is drained so a chatty CLI cannot fill the pipe and deadlock.
+    child.stderr.on('data', () => {});
+    child.on('error', (error) =>
+      finish({ ok: false, reason: `${cli.command} failed: ${error?.message || error}` })
+    );
+    // NON-ZERO IS NOT ALWAYS EMPTY. Some of these print the reply and then
+    // exit non-zero over an unrelated cleanup complaint, so a parseable array
+    // already in hand beats the exit code; the code decides only when there is
+    // nothing to parse.
+    child.on('close', (code) =>
+      code === 0 || findingsIn(out)
+        ? finish({ ok: true, text: out })
+        : finish({ ok: false, reason: `${cli.command} exited ${code}` })
+    );
+
+    try {
+      // Closed either way: a child left waiting on a pipe that will never
+      // carry anything hangs until the timeout, which is the slowest possible
+      // way to produce nothing.
+      if (fileMode) child.stdin.end();
+      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+    } catch {
+      finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
+    }
+  });
+}
+
+/**
+ * Is the host CLI available as a harvest backend for this client?
+ *
+ * OPT-IN, deliberately, and this is the one default in this file that is not
+ * on. Every other path either reads local files or spends a key the user
+ * already configured for this purpose; this one spends the subscription that
+ * runs their editor, automatically, at the end of every session. HeadRoom
+ * makes the equivalent call user-invoked (`headroom learn`, cli/learn.py) and
+ * its own design note says to log events and analyse offline. Charging someone
+ * quota they did not ask to spend is not a default worth taking.
+ */
+export function hostCliHarvest(client = undefined, env = process.env) {
+  const enabled = /^(1|true|yes|on)$/i.test(env.TOKEN_OPTIMIZER_HARVEST_CLI || '');
+  if (!enabled) return null;
+  return harvestCliFor(client === undefined ? env.TOKEN_OPTIMIZER_CLIENT : client, env);
+}
+
 export async function extract(
   digest,
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
@@ -491,11 +794,40 @@ export async function extract(
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return failed('no api key for a remote endpoint');
+  // The host CLI carries its own auth -- the user is already signed into the
+  // client that is running this -- so the key requirement is about the HTTP
+  // backends only.
+  if (!local && !key && !hostCliHarvest()) {
+    return failed('no api key for a remote endpoint');
+  }
 
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // Computed before the CLI branch because BOTH backends need it. It used to
+  // sit below, so the host CLI was the one path that never learned which
+  // files it was allowed to anchor to -- and the anchor gate is what silently
+  // eats a harvest. Caught end to end on a real session: 10 findings
+  // extracted through `claude -p`, 0 surviving `validate`.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+
+  // The host client's own CLI, when the user has opted in. Tried first
+  // because it needs no key and no local model -- the two things whose
+  // absence has kept this path at 3 harvested findings on this machine.
+  const hostCli = hostCliHarvest();
+  if (hostCli) {
+    const result = await runHostCli(
+      hostCli,
+      withAnchorChoices(system, anchorChoices),
+      digest,
+      hostCliTimeoutMs(timeoutMs)
+    );
+    if (!result.ok) return failed(result.reason);
+    const parsed = findingsIn(result.text);
+    if (!parsed) return failed(`no JSON array in the ${hostCli.command} reply`);
+    return succeeded(parsed);
+  }
 
   // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
   //
@@ -514,7 +846,6 @@ export async function extract(
   // Only when the caller knows the list. `buildFullDelta` is raw transcript
   // with no file heading, and its caller passes no knownFiles for the same
   // reason -- an empty enum would forbid every anchor rather than free it.
-  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
   const schema = anchorChoices.length
     ? {
         ...FINDINGS_SCHEMA,
@@ -662,17 +993,8 @@ export async function extract(
       '';
     if (!text) return failed('endpoint answered in an unrecognised shape');
 
-    // Models wrap JSON in prose or fences often enough that finding the array
-    // is more reliable than insisting the whole response parse.
-    const start = text.indexOf('[');
-    const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return failed('no JSON array in the reply');
-
-    try {
-      return succeeded(JSON.parse(text.slice(start, end + 1)));
-    } catch {
-      return failed('the JSON array in the reply did not parse');
-    }
+    const parsed = findingsIn(text);
+    return parsed ? succeeded(parsed) : failed('no usable JSON array in the reply');
   } catch (error) {
     return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -695,6 +695,15 @@ function extractionNotice() {
         '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
         'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
       );
+    case 'host-cli':
+      // The extractor is this client's own headless CLI, which the user opted
+      // into. Worth its own case rather than folding into `remote`: no
+      // credential is involved, and the digest goes to the same vendor that
+      // already ran the session, which is a materially different disclosure.
+      return (
+        '\n\nSemantic extraction also runs after this session through this client\'s own CLI, ' +
+        'from a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
     case 'off:mode':
       // The whole optimizer is off and this text is not emitted anyway. Saying
       // anything here would be noise stacked on an explicit choice.

--- a/integrations/gemini/hooks/lib/capabilities.mjs
+++ b/integrations/gemini/hooks/lib/capabilities.mjs
@@ -194,6 +194,181 @@ const native = (profile) => ({
   ...profile,
 });
 
+/**
+ * How each client's own CLI can be driven headlessly, when it has one.
+ *
+ * THE HARVEST MODEL IS THE HOST ITSELF. Semantic extraction has always
+ * needed an API key or a local endpoint, and on a machine with neither it
+ * simply does not run -- measured on this one, 3 harvested findings against
+ * 237 written by the agent. But the client that just ran the session is
+ * installed BY DEFINITION and every one of these ships a headless mode, so
+ * the model was already on the machine. Nothing needed configuring; it only
+ * needed asking.
+ *
+ * ONE ROW PER CLIENT, not a hardcoded backend list. The nearest competitor
+ * picks from three (claude, gemini, codex), so its Cursor, Zed, Amp, Crush
+ * or Droid users get no semantic harvest at all. Every client this package
+ * supports gets a row here or an explicit null, and `npm run sync:hooks`
+ * copies the same table into all 16 integrations so the design cannot drift
+ * per client.
+ *
+ * NEVER ANOTHER VENDOR'S CLI. Reaching for whatever happens to be on PATH
+ * would send this session's digest to a model the user never chose, which is
+ * a disclosure they did not agree to. The host is the only defensible
+ * default, and TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND is the only way to pick a
+ * different one.
+ *
+ * DELIVERY IS PART OF THE ROW because the CLIs genuinely differ, and getting
+ * it wrong is silent:
+ *   - 'stdin'       the whole payload goes to the child's stdin.
+ *   - 'arg-stdin'   a short instruction is the final argument and the digest
+ *                   goes to stdin, for CLIs whose prompt flag needs a value
+ *                   but which still read stdin.
+ *   - 'prompt-file' the payload is written to a temp file and the final
+ *                   argument tells the agent to read it, for CLIs that do
+ *                   not read stdin at all.
+ *
+ * WHY A FILE AND NOT JUST A LONG ARGUMENT. Passing the payload itself as an
+ * argument was tried and abandoned on evidence. On POSIX it is fine; on
+ * Windows every one of these installs as a .cmd shim, which Node will not
+ * spawn without a shell, and cmd.exe cannot carry a newline inside an
+ * argument at all. Routing through PowerShell with the payload base64-encoded
+ * got past cmd.exe and then hit PowerShell 5.1's native-argument binder,
+ * which does not escape embedded double quotes: the prompt is JSON, so the
+ * first `\"type\":` ended the quoting and the child received 32 arguments
+ * instead of 1. A path has no spaces we did not choose, no quotes and no
+ * newlines, and it also lifts the ARG_MAX ceiling entirely -- these are
+ * agentic CLIs whose whole purpose is reading files, and the route is
+ * verified: copilot asked to read a payload file returned the exact array.
+ *
+ * VERIFIED means a probe was executed against the installed CLI in this
+ * repository and its reply parsed. DOCUMENTED means the shape comes from the
+ * vendor's own `--help` or published headless docs and has not been executed
+ * here, because the CLI is not installed on this machine. Both ship; the
+ * distinction is recorded so nobody mistakes the second for the first, and a
+ * wrong DOCUMENTED row fails loudly through `harvestFailure()` and doctor
+ * rather than silently producing nothing.
+ */
+const harvestCli = (command, args, { delivery = 'stdin', verified = false } = {}) =>
+  Object.freeze({ command, args: Object.freeze([...args]), delivery, verified });
+
+export const CLIENT_HARVEST_CLI = Object.freeze({
+  // VERIFIED: `claude -p` with the payload on stdin returned the exact array
+  // asked for. --output-format stream-json was tried first and rejected: its
+  // envelopes are themselves JSON containing brackets, which is a parsing
+  // hazard for no gain when plain text is already the model's reply.
+  'claude-code': harvestCli('claude', ['-p'], { verified: true }),
+  // VERIFIED: `codex exec -` reads instructions from stdin (its own --help
+  // says so, and a probe returned the array). It prints a banner containing
+  // `[workdir, /tmp, $TMPDIR]` before the reply, which is exactly why the
+  // reply parser has to try more than the first bracket it finds.
+  codex: harvestCli('codex', ['exec', '-'], { verified: true }),
+  // VERIFIED both ways. Asked to follow instructions on stdin the agent
+  // answered that it was unable to read stdin and exited 0 -- a silent
+  // no-findings result indistinguishable from a quiet session. Asked instead
+  // to read a payload file it returned the exact array requested, which is
+  // why this row is prompt-file. --allow-all-tools is required for
+  // non-interactive use by copilot's own help text, and -s drops the stats
+  // banner.
+  copilot: harvestCli('copilot', ['-s', '--allow-all-tools', '-p'], {
+    delivery: 'prompt-file',
+    verified: true,
+  }),
+  // DOCUMENTED: `gemini --help` states that -p runs headless and that the
+  // prompt is "Appended to input on stdin (if any)", so the digest rides
+  // stdin and the instruction is the flag value. Not executed here: this
+  // machine's gemini is unauthenticated and fails in refreshAuth before any
+  // prompt is read.
+  gemini: harvestCli('gemini', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: qwen-code is a fork of gemini-cli and keeps its flag surface.
+  qwen: harvestCli('qwen', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: `opencode run <message>` is its non-interactive entry point.
+  opencode: harvestCli('opencode', ['run'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `crush run <prompt>` runs a single non-interactive prompt.
+  crush: harvestCli('crush', ['run', '-q'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `droid exec <prompt>` is Factory's headless mode.
+  droid: harvestCli('droid', ['exec'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `amp -x <prompt>` executes a single prompt and exits.
+  amp: harvestCli('amp', ['-x'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: the Continue CLI installs as `cn` and takes -p for headless.
+  continue: harvestCli('cn', ['-p'], { delivery: 'prompt-file' }),
+
+  // NO HEADLESS CLI OF THEIR OWN. These are editor- and extension-hosted:
+  // the assistant runs inside the IDE process and ships no command a hook
+  // could spawn. Declaring null keeps that a stated fact rather than an
+  // omission, and these clients fall back to a configured endpoint --
+  // borrowing a neighbouring vendor's CLI would send the digest to a model
+  // the user never chose.
+  cursor: null,
+  cline: null,
+  windsurf: null,
+  kilo: null,
+  roo: null,
+  zed: null,
+});
+
+/**
+ * Splits a configured command line into words, respecting quotes.
+ *
+ * SPLITTING ON WHITESPACE ALONE IS WRONG ON WINDOWS, and the first test
+ * written against this caught it: the natural thing to configure is the
+ * interpreter you already have, and on Windows that is
+ * `C:\\Program Files\\nodejs\\node.exe`. A bare split turned that into the
+ * command `C:\\Program` and reported `C:\\Program exited 1`, which is a
+ * diagnostic nobody can act on. Quoting a path with spaces is the ordinary
+ * way to write a command line, so it has to mean what it says.
+ */
+function commandWords(line) {
+  const words = [];
+  let current = '';
+  let quote = '';
+  let started = false;
+  for (const ch of String(line)) {
+    if (quote) {
+      if (ch === quote) quote = '';
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (started) words.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (started) words.push(current);
+  return words;
+}
+
+/**
+ * The harvest CLI for a client, or null when it has none.
+ *
+ * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
+ * client with no row -- or one whose vendor changed its flags after this
+ * shipped -- is a configuration away from working rather than a release away.
+ * The value is a command and its arguments. The payload goes to stdin unless
+ * the string ends in `{}`, which is replaced by the path of a file holding
+ * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ */
+export function harvestCliFor(client, env = process.env) {
+  const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
+  if (override) {
+    const parts = commandWords(override);
+    const arg = parts[parts.length - 1] === '{}';
+    if (arg) parts.pop();
+    const [command, ...args] = parts;
+    if (!command) return null;
+    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+  }
+  return CLIENT_HARVEST_CLI[client] || null;
+}
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({
     name: 'Claude Code',

--- a/integrations/gemini/hooks/lib/capabilities.mjs
+++ b/integrations/gemini/hooks/lib/capabilities.mjs
@@ -353,21 +353,40 @@ function commandWords(line) {
  * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
  * client with no row -- or one whose vendor changed its flags after this
  * shipped -- is a configuration away from working rather than a release away.
- * The value is a command and its arguments. The payload goes to stdin unless
- * the string ends in `{}`, which is replaced by the path of a file holding
- * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ * The value is a command and its arguments, and its last word may name a
+ * delivery:
+ *   (nothing)  the payload goes to the command's stdin.
+ *   `{}`       it is written to a file and the path becomes the last
+ *              argument -- what an agentic CLI that ignores stdin needs.
+ *   `{-}`      the payload goes to stdin and a short instruction becomes the
+ *              last argument, for a CLI whose prompt flag demands a value
+ *              but which still reads stdin. gemini and qwen are shaped this
+ *              way, and without this an override could not reach that shape
+ *              at all.
  */
 export function harvestCliFor(client, env = process.env) {
   const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
   if (override) {
     const parts = commandWords(override);
-    const arg = parts[parts.length - 1] === '{}';
-    if (arg) parts.pop();
+    const last = parts[parts.length - 1];
+    const delivery =
+      last === '{}' ? 'prompt-file' : last === '{-}' ? 'arg-stdin' : 'stdin';
+    if (delivery !== 'stdin') parts.pop();
     const [command, ...args] = parts;
     if (!command) return null;
-    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+    return harvestCli(command, args, { delivery });
   }
-  return CLIENT_HARVEST_CLI[client] || null;
+  // NORMALISED AND OWN-PROPERTY ONLY, matching `capabilityFor` below.
+  //
+  // A bare index disagreed with its own sibling and reached the prototype.
+  // Reproduced: TOKEN_OPTIMIZER_CLIENT=Codex resolved a capability profile
+  // through capabilityFor -- which lower-cases -- and NO harvest CLI here, so
+  // harvestMode() fell through to off:no-key and an opted-in harvest silently
+  // did nothing on a client that plainly has one. And
+  // harvestCliFor('constructor') returned a function, whose `command` is
+  // undefined, which runHostCli would have handed straight to spawn.
+  const key = String(client || '').toLowerCase();
+  return Object.hasOwn(CLIENT_HARVEST_CLI, key) ? CLIENT_HARVEST_CLI[key] : null;
 }
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({

--- a/integrations/gemini/hooks/lib/doctor.mjs
+++ b/integrations/gemini/hooks/lib/doctor.mjs
@@ -246,6 +246,23 @@ export function probeHarvest() {
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
+  // The host client's own CLI, opted into with TOKEN_OPTIMIZER_HARVEST_CLI.
+  // Reported with the same failure-reason read as `local`, because the two
+  // share the property that made a broken configuration invisible: they
+  // return [] on failure and look exactly like a session with nothing to
+  // learn.
+  if (mode === 'host-cli') {
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check that this client\'s CLI is on PATH and signed in, or unset ' +
+        'TOKEN_OPTIMIZER_HARVEST_CLI to fall back to a configured endpoint')];
+    }
+    return [ok('finding extraction is available',
+      "this client's own CLI runs the semantic harvest -- no separate credential and no " +
+      'second vendor. Active-model wiki_write remains the primary path')];
+  }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
       'active-model wiki_write is primary; a credential also enables fallback extraction from ' +

--- a/integrations/gemini/hooks/lib/harvest.mjs
+++ b/integrations/gemini/hooks/lib/harvest.mjs
@@ -23,6 +23,7 @@
 import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { harvestCliFor } from './capabilities.mjs';
 
@@ -588,6 +589,14 @@ function withAnchorChoices(system, choices) {
   );
 }
 
+/**
+ * The `-p` value for a CLI whose prompt flag needs one but which still reads
+ * stdin. One line, no quotes, no newlines: everything a Windows command line
+ * cannot carry.
+ */
+export const ARG_STDIN_INSTRUCTION =
+  'Follow the instructions in the input above and reply with only the JSON array they ask for.';
+
 /** Restated at the end of a prompt file, where an agent skimming will see it. */
 const TRAILER =
   'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
@@ -652,7 +661,11 @@ async function runHostCli(cli, system, digest, timeoutMs) {
     // under the OS temp directory, which every one of these CLIs can read by
     // default, and removed in `finish` whatever the outcome.
     try {
-      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // UNGUESSABLE, NOT MERELY UNIQUE. pid and clock are both predictable
+      // enough for another local user to pre-create the path in a shared temp
+      // directory; randomUUID removes the guess, and `flag: 'wx'` below
+      // removes the race that remains.
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${randomUUID()}.txt`);
       // 0600. This is a digest of the user's session -- paths, commands and
       // prompts -- sitting in a shared temp directory for as long as the child
       // takes to read it. It is removed in `finish`, but a kill between the two
@@ -669,6 +682,12 @@ async function runHostCli(cli, system, digest, timeoutMs) {
       writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
         encoding: 'utf8',
         mode: 0o600,
+        // EXCLUSIVE CREATE. `mode` governs a file this call makes; it does
+        // nothing about one that already exists, and the default flag 'w'
+        // happily follows a symlink someone else placed at the path -- which
+        // would redirect a digest of the user's session wherever they chose.
+        // 'wx' fails instead of following.
+        flag: 'wx',
       });
     } catch (error) {
       return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
@@ -679,9 +698,16 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         'instructions and output the JSON array they ask for, and nothing else.'
     );
   } else if (cli.delivery === 'arg-stdin') {
-    // The flag needs a value and the CLI appends it after stdin, so the short
-    // instruction is the argument and the bulky digest still rides stdin.
-    args.push(system);
+    // A SHORT SINGLE LINE, NEVER THE PROMPT. The flag needs a value, and the
+    // obvious value -- `system` -- is the multi-line PROMPT, which
+    // withAnchorChoices extends with a newline-separated file list and which
+    // is full of the JSON prompt's double quotes. That is the exact payload
+    // the prompt-file route exists to keep off a Windows command line:
+    // cmd.exe cannot carry a newline inside an argument, and the quoting
+    // doubles every `"`. These CLIs document the flag value as being
+    // APPENDED to stdin, so the whole payload rides stdin and the argument
+    // is one line of ASCII that any shell survives.
+    args.push(ARG_STDIN_INSTRUCTION);
   }
 
   if (process.platform === 'win32' && file === cli.command) {
@@ -750,12 +776,26 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         : finish({ ok: false, reason: `${cli.command} exited ${code}` })
     );
 
+    // EPIPE ARRIVES AS AN EVENT, NOT AS A THROW. The try/catch below sees
+    // only a synchronous failure; a child that exits without reading stdin
+    // fails the write asynchronously, and Node delivers that on the stream.
+    // With no listener it is an uncaught exception that takes down the hook
+    // process instead of resolving this promise -- and the path is not
+    // hypothetical: copilot, asked to read a prompt on stdin, answers that it
+    // cannot and exits 0, which is why its row is prompt-file at all.
+    child.stdin.on('error', (error) =>
+      finish({
+        ok: false,
+        reason: `could not write the digest to ${cli.command}: ${error?.message || error}`,
+      })
+    );
+
     try {
       // Closed either way: a child left waiting on a pipe that will never
       // carry anything hangs until the timeout, which is the slowest possible
       // way to produce nothing.
       if (fileMode) child.stdin.end();
-      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+      else child.stdin.end(payload);
     } catch {
       finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
     }

--- a/integrations/gemini/hooks/lib/harvest.mjs
+++ b/integrations/gemini/hooks/lib/harvest.mjs
@@ -20,9 +20,11 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { harvestCliFor } from './capabilities.mjs';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -178,13 +180,25 @@ export function harvestMode() {
   // Free and private, so nothing further to weigh: no credential, no billing, no digest leaving
   // the machine.
   if (localEndpoint()) return 'local';
+  // THE HOST CLI IS A BACKEND, so the enablement check has to know about it.
+  // Without this the gate answers off:no-key and `extract` never reaches the
+  // CLI path -- which defeats the whole point of a backend that needs no key.
+  // Caught end to end rather than reasoned about: with no endpoint and no key,
+  // the first run of the opted-in host-CLI harvest returned
+  // `harvest is off:no-key` in 0s, having never spawned anything.
+  if (hostCliHarvest()) return 'host-cli';
+
 
   return apiKey() ? 'remote' : 'off:no-key';
 }
 
 export function harvestEnabled() {
   const mode = harvestMode();
-  return mode === 'local' || mode === 'remote';
+  // host-cli belongs here for the same reason local and remote do: it is a
+  // backend that can actually answer. Leaving it out would let the mode say
+  // `host-cli` while every caller that asks `harvestEnabled()` -- the Stop
+  // hook, the worker, extract's own first line -- skipped the harvest.
+  return mode === 'local' || mode === 'remote' || mode === 'host-cli';
 }
 
 /**
@@ -476,6 +490,295 @@ const succeeded = (findings) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
+/**
+ * The findings array inside a reply, or null.
+ *
+ * Models wrap JSON in prose or fences often enough that locating the array is
+ * more reliable than insisting the whole response parses -- and a CLI adds its
+ * own banner lines and stream-json envelopes on top, so both callers need the
+ * same tolerance. Shared so the two cannot drift.
+ */
+function findingsIn(text) {
+  const raw = String(text || '');
+
+  // FIRST BRACKET TO LAST IS NOT ENOUGH, and a CLI is where that breaks.
+  // `codex exec` prints a banner line reading `sandbox: workspace-write
+  // [workdir, /tmp, $TMPDIR]` before the model says anything, so the first
+  // `[` in the stream belongs to the banner and the naive slice parses to
+  // nothing -- an empty harvest that looks exactly like a session with
+  // nothing to learn. Closing brackets are walked from the end and opening
+  // brackets from the start, so the widest array that actually parses wins,
+  // and prose on either side is tolerated the way it already was for HTTP.
+  const closes = [];
+  for (let i = raw.length - 1; i >= 0 && closes.length < CLOSE_TRIES; i -= 1) {
+    if (raw[i] === ']') closes.push(i);
+  }
+  for (const end of closes) {
+    let tries = 0;
+    for (let start = raw.indexOf('['); start !== -1 && start < end; start = raw.indexOf('[', start + 1)) {
+      if ((tries += 1) > OPEN_TRIES) break;
+      try {
+        const parsed = JSON.parse(raw.slice(start, end + 1));
+        if (Array.isArray(parsed)) return parsed;
+      } catch {
+        /* not this pair */
+      }
+    }
+  }
+  return null;
+}
+
+// Bounded so a pathological reply cannot turn parsing into an O(n^2) walk of
+// a megabyte. A real findings array is at the end of the reply and preceded
+// by a banner or a sentence, not by hundreds of brackets.
+const CLOSE_TRIES = 8;
+const OPEN_TRIES = 40;
+
+/**
+ * Launches a Windows command through cmd.exe WITHOUT letting Node build the
+ * command line.
+ *
+ * These CLIs all install as .cmd shims, and Node has refused to spawn .cmd
+ * or .bat without a shell since the 2024 command-injection fix -- so a shell
+ * is not optional. But Node's own `shell: true` builds the cmd.exe line by
+ * joining argv with single spaces and no quoting at all, which breaks the
+ * moment any part contains one. Caught by the first test written against
+ * this: pointing the override at `C:\\Program Files\\nodejs\\node.exe`
+ * produced `C:\\Program Files\\nodejs\\node.exe exited 1`, because cmd.exe
+ * had been handed `C:\\Program` as the command. Quoting each part and passing
+ * the line verbatim is the fix.
+ */
+function windowsShellCommand(file, args) {
+  const quote = (part) => {
+    const value = String(part);
+    // Doubling is cmd.exe's own escape for a quote inside a quoted token.
+    return /[\s"]/.test(value)
+      ? `"${value.replace(/"/g, '""')}"`
+      : value;
+  };
+  const line = [file, ...args].map(quote).join(' ');
+  return [process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', `"${line}"`]];
+}
+
+/**
+ * States the anchor list in the prompt, for a backend that cannot be handed
+ * a schema.
+ *
+ * THE ANCHOR GATE IS WHAT SILENTLY EATS A HARVEST. `validate` keeps only
+ * anchors naming a file the session actually touched, and a model asked in
+ * English for a path writes a plausible one rather than a real one. Measured
+ * over four runs of qwen2.5:7b on a real digest against that gate:
+ * unconstrained, 4 extracted and 0 accepted; constrained to the list, 4 of 4.
+ *
+ * The HTTP path gets that constraint from a server-enforced enum. A CLI has
+ * no server to enforce it, so the same constraint is stated as strongly as a
+ * prompt can state it -- the exact strings, and an instruction to copy rather
+ * than compose. Not as good as an enum, and much better than nothing: the
+ * first end-to-end run without this extracted 10 findings and kept none.
+ */
+function withAnchorChoices(system, choices) {
+  if (!choices.length) return system;
+  const list = choices.map((file) => `- ${file}`).join('\n');
+  return (
+    `${system}\n\n` +
+    'Every entry in "anchors" MUST be copied verbatim from this list -- pick the ' +
+    'entries that best match the finding, and never write a path that is not ' +
+    'listed. Choosing the nearest match is right; dropping the finding is not:\n' +
+    list
+  );
+}
+
+/** Restated at the end of a prompt file, where an agent skimming will see it. */
+const TRAILER =
+  'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
+  'reply with the JSON array of findings and nothing else. If nothing in the ' +
+  'session is worth recording, reply with an empty array.';
+
+/**
+ * Runs the host client's own CLI as the harvest model.
+ *
+ * THE CHILD MUST NOT HARVEST. The harvest runs from the Stop hook, and a
+ * child session fires its own Stop hook -- verified, not assumed: a bare
+ * `claude -p` with our plugin installed wrote mcp-client, episode-outcome and
+ * derive events to the graph. Left unguarded that is unbounded recursion,
+ * each level spending real quota.
+ *
+ * TOKEN_OPTIMIZER_MODE=off IS THE GUARD, and it is the one that works.
+ * Measured on the same probe: TOKEN_OPTIMIZER_HARVEST=0 still ran the child's
+ * Stop hook and still wrote derive events -- it disables the harvest but not
+ * the hooks around it -- while MODE=off suppressed everything but a single
+ * mcp-client row. The kill switch is the only setting that makes the child
+ * inert, so the child is spawned with it and nothing else is relied upon.
+ *
+ * DELIVERY COMES FROM THE ROW, not from an assumption that every CLI reads
+ * stdin. Copilot does not: asked to follow instructions on stdin it replies
+ * that it cannot read stdin, exits 0, and yields no findings -- which looks
+ * exactly like a session with nothing to learn. Guessing here fails silently,
+ * so it is not guessed.
+ */
+/**
+ * How long to let the host CLI run.
+ *
+ * THE 30s HTTP DEFAULT KILLS EVERY CLI HARVEST, so it cannot be shared. That
+ * budget is sized for one completion against an endpoint that is already
+ * listening. A host CLI is an agent: it starts a process, loads its plugin
+ * and hook tree, opens a session, then thinks. Measured here on a 23 KB
+ * digest with no key and no local model, `claude -p` returned 10 findings in
+ * 104 SECONDS -- correct, and more than three times over the HTTP budget.
+ * `codex exec` on the same machine defaults to xhigh reasoning effort and
+ * had not finished at 300s, which is why this is configurable rather than
+ * merely larger.
+ *
+ * A caller that asks for MORE keeps it; the floor only lifts a default that
+ * was never chosen with this backend in mind.
+ */
+function hostCliTimeoutMs(requested) {
+  const configured = Number(process.env.TOKEN_OPTIMIZER_HARVEST_CLI_TIMEOUT_MS);
+  const floor = Number.isFinite(configured) && configured > 0 ? configured : 180_000;
+  return Math.max(floor, Number(requested) || 0);
+}
+
+async function runHostCli(cli, system, digest, timeoutMs) {
+  const payload = `${system}\n\n${digest}`;
+  const fileMode = cli.delivery === 'prompt-file';
+  let file = cli.command;
+  let args = [...cli.args];
+  let verbatim = false;
+  let promptFile = null;
+
+  if (fileMode) {
+    // A PATH, NOT THE PAYLOAD. See CLIENT_HARVEST_CLI for why the payload
+    // itself cannot travel as an argument on Windows. The file is written
+    // under the OS temp directory, which every one of these CLIs can read by
+    // default, and removed in `finish` whatever the outcome.
+    try {
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // 0600. This is a digest of the user's session -- paths, commands and
+      // prompts -- sitting in a shared temp directory for as long as the child
+      // takes to read it. It is removed in `finish`, but a kill between the two
+      // would leave it behind, so it is unreadable to other users meanwhile.
+      // (Windows ignores the mode; NTFS inheritance already keeps the per-user
+      // temp directory private.)
+      // THE CONTRACT IS REPEATED AT THE END. The instructions lead the file and
+      // the digest follows, which is the natural order and the one that failed:
+      // handed 23 KB this way, copilot reported the file as "a scratchpad
+      // /summary document" with no instruction in it and asked what JSON array
+      // was wanted. An agent skimming a long file sees its tail; restating the
+      // ask there costs one line and removes the dependence on how the file is
+      // read.
+      writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
+        encoding: 'utf8',
+        mode: 0o600,
+      });
+    } catch (error) {
+      return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
+    }
+    args.push(
+      `Read the whole file at ${promptFile}. It opens with instructions, then a ` +
+        'digest of a coding session, then repeats what to reply. Follow those ' +
+        'instructions and output the JSON array they ask for, and nothing else.'
+    );
+  } else if (cli.delivery === 'arg-stdin') {
+    // The flag needs a value and the CLI appends it after stdin, so the short
+    // instruction is the argument and the bulky digest still rides stdin.
+    args.push(system);
+  }
+
+  if (process.platform === 'win32' && file === cli.command) {
+    [file, args] = windowsShellCommand(file, args);
+    verbatim = true;
+  }
+
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(file, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        // The command line was built above where it needed cmd.exe, so Node
+        // must not rebuild it: `shell: true` would join argv unquoted.
+        windowsVerbatimArguments: verbatim,
+        env: {
+          ...process.env,
+          TOKEN_OPTIMIZER_MODE: 'off',
+        },
+      });
+    } catch (error) {
+      resolve({ ok: false, reason: `${cli.command} could not start: ${error?.message || error}` });
+      return;
+    }
+
+    let out = '';
+    let done = false;
+    const finish = (value) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      try {
+        child.kill();
+      } catch {
+        /* already gone */
+      }
+      if (promptFile) {
+        try {
+          rmSync(promptFile, { force: true });
+        } catch {
+          /* a leftover in the temp directory is not worth failing a harvest */
+        }
+      }
+      resolve(value);
+    };
+    const timer = setTimeout(
+      () => finish({ ok: false, reason: `${cli.command} timed out after ${timeoutMs}ms` }),
+      timeoutMs
+    );
+
+    child.stdout.on('data', (c) => {
+      out += c;
+    });
+    // stderr is drained so a chatty CLI cannot fill the pipe and deadlock.
+    child.stderr.on('data', () => {});
+    child.on('error', (error) =>
+      finish({ ok: false, reason: `${cli.command} failed: ${error?.message || error}` })
+    );
+    // NON-ZERO IS NOT ALWAYS EMPTY. Some of these print the reply and then
+    // exit non-zero over an unrelated cleanup complaint, so a parseable array
+    // already in hand beats the exit code; the code decides only when there is
+    // nothing to parse.
+    child.on('close', (code) =>
+      code === 0 || findingsIn(out)
+        ? finish({ ok: true, text: out })
+        : finish({ ok: false, reason: `${cli.command} exited ${code}` })
+    );
+
+    try {
+      // Closed either way: a child left waiting on a pipe that will never
+      // carry anything hangs until the timeout, which is the slowest possible
+      // way to produce nothing.
+      if (fileMode) child.stdin.end();
+      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+    } catch {
+      finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
+    }
+  });
+}
+
+/**
+ * Is the host CLI available as a harvest backend for this client?
+ *
+ * OPT-IN, deliberately, and this is the one default in this file that is not
+ * on. Every other path either reads local files or spends a key the user
+ * already configured for this purpose; this one spends the subscription that
+ * runs their editor, automatically, at the end of every session. HeadRoom
+ * makes the equivalent call user-invoked (`headroom learn`, cli/learn.py) and
+ * its own design note says to log events and analyse offline. Charging someone
+ * quota they did not ask to spend is not a default worth taking.
+ */
+export function hostCliHarvest(client = undefined, env = process.env) {
+  const enabled = /^(1|true|yes|on)$/i.test(env.TOKEN_OPTIMIZER_HARVEST_CLI || '');
+  if (!enabled) return null;
+  return harvestCliFor(client === undefined ? env.TOKEN_OPTIMIZER_CLIENT : client, env);
+}
+
 export async function extract(
   digest,
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
@@ -491,11 +794,40 @@ export async function extract(
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return failed('no api key for a remote endpoint');
+  // The host CLI carries its own auth -- the user is already signed into the
+  // client that is running this -- so the key requirement is about the HTTP
+  // backends only.
+  if (!local && !key && !hostCliHarvest()) {
+    return failed('no api key for a remote endpoint');
+  }
 
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // Computed before the CLI branch because BOTH backends need it. It used to
+  // sit below, so the host CLI was the one path that never learned which
+  // files it was allowed to anchor to -- and the anchor gate is what silently
+  // eats a harvest. Caught end to end on a real session: 10 findings
+  // extracted through `claude -p`, 0 surviving `validate`.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+
+  // The host client's own CLI, when the user has opted in. Tried first
+  // because it needs no key and no local model -- the two things whose
+  // absence has kept this path at 3 harvested findings on this machine.
+  const hostCli = hostCliHarvest();
+  if (hostCli) {
+    const result = await runHostCli(
+      hostCli,
+      withAnchorChoices(system, anchorChoices),
+      digest,
+      hostCliTimeoutMs(timeoutMs)
+    );
+    if (!result.ok) return failed(result.reason);
+    const parsed = findingsIn(result.text);
+    if (!parsed) return failed(`no JSON array in the ${hostCli.command} reply`);
+    return succeeded(parsed);
+  }
 
   // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
   //
@@ -514,7 +846,6 @@ export async function extract(
   // Only when the caller knows the list. `buildFullDelta` is raw transcript
   // with no file heading, and its caller passes no knownFiles for the same
   // reason -- an empty enum would forbid every anchor rather than free it.
-  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
   const schema = anchorChoices.length
     ? {
         ...FINDINGS_SCHEMA,
@@ -662,17 +993,8 @@ export async function extract(
       '';
     if (!text) return failed('endpoint answered in an unrecognised shape');
 
-    // Models wrap JSON in prose or fences often enough that finding the array
-    // is more reliable than insisting the whole response parse.
-    const start = text.indexOf('[');
-    const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return failed('no JSON array in the reply');
-
-    try {
-      return succeeded(JSON.parse(text.slice(start, end + 1)));
-    } catch {
-      return failed('the JSON array in the reply did not parse');
-    }
+    const parsed = findingsIn(text);
+    return parsed ? succeeded(parsed) : failed('no usable JSON array in the reply');
   } catch (error) {
     return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -695,6 +695,15 @@ function extractionNotice() {
         '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
         'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
       );
+    case 'host-cli':
+      // The extractor is this client's own headless CLI, which the user opted
+      // into. Worth its own case rather than folding into `remote`: no
+      // credential is involved, and the digest goes to the same vendor that
+      // already ran the session, which is a materially different disclosure.
+      return (
+        '\n\nSemantic extraction also runs after this session through this client\'s own CLI, ' +
+        'from a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
     case 'off:mode':
       // The whole optimizer is off and this text is not emitted anyway. Saying
       // anything here would be noise stacked on an explicit choice.

--- a/integrations/kilo/hooks/lib/capabilities.mjs
+++ b/integrations/kilo/hooks/lib/capabilities.mjs
@@ -194,6 +194,181 @@ const native = (profile) => ({
   ...profile,
 });
 
+/**
+ * How each client's own CLI can be driven headlessly, when it has one.
+ *
+ * THE HARVEST MODEL IS THE HOST ITSELF. Semantic extraction has always
+ * needed an API key or a local endpoint, and on a machine with neither it
+ * simply does not run -- measured on this one, 3 harvested findings against
+ * 237 written by the agent. But the client that just ran the session is
+ * installed BY DEFINITION and every one of these ships a headless mode, so
+ * the model was already on the machine. Nothing needed configuring; it only
+ * needed asking.
+ *
+ * ONE ROW PER CLIENT, not a hardcoded backend list. The nearest competitor
+ * picks from three (claude, gemini, codex), so its Cursor, Zed, Amp, Crush
+ * or Droid users get no semantic harvest at all. Every client this package
+ * supports gets a row here or an explicit null, and `npm run sync:hooks`
+ * copies the same table into all 16 integrations so the design cannot drift
+ * per client.
+ *
+ * NEVER ANOTHER VENDOR'S CLI. Reaching for whatever happens to be on PATH
+ * would send this session's digest to a model the user never chose, which is
+ * a disclosure they did not agree to. The host is the only defensible
+ * default, and TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND is the only way to pick a
+ * different one.
+ *
+ * DELIVERY IS PART OF THE ROW because the CLIs genuinely differ, and getting
+ * it wrong is silent:
+ *   - 'stdin'       the whole payload goes to the child's stdin.
+ *   - 'arg-stdin'   a short instruction is the final argument and the digest
+ *                   goes to stdin, for CLIs whose prompt flag needs a value
+ *                   but which still read stdin.
+ *   - 'prompt-file' the payload is written to a temp file and the final
+ *                   argument tells the agent to read it, for CLIs that do
+ *                   not read stdin at all.
+ *
+ * WHY A FILE AND NOT JUST A LONG ARGUMENT. Passing the payload itself as an
+ * argument was tried and abandoned on evidence. On POSIX it is fine; on
+ * Windows every one of these installs as a .cmd shim, which Node will not
+ * spawn without a shell, and cmd.exe cannot carry a newline inside an
+ * argument at all. Routing through PowerShell with the payload base64-encoded
+ * got past cmd.exe and then hit PowerShell 5.1's native-argument binder,
+ * which does not escape embedded double quotes: the prompt is JSON, so the
+ * first `\"type\":` ended the quoting and the child received 32 arguments
+ * instead of 1. A path has no spaces we did not choose, no quotes and no
+ * newlines, and it also lifts the ARG_MAX ceiling entirely -- these are
+ * agentic CLIs whose whole purpose is reading files, and the route is
+ * verified: copilot asked to read a payload file returned the exact array.
+ *
+ * VERIFIED means a probe was executed against the installed CLI in this
+ * repository and its reply parsed. DOCUMENTED means the shape comes from the
+ * vendor's own `--help` or published headless docs and has not been executed
+ * here, because the CLI is not installed on this machine. Both ship; the
+ * distinction is recorded so nobody mistakes the second for the first, and a
+ * wrong DOCUMENTED row fails loudly through `harvestFailure()` and doctor
+ * rather than silently producing nothing.
+ */
+const harvestCli = (command, args, { delivery = 'stdin', verified = false } = {}) =>
+  Object.freeze({ command, args: Object.freeze([...args]), delivery, verified });
+
+export const CLIENT_HARVEST_CLI = Object.freeze({
+  // VERIFIED: `claude -p` with the payload on stdin returned the exact array
+  // asked for. --output-format stream-json was tried first and rejected: its
+  // envelopes are themselves JSON containing brackets, which is a parsing
+  // hazard for no gain when plain text is already the model's reply.
+  'claude-code': harvestCli('claude', ['-p'], { verified: true }),
+  // VERIFIED: `codex exec -` reads instructions from stdin (its own --help
+  // says so, and a probe returned the array). It prints a banner containing
+  // `[workdir, /tmp, $TMPDIR]` before the reply, which is exactly why the
+  // reply parser has to try more than the first bracket it finds.
+  codex: harvestCli('codex', ['exec', '-'], { verified: true }),
+  // VERIFIED both ways. Asked to follow instructions on stdin the agent
+  // answered that it was unable to read stdin and exited 0 -- a silent
+  // no-findings result indistinguishable from a quiet session. Asked instead
+  // to read a payload file it returned the exact array requested, which is
+  // why this row is prompt-file. --allow-all-tools is required for
+  // non-interactive use by copilot's own help text, and -s drops the stats
+  // banner.
+  copilot: harvestCli('copilot', ['-s', '--allow-all-tools', '-p'], {
+    delivery: 'prompt-file',
+    verified: true,
+  }),
+  // DOCUMENTED: `gemini --help` states that -p runs headless and that the
+  // prompt is "Appended to input on stdin (if any)", so the digest rides
+  // stdin and the instruction is the flag value. Not executed here: this
+  // machine's gemini is unauthenticated and fails in refreshAuth before any
+  // prompt is read.
+  gemini: harvestCli('gemini', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: qwen-code is a fork of gemini-cli and keeps its flag surface.
+  qwen: harvestCli('qwen', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: `opencode run <message>` is its non-interactive entry point.
+  opencode: harvestCli('opencode', ['run'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `crush run <prompt>` runs a single non-interactive prompt.
+  crush: harvestCli('crush', ['run', '-q'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `droid exec <prompt>` is Factory's headless mode.
+  droid: harvestCli('droid', ['exec'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `amp -x <prompt>` executes a single prompt and exits.
+  amp: harvestCli('amp', ['-x'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: the Continue CLI installs as `cn` and takes -p for headless.
+  continue: harvestCli('cn', ['-p'], { delivery: 'prompt-file' }),
+
+  // NO HEADLESS CLI OF THEIR OWN. These are editor- and extension-hosted:
+  // the assistant runs inside the IDE process and ships no command a hook
+  // could spawn. Declaring null keeps that a stated fact rather than an
+  // omission, and these clients fall back to a configured endpoint --
+  // borrowing a neighbouring vendor's CLI would send the digest to a model
+  // the user never chose.
+  cursor: null,
+  cline: null,
+  windsurf: null,
+  kilo: null,
+  roo: null,
+  zed: null,
+});
+
+/**
+ * Splits a configured command line into words, respecting quotes.
+ *
+ * SPLITTING ON WHITESPACE ALONE IS WRONG ON WINDOWS, and the first test
+ * written against this caught it: the natural thing to configure is the
+ * interpreter you already have, and on Windows that is
+ * `C:\\Program Files\\nodejs\\node.exe`. A bare split turned that into the
+ * command `C:\\Program` and reported `C:\\Program exited 1`, which is a
+ * diagnostic nobody can act on. Quoting a path with spaces is the ordinary
+ * way to write a command line, so it has to mean what it says.
+ */
+function commandWords(line) {
+  const words = [];
+  let current = '';
+  let quote = '';
+  let started = false;
+  for (const ch of String(line)) {
+    if (quote) {
+      if (ch === quote) quote = '';
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (started) words.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (started) words.push(current);
+  return words;
+}
+
+/**
+ * The harvest CLI for a client, or null when it has none.
+ *
+ * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
+ * client with no row -- or one whose vendor changed its flags after this
+ * shipped -- is a configuration away from working rather than a release away.
+ * The value is a command and its arguments. The payload goes to stdin unless
+ * the string ends in `{}`, which is replaced by the path of a file holding
+ * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ */
+export function harvestCliFor(client, env = process.env) {
+  const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
+  if (override) {
+    const parts = commandWords(override);
+    const arg = parts[parts.length - 1] === '{}';
+    if (arg) parts.pop();
+    const [command, ...args] = parts;
+    if (!command) return null;
+    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+  }
+  return CLIENT_HARVEST_CLI[client] || null;
+}
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({
     name: 'Claude Code',

--- a/integrations/kilo/hooks/lib/capabilities.mjs
+++ b/integrations/kilo/hooks/lib/capabilities.mjs
@@ -353,21 +353,40 @@ function commandWords(line) {
  * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
  * client with no row -- or one whose vendor changed its flags after this
  * shipped -- is a configuration away from working rather than a release away.
- * The value is a command and its arguments. The payload goes to stdin unless
- * the string ends in `{}`, which is replaced by the path of a file holding
- * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ * The value is a command and its arguments, and its last word may name a
+ * delivery:
+ *   (nothing)  the payload goes to the command's stdin.
+ *   `{}`       it is written to a file and the path becomes the last
+ *              argument -- what an agentic CLI that ignores stdin needs.
+ *   `{-}`      the payload goes to stdin and a short instruction becomes the
+ *              last argument, for a CLI whose prompt flag demands a value
+ *              but which still reads stdin. gemini and qwen are shaped this
+ *              way, and without this an override could not reach that shape
+ *              at all.
  */
 export function harvestCliFor(client, env = process.env) {
   const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
   if (override) {
     const parts = commandWords(override);
-    const arg = parts[parts.length - 1] === '{}';
-    if (arg) parts.pop();
+    const last = parts[parts.length - 1];
+    const delivery =
+      last === '{}' ? 'prompt-file' : last === '{-}' ? 'arg-stdin' : 'stdin';
+    if (delivery !== 'stdin') parts.pop();
     const [command, ...args] = parts;
     if (!command) return null;
-    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+    return harvestCli(command, args, { delivery });
   }
-  return CLIENT_HARVEST_CLI[client] || null;
+  // NORMALISED AND OWN-PROPERTY ONLY, matching `capabilityFor` below.
+  //
+  // A bare index disagreed with its own sibling and reached the prototype.
+  // Reproduced: TOKEN_OPTIMIZER_CLIENT=Codex resolved a capability profile
+  // through capabilityFor -- which lower-cases -- and NO harvest CLI here, so
+  // harvestMode() fell through to off:no-key and an opted-in harvest silently
+  // did nothing on a client that plainly has one. And
+  // harvestCliFor('constructor') returned a function, whose `command` is
+  // undefined, which runHostCli would have handed straight to spawn.
+  const key = String(client || '').toLowerCase();
+  return Object.hasOwn(CLIENT_HARVEST_CLI, key) ? CLIENT_HARVEST_CLI[key] : null;
 }
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({

--- a/integrations/kilo/hooks/lib/doctor.mjs
+++ b/integrations/kilo/hooks/lib/doctor.mjs
@@ -246,6 +246,23 @@ export function probeHarvest() {
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
+  // The host client's own CLI, opted into with TOKEN_OPTIMIZER_HARVEST_CLI.
+  // Reported with the same failure-reason read as `local`, because the two
+  // share the property that made a broken configuration invisible: they
+  // return [] on failure and look exactly like a session with nothing to
+  // learn.
+  if (mode === 'host-cli') {
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check that this client\'s CLI is on PATH and signed in, or unset ' +
+        'TOKEN_OPTIMIZER_HARVEST_CLI to fall back to a configured endpoint')];
+    }
+    return [ok('finding extraction is available',
+      "this client's own CLI runs the semantic harvest -- no separate credential and no " +
+      'second vendor. Active-model wiki_write remains the primary path')];
+  }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
       'active-model wiki_write is primary; a credential also enables fallback extraction from ' +

--- a/integrations/kilo/hooks/lib/harvest.mjs
+++ b/integrations/kilo/hooks/lib/harvest.mjs
@@ -23,6 +23,7 @@
 import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { harvestCliFor } from './capabilities.mjs';
 
@@ -588,6 +589,14 @@ function withAnchorChoices(system, choices) {
   );
 }
 
+/**
+ * The `-p` value for a CLI whose prompt flag needs one but which still reads
+ * stdin. One line, no quotes, no newlines: everything a Windows command line
+ * cannot carry.
+ */
+export const ARG_STDIN_INSTRUCTION =
+  'Follow the instructions in the input above and reply with only the JSON array they ask for.';
+
 /** Restated at the end of a prompt file, where an agent skimming will see it. */
 const TRAILER =
   'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
@@ -652,7 +661,11 @@ async function runHostCli(cli, system, digest, timeoutMs) {
     // under the OS temp directory, which every one of these CLIs can read by
     // default, and removed in `finish` whatever the outcome.
     try {
-      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // UNGUESSABLE, NOT MERELY UNIQUE. pid and clock are both predictable
+      // enough for another local user to pre-create the path in a shared temp
+      // directory; randomUUID removes the guess, and `flag: 'wx'` below
+      // removes the race that remains.
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${randomUUID()}.txt`);
       // 0600. This is a digest of the user's session -- paths, commands and
       // prompts -- sitting in a shared temp directory for as long as the child
       // takes to read it. It is removed in `finish`, but a kill between the two
@@ -669,6 +682,12 @@ async function runHostCli(cli, system, digest, timeoutMs) {
       writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
         encoding: 'utf8',
         mode: 0o600,
+        // EXCLUSIVE CREATE. `mode` governs a file this call makes; it does
+        // nothing about one that already exists, and the default flag 'w'
+        // happily follows a symlink someone else placed at the path -- which
+        // would redirect a digest of the user's session wherever they chose.
+        // 'wx' fails instead of following.
+        flag: 'wx',
       });
     } catch (error) {
       return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
@@ -679,9 +698,16 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         'instructions and output the JSON array they ask for, and nothing else.'
     );
   } else if (cli.delivery === 'arg-stdin') {
-    // The flag needs a value and the CLI appends it after stdin, so the short
-    // instruction is the argument and the bulky digest still rides stdin.
-    args.push(system);
+    // A SHORT SINGLE LINE, NEVER THE PROMPT. The flag needs a value, and the
+    // obvious value -- `system` -- is the multi-line PROMPT, which
+    // withAnchorChoices extends with a newline-separated file list and which
+    // is full of the JSON prompt's double quotes. That is the exact payload
+    // the prompt-file route exists to keep off a Windows command line:
+    // cmd.exe cannot carry a newline inside an argument, and the quoting
+    // doubles every `"`. These CLIs document the flag value as being
+    // APPENDED to stdin, so the whole payload rides stdin and the argument
+    // is one line of ASCII that any shell survives.
+    args.push(ARG_STDIN_INSTRUCTION);
   }
 
   if (process.platform === 'win32' && file === cli.command) {
@@ -750,12 +776,26 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         : finish({ ok: false, reason: `${cli.command} exited ${code}` })
     );
 
+    // EPIPE ARRIVES AS AN EVENT, NOT AS A THROW. The try/catch below sees
+    // only a synchronous failure; a child that exits without reading stdin
+    // fails the write asynchronously, and Node delivers that on the stream.
+    // With no listener it is an uncaught exception that takes down the hook
+    // process instead of resolving this promise -- and the path is not
+    // hypothetical: copilot, asked to read a prompt on stdin, answers that it
+    // cannot and exits 0, which is why its row is prompt-file at all.
+    child.stdin.on('error', (error) =>
+      finish({
+        ok: false,
+        reason: `could not write the digest to ${cli.command}: ${error?.message || error}`,
+      })
+    );
+
     try {
       // Closed either way: a child left waiting on a pipe that will never
       // carry anything hangs until the timeout, which is the slowest possible
       // way to produce nothing.
       if (fileMode) child.stdin.end();
-      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+      else child.stdin.end(payload);
     } catch {
       finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
     }

--- a/integrations/kilo/hooks/lib/harvest.mjs
+++ b/integrations/kilo/hooks/lib/harvest.mjs
@@ -20,9 +20,11 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { harvestCliFor } from './capabilities.mjs';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -178,13 +180,25 @@ export function harvestMode() {
   // Free and private, so nothing further to weigh: no credential, no billing, no digest leaving
   // the machine.
   if (localEndpoint()) return 'local';
+  // THE HOST CLI IS A BACKEND, so the enablement check has to know about it.
+  // Without this the gate answers off:no-key and `extract` never reaches the
+  // CLI path -- which defeats the whole point of a backend that needs no key.
+  // Caught end to end rather than reasoned about: with no endpoint and no key,
+  // the first run of the opted-in host-CLI harvest returned
+  // `harvest is off:no-key` in 0s, having never spawned anything.
+  if (hostCliHarvest()) return 'host-cli';
+
 
   return apiKey() ? 'remote' : 'off:no-key';
 }
 
 export function harvestEnabled() {
   const mode = harvestMode();
-  return mode === 'local' || mode === 'remote';
+  // host-cli belongs here for the same reason local and remote do: it is a
+  // backend that can actually answer. Leaving it out would let the mode say
+  // `host-cli` while every caller that asks `harvestEnabled()` -- the Stop
+  // hook, the worker, extract's own first line -- skipped the harvest.
+  return mode === 'local' || mode === 'remote' || mode === 'host-cli';
 }
 
 /**
@@ -476,6 +490,295 @@ const succeeded = (findings) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
+/**
+ * The findings array inside a reply, or null.
+ *
+ * Models wrap JSON in prose or fences often enough that locating the array is
+ * more reliable than insisting the whole response parses -- and a CLI adds its
+ * own banner lines and stream-json envelopes on top, so both callers need the
+ * same tolerance. Shared so the two cannot drift.
+ */
+function findingsIn(text) {
+  const raw = String(text || '');
+
+  // FIRST BRACKET TO LAST IS NOT ENOUGH, and a CLI is where that breaks.
+  // `codex exec` prints a banner line reading `sandbox: workspace-write
+  // [workdir, /tmp, $TMPDIR]` before the model says anything, so the first
+  // `[` in the stream belongs to the banner and the naive slice parses to
+  // nothing -- an empty harvest that looks exactly like a session with
+  // nothing to learn. Closing brackets are walked from the end and opening
+  // brackets from the start, so the widest array that actually parses wins,
+  // and prose on either side is tolerated the way it already was for HTTP.
+  const closes = [];
+  for (let i = raw.length - 1; i >= 0 && closes.length < CLOSE_TRIES; i -= 1) {
+    if (raw[i] === ']') closes.push(i);
+  }
+  for (const end of closes) {
+    let tries = 0;
+    for (let start = raw.indexOf('['); start !== -1 && start < end; start = raw.indexOf('[', start + 1)) {
+      if ((tries += 1) > OPEN_TRIES) break;
+      try {
+        const parsed = JSON.parse(raw.slice(start, end + 1));
+        if (Array.isArray(parsed)) return parsed;
+      } catch {
+        /* not this pair */
+      }
+    }
+  }
+  return null;
+}
+
+// Bounded so a pathological reply cannot turn parsing into an O(n^2) walk of
+// a megabyte. A real findings array is at the end of the reply and preceded
+// by a banner or a sentence, not by hundreds of brackets.
+const CLOSE_TRIES = 8;
+const OPEN_TRIES = 40;
+
+/**
+ * Launches a Windows command through cmd.exe WITHOUT letting Node build the
+ * command line.
+ *
+ * These CLIs all install as .cmd shims, and Node has refused to spawn .cmd
+ * or .bat without a shell since the 2024 command-injection fix -- so a shell
+ * is not optional. But Node's own `shell: true` builds the cmd.exe line by
+ * joining argv with single spaces and no quoting at all, which breaks the
+ * moment any part contains one. Caught by the first test written against
+ * this: pointing the override at `C:\\Program Files\\nodejs\\node.exe`
+ * produced `C:\\Program Files\\nodejs\\node.exe exited 1`, because cmd.exe
+ * had been handed `C:\\Program` as the command. Quoting each part and passing
+ * the line verbatim is the fix.
+ */
+function windowsShellCommand(file, args) {
+  const quote = (part) => {
+    const value = String(part);
+    // Doubling is cmd.exe's own escape for a quote inside a quoted token.
+    return /[\s"]/.test(value)
+      ? `"${value.replace(/"/g, '""')}"`
+      : value;
+  };
+  const line = [file, ...args].map(quote).join(' ');
+  return [process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', `"${line}"`]];
+}
+
+/**
+ * States the anchor list in the prompt, for a backend that cannot be handed
+ * a schema.
+ *
+ * THE ANCHOR GATE IS WHAT SILENTLY EATS A HARVEST. `validate` keeps only
+ * anchors naming a file the session actually touched, and a model asked in
+ * English for a path writes a plausible one rather than a real one. Measured
+ * over four runs of qwen2.5:7b on a real digest against that gate:
+ * unconstrained, 4 extracted and 0 accepted; constrained to the list, 4 of 4.
+ *
+ * The HTTP path gets that constraint from a server-enforced enum. A CLI has
+ * no server to enforce it, so the same constraint is stated as strongly as a
+ * prompt can state it -- the exact strings, and an instruction to copy rather
+ * than compose. Not as good as an enum, and much better than nothing: the
+ * first end-to-end run without this extracted 10 findings and kept none.
+ */
+function withAnchorChoices(system, choices) {
+  if (!choices.length) return system;
+  const list = choices.map((file) => `- ${file}`).join('\n');
+  return (
+    `${system}\n\n` +
+    'Every entry in "anchors" MUST be copied verbatim from this list -- pick the ' +
+    'entries that best match the finding, and never write a path that is not ' +
+    'listed. Choosing the nearest match is right; dropping the finding is not:\n' +
+    list
+  );
+}
+
+/** Restated at the end of a prompt file, where an agent skimming will see it. */
+const TRAILER =
+  'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
+  'reply with the JSON array of findings and nothing else. If nothing in the ' +
+  'session is worth recording, reply with an empty array.';
+
+/**
+ * Runs the host client's own CLI as the harvest model.
+ *
+ * THE CHILD MUST NOT HARVEST. The harvest runs from the Stop hook, and a
+ * child session fires its own Stop hook -- verified, not assumed: a bare
+ * `claude -p` with our plugin installed wrote mcp-client, episode-outcome and
+ * derive events to the graph. Left unguarded that is unbounded recursion,
+ * each level spending real quota.
+ *
+ * TOKEN_OPTIMIZER_MODE=off IS THE GUARD, and it is the one that works.
+ * Measured on the same probe: TOKEN_OPTIMIZER_HARVEST=0 still ran the child's
+ * Stop hook and still wrote derive events -- it disables the harvest but not
+ * the hooks around it -- while MODE=off suppressed everything but a single
+ * mcp-client row. The kill switch is the only setting that makes the child
+ * inert, so the child is spawned with it and nothing else is relied upon.
+ *
+ * DELIVERY COMES FROM THE ROW, not from an assumption that every CLI reads
+ * stdin. Copilot does not: asked to follow instructions on stdin it replies
+ * that it cannot read stdin, exits 0, and yields no findings -- which looks
+ * exactly like a session with nothing to learn. Guessing here fails silently,
+ * so it is not guessed.
+ */
+/**
+ * How long to let the host CLI run.
+ *
+ * THE 30s HTTP DEFAULT KILLS EVERY CLI HARVEST, so it cannot be shared. That
+ * budget is sized for one completion against an endpoint that is already
+ * listening. A host CLI is an agent: it starts a process, loads its plugin
+ * and hook tree, opens a session, then thinks. Measured here on a 23 KB
+ * digest with no key and no local model, `claude -p` returned 10 findings in
+ * 104 SECONDS -- correct, and more than three times over the HTTP budget.
+ * `codex exec` on the same machine defaults to xhigh reasoning effort and
+ * had not finished at 300s, which is why this is configurable rather than
+ * merely larger.
+ *
+ * A caller that asks for MORE keeps it; the floor only lifts a default that
+ * was never chosen with this backend in mind.
+ */
+function hostCliTimeoutMs(requested) {
+  const configured = Number(process.env.TOKEN_OPTIMIZER_HARVEST_CLI_TIMEOUT_MS);
+  const floor = Number.isFinite(configured) && configured > 0 ? configured : 180_000;
+  return Math.max(floor, Number(requested) || 0);
+}
+
+async function runHostCli(cli, system, digest, timeoutMs) {
+  const payload = `${system}\n\n${digest}`;
+  const fileMode = cli.delivery === 'prompt-file';
+  let file = cli.command;
+  let args = [...cli.args];
+  let verbatim = false;
+  let promptFile = null;
+
+  if (fileMode) {
+    // A PATH, NOT THE PAYLOAD. See CLIENT_HARVEST_CLI for why the payload
+    // itself cannot travel as an argument on Windows. The file is written
+    // under the OS temp directory, which every one of these CLIs can read by
+    // default, and removed in `finish` whatever the outcome.
+    try {
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // 0600. This is a digest of the user's session -- paths, commands and
+      // prompts -- sitting in a shared temp directory for as long as the child
+      // takes to read it. It is removed in `finish`, but a kill between the two
+      // would leave it behind, so it is unreadable to other users meanwhile.
+      // (Windows ignores the mode; NTFS inheritance already keeps the per-user
+      // temp directory private.)
+      // THE CONTRACT IS REPEATED AT THE END. The instructions lead the file and
+      // the digest follows, which is the natural order and the one that failed:
+      // handed 23 KB this way, copilot reported the file as "a scratchpad
+      // /summary document" with no instruction in it and asked what JSON array
+      // was wanted. An agent skimming a long file sees its tail; restating the
+      // ask there costs one line and removes the dependence on how the file is
+      // read.
+      writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
+        encoding: 'utf8',
+        mode: 0o600,
+      });
+    } catch (error) {
+      return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
+    }
+    args.push(
+      `Read the whole file at ${promptFile}. It opens with instructions, then a ` +
+        'digest of a coding session, then repeats what to reply. Follow those ' +
+        'instructions and output the JSON array they ask for, and nothing else.'
+    );
+  } else if (cli.delivery === 'arg-stdin') {
+    // The flag needs a value and the CLI appends it after stdin, so the short
+    // instruction is the argument and the bulky digest still rides stdin.
+    args.push(system);
+  }
+
+  if (process.platform === 'win32' && file === cli.command) {
+    [file, args] = windowsShellCommand(file, args);
+    verbatim = true;
+  }
+
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(file, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        // The command line was built above where it needed cmd.exe, so Node
+        // must not rebuild it: `shell: true` would join argv unquoted.
+        windowsVerbatimArguments: verbatim,
+        env: {
+          ...process.env,
+          TOKEN_OPTIMIZER_MODE: 'off',
+        },
+      });
+    } catch (error) {
+      resolve({ ok: false, reason: `${cli.command} could not start: ${error?.message || error}` });
+      return;
+    }
+
+    let out = '';
+    let done = false;
+    const finish = (value) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      try {
+        child.kill();
+      } catch {
+        /* already gone */
+      }
+      if (promptFile) {
+        try {
+          rmSync(promptFile, { force: true });
+        } catch {
+          /* a leftover in the temp directory is not worth failing a harvest */
+        }
+      }
+      resolve(value);
+    };
+    const timer = setTimeout(
+      () => finish({ ok: false, reason: `${cli.command} timed out after ${timeoutMs}ms` }),
+      timeoutMs
+    );
+
+    child.stdout.on('data', (c) => {
+      out += c;
+    });
+    // stderr is drained so a chatty CLI cannot fill the pipe and deadlock.
+    child.stderr.on('data', () => {});
+    child.on('error', (error) =>
+      finish({ ok: false, reason: `${cli.command} failed: ${error?.message || error}` })
+    );
+    // NON-ZERO IS NOT ALWAYS EMPTY. Some of these print the reply and then
+    // exit non-zero over an unrelated cleanup complaint, so a parseable array
+    // already in hand beats the exit code; the code decides only when there is
+    // nothing to parse.
+    child.on('close', (code) =>
+      code === 0 || findingsIn(out)
+        ? finish({ ok: true, text: out })
+        : finish({ ok: false, reason: `${cli.command} exited ${code}` })
+    );
+
+    try {
+      // Closed either way: a child left waiting on a pipe that will never
+      // carry anything hangs until the timeout, which is the slowest possible
+      // way to produce nothing.
+      if (fileMode) child.stdin.end();
+      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+    } catch {
+      finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
+    }
+  });
+}
+
+/**
+ * Is the host CLI available as a harvest backend for this client?
+ *
+ * OPT-IN, deliberately, and this is the one default in this file that is not
+ * on. Every other path either reads local files or spends a key the user
+ * already configured for this purpose; this one spends the subscription that
+ * runs their editor, automatically, at the end of every session. HeadRoom
+ * makes the equivalent call user-invoked (`headroom learn`, cli/learn.py) and
+ * its own design note says to log events and analyse offline. Charging someone
+ * quota they did not ask to spend is not a default worth taking.
+ */
+export function hostCliHarvest(client = undefined, env = process.env) {
+  const enabled = /^(1|true|yes|on)$/i.test(env.TOKEN_OPTIMIZER_HARVEST_CLI || '');
+  if (!enabled) return null;
+  return harvestCliFor(client === undefined ? env.TOKEN_OPTIMIZER_CLIENT : client, env);
+}
+
 export async function extract(
   digest,
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
@@ -491,11 +794,40 @@ export async function extract(
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return failed('no api key for a remote endpoint');
+  // The host CLI carries its own auth -- the user is already signed into the
+  // client that is running this -- so the key requirement is about the HTTP
+  // backends only.
+  if (!local && !key && !hostCliHarvest()) {
+    return failed('no api key for a remote endpoint');
+  }
 
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // Computed before the CLI branch because BOTH backends need it. It used to
+  // sit below, so the host CLI was the one path that never learned which
+  // files it was allowed to anchor to -- and the anchor gate is what silently
+  // eats a harvest. Caught end to end on a real session: 10 findings
+  // extracted through `claude -p`, 0 surviving `validate`.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+
+  // The host client's own CLI, when the user has opted in. Tried first
+  // because it needs no key and no local model -- the two things whose
+  // absence has kept this path at 3 harvested findings on this machine.
+  const hostCli = hostCliHarvest();
+  if (hostCli) {
+    const result = await runHostCli(
+      hostCli,
+      withAnchorChoices(system, anchorChoices),
+      digest,
+      hostCliTimeoutMs(timeoutMs)
+    );
+    if (!result.ok) return failed(result.reason);
+    const parsed = findingsIn(result.text);
+    if (!parsed) return failed(`no JSON array in the ${hostCli.command} reply`);
+    return succeeded(parsed);
+  }
 
   // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
   //
@@ -514,7 +846,6 @@ export async function extract(
   // Only when the caller knows the list. `buildFullDelta` is raw transcript
   // with no file heading, and its caller passes no knownFiles for the same
   // reason -- an empty enum would forbid every anchor rather than free it.
-  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
   const schema = anchorChoices.length
     ? {
         ...FINDINGS_SCHEMA,
@@ -662,17 +993,8 @@ export async function extract(
       '';
     if (!text) return failed('endpoint answered in an unrecognised shape');
 
-    // Models wrap JSON in prose or fences often enough that finding the array
-    // is more reliable than insisting the whole response parse.
-    const start = text.indexOf('[');
-    const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return failed('no JSON array in the reply');
-
-    try {
-      return succeeded(JSON.parse(text.slice(start, end + 1)));
-    } catch {
-      return failed('the JSON array in the reply did not parse');
-    }
+    const parsed = findingsIn(text);
+    return parsed ? succeeded(parsed) : failed('no usable JSON array in the reply');
   } catch (error) {
     return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -695,6 +695,15 @@ function extractionNotice() {
         '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
         'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
       );
+    case 'host-cli':
+      // The extractor is this client's own headless CLI, which the user opted
+      // into. Worth its own case rather than folding into `remote`: no
+      // credential is involved, and the digest goes to the same vendor that
+      // already ran the session, which is a materially different disclosure.
+      return (
+        '\n\nSemantic extraction also runs after this session through this client\'s own CLI, ' +
+        'from a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
     case 'off:mode':
       // The whole optimizer is off and this text is not emitted anyway. Saying
       // anything here would be noise stacked on an explicit choice.

--- a/integrations/opencode/hooks/lib/capabilities.mjs
+++ b/integrations/opencode/hooks/lib/capabilities.mjs
@@ -194,6 +194,181 @@ const native = (profile) => ({
   ...profile,
 });
 
+/**
+ * How each client's own CLI can be driven headlessly, when it has one.
+ *
+ * THE HARVEST MODEL IS THE HOST ITSELF. Semantic extraction has always
+ * needed an API key or a local endpoint, and on a machine with neither it
+ * simply does not run -- measured on this one, 3 harvested findings against
+ * 237 written by the agent. But the client that just ran the session is
+ * installed BY DEFINITION and every one of these ships a headless mode, so
+ * the model was already on the machine. Nothing needed configuring; it only
+ * needed asking.
+ *
+ * ONE ROW PER CLIENT, not a hardcoded backend list. The nearest competitor
+ * picks from three (claude, gemini, codex), so its Cursor, Zed, Amp, Crush
+ * or Droid users get no semantic harvest at all. Every client this package
+ * supports gets a row here or an explicit null, and `npm run sync:hooks`
+ * copies the same table into all 16 integrations so the design cannot drift
+ * per client.
+ *
+ * NEVER ANOTHER VENDOR'S CLI. Reaching for whatever happens to be on PATH
+ * would send this session's digest to a model the user never chose, which is
+ * a disclosure they did not agree to. The host is the only defensible
+ * default, and TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND is the only way to pick a
+ * different one.
+ *
+ * DELIVERY IS PART OF THE ROW because the CLIs genuinely differ, and getting
+ * it wrong is silent:
+ *   - 'stdin'       the whole payload goes to the child's stdin.
+ *   - 'arg-stdin'   a short instruction is the final argument and the digest
+ *                   goes to stdin, for CLIs whose prompt flag needs a value
+ *                   but which still read stdin.
+ *   - 'prompt-file' the payload is written to a temp file and the final
+ *                   argument tells the agent to read it, for CLIs that do
+ *                   not read stdin at all.
+ *
+ * WHY A FILE AND NOT JUST A LONG ARGUMENT. Passing the payload itself as an
+ * argument was tried and abandoned on evidence. On POSIX it is fine; on
+ * Windows every one of these installs as a .cmd shim, which Node will not
+ * spawn without a shell, and cmd.exe cannot carry a newline inside an
+ * argument at all. Routing through PowerShell with the payload base64-encoded
+ * got past cmd.exe and then hit PowerShell 5.1's native-argument binder,
+ * which does not escape embedded double quotes: the prompt is JSON, so the
+ * first `\"type\":` ended the quoting and the child received 32 arguments
+ * instead of 1. A path has no spaces we did not choose, no quotes and no
+ * newlines, and it also lifts the ARG_MAX ceiling entirely -- these are
+ * agentic CLIs whose whole purpose is reading files, and the route is
+ * verified: copilot asked to read a payload file returned the exact array.
+ *
+ * VERIFIED means a probe was executed against the installed CLI in this
+ * repository and its reply parsed. DOCUMENTED means the shape comes from the
+ * vendor's own `--help` or published headless docs and has not been executed
+ * here, because the CLI is not installed on this machine. Both ship; the
+ * distinction is recorded so nobody mistakes the second for the first, and a
+ * wrong DOCUMENTED row fails loudly through `harvestFailure()` and doctor
+ * rather than silently producing nothing.
+ */
+const harvestCli = (command, args, { delivery = 'stdin', verified = false } = {}) =>
+  Object.freeze({ command, args: Object.freeze([...args]), delivery, verified });
+
+export const CLIENT_HARVEST_CLI = Object.freeze({
+  // VERIFIED: `claude -p` with the payload on stdin returned the exact array
+  // asked for. --output-format stream-json was tried first and rejected: its
+  // envelopes are themselves JSON containing brackets, which is a parsing
+  // hazard for no gain when plain text is already the model's reply.
+  'claude-code': harvestCli('claude', ['-p'], { verified: true }),
+  // VERIFIED: `codex exec -` reads instructions from stdin (its own --help
+  // says so, and a probe returned the array). It prints a banner containing
+  // `[workdir, /tmp, $TMPDIR]` before the reply, which is exactly why the
+  // reply parser has to try more than the first bracket it finds.
+  codex: harvestCli('codex', ['exec', '-'], { verified: true }),
+  // VERIFIED both ways. Asked to follow instructions on stdin the agent
+  // answered that it was unable to read stdin and exited 0 -- a silent
+  // no-findings result indistinguishable from a quiet session. Asked instead
+  // to read a payload file it returned the exact array requested, which is
+  // why this row is prompt-file. --allow-all-tools is required for
+  // non-interactive use by copilot's own help text, and -s drops the stats
+  // banner.
+  copilot: harvestCli('copilot', ['-s', '--allow-all-tools', '-p'], {
+    delivery: 'prompt-file',
+    verified: true,
+  }),
+  // DOCUMENTED: `gemini --help` states that -p runs headless and that the
+  // prompt is "Appended to input on stdin (if any)", so the digest rides
+  // stdin and the instruction is the flag value. Not executed here: this
+  // machine's gemini is unauthenticated and fails in refreshAuth before any
+  // prompt is read.
+  gemini: harvestCli('gemini', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: qwen-code is a fork of gemini-cli and keeps its flag surface.
+  qwen: harvestCli('qwen', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: `opencode run <message>` is its non-interactive entry point.
+  opencode: harvestCli('opencode', ['run'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `crush run <prompt>` runs a single non-interactive prompt.
+  crush: harvestCli('crush', ['run', '-q'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `droid exec <prompt>` is Factory's headless mode.
+  droid: harvestCli('droid', ['exec'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `amp -x <prompt>` executes a single prompt and exits.
+  amp: harvestCli('amp', ['-x'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: the Continue CLI installs as `cn` and takes -p for headless.
+  continue: harvestCli('cn', ['-p'], { delivery: 'prompt-file' }),
+
+  // NO HEADLESS CLI OF THEIR OWN. These are editor- and extension-hosted:
+  // the assistant runs inside the IDE process and ships no command a hook
+  // could spawn. Declaring null keeps that a stated fact rather than an
+  // omission, and these clients fall back to a configured endpoint --
+  // borrowing a neighbouring vendor's CLI would send the digest to a model
+  // the user never chose.
+  cursor: null,
+  cline: null,
+  windsurf: null,
+  kilo: null,
+  roo: null,
+  zed: null,
+});
+
+/**
+ * Splits a configured command line into words, respecting quotes.
+ *
+ * SPLITTING ON WHITESPACE ALONE IS WRONG ON WINDOWS, and the first test
+ * written against this caught it: the natural thing to configure is the
+ * interpreter you already have, and on Windows that is
+ * `C:\\Program Files\\nodejs\\node.exe`. A bare split turned that into the
+ * command `C:\\Program` and reported `C:\\Program exited 1`, which is a
+ * diagnostic nobody can act on. Quoting a path with spaces is the ordinary
+ * way to write a command line, so it has to mean what it says.
+ */
+function commandWords(line) {
+  const words = [];
+  let current = '';
+  let quote = '';
+  let started = false;
+  for (const ch of String(line)) {
+    if (quote) {
+      if (ch === quote) quote = '';
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (started) words.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (started) words.push(current);
+  return words;
+}
+
+/**
+ * The harvest CLI for a client, or null when it has none.
+ *
+ * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
+ * client with no row -- or one whose vendor changed its flags after this
+ * shipped -- is a configuration away from working rather than a release away.
+ * The value is a command and its arguments. The payload goes to stdin unless
+ * the string ends in `{}`, which is replaced by the path of a file holding
+ * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ */
+export function harvestCliFor(client, env = process.env) {
+  const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
+  if (override) {
+    const parts = commandWords(override);
+    const arg = parts[parts.length - 1] === '{}';
+    if (arg) parts.pop();
+    const [command, ...args] = parts;
+    if (!command) return null;
+    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+  }
+  return CLIENT_HARVEST_CLI[client] || null;
+}
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({
     name: 'Claude Code',

--- a/integrations/opencode/hooks/lib/capabilities.mjs
+++ b/integrations/opencode/hooks/lib/capabilities.mjs
@@ -353,21 +353,40 @@ function commandWords(line) {
  * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
  * client with no row -- or one whose vendor changed its flags after this
  * shipped -- is a configuration away from working rather than a release away.
- * The value is a command and its arguments. The payload goes to stdin unless
- * the string ends in `{}`, which is replaced by the path of a file holding
- * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ * The value is a command and its arguments, and its last word may name a
+ * delivery:
+ *   (nothing)  the payload goes to the command's stdin.
+ *   `{}`       it is written to a file and the path becomes the last
+ *              argument -- what an agentic CLI that ignores stdin needs.
+ *   `{-}`      the payload goes to stdin and a short instruction becomes the
+ *              last argument, for a CLI whose prompt flag demands a value
+ *              but which still reads stdin. gemini and qwen are shaped this
+ *              way, and without this an override could not reach that shape
+ *              at all.
  */
 export function harvestCliFor(client, env = process.env) {
   const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
   if (override) {
     const parts = commandWords(override);
-    const arg = parts[parts.length - 1] === '{}';
-    if (arg) parts.pop();
+    const last = parts[parts.length - 1];
+    const delivery =
+      last === '{}' ? 'prompt-file' : last === '{-}' ? 'arg-stdin' : 'stdin';
+    if (delivery !== 'stdin') parts.pop();
     const [command, ...args] = parts;
     if (!command) return null;
-    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+    return harvestCli(command, args, { delivery });
   }
-  return CLIENT_HARVEST_CLI[client] || null;
+  // NORMALISED AND OWN-PROPERTY ONLY, matching `capabilityFor` below.
+  //
+  // A bare index disagreed with its own sibling and reached the prototype.
+  // Reproduced: TOKEN_OPTIMIZER_CLIENT=Codex resolved a capability profile
+  // through capabilityFor -- which lower-cases -- and NO harvest CLI here, so
+  // harvestMode() fell through to off:no-key and an opted-in harvest silently
+  // did nothing on a client that plainly has one. And
+  // harvestCliFor('constructor') returned a function, whose `command` is
+  // undefined, which runHostCli would have handed straight to spawn.
+  const key = String(client || '').toLowerCase();
+  return Object.hasOwn(CLIENT_HARVEST_CLI, key) ? CLIENT_HARVEST_CLI[key] : null;
 }
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({

--- a/integrations/opencode/hooks/lib/doctor.mjs
+++ b/integrations/opencode/hooks/lib/doctor.mjs
@@ -246,6 +246,23 @@ export function probeHarvest() {
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
+  // The host client's own CLI, opted into with TOKEN_OPTIMIZER_HARVEST_CLI.
+  // Reported with the same failure-reason read as `local`, because the two
+  // share the property that made a broken configuration invisible: they
+  // return [] on failure and look exactly like a session with nothing to
+  // learn.
+  if (mode === 'host-cli') {
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check that this client\'s CLI is on PATH and signed in, or unset ' +
+        'TOKEN_OPTIMIZER_HARVEST_CLI to fall back to a configured endpoint')];
+    }
+    return [ok('finding extraction is available',
+      "this client's own CLI runs the semantic harvest -- no separate credential and no " +
+      'second vendor. Active-model wiki_write remains the primary path')];
+  }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
       'active-model wiki_write is primary; a credential also enables fallback extraction from ' +

--- a/integrations/opencode/hooks/lib/harvest.mjs
+++ b/integrations/opencode/hooks/lib/harvest.mjs
@@ -23,6 +23,7 @@
 import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { harvestCliFor } from './capabilities.mjs';
 
@@ -588,6 +589,14 @@ function withAnchorChoices(system, choices) {
   );
 }
 
+/**
+ * The `-p` value for a CLI whose prompt flag needs one but which still reads
+ * stdin. One line, no quotes, no newlines: everything a Windows command line
+ * cannot carry.
+ */
+export const ARG_STDIN_INSTRUCTION =
+  'Follow the instructions in the input above and reply with only the JSON array they ask for.';
+
 /** Restated at the end of a prompt file, where an agent skimming will see it. */
 const TRAILER =
   'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
@@ -652,7 +661,11 @@ async function runHostCli(cli, system, digest, timeoutMs) {
     // under the OS temp directory, which every one of these CLIs can read by
     // default, and removed in `finish` whatever the outcome.
     try {
-      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // UNGUESSABLE, NOT MERELY UNIQUE. pid and clock are both predictable
+      // enough for another local user to pre-create the path in a shared temp
+      // directory; randomUUID removes the guess, and `flag: 'wx'` below
+      // removes the race that remains.
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${randomUUID()}.txt`);
       // 0600. This is a digest of the user's session -- paths, commands and
       // prompts -- sitting in a shared temp directory for as long as the child
       // takes to read it. It is removed in `finish`, but a kill between the two
@@ -669,6 +682,12 @@ async function runHostCli(cli, system, digest, timeoutMs) {
       writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
         encoding: 'utf8',
         mode: 0o600,
+        // EXCLUSIVE CREATE. `mode` governs a file this call makes; it does
+        // nothing about one that already exists, and the default flag 'w'
+        // happily follows a symlink someone else placed at the path -- which
+        // would redirect a digest of the user's session wherever they chose.
+        // 'wx' fails instead of following.
+        flag: 'wx',
       });
     } catch (error) {
       return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
@@ -679,9 +698,16 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         'instructions and output the JSON array they ask for, and nothing else.'
     );
   } else if (cli.delivery === 'arg-stdin') {
-    // The flag needs a value and the CLI appends it after stdin, so the short
-    // instruction is the argument and the bulky digest still rides stdin.
-    args.push(system);
+    // A SHORT SINGLE LINE, NEVER THE PROMPT. The flag needs a value, and the
+    // obvious value -- `system` -- is the multi-line PROMPT, which
+    // withAnchorChoices extends with a newline-separated file list and which
+    // is full of the JSON prompt's double quotes. That is the exact payload
+    // the prompt-file route exists to keep off a Windows command line:
+    // cmd.exe cannot carry a newline inside an argument, and the quoting
+    // doubles every `"`. These CLIs document the flag value as being
+    // APPENDED to stdin, so the whole payload rides stdin and the argument
+    // is one line of ASCII that any shell survives.
+    args.push(ARG_STDIN_INSTRUCTION);
   }
 
   if (process.platform === 'win32' && file === cli.command) {
@@ -750,12 +776,26 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         : finish({ ok: false, reason: `${cli.command} exited ${code}` })
     );
 
+    // EPIPE ARRIVES AS AN EVENT, NOT AS A THROW. The try/catch below sees
+    // only a synchronous failure; a child that exits without reading stdin
+    // fails the write asynchronously, and Node delivers that on the stream.
+    // With no listener it is an uncaught exception that takes down the hook
+    // process instead of resolving this promise -- and the path is not
+    // hypothetical: copilot, asked to read a prompt on stdin, answers that it
+    // cannot and exits 0, which is why its row is prompt-file at all.
+    child.stdin.on('error', (error) =>
+      finish({
+        ok: false,
+        reason: `could not write the digest to ${cli.command}: ${error?.message || error}`,
+      })
+    );
+
     try {
       // Closed either way: a child left waiting on a pipe that will never
       // carry anything hangs until the timeout, which is the slowest possible
       // way to produce nothing.
       if (fileMode) child.stdin.end();
-      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+      else child.stdin.end(payload);
     } catch {
       finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
     }

--- a/integrations/opencode/hooks/lib/harvest.mjs
+++ b/integrations/opencode/hooks/lib/harvest.mjs
@@ -20,9 +20,11 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { harvestCliFor } from './capabilities.mjs';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -178,13 +180,25 @@ export function harvestMode() {
   // Free and private, so nothing further to weigh: no credential, no billing, no digest leaving
   // the machine.
   if (localEndpoint()) return 'local';
+  // THE HOST CLI IS A BACKEND, so the enablement check has to know about it.
+  // Without this the gate answers off:no-key and `extract` never reaches the
+  // CLI path -- which defeats the whole point of a backend that needs no key.
+  // Caught end to end rather than reasoned about: with no endpoint and no key,
+  // the first run of the opted-in host-CLI harvest returned
+  // `harvest is off:no-key` in 0s, having never spawned anything.
+  if (hostCliHarvest()) return 'host-cli';
+
 
   return apiKey() ? 'remote' : 'off:no-key';
 }
 
 export function harvestEnabled() {
   const mode = harvestMode();
-  return mode === 'local' || mode === 'remote';
+  // host-cli belongs here for the same reason local and remote do: it is a
+  // backend that can actually answer. Leaving it out would let the mode say
+  // `host-cli` while every caller that asks `harvestEnabled()` -- the Stop
+  // hook, the worker, extract's own first line -- skipped the harvest.
+  return mode === 'local' || mode === 'remote' || mode === 'host-cli';
 }
 
 /**
@@ -476,6 +490,295 @@ const succeeded = (findings) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
+/**
+ * The findings array inside a reply, or null.
+ *
+ * Models wrap JSON in prose or fences often enough that locating the array is
+ * more reliable than insisting the whole response parses -- and a CLI adds its
+ * own banner lines and stream-json envelopes on top, so both callers need the
+ * same tolerance. Shared so the two cannot drift.
+ */
+function findingsIn(text) {
+  const raw = String(text || '');
+
+  // FIRST BRACKET TO LAST IS NOT ENOUGH, and a CLI is where that breaks.
+  // `codex exec` prints a banner line reading `sandbox: workspace-write
+  // [workdir, /tmp, $TMPDIR]` before the model says anything, so the first
+  // `[` in the stream belongs to the banner and the naive slice parses to
+  // nothing -- an empty harvest that looks exactly like a session with
+  // nothing to learn. Closing brackets are walked from the end and opening
+  // brackets from the start, so the widest array that actually parses wins,
+  // and prose on either side is tolerated the way it already was for HTTP.
+  const closes = [];
+  for (let i = raw.length - 1; i >= 0 && closes.length < CLOSE_TRIES; i -= 1) {
+    if (raw[i] === ']') closes.push(i);
+  }
+  for (const end of closes) {
+    let tries = 0;
+    for (let start = raw.indexOf('['); start !== -1 && start < end; start = raw.indexOf('[', start + 1)) {
+      if ((tries += 1) > OPEN_TRIES) break;
+      try {
+        const parsed = JSON.parse(raw.slice(start, end + 1));
+        if (Array.isArray(parsed)) return parsed;
+      } catch {
+        /* not this pair */
+      }
+    }
+  }
+  return null;
+}
+
+// Bounded so a pathological reply cannot turn parsing into an O(n^2) walk of
+// a megabyte. A real findings array is at the end of the reply and preceded
+// by a banner or a sentence, not by hundreds of brackets.
+const CLOSE_TRIES = 8;
+const OPEN_TRIES = 40;
+
+/**
+ * Launches a Windows command through cmd.exe WITHOUT letting Node build the
+ * command line.
+ *
+ * These CLIs all install as .cmd shims, and Node has refused to spawn .cmd
+ * or .bat without a shell since the 2024 command-injection fix -- so a shell
+ * is not optional. But Node's own `shell: true` builds the cmd.exe line by
+ * joining argv with single spaces and no quoting at all, which breaks the
+ * moment any part contains one. Caught by the first test written against
+ * this: pointing the override at `C:\\Program Files\\nodejs\\node.exe`
+ * produced `C:\\Program Files\\nodejs\\node.exe exited 1`, because cmd.exe
+ * had been handed `C:\\Program` as the command. Quoting each part and passing
+ * the line verbatim is the fix.
+ */
+function windowsShellCommand(file, args) {
+  const quote = (part) => {
+    const value = String(part);
+    // Doubling is cmd.exe's own escape for a quote inside a quoted token.
+    return /[\s"]/.test(value)
+      ? `"${value.replace(/"/g, '""')}"`
+      : value;
+  };
+  const line = [file, ...args].map(quote).join(' ');
+  return [process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', `"${line}"`]];
+}
+
+/**
+ * States the anchor list in the prompt, for a backend that cannot be handed
+ * a schema.
+ *
+ * THE ANCHOR GATE IS WHAT SILENTLY EATS A HARVEST. `validate` keeps only
+ * anchors naming a file the session actually touched, and a model asked in
+ * English for a path writes a plausible one rather than a real one. Measured
+ * over four runs of qwen2.5:7b on a real digest against that gate:
+ * unconstrained, 4 extracted and 0 accepted; constrained to the list, 4 of 4.
+ *
+ * The HTTP path gets that constraint from a server-enforced enum. A CLI has
+ * no server to enforce it, so the same constraint is stated as strongly as a
+ * prompt can state it -- the exact strings, and an instruction to copy rather
+ * than compose. Not as good as an enum, and much better than nothing: the
+ * first end-to-end run without this extracted 10 findings and kept none.
+ */
+function withAnchorChoices(system, choices) {
+  if (!choices.length) return system;
+  const list = choices.map((file) => `- ${file}`).join('\n');
+  return (
+    `${system}\n\n` +
+    'Every entry in "anchors" MUST be copied verbatim from this list -- pick the ' +
+    'entries that best match the finding, and never write a path that is not ' +
+    'listed. Choosing the nearest match is right; dropping the finding is not:\n' +
+    list
+  );
+}
+
+/** Restated at the end of a prompt file, where an agent skimming will see it. */
+const TRAILER =
+  'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
+  'reply with the JSON array of findings and nothing else. If nothing in the ' +
+  'session is worth recording, reply with an empty array.';
+
+/**
+ * Runs the host client's own CLI as the harvest model.
+ *
+ * THE CHILD MUST NOT HARVEST. The harvest runs from the Stop hook, and a
+ * child session fires its own Stop hook -- verified, not assumed: a bare
+ * `claude -p` with our plugin installed wrote mcp-client, episode-outcome and
+ * derive events to the graph. Left unguarded that is unbounded recursion,
+ * each level spending real quota.
+ *
+ * TOKEN_OPTIMIZER_MODE=off IS THE GUARD, and it is the one that works.
+ * Measured on the same probe: TOKEN_OPTIMIZER_HARVEST=0 still ran the child's
+ * Stop hook and still wrote derive events -- it disables the harvest but not
+ * the hooks around it -- while MODE=off suppressed everything but a single
+ * mcp-client row. The kill switch is the only setting that makes the child
+ * inert, so the child is spawned with it and nothing else is relied upon.
+ *
+ * DELIVERY COMES FROM THE ROW, not from an assumption that every CLI reads
+ * stdin. Copilot does not: asked to follow instructions on stdin it replies
+ * that it cannot read stdin, exits 0, and yields no findings -- which looks
+ * exactly like a session with nothing to learn. Guessing here fails silently,
+ * so it is not guessed.
+ */
+/**
+ * How long to let the host CLI run.
+ *
+ * THE 30s HTTP DEFAULT KILLS EVERY CLI HARVEST, so it cannot be shared. That
+ * budget is sized for one completion against an endpoint that is already
+ * listening. A host CLI is an agent: it starts a process, loads its plugin
+ * and hook tree, opens a session, then thinks. Measured here on a 23 KB
+ * digest with no key and no local model, `claude -p` returned 10 findings in
+ * 104 SECONDS -- correct, and more than three times over the HTTP budget.
+ * `codex exec` on the same machine defaults to xhigh reasoning effort and
+ * had not finished at 300s, which is why this is configurable rather than
+ * merely larger.
+ *
+ * A caller that asks for MORE keeps it; the floor only lifts a default that
+ * was never chosen with this backend in mind.
+ */
+function hostCliTimeoutMs(requested) {
+  const configured = Number(process.env.TOKEN_OPTIMIZER_HARVEST_CLI_TIMEOUT_MS);
+  const floor = Number.isFinite(configured) && configured > 0 ? configured : 180_000;
+  return Math.max(floor, Number(requested) || 0);
+}
+
+async function runHostCli(cli, system, digest, timeoutMs) {
+  const payload = `${system}\n\n${digest}`;
+  const fileMode = cli.delivery === 'prompt-file';
+  let file = cli.command;
+  let args = [...cli.args];
+  let verbatim = false;
+  let promptFile = null;
+
+  if (fileMode) {
+    // A PATH, NOT THE PAYLOAD. See CLIENT_HARVEST_CLI for why the payload
+    // itself cannot travel as an argument on Windows. The file is written
+    // under the OS temp directory, which every one of these CLIs can read by
+    // default, and removed in `finish` whatever the outcome.
+    try {
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // 0600. This is a digest of the user's session -- paths, commands and
+      // prompts -- sitting in a shared temp directory for as long as the child
+      // takes to read it. It is removed in `finish`, but a kill between the two
+      // would leave it behind, so it is unreadable to other users meanwhile.
+      // (Windows ignores the mode; NTFS inheritance already keeps the per-user
+      // temp directory private.)
+      // THE CONTRACT IS REPEATED AT THE END. The instructions lead the file and
+      // the digest follows, which is the natural order and the one that failed:
+      // handed 23 KB this way, copilot reported the file as "a scratchpad
+      // /summary document" with no instruction in it and asked what JSON array
+      // was wanted. An agent skimming a long file sees its tail; restating the
+      // ask there costs one line and removes the dependence on how the file is
+      // read.
+      writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
+        encoding: 'utf8',
+        mode: 0o600,
+      });
+    } catch (error) {
+      return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
+    }
+    args.push(
+      `Read the whole file at ${promptFile}. It opens with instructions, then a ` +
+        'digest of a coding session, then repeats what to reply. Follow those ' +
+        'instructions and output the JSON array they ask for, and nothing else.'
+    );
+  } else if (cli.delivery === 'arg-stdin') {
+    // The flag needs a value and the CLI appends it after stdin, so the short
+    // instruction is the argument and the bulky digest still rides stdin.
+    args.push(system);
+  }
+
+  if (process.platform === 'win32' && file === cli.command) {
+    [file, args] = windowsShellCommand(file, args);
+    verbatim = true;
+  }
+
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(file, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        // The command line was built above where it needed cmd.exe, so Node
+        // must not rebuild it: `shell: true` would join argv unquoted.
+        windowsVerbatimArguments: verbatim,
+        env: {
+          ...process.env,
+          TOKEN_OPTIMIZER_MODE: 'off',
+        },
+      });
+    } catch (error) {
+      resolve({ ok: false, reason: `${cli.command} could not start: ${error?.message || error}` });
+      return;
+    }
+
+    let out = '';
+    let done = false;
+    const finish = (value) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      try {
+        child.kill();
+      } catch {
+        /* already gone */
+      }
+      if (promptFile) {
+        try {
+          rmSync(promptFile, { force: true });
+        } catch {
+          /* a leftover in the temp directory is not worth failing a harvest */
+        }
+      }
+      resolve(value);
+    };
+    const timer = setTimeout(
+      () => finish({ ok: false, reason: `${cli.command} timed out after ${timeoutMs}ms` }),
+      timeoutMs
+    );
+
+    child.stdout.on('data', (c) => {
+      out += c;
+    });
+    // stderr is drained so a chatty CLI cannot fill the pipe and deadlock.
+    child.stderr.on('data', () => {});
+    child.on('error', (error) =>
+      finish({ ok: false, reason: `${cli.command} failed: ${error?.message || error}` })
+    );
+    // NON-ZERO IS NOT ALWAYS EMPTY. Some of these print the reply and then
+    // exit non-zero over an unrelated cleanup complaint, so a parseable array
+    // already in hand beats the exit code; the code decides only when there is
+    // nothing to parse.
+    child.on('close', (code) =>
+      code === 0 || findingsIn(out)
+        ? finish({ ok: true, text: out })
+        : finish({ ok: false, reason: `${cli.command} exited ${code}` })
+    );
+
+    try {
+      // Closed either way: a child left waiting on a pipe that will never
+      // carry anything hangs until the timeout, which is the slowest possible
+      // way to produce nothing.
+      if (fileMode) child.stdin.end();
+      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+    } catch {
+      finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
+    }
+  });
+}
+
+/**
+ * Is the host CLI available as a harvest backend for this client?
+ *
+ * OPT-IN, deliberately, and this is the one default in this file that is not
+ * on. Every other path either reads local files or spends a key the user
+ * already configured for this purpose; this one spends the subscription that
+ * runs their editor, automatically, at the end of every session. HeadRoom
+ * makes the equivalent call user-invoked (`headroom learn`, cli/learn.py) and
+ * its own design note says to log events and analyse offline. Charging someone
+ * quota they did not ask to spend is not a default worth taking.
+ */
+export function hostCliHarvest(client = undefined, env = process.env) {
+  const enabled = /^(1|true|yes|on)$/i.test(env.TOKEN_OPTIMIZER_HARVEST_CLI || '');
+  if (!enabled) return null;
+  return harvestCliFor(client === undefined ? env.TOKEN_OPTIMIZER_CLIENT : client, env);
+}
+
 export async function extract(
   digest,
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
@@ -491,11 +794,40 @@ export async function extract(
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return failed('no api key for a remote endpoint');
+  // The host CLI carries its own auth -- the user is already signed into the
+  // client that is running this -- so the key requirement is about the HTTP
+  // backends only.
+  if (!local && !key && !hostCliHarvest()) {
+    return failed('no api key for a remote endpoint');
+  }
 
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // Computed before the CLI branch because BOTH backends need it. It used to
+  // sit below, so the host CLI was the one path that never learned which
+  // files it was allowed to anchor to -- and the anchor gate is what silently
+  // eats a harvest. Caught end to end on a real session: 10 findings
+  // extracted through `claude -p`, 0 surviving `validate`.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+
+  // The host client's own CLI, when the user has opted in. Tried first
+  // because it needs no key and no local model -- the two things whose
+  // absence has kept this path at 3 harvested findings on this machine.
+  const hostCli = hostCliHarvest();
+  if (hostCli) {
+    const result = await runHostCli(
+      hostCli,
+      withAnchorChoices(system, anchorChoices),
+      digest,
+      hostCliTimeoutMs(timeoutMs)
+    );
+    if (!result.ok) return failed(result.reason);
+    const parsed = findingsIn(result.text);
+    if (!parsed) return failed(`no JSON array in the ${hostCli.command} reply`);
+    return succeeded(parsed);
+  }
 
   // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
   //
@@ -514,7 +846,6 @@ export async function extract(
   // Only when the caller knows the list. `buildFullDelta` is raw transcript
   // with no file heading, and its caller passes no knownFiles for the same
   // reason -- an empty enum would forbid every anchor rather than free it.
-  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
   const schema = anchorChoices.length
     ? {
         ...FINDINGS_SCHEMA,
@@ -662,17 +993,8 @@ export async function extract(
       '';
     if (!text) return failed('endpoint answered in an unrecognised shape');
 
-    // Models wrap JSON in prose or fences often enough that finding the array
-    // is more reliable than insisting the whole response parse.
-    const start = text.indexOf('[');
-    const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return failed('no JSON array in the reply');
-
-    try {
-      return succeeded(JSON.parse(text.slice(start, end + 1)));
-    } catch {
-      return failed('the JSON array in the reply did not parse');
-    }
+    const parsed = findingsIn(text);
+    return parsed ? succeeded(parsed) : failed('no usable JSON array in the reply');
   } catch (error) {
     return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -695,6 +695,15 @@ function extractionNotice() {
         '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
         'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
       );
+    case 'host-cli':
+      // The extractor is this client's own headless CLI, which the user opted
+      // into. Worth its own case rather than folding into `remote`: no
+      // credential is involved, and the digest goes to the same vendor that
+      // already ran the session, which is a materially different disclosure.
+      return (
+        '\n\nSemantic extraction also runs after this session through this client\'s own CLI, ' +
+        'from a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
     case 'off:mode':
       // The whole optimizer is off and this text is not emitted anyway. Saying
       // anything here would be noise stacked on an explicit choice.

--- a/integrations/qwen/hooks/lib/capabilities.mjs
+++ b/integrations/qwen/hooks/lib/capabilities.mjs
@@ -194,6 +194,181 @@ const native = (profile) => ({
   ...profile,
 });
 
+/**
+ * How each client's own CLI can be driven headlessly, when it has one.
+ *
+ * THE HARVEST MODEL IS THE HOST ITSELF. Semantic extraction has always
+ * needed an API key or a local endpoint, and on a machine with neither it
+ * simply does not run -- measured on this one, 3 harvested findings against
+ * 237 written by the agent. But the client that just ran the session is
+ * installed BY DEFINITION and every one of these ships a headless mode, so
+ * the model was already on the machine. Nothing needed configuring; it only
+ * needed asking.
+ *
+ * ONE ROW PER CLIENT, not a hardcoded backend list. The nearest competitor
+ * picks from three (claude, gemini, codex), so its Cursor, Zed, Amp, Crush
+ * or Droid users get no semantic harvest at all. Every client this package
+ * supports gets a row here or an explicit null, and `npm run sync:hooks`
+ * copies the same table into all 16 integrations so the design cannot drift
+ * per client.
+ *
+ * NEVER ANOTHER VENDOR'S CLI. Reaching for whatever happens to be on PATH
+ * would send this session's digest to a model the user never chose, which is
+ * a disclosure they did not agree to. The host is the only defensible
+ * default, and TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND is the only way to pick a
+ * different one.
+ *
+ * DELIVERY IS PART OF THE ROW because the CLIs genuinely differ, and getting
+ * it wrong is silent:
+ *   - 'stdin'       the whole payload goes to the child's stdin.
+ *   - 'arg-stdin'   a short instruction is the final argument and the digest
+ *                   goes to stdin, for CLIs whose prompt flag needs a value
+ *                   but which still read stdin.
+ *   - 'prompt-file' the payload is written to a temp file and the final
+ *                   argument tells the agent to read it, for CLIs that do
+ *                   not read stdin at all.
+ *
+ * WHY A FILE AND NOT JUST A LONG ARGUMENT. Passing the payload itself as an
+ * argument was tried and abandoned on evidence. On POSIX it is fine; on
+ * Windows every one of these installs as a .cmd shim, which Node will not
+ * spawn without a shell, and cmd.exe cannot carry a newline inside an
+ * argument at all. Routing through PowerShell with the payload base64-encoded
+ * got past cmd.exe and then hit PowerShell 5.1's native-argument binder,
+ * which does not escape embedded double quotes: the prompt is JSON, so the
+ * first `\"type\":` ended the quoting and the child received 32 arguments
+ * instead of 1. A path has no spaces we did not choose, no quotes and no
+ * newlines, and it also lifts the ARG_MAX ceiling entirely -- these are
+ * agentic CLIs whose whole purpose is reading files, and the route is
+ * verified: copilot asked to read a payload file returned the exact array.
+ *
+ * VERIFIED means a probe was executed against the installed CLI in this
+ * repository and its reply parsed. DOCUMENTED means the shape comes from the
+ * vendor's own `--help` or published headless docs and has not been executed
+ * here, because the CLI is not installed on this machine. Both ship; the
+ * distinction is recorded so nobody mistakes the second for the first, and a
+ * wrong DOCUMENTED row fails loudly through `harvestFailure()` and doctor
+ * rather than silently producing nothing.
+ */
+const harvestCli = (command, args, { delivery = 'stdin', verified = false } = {}) =>
+  Object.freeze({ command, args: Object.freeze([...args]), delivery, verified });
+
+export const CLIENT_HARVEST_CLI = Object.freeze({
+  // VERIFIED: `claude -p` with the payload on stdin returned the exact array
+  // asked for. --output-format stream-json was tried first and rejected: its
+  // envelopes are themselves JSON containing brackets, which is a parsing
+  // hazard for no gain when plain text is already the model's reply.
+  'claude-code': harvestCli('claude', ['-p'], { verified: true }),
+  // VERIFIED: `codex exec -` reads instructions from stdin (its own --help
+  // says so, and a probe returned the array). It prints a banner containing
+  // `[workdir, /tmp, $TMPDIR]` before the reply, which is exactly why the
+  // reply parser has to try more than the first bracket it finds.
+  codex: harvestCli('codex', ['exec', '-'], { verified: true }),
+  // VERIFIED both ways. Asked to follow instructions on stdin the agent
+  // answered that it was unable to read stdin and exited 0 -- a silent
+  // no-findings result indistinguishable from a quiet session. Asked instead
+  // to read a payload file it returned the exact array requested, which is
+  // why this row is prompt-file. --allow-all-tools is required for
+  // non-interactive use by copilot's own help text, and -s drops the stats
+  // banner.
+  copilot: harvestCli('copilot', ['-s', '--allow-all-tools', '-p'], {
+    delivery: 'prompt-file',
+    verified: true,
+  }),
+  // DOCUMENTED: `gemini --help` states that -p runs headless and that the
+  // prompt is "Appended to input on stdin (if any)", so the digest rides
+  // stdin and the instruction is the flag value. Not executed here: this
+  // machine's gemini is unauthenticated and fails in refreshAuth before any
+  // prompt is read.
+  gemini: harvestCli('gemini', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: qwen-code is a fork of gemini-cli and keeps its flag surface.
+  qwen: harvestCli('qwen', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: `opencode run <message>` is its non-interactive entry point.
+  opencode: harvestCli('opencode', ['run'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `crush run <prompt>` runs a single non-interactive prompt.
+  crush: harvestCli('crush', ['run', '-q'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `droid exec <prompt>` is Factory's headless mode.
+  droid: harvestCli('droid', ['exec'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `amp -x <prompt>` executes a single prompt and exits.
+  amp: harvestCli('amp', ['-x'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: the Continue CLI installs as `cn` and takes -p for headless.
+  continue: harvestCli('cn', ['-p'], { delivery: 'prompt-file' }),
+
+  // NO HEADLESS CLI OF THEIR OWN. These are editor- and extension-hosted:
+  // the assistant runs inside the IDE process and ships no command a hook
+  // could spawn. Declaring null keeps that a stated fact rather than an
+  // omission, and these clients fall back to a configured endpoint --
+  // borrowing a neighbouring vendor's CLI would send the digest to a model
+  // the user never chose.
+  cursor: null,
+  cline: null,
+  windsurf: null,
+  kilo: null,
+  roo: null,
+  zed: null,
+});
+
+/**
+ * Splits a configured command line into words, respecting quotes.
+ *
+ * SPLITTING ON WHITESPACE ALONE IS WRONG ON WINDOWS, and the first test
+ * written against this caught it: the natural thing to configure is the
+ * interpreter you already have, and on Windows that is
+ * `C:\\Program Files\\nodejs\\node.exe`. A bare split turned that into the
+ * command `C:\\Program` and reported `C:\\Program exited 1`, which is a
+ * diagnostic nobody can act on. Quoting a path with spaces is the ordinary
+ * way to write a command line, so it has to mean what it says.
+ */
+function commandWords(line) {
+  const words = [];
+  let current = '';
+  let quote = '';
+  let started = false;
+  for (const ch of String(line)) {
+    if (quote) {
+      if (ch === quote) quote = '';
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (started) words.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (started) words.push(current);
+  return words;
+}
+
+/**
+ * The harvest CLI for a client, or null when it has none.
+ *
+ * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
+ * client with no row -- or one whose vendor changed its flags after this
+ * shipped -- is a configuration away from working rather than a release away.
+ * The value is a command and its arguments. The payload goes to stdin unless
+ * the string ends in `{}`, which is replaced by the path of a file holding
+ * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ */
+export function harvestCliFor(client, env = process.env) {
+  const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
+  if (override) {
+    const parts = commandWords(override);
+    const arg = parts[parts.length - 1] === '{}';
+    if (arg) parts.pop();
+    const [command, ...args] = parts;
+    if (!command) return null;
+    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+  }
+  return CLIENT_HARVEST_CLI[client] || null;
+}
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({
     name: 'Claude Code',

--- a/integrations/qwen/hooks/lib/capabilities.mjs
+++ b/integrations/qwen/hooks/lib/capabilities.mjs
@@ -353,21 +353,40 @@ function commandWords(line) {
  * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
  * client with no row -- or one whose vendor changed its flags after this
  * shipped -- is a configuration away from working rather than a release away.
- * The value is a command and its arguments. The payload goes to stdin unless
- * the string ends in `{}`, which is replaced by the path of a file holding
- * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ * The value is a command and its arguments, and its last word may name a
+ * delivery:
+ *   (nothing)  the payload goes to the command's stdin.
+ *   `{}`       it is written to a file and the path becomes the last
+ *              argument -- what an agentic CLI that ignores stdin needs.
+ *   `{-}`      the payload goes to stdin and a short instruction becomes the
+ *              last argument, for a CLI whose prompt flag demands a value
+ *              but which still reads stdin. gemini and qwen are shaped this
+ *              way, and without this an override could not reach that shape
+ *              at all.
  */
 export function harvestCliFor(client, env = process.env) {
   const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
   if (override) {
     const parts = commandWords(override);
-    const arg = parts[parts.length - 1] === '{}';
-    if (arg) parts.pop();
+    const last = parts[parts.length - 1];
+    const delivery =
+      last === '{}' ? 'prompt-file' : last === '{-}' ? 'arg-stdin' : 'stdin';
+    if (delivery !== 'stdin') parts.pop();
     const [command, ...args] = parts;
     if (!command) return null;
-    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+    return harvestCli(command, args, { delivery });
   }
-  return CLIENT_HARVEST_CLI[client] || null;
+  // NORMALISED AND OWN-PROPERTY ONLY, matching `capabilityFor` below.
+  //
+  // A bare index disagreed with its own sibling and reached the prototype.
+  // Reproduced: TOKEN_OPTIMIZER_CLIENT=Codex resolved a capability profile
+  // through capabilityFor -- which lower-cases -- and NO harvest CLI here, so
+  // harvestMode() fell through to off:no-key and an opted-in harvest silently
+  // did nothing on a client that plainly has one. And
+  // harvestCliFor('constructor') returned a function, whose `command` is
+  // undefined, which runHostCli would have handed straight to spawn.
+  const key = String(client || '').toLowerCase();
+  return Object.hasOwn(CLIENT_HARVEST_CLI, key) ? CLIENT_HARVEST_CLI[key] : null;
 }
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({

--- a/integrations/qwen/hooks/lib/doctor.mjs
+++ b/integrations/qwen/hooks/lib/doctor.mjs
@@ -246,6 +246,23 @@ export function probeHarvest() {
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
+  // The host client's own CLI, opted into with TOKEN_OPTIMIZER_HARVEST_CLI.
+  // Reported with the same failure-reason read as `local`, because the two
+  // share the property that made a broken configuration invisible: they
+  // return [] on failure and look exactly like a session with nothing to
+  // learn.
+  if (mode === 'host-cli') {
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check that this client\'s CLI is on PATH and signed in, or unset ' +
+        'TOKEN_OPTIMIZER_HARVEST_CLI to fall back to a configured endpoint')];
+    }
+    return [ok('finding extraction is available',
+      "this client's own CLI runs the semantic harvest -- no separate credential and no " +
+      'second vendor. Active-model wiki_write remains the primary path')];
+  }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
       'active-model wiki_write is primary; a credential also enables fallback extraction from ' +

--- a/integrations/qwen/hooks/lib/harvest.mjs
+++ b/integrations/qwen/hooks/lib/harvest.mjs
@@ -23,6 +23,7 @@
 import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { harvestCliFor } from './capabilities.mjs';
 
@@ -588,6 +589,14 @@ function withAnchorChoices(system, choices) {
   );
 }
 
+/**
+ * The `-p` value for a CLI whose prompt flag needs one but which still reads
+ * stdin. One line, no quotes, no newlines: everything a Windows command line
+ * cannot carry.
+ */
+export const ARG_STDIN_INSTRUCTION =
+  'Follow the instructions in the input above and reply with only the JSON array they ask for.';
+
 /** Restated at the end of a prompt file, where an agent skimming will see it. */
 const TRAILER =
   'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
@@ -652,7 +661,11 @@ async function runHostCli(cli, system, digest, timeoutMs) {
     // under the OS temp directory, which every one of these CLIs can read by
     // default, and removed in `finish` whatever the outcome.
     try {
-      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // UNGUESSABLE, NOT MERELY UNIQUE. pid and clock are both predictable
+      // enough for another local user to pre-create the path in a shared temp
+      // directory; randomUUID removes the guess, and `flag: 'wx'` below
+      // removes the race that remains.
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${randomUUID()}.txt`);
       // 0600. This is a digest of the user's session -- paths, commands and
       // prompts -- sitting in a shared temp directory for as long as the child
       // takes to read it. It is removed in `finish`, but a kill between the two
@@ -669,6 +682,12 @@ async function runHostCli(cli, system, digest, timeoutMs) {
       writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
         encoding: 'utf8',
         mode: 0o600,
+        // EXCLUSIVE CREATE. `mode` governs a file this call makes; it does
+        // nothing about one that already exists, and the default flag 'w'
+        // happily follows a symlink someone else placed at the path -- which
+        // would redirect a digest of the user's session wherever they chose.
+        // 'wx' fails instead of following.
+        flag: 'wx',
       });
     } catch (error) {
       return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
@@ -679,9 +698,16 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         'instructions and output the JSON array they ask for, and nothing else.'
     );
   } else if (cli.delivery === 'arg-stdin') {
-    // The flag needs a value and the CLI appends it after stdin, so the short
-    // instruction is the argument and the bulky digest still rides stdin.
-    args.push(system);
+    // A SHORT SINGLE LINE, NEVER THE PROMPT. The flag needs a value, and the
+    // obvious value -- `system` -- is the multi-line PROMPT, which
+    // withAnchorChoices extends with a newline-separated file list and which
+    // is full of the JSON prompt's double quotes. That is the exact payload
+    // the prompt-file route exists to keep off a Windows command line:
+    // cmd.exe cannot carry a newline inside an argument, and the quoting
+    // doubles every `"`. These CLIs document the flag value as being
+    // APPENDED to stdin, so the whole payload rides stdin and the argument
+    // is one line of ASCII that any shell survives.
+    args.push(ARG_STDIN_INSTRUCTION);
   }
 
   if (process.platform === 'win32' && file === cli.command) {
@@ -750,12 +776,26 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         : finish({ ok: false, reason: `${cli.command} exited ${code}` })
     );
 
+    // EPIPE ARRIVES AS AN EVENT, NOT AS A THROW. The try/catch below sees
+    // only a synchronous failure; a child that exits without reading stdin
+    // fails the write asynchronously, and Node delivers that on the stream.
+    // With no listener it is an uncaught exception that takes down the hook
+    // process instead of resolving this promise -- and the path is not
+    // hypothetical: copilot, asked to read a prompt on stdin, answers that it
+    // cannot and exits 0, which is why its row is prompt-file at all.
+    child.stdin.on('error', (error) =>
+      finish({
+        ok: false,
+        reason: `could not write the digest to ${cli.command}: ${error?.message || error}`,
+      })
+    );
+
     try {
       // Closed either way: a child left waiting on a pipe that will never
       // carry anything hangs until the timeout, which is the slowest possible
       // way to produce nothing.
       if (fileMode) child.stdin.end();
-      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+      else child.stdin.end(payload);
     } catch {
       finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
     }

--- a/integrations/qwen/hooks/lib/harvest.mjs
+++ b/integrations/qwen/hooks/lib/harvest.mjs
@@ -20,9 +20,11 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { harvestCliFor } from './capabilities.mjs';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -178,13 +180,25 @@ export function harvestMode() {
   // Free and private, so nothing further to weigh: no credential, no billing, no digest leaving
   // the machine.
   if (localEndpoint()) return 'local';
+  // THE HOST CLI IS A BACKEND, so the enablement check has to know about it.
+  // Without this the gate answers off:no-key and `extract` never reaches the
+  // CLI path -- which defeats the whole point of a backend that needs no key.
+  // Caught end to end rather than reasoned about: with no endpoint and no key,
+  // the first run of the opted-in host-CLI harvest returned
+  // `harvest is off:no-key` in 0s, having never spawned anything.
+  if (hostCliHarvest()) return 'host-cli';
+
 
   return apiKey() ? 'remote' : 'off:no-key';
 }
 
 export function harvestEnabled() {
   const mode = harvestMode();
-  return mode === 'local' || mode === 'remote';
+  // host-cli belongs here for the same reason local and remote do: it is a
+  // backend that can actually answer. Leaving it out would let the mode say
+  // `host-cli` while every caller that asks `harvestEnabled()` -- the Stop
+  // hook, the worker, extract's own first line -- skipped the harvest.
+  return mode === 'local' || mode === 'remote' || mode === 'host-cli';
 }
 
 /**
@@ -476,6 +490,295 @@ const succeeded = (findings) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
+/**
+ * The findings array inside a reply, or null.
+ *
+ * Models wrap JSON in prose or fences often enough that locating the array is
+ * more reliable than insisting the whole response parses -- and a CLI adds its
+ * own banner lines and stream-json envelopes on top, so both callers need the
+ * same tolerance. Shared so the two cannot drift.
+ */
+function findingsIn(text) {
+  const raw = String(text || '');
+
+  // FIRST BRACKET TO LAST IS NOT ENOUGH, and a CLI is where that breaks.
+  // `codex exec` prints a banner line reading `sandbox: workspace-write
+  // [workdir, /tmp, $TMPDIR]` before the model says anything, so the first
+  // `[` in the stream belongs to the banner and the naive slice parses to
+  // nothing -- an empty harvest that looks exactly like a session with
+  // nothing to learn. Closing brackets are walked from the end and opening
+  // brackets from the start, so the widest array that actually parses wins,
+  // and prose on either side is tolerated the way it already was for HTTP.
+  const closes = [];
+  for (let i = raw.length - 1; i >= 0 && closes.length < CLOSE_TRIES; i -= 1) {
+    if (raw[i] === ']') closes.push(i);
+  }
+  for (const end of closes) {
+    let tries = 0;
+    for (let start = raw.indexOf('['); start !== -1 && start < end; start = raw.indexOf('[', start + 1)) {
+      if ((tries += 1) > OPEN_TRIES) break;
+      try {
+        const parsed = JSON.parse(raw.slice(start, end + 1));
+        if (Array.isArray(parsed)) return parsed;
+      } catch {
+        /* not this pair */
+      }
+    }
+  }
+  return null;
+}
+
+// Bounded so a pathological reply cannot turn parsing into an O(n^2) walk of
+// a megabyte. A real findings array is at the end of the reply and preceded
+// by a banner or a sentence, not by hundreds of brackets.
+const CLOSE_TRIES = 8;
+const OPEN_TRIES = 40;
+
+/**
+ * Launches a Windows command through cmd.exe WITHOUT letting Node build the
+ * command line.
+ *
+ * These CLIs all install as .cmd shims, and Node has refused to spawn .cmd
+ * or .bat without a shell since the 2024 command-injection fix -- so a shell
+ * is not optional. But Node's own `shell: true` builds the cmd.exe line by
+ * joining argv with single spaces and no quoting at all, which breaks the
+ * moment any part contains one. Caught by the first test written against
+ * this: pointing the override at `C:\\Program Files\\nodejs\\node.exe`
+ * produced `C:\\Program Files\\nodejs\\node.exe exited 1`, because cmd.exe
+ * had been handed `C:\\Program` as the command. Quoting each part and passing
+ * the line verbatim is the fix.
+ */
+function windowsShellCommand(file, args) {
+  const quote = (part) => {
+    const value = String(part);
+    // Doubling is cmd.exe's own escape for a quote inside a quoted token.
+    return /[\s"]/.test(value)
+      ? `"${value.replace(/"/g, '""')}"`
+      : value;
+  };
+  const line = [file, ...args].map(quote).join(' ');
+  return [process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', `"${line}"`]];
+}
+
+/**
+ * States the anchor list in the prompt, for a backend that cannot be handed
+ * a schema.
+ *
+ * THE ANCHOR GATE IS WHAT SILENTLY EATS A HARVEST. `validate` keeps only
+ * anchors naming a file the session actually touched, and a model asked in
+ * English for a path writes a plausible one rather than a real one. Measured
+ * over four runs of qwen2.5:7b on a real digest against that gate:
+ * unconstrained, 4 extracted and 0 accepted; constrained to the list, 4 of 4.
+ *
+ * The HTTP path gets that constraint from a server-enforced enum. A CLI has
+ * no server to enforce it, so the same constraint is stated as strongly as a
+ * prompt can state it -- the exact strings, and an instruction to copy rather
+ * than compose. Not as good as an enum, and much better than nothing: the
+ * first end-to-end run without this extracted 10 findings and kept none.
+ */
+function withAnchorChoices(system, choices) {
+  if (!choices.length) return system;
+  const list = choices.map((file) => `- ${file}`).join('\n');
+  return (
+    `${system}\n\n` +
+    'Every entry in "anchors" MUST be copied verbatim from this list -- pick the ' +
+    'entries that best match the finding, and never write a path that is not ' +
+    'listed. Choosing the nearest match is right; dropping the finding is not:\n' +
+    list
+  );
+}
+
+/** Restated at the end of a prompt file, where an agent skimming will see it. */
+const TRAILER =
+  'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
+  'reply with the JSON array of findings and nothing else. If nothing in the ' +
+  'session is worth recording, reply with an empty array.';
+
+/**
+ * Runs the host client's own CLI as the harvest model.
+ *
+ * THE CHILD MUST NOT HARVEST. The harvest runs from the Stop hook, and a
+ * child session fires its own Stop hook -- verified, not assumed: a bare
+ * `claude -p` with our plugin installed wrote mcp-client, episode-outcome and
+ * derive events to the graph. Left unguarded that is unbounded recursion,
+ * each level spending real quota.
+ *
+ * TOKEN_OPTIMIZER_MODE=off IS THE GUARD, and it is the one that works.
+ * Measured on the same probe: TOKEN_OPTIMIZER_HARVEST=0 still ran the child's
+ * Stop hook and still wrote derive events -- it disables the harvest but not
+ * the hooks around it -- while MODE=off suppressed everything but a single
+ * mcp-client row. The kill switch is the only setting that makes the child
+ * inert, so the child is spawned with it and nothing else is relied upon.
+ *
+ * DELIVERY COMES FROM THE ROW, not from an assumption that every CLI reads
+ * stdin. Copilot does not: asked to follow instructions on stdin it replies
+ * that it cannot read stdin, exits 0, and yields no findings -- which looks
+ * exactly like a session with nothing to learn. Guessing here fails silently,
+ * so it is not guessed.
+ */
+/**
+ * How long to let the host CLI run.
+ *
+ * THE 30s HTTP DEFAULT KILLS EVERY CLI HARVEST, so it cannot be shared. That
+ * budget is sized for one completion against an endpoint that is already
+ * listening. A host CLI is an agent: it starts a process, loads its plugin
+ * and hook tree, opens a session, then thinks. Measured here on a 23 KB
+ * digest with no key and no local model, `claude -p` returned 10 findings in
+ * 104 SECONDS -- correct, and more than three times over the HTTP budget.
+ * `codex exec` on the same machine defaults to xhigh reasoning effort and
+ * had not finished at 300s, which is why this is configurable rather than
+ * merely larger.
+ *
+ * A caller that asks for MORE keeps it; the floor only lifts a default that
+ * was never chosen with this backend in mind.
+ */
+function hostCliTimeoutMs(requested) {
+  const configured = Number(process.env.TOKEN_OPTIMIZER_HARVEST_CLI_TIMEOUT_MS);
+  const floor = Number.isFinite(configured) && configured > 0 ? configured : 180_000;
+  return Math.max(floor, Number(requested) || 0);
+}
+
+async function runHostCli(cli, system, digest, timeoutMs) {
+  const payload = `${system}\n\n${digest}`;
+  const fileMode = cli.delivery === 'prompt-file';
+  let file = cli.command;
+  let args = [...cli.args];
+  let verbatim = false;
+  let promptFile = null;
+
+  if (fileMode) {
+    // A PATH, NOT THE PAYLOAD. See CLIENT_HARVEST_CLI for why the payload
+    // itself cannot travel as an argument on Windows. The file is written
+    // under the OS temp directory, which every one of these CLIs can read by
+    // default, and removed in `finish` whatever the outcome.
+    try {
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // 0600. This is a digest of the user's session -- paths, commands and
+      // prompts -- sitting in a shared temp directory for as long as the child
+      // takes to read it. It is removed in `finish`, but a kill between the two
+      // would leave it behind, so it is unreadable to other users meanwhile.
+      // (Windows ignores the mode; NTFS inheritance already keeps the per-user
+      // temp directory private.)
+      // THE CONTRACT IS REPEATED AT THE END. The instructions lead the file and
+      // the digest follows, which is the natural order and the one that failed:
+      // handed 23 KB this way, copilot reported the file as "a scratchpad
+      // /summary document" with no instruction in it and asked what JSON array
+      // was wanted. An agent skimming a long file sees its tail; restating the
+      // ask there costs one line and removes the dependence on how the file is
+      // read.
+      writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
+        encoding: 'utf8',
+        mode: 0o600,
+      });
+    } catch (error) {
+      return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
+    }
+    args.push(
+      `Read the whole file at ${promptFile}. It opens with instructions, then a ` +
+        'digest of a coding session, then repeats what to reply. Follow those ' +
+        'instructions and output the JSON array they ask for, and nothing else.'
+    );
+  } else if (cli.delivery === 'arg-stdin') {
+    // The flag needs a value and the CLI appends it after stdin, so the short
+    // instruction is the argument and the bulky digest still rides stdin.
+    args.push(system);
+  }
+
+  if (process.platform === 'win32' && file === cli.command) {
+    [file, args] = windowsShellCommand(file, args);
+    verbatim = true;
+  }
+
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(file, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        // The command line was built above where it needed cmd.exe, so Node
+        // must not rebuild it: `shell: true` would join argv unquoted.
+        windowsVerbatimArguments: verbatim,
+        env: {
+          ...process.env,
+          TOKEN_OPTIMIZER_MODE: 'off',
+        },
+      });
+    } catch (error) {
+      resolve({ ok: false, reason: `${cli.command} could not start: ${error?.message || error}` });
+      return;
+    }
+
+    let out = '';
+    let done = false;
+    const finish = (value) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      try {
+        child.kill();
+      } catch {
+        /* already gone */
+      }
+      if (promptFile) {
+        try {
+          rmSync(promptFile, { force: true });
+        } catch {
+          /* a leftover in the temp directory is not worth failing a harvest */
+        }
+      }
+      resolve(value);
+    };
+    const timer = setTimeout(
+      () => finish({ ok: false, reason: `${cli.command} timed out after ${timeoutMs}ms` }),
+      timeoutMs
+    );
+
+    child.stdout.on('data', (c) => {
+      out += c;
+    });
+    // stderr is drained so a chatty CLI cannot fill the pipe and deadlock.
+    child.stderr.on('data', () => {});
+    child.on('error', (error) =>
+      finish({ ok: false, reason: `${cli.command} failed: ${error?.message || error}` })
+    );
+    // NON-ZERO IS NOT ALWAYS EMPTY. Some of these print the reply and then
+    // exit non-zero over an unrelated cleanup complaint, so a parseable array
+    // already in hand beats the exit code; the code decides only when there is
+    // nothing to parse.
+    child.on('close', (code) =>
+      code === 0 || findingsIn(out)
+        ? finish({ ok: true, text: out })
+        : finish({ ok: false, reason: `${cli.command} exited ${code}` })
+    );
+
+    try {
+      // Closed either way: a child left waiting on a pipe that will never
+      // carry anything hangs until the timeout, which is the slowest possible
+      // way to produce nothing.
+      if (fileMode) child.stdin.end();
+      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+    } catch {
+      finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
+    }
+  });
+}
+
+/**
+ * Is the host CLI available as a harvest backend for this client?
+ *
+ * OPT-IN, deliberately, and this is the one default in this file that is not
+ * on. Every other path either reads local files or spends a key the user
+ * already configured for this purpose; this one spends the subscription that
+ * runs their editor, automatically, at the end of every session. HeadRoom
+ * makes the equivalent call user-invoked (`headroom learn`, cli/learn.py) and
+ * its own design note says to log events and analyse offline. Charging someone
+ * quota they did not ask to spend is not a default worth taking.
+ */
+export function hostCliHarvest(client = undefined, env = process.env) {
+  const enabled = /^(1|true|yes|on)$/i.test(env.TOKEN_OPTIMIZER_HARVEST_CLI || '');
+  if (!enabled) return null;
+  return harvestCliFor(client === undefined ? env.TOKEN_OPTIMIZER_CLIENT : client, env);
+}
+
 export async function extract(
   digest,
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
@@ -491,11 +794,40 @@ export async function extract(
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return failed('no api key for a remote endpoint');
+  // The host CLI carries its own auth -- the user is already signed into the
+  // client that is running this -- so the key requirement is about the HTTP
+  // backends only.
+  if (!local && !key && !hostCliHarvest()) {
+    return failed('no api key for a remote endpoint');
+  }
 
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // Computed before the CLI branch because BOTH backends need it. It used to
+  // sit below, so the host CLI was the one path that never learned which
+  // files it was allowed to anchor to -- and the anchor gate is what silently
+  // eats a harvest. Caught end to end on a real session: 10 findings
+  // extracted through `claude -p`, 0 surviving `validate`.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+
+  // The host client's own CLI, when the user has opted in. Tried first
+  // because it needs no key and no local model -- the two things whose
+  // absence has kept this path at 3 harvested findings on this machine.
+  const hostCli = hostCliHarvest();
+  if (hostCli) {
+    const result = await runHostCli(
+      hostCli,
+      withAnchorChoices(system, anchorChoices),
+      digest,
+      hostCliTimeoutMs(timeoutMs)
+    );
+    if (!result.ok) return failed(result.reason);
+    const parsed = findingsIn(result.text);
+    if (!parsed) return failed(`no JSON array in the ${hostCli.command} reply`);
+    return succeeded(parsed);
+  }
 
   // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
   //
@@ -514,7 +846,6 @@ export async function extract(
   // Only when the caller knows the list. `buildFullDelta` is raw transcript
   // with no file heading, and its caller passes no knownFiles for the same
   // reason -- an empty enum would forbid every anchor rather than free it.
-  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
   const schema = anchorChoices.length
     ? {
         ...FINDINGS_SCHEMA,
@@ -662,17 +993,8 @@ export async function extract(
       '';
     if (!text) return failed('endpoint answered in an unrecognised shape');
 
-    // Models wrap JSON in prose or fences often enough that finding the array
-    // is more reliable than insisting the whole response parse.
-    const start = text.indexOf('[');
-    const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return failed('no JSON array in the reply');
-
-    try {
-      return succeeded(JSON.parse(text.slice(start, end + 1)));
-    } catch {
-      return failed('the JSON array in the reply did not parse');
-    }
+    const parsed = findingsIn(text);
+    return parsed ? succeeded(parsed) : failed('no usable JSON array in the reply');
   } catch (error) {
     return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -695,6 +695,15 @@ function extractionNotice() {
         '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
         'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
       );
+    case 'host-cli':
+      // The extractor is this client's own headless CLI, which the user opted
+      // into. Worth its own case rather than folding into `remote`: no
+      // credential is involved, and the digest goes to the same vendor that
+      // already ran the session, which is a materially different disclosure.
+      return (
+        '\n\nSemantic extraction also runs after this session through this client\'s own CLI, ' +
+        'from a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
     case 'off:mode':
       // The whole optimizer is off and this text is not emitted anyway. Saying
       // anything here would be noise stacked on an explicit choice.

--- a/integrations/windsurf/hooks/lib/capabilities.mjs
+++ b/integrations/windsurf/hooks/lib/capabilities.mjs
@@ -194,6 +194,181 @@ const native = (profile) => ({
   ...profile,
 });
 
+/**
+ * How each client's own CLI can be driven headlessly, when it has one.
+ *
+ * THE HARVEST MODEL IS THE HOST ITSELF. Semantic extraction has always
+ * needed an API key or a local endpoint, and on a machine with neither it
+ * simply does not run -- measured on this one, 3 harvested findings against
+ * 237 written by the agent. But the client that just ran the session is
+ * installed BY DEFINITION and every one of these ships a headless mode, so
+ * the model was already on the machine. Nothing needed configuring; it only
+ * needed asking.
+ *
+ * ONE ROW PER CLIENT, not a hardcoded backend list. The nearest competitor
+ * picks from three (claude, gemini, codex), so its Cursor, Zed, Amp, Crush
+ * or Droid users get no semantic harvest at all. Every client this package
+ * supports gets a row here or an explicit null, and `npm run sync:hooks`
+ * copies the same table into all 16 integrations so the design cannot drift
+ * per client.
+ *
+ * NEVER ANOTHER VENDOR'S CLI. Reaching for whatever happens to be on PATH
+ * would send this session's digest to a model the user never chose, which is
+ * a disclosure they did not agree to. The host is the only defensible
+ * default, and TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND is the only way to pick a
+ * different one.
+ *
+ * DELIVERY IS PART OF THE ROW because the CLIs genuinely differ, and getting
+ * it wrong is silent:
+ *   - 'stdin'       the whole payload goes to the child's stdin.
+ *   - 'arg-stdin'   a short instruction is the final argument and the digest
+ *                   goes to stdin, for CLIs whose prompt flag needs a value
+ *                   but which still read stdin.
+ *   - 'prompt-file' the payload is written to a temp file and the final
+ *                   argument tells the agent to read it, for CLIs that do
+ *                   not read stdin at all.
+ *
+ * WHY A FILE AND NOT JUST A LONG ARGUMENT. Passing the payload itself as an
+ * argument was tried and abandoned on evidence. On POSIX it is fine; on
+ * Windows every one of these installs as a .cmd shim, which Node will not
+ * spawn without a shell, and cmd.exe cannot carry a newline inside an
+ * argument at all. Routing through PowerShell with the payload base64-encoded
+ * got past cmd.exe and then hit PowerShell 5.1's native-argument binder,
+ * which does not escape embedded double quotes: the prompt is JSON, so the
+ * first `\"type\":` ended the quoting and the child received 32 arguments
+ * instead of 1. A path has no spaces we did not choose, no quotes and no
+ * newlines, and it also lifts the ARG_MAX ceiling entirely -- these are
+ * agentic CLIs whose whole purpose is reading files, and the route is
+ * verified: copilot asked to read a payload file returned the exact array.
+ *
+ * VERIFIED means a probe was executed against the installed CLI in this
+ * repository and its reply parsed. DOCUMENTED means the shape comes from the
+ * vendor's own `--help` or published headless docs and has not been executed
+ * here, because the CLI is not installed on this machine. Both ship; the
+ * distinction is recorded so nobody mistakes the second for the first, and a
+ * wrong DOCUMENTED row fails loudly through `harvestFailure()` and doctor
+ * rather than silently producing nothing.
+ */
+const harvestCli = (command, args, { delivery = 'stdin', verified = false } = {}) =>
+  Object.freeze({ command, args: Object.freeze([...args]), delivery, verified });
+
+export const CLIENT_HARVEST_CLI = Object.freeze({
+  // VERIFIED: `claude -p` with the payload on stdin returned the exact array
+  // asked for. --output-format stream-json was tried first and rejected: its
+  // envelopes are themselves JSON containing brackets, which is a parsing
+  // hazard for no gain when plain text is already the model's reply.
+  'claude-code': harvestCli('claude', ['-p'], { verified: true }),
+  // VERIFIED: `codex exec -` reads instructions from stdin (its own --help
+  // says so, and a probe returned the array). It prints a banner containing
+  // `[workdir, /tmp, $TMPDIR]` before the reply, which is exactly why the
+  // reply parser has to try more than the first bracket it finds.
+  codex: harvestCli('codex', ['exec', '-'], { verified: true }),
+  // VERIFIED both ways. Asked to follow instructions on stdin the agent
+  // answered that it was unable to read stdin and exited 0 -- a silent
+  // no-findings result indistinguishable from a quiet session. Asked instead
+  // to read a payload file it returned the exact array requested, which is
+  // why this row is prompt-file. --allow-all-tools is required for
+  // non-interactive use by copilot's own help text, and -s drops the stats
+  // banner.
+  copilot: harvestCli('copilot', ['-s', '--allow-all-tools', '-p'], {
+    delivery: 'prompt-file',
+    verified: true,
+  }),
+  // DOCUMENTED: `gemini --help` states that -p runs headless and that the
+  // prompt is "Appended to input on stdin (if any)", so the digest rides
+  // stdin and the instruction is the flag value. Not executed here: this
+  // machine's gemini is unauthenticated and fails in refreshAuth before any
+  // prompt is read.
+  gemini: harvestCli('gemini', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: qwen-code is a fork of gemini-cli and keeps its flag surface.
+  qwen: harvestCli('qwen', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: `opencode run <message>` is its non-interactive entry point.
+  opencode: harvestCli('opencode', ['run'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `crush run <prompt>` runs a single non-interactive prompt.
+  crush: harvestCli('crush', ['run', '-q'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `droid exec <prompt>` is Factory's headless mode.
+  droid: harvestCli('droid', ['exec'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `amp -x <prompt>` executes a single prompt and exits.
+  amp: harvestCli('amp', ['-x'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: the Continue CLI installs as `cn` and takes -p for headless.
+  continue: harvestCli('cn', ['-p'], { delivery: 'prompt-file' }),
+
+  // NO HEADLESS CLI OF THEIR OWN. These are editor- and extension-hosted:
+  // the assistant runs inside the IDE process and ships no command a hook
+  // could spawn. Declaring null keeps that a stated fact rather than an
+  // omission, and these clients fall back to a configured endpoint --
+  // borrowing a neighbouring vendor's CLI would send the digest to a model
+  // the user never chose.
+  cursor: null,
+  cline: null,
+  windsurf: null,
+  kilo: null,
+  roo: null,
+  zed: null,
+});
+
+/**
+ * Splits a configured command line into words, respecting quotes.
+ *
+ * SPLITTING ON WHITESPACE ALONE IS WRONG ON WINDOWS, and the first test
+ * written against this caught it: the natural thing to configure is the
+ * interpreter you already have, and on Windows that is
+ * `C:\\Program Files\\nodejs\\node.exe`. A bare split turned that into the
+ * command `C:\\Program` and reported `C:\\Program exited 1`, which is a
+ * diagnostic nobody can act on. Quoting a path with spaces is the ordinary
+ * way to write a command line, so it has to mean what it says.
+ */
+function commandWords(line) {
+  const words = [];
+  let current = '';
+  let quote = '';
+  let started = false;
+  for (const ch of String(line)) {
+    if (quote) {
+      if (ch === quote) quote = '';
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (started) words.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (started) words.push(current);
+  return words;
+}
+
+/**
+ * The harvest CLI for a client, or null when it has none.
+ *
+ * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
+ * client with no row -- or one whose vendor changed its flags after this
+ * shipped -- is a configuration away from working rather than a release away.
+ * The value is a command and its arguments. The payload goes to stdin unless
+ * the string ends in `{}`, which is replaced by the path of a file holding
+ * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ */
+export function harvestCliFor(client, env = process.env) {
+  const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
+  if (override) {
+    const parts = commandWords(override);
+    const arg = parts[parts.length - 1] === '{}';
+    if (arg) parts.pop();
+    const [command, ...args] = parts;
+    if (!command) return null;
+    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+  }
+  return CLIENT_HARVEST_CLI[client] || null;
+}
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({
     name: 'Claude Code',

--- a/integrations/windsurf/hooks/lib/capabilities.mjs
+++ b/integrations/windsurf/hooks/lib/capabilities.mjs
@@ -353,21 +353,40 @@ function commandWords(line) {
  * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
  * client with no row -- or one whose vendor changed its flags after this
  * shipped -- is a configuration away from working rather than a release away.
- * The value is a command and its arguments. The payload goes to stdin unless
- * the string ends in `{}`, which is replaced by the path of a file holding
- * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ * The value is a command and its arguments, and its last word may name a
+ * delivery:
+ *   (nothing)  the payload goes to the command's stdin.
+ *   `{}`       it is written to a file and the path becomes the last
+ *              argument -- what an agentic CLI that ignores stdin needs.
+ *   `{-}`      the payload goes to stdin and a short instruction becomes the
+ *              last argument, for a CLI whose prompt flag demands a value
+ *              but which still reads stdin. gemini and qwen are shaped this
+ *              way, and without this an override could not reach that shape
+ *              at all.
  */
 export function harvestCliFor(client, env = process.env) {
   const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
   if (override) {
     const parts = commandWords(override);
-    const arg = parts[parts.length - 1] === '{}';
-    if (arg) parts.pop();
+    const last = parts[parts.length - 1];
+    const delivery =
+      last === '{}' ? 'prompt-file' : last === '{-}' ? 'arg-stdin' : 'stdin';
+    if (delivery !== 'stdin') parts.pop();
     const [command, ...args] = parts;
     if (!command) return null;
-    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+    return harvestCli(command, args, { delivery });
   }
-  return CLIENT_HARVEST_CLI[client] || null;
+  // NORMALISED AND OWN-PROPERTY ONLY, matching `capabilityFor` below.
+  //
+  // A bare index disagreed with its own sibling and reached the prototype.
+  // Reproduced: TOKEN_OPTIMIZER_CLIENT=Codex resolved a capability profile
+  // through capabilityFor -- which lower-cases -- and NO harvest CLI here, so
+  // harvestMode() fell through to off:no-key and an opted-in harvest silently
+  // did nothing on a client that plainly has one. And
+  // harvestCliFor('constructor') returned a function, whose `command` is
+  // undefined, which runHostCli would have handed straight to spawn.
+  const key = String(client || '').toLowerCase();
+  return Object.hasOwn(CLIENT_HARVEST_CLI, key) ? CLIENT_HARVEST_CLI[key] : null;
 }
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({

--- a/integrations/windsurf/hooks/lib/doctor.mjs
+++ b/integrations/windsurf/hooks/lib/doctor.mjs
@@ -246,6 +246,23 @@ export function probeHarvest() {
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
+  // The host client's own CLI, opted into with TOKEN_OPTIMIZER_HARVEST_CLI.
+  // Reported with the same failure-reason read as `local`, because the two
+  // share the property that made a broken configuration invisible: they
+  // return [] on failure and look exactly like a session with nothing to
+  // learn.
+  if (mode === 'host-cli') {
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check that this client\'s CLI is on PATH and signed in, or unset ' +
+        'TOKEN_OPTIMIZER_HARVEST_CLI to fall back to a configured endpoint')];
+    }
+    return [ok('finding extraction is available',
+      "this client's own CLI runs the semantic harvest -- no separate credential and no " +
+      'second vendor. Active-model wiki_write remains the primary path')];
+  }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
       'active-model wiki_write is primary; a credential also enables fallback extraction from ' +

--- a/integrations/windsurf/hooks/lib/harvest.mjs
+++ b/integrations/windsurf/hooks/lib/harvest.mjs
@@ -23,6 +23,7 @@
 import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { harvestCliFor } from './capabilities.mjs';
 
@@ -588,6 +589,14 @@ function withAnchorChoices(system, choices) {
   );
 }
 
+/**
+ * The `-p` value for a CLI whose prompt flag needs one but which still reads
+ * stdin. One line, no quotes, no newlines: everything a Windows command line
+ * cannot carry.
+ */
+export const ARG_STDIN_INSTRUCTION =
+  'Follow the instructions in the input above and reply with only the JSON array they ask for.';
+
 /** Restated at the end of a prompt file, where an agent skimming will see it. */
 const TRAILER =
   'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
@@ -652,7 +661,11 @@ async function runHostCli(cli, system, digest, timeoutMs) {
     // under the OS temp directory, which every one of these CLIs can read by
     // default, and removed in `finish` whatever the outcome.
     try {
-      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // UNGUESSABLE, NOT MERELY UNIQUE. pid and clock are both predictable
+      // enough for another local user to pre-create the path in a shared temp
+      // directory; randomUUID removes the guess, and `flag: 'wx'` below
+      // removes the race that remains.
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${randomUUID()}.txt`);
       // 0600. This is a digest of the user's session -- paths, commands and
       // prompts -- sitting in a shared temp directory for as long as the child
       // takes to read it. It is removed in `finish`, but a kill between the two
@@ -669,6 +682,12 @@ async function runHostCli(cli, system, digest, timeoutMs) {
       writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
         encoding: 'utf8',
         mode: 0o600,
+        // EXCLUSIVE CREATE. `mode` governs a file this call makes; it does
+        // nothing about one that already exists, and the default flag 'w'
+        // happily follows a symlink someone else placed at the path -- which
+        // would redirect a digest of the user's session wherever they chose.
+        // 'wx' fails instead of following.
+        flag: 'wx',
       });
     } catch (error) {
       return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
@@ -679,9 +698,16 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         'instructions and output the JSON array they ask for, and nothing else.'
     );
   } else if (cli.delivery === 'arg-stdin') {
-    // The flag needs a value and the CLI appends it after stdin, so the short
-    // instruction is the argument and the bulky digest still rides stdin.
-    args.push(system);
+    // A SHORT SINGLE LINE, NEVER THE PROMPT. The flag needs a value, and the
+    // obvious value -- `system` -- is the multi-line PROMPT, which
+    // withAnchorChoices extends with a newline-separated file list and which
+    // is full of the JSON prompt's double quotes. That is the exact payload
+    // the prompt-file route exists to keep off a Windows command line:
+    // cmd.exe cannot carry a newline inside an argument, and the quoting
+    // doubles every `"`. These CLIs document the flag value as being
+    // APPENDED to stdin, so the whole payload rides stdin and the argument
+    // is one line of ASCII that any shell survives.
+    args.push(ARG_STDIN_INSTRUCTION);
   }
 
   if (process.platform === 'win32' && file === cli.command) {
@@ -750,12 +776,26 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         : finish({ ok: false, reason: `${cli.command} exited ${code}` })
     );
 
+    // EPIPE ARRIVES AS AN EVENT, NOT AS A THROW. The try/catch below sees
+    // only a synchronous failure; a child that exits without reading stdin
+    // fails the write asynchronously, and Node delivers that on the stream.
+    // With no listener it is an uncaught exception that takes down the hook
+    // process instead of resolving this promise -- and the path is not
+    // hypothetical: copilot, asked to read a prompt on stdin, answers that it
+    // cannot and exits 0, which is why its row is prompt-file at all.
+    child.stdin.on('error', (error) =>
+      finish({
+        ok: false,
+        reason: `could not write the digest to ${cli.command}: ${error?.message || error}`,
+      })
+    );
+
     try {
       // Closed either way: a child left waiting on a pipe that will never
       // carry anything hangs until the timeout, which is the slowest possible
       // way to produce nothing.
       if (fileMode) child.stdin.end();
-      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+      else child.stdin.end(payload);
     } catch {
       finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
     }

--- a/integrations/windsurf/hooks/lib/harvest.mjs
+++ b/integrations/windsurf/hooks/lib/harvest.mjs
@@ -20,9 +20,11 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { harvestCliFor } from './capabilities.mjs';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -178,13 +180,25 @@ export function harvestMode() {
   // Free and private, so nothing further to weigh: no credential, no billing, no digest leaving
   // the machine.
   if (localEndpoint()) return 'local';
+  // THE HOST CLI IS A BACKEND, so the enablement check has to know about it.
+  // Without this the gate answers off:no-key and `extract` never reaches the
+  // CLI path -- which defeats the whole point of a backend that needs no key.
+  // Caught end to end rather than reasoned about: with no endpoint and no key,
+  // the first run of the opted-in host-CLI harvest returned
+  // `harvest is off:no-key` in 0s, having never spawned anything.
+  if (hostCliHarvest()) return 'host-cli';
+
 
   return apiKey() ? 'remote' : 'off:no-key';
 }
 
 export function harvestEnabled() {
   const mode = harvestMode();
-  return mode === 'local' || mode === 'remote';
+  // host-cli belongs here for the same reason local and remote do: it is a
+  // backend that can actually answer. Leaving it out would let the mode say
+  // `host-cli` while every caller that asks `harvestEnabled()` -- the Stop
+  // hook, the worker, extract's own first line -- skipped the harvest.
+  return mode === 'local' || mode === 'remote' || mode === 'host-cli';
 }
 
 /**
@@ -476,6 +490,295 @@ const succeeded = (findings) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
+/**
+ * The findings array inside a reply, or null.
+ *
+ * Models wrap JSON in prose or fences often enough that locating the array is
+ * more reliable than insisting the whole response parses -- and a CLI adds its
+ * own banner lines and stream-json envelopes on top, so both callers need the
+ * same tolerance. Shared so the two cannot drift.
+ */
+function findingsIn(text) {
+  const raw = String(text || '');
+
+  // FIRST BRACKET TO LAST IS NOT ENOUGH, and a CLI is where that breaks.
+  // `codex exec` prints a banner line reading `sandbox: workspace-write
+  // [workdir, /tmp, $TMPDIR]` before the model says anything, so the first
+  // `[` in the stream belongs to the banner and the naive slice parses to
+  // nothing -- an empty harvest that looks exactly like a session with
+  // nothing to learn. Closing brackets are walked from the end and opening
+  // brackets from the start, so the widest array that actually parses wins,
+  // and prose on either side is tolerated the way it already was for HTTP.
+  const closes = [];
+  for (let i = raw.length - 1; i >= 0 && closes.length < CLOSE_TRIES; i -= 1) {
+    if (raw[i] === ']') closes.push(i);
+  }
+  for (const end of closes) {
+    let tries = 0;
+    for (let start = raw.indexOf('['); start !== -1 && start < end; start = raw.indexOf('[', start + 1)) {
+      if ((tries += 1) > OPEN_TRIES) break;
+      try {
+        const parsed = JSON.parse(raw.slice(start, end + 1));
+        if (Array.isArray(parsed)) return parsed;
+      } catch {
+        /* not this pair */
+      }
+    }
+  }
+  return null;
+}
+
+// Bounded so a pathological reply cannot turn parsing into an O(n^2) walk of
+// a megabyte. A real findings array is at the end of the reply and preceded
+// by a banner or a sentence, not by hundreds of brackets.
+const CLOSE_TRIES = 8;
+const OPEN_TRIES = 40;
+
+/**
+ * Launches a Windows command through cmd.exe WITHOUT letting Node build the
+ * command line.
+ *
+ * These CLIs all install as .cmd shims, and Node has refused to spawn .cmd
+ * or .bat without a shell since the 2024 command-injection fix -- so a shell
+ * is not optional. But Node's own `shell: true` builds the cmd.exe line by
+ * joining argv with single spaces and no quoting at all, which breaks the
+ * moment any part contains one. Caught by the first test written against
+ * this: pointing the override at `C:\\Program Files\\nodejs\\node.exe`
+ * produced `C:\\Program Files\\nodejs\\node.exe exited 1`, because cmd.exe
+ * had been handed `C:\\Program` as the command. Quoting each part and passing
+ * the line verbatim is the fix.
+ */
+function windowsShellCommand(file, args) {
+  const quote = (part) => {
+    const value = String(part);
+    // Doubling is cmd.exe's own escape for a quote inside a quoted token.
+    return /[\s"]/.test(value)
+      ? `"${value.replace(/"/g, '""')}"`
+      : value;
+  };
+  const line = [file, ...args].map(quote).join(' ');
+  return [process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', `"${line}"`]];
+}
+
+/**
+ * States the anchor list in the prompt, for a backend that cannot be handed
+ * a schema.
+ *
+ * THE ANCHOR GATE IS WHAT SILENTLY EATS A HARVEST. `validate` keeps only
+ * anchors naming a file the session actually touched, and a model asked in
+ * English for a path writes a plausible one rather than a real one. Measured
+ * over four runs of qwen2.5:7b on a real digest against that gate:
+ * unconstrained, 4 extracted and 0 accepted; constrained to the list, 4 of 4.
+ *
+ * The HTTP path gets that constraint from a server-enforced enum. A CLI has
+ * no server to enforce it, so the same constraint is stated as strongly as a
+ * prompt can state it -- the exact strings, and an instruction to copy rather
+ * than compose. Not as good as an enum, and much better than nothing: the
+ * first end-to-end run without this extracted 10 findings and kept none.
+ */
+function withAnchorChoices(system, choices) {
+  if (!choices.length) return system;
+  const list = choices.map((file) => `- ${file}`).join('\n');
+  return (
+    `${system}\n\n` +
+    'Every entry in "anchors" MUST be copied verbatim from this list -- pick the ' +
+    'entries that best match the finding, and never write a path that is not ' +
+    'listed. Choosing the nearest match is right; dropping the finding is not:\n' +
+    list
+  );
+}
+
+/** Restated at the end of a prompt file, where an agent skimming will see it. */
+const TRAILER =
+  'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
+  'reply with the JSON array of findings and nothing else. If nothing in the ' +
+  'session is worth recording, reply with an empty array.';
+
+/**
+ * Runs the host client's own CLI as the harvest model.
+ *
+ * THE CHILD MUST NOT HARVEST. The harvest runs from the Stop hook, and a
+ * child session fires its own Stop hook -- verified, not assumed: a bare
+ * `claude -p` with our plugin installed wrote mcp-client, episode-outcome and
+ * derive events to the graph. Left unguarded that is unbounded recursion,
+ * each level spending real quota.
+ *
+ * TOKEN_OPTIMIZER_MODE=off IS THE GUARD, and it is the one that works.
+ * Measured on the same probe: TOKEN_OPTIMIZER_HARVEST=0 still ran the child's
+ * Stop hook and still wrote derive events -- it disables the harvest but not
+ * the hooks around it -- while MODE=off suppressed everything but a single
+ * mcp-client row. The kill switch is the only setting that makes the child
+ * inert, so the child is spawned with it and nothing else is relied upon.
+ *
+ * DELIVERY COMES FROM THE ROW, not from an assumption that every CLI reads
+ * stdin. Copilot does not: asked to follow instructions on stdin it replies
+ * that it cannot read stdin, exits 0, and yields no findings -- which looks
+ * exactly like a session with nothing to learn. Guessing here fails silently,
+ * so it is not guessed.
+ */
+/**
+ * How long to let the host CLI run.
+ *
+ * THE 30s HTTP DEFAULT KILLS EVERY CLI HARVEST, so it cannot be shared. That
+ * budget is sized for one completion against an endpoint that is already
+ * listening. A host CLI is an agent: it starts a process, loads its plugin
+ * and hook tree, opens a session, then thinks. Measured here on a 23 KB
+ * digest with no key and no local model, `claude -p` returned 10 findings in
+ * 104 SECONDS -- correct, and more than three times over the HTTP budget.
+ * `codex exec` on the same machine defaults to xhigh reasoning effort and
+ * had not finished at 300s, which is why this is configurable rather than
+ * merely larger.
+ *
+ * A caller that asks for MORE keeps it; the floor only lifts a default that
+ * was never chosen with this backend in mind.
+ */
+function hostCliTimeoutMs(requested) {
+  const configured = Number(process.env.TOKEN_OPTIMIZER_HARVEST_CLI_TIMEOUT_MS);
+  const floor = Number.isFinite(configured) && configured > 0 ? configured : 180_000;
+  return Math.max(floor, Number(requested) || 0);
+}
+
+async function runHostCli(cli, system, digest, timeoutMs) {
+  const payload = `${system}\n\n${digest}`;
+  const fileMode = cli.delivery === 'prompt-file';
+  let file = cli.command;
+  let args = [...cli.args];
+  let verbatim = false;
+  let promptFile = null;
+
+  if (fileMode) {
+    // A PATH, NOT THE PAYLOAD. See CLIENT_HARVEST_CLI for why the payload
+    // itself cannot travel as an argument on Windows. The file is written
+    // under the OS temp directory, which every one of these CLIs can read by
+    // default, and removed in `finish` whatever the outcome.
+    try {
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // 0600. This is a digest of the user's session -- paths, commands and
+      // prompts -- sitting in a shared temp directory for as long as the child
+      // takes to read it. It is removed in `finish`, but a kill between the two
+      // would leave it behind, so it is unreadable to other users meanwhile.
+      // (Windows ignores the mode; NTFS inheritance already keeps the per-user
+      // temp directory private.)
+      // THE CONTRACT IS REPEATED AT THE END. The instructions lead the file and
+      // the digest follows, which is the natural order and the one that failed:
+      // handed 23 KB this way, copilot reported the file as "a scratchpad
+      // /summary document" with no instruction in it and asked what JSON array
+      // was wanted. An agent skimming a long file sees its tail; restating the
+      // ask there costs one line and removes the dependence on how the file is
+      // read.
+      writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
+        encoding: 'utf8',
+        mode: 0o600,
+      });
+    } catch (error) {
+      return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
+    }
+    args.push(
+      `Read the whole file at ${promptFile}. It opens with instructions, then a ` +
+        'digest of a coding session, then repeats what to reply. Follow those ' +
+        'instructions and output the JSON array they ask for, and nothing else.'
+    );
+  } else if (cli.delivery === 'arg-stdin') {
+    // The flag needs a value and the CLI appends it after stdin, so the short
+    // instruction is the argument and the bulky digest still rides stdin.
+    args.push(system);
+  }
+
+  if (process.platform === 'win32' && file === cli.command) {
+    [file, args] = windowsShellCommand(file, args);
+    verbatim = true;
+  }
+
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(file, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        // The command line was built above where it needed cmd.exe, so Node
+        // must not rebuild it: `shell: true` would join argv unquoted.
+        windowsVerbatimArguments: verbatim,
+        env: {
+          ...process.env,
+          TOKEN_OPTIMIZER_MODE: 'off',
+        },
+      });
+    } catch (error) {
+      resolve({ ok: false, reason: `${cli.command} could not start: ${error?.message || error}` });
+      return;
+    }
+
+    let out = '';
+    let done = false;
+    const finish = (value) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      try {
+        child.kill();
+      } catch {
+        /* already gone */
+      }
+      if (promptFile) {
+        try {
+          rmSync(promptFile, { force: true });
+        } catch {
+          /* a leftover in the temp directory is not worth failing a harvest */
+        }
+      }
+      resolve(value);
+    };
+    const timer = setTimeout(
+      () => finish({ ok: false, reason: `${cli.command} timed out after ${timeoutMs}ms` }),
+      timeoutMs
+    );
+
+    child.stdout.on('data', (c) => {
+      out += c;
+    });
+    // stderr is drained so a chatty CLI cannot fill the pipe and deadlock.
+    child.stderr.on('data', () => {});
+    child.on('error', (error) =>
+      finish({ ok: false, reason: `${cli.command} failed: ${error?.message || error}` })
+    );
+    // NON-ZERO IS NOT ALWAYS EMPTY. Some of these print the reply and then
+    // exit non-zero over an unrelated cleanup complaint, so a parseable array
+    // already in hand beats the exit code; the code decides only when there is
+    // nothing to parse.
+    child.on('close', (code) =>
+      code === 0 || findingsIn(out)
+        ? finish({ ok: true, text: out })
+        : finish({ ok: false, reason: `${cli.command} exited ${code}` })
+    );
+
+    try {
+      // Closed either way: a child left waiting on a pipe that will never
+      // carry anything hangs until the timeout, which is the slowest possible
+      // way to produce nothing.
+      if (fileMode) child.stdin.end();
+      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+    } catch {
+      finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
+    }
+  });
+}
+
+/**
+ * Is the host CLI available as a harvest backend for this client?
+ *
+ * OPT-IN, deliberately, and this is the one default in this file that is not
+ * on. Every other path either reads local files or spends a key the user
+ * already configured for this purpose; this one spends the subscription that
+ * runs their editor, automatically, at the end of every session. HeadRoom
+ * makes the equivalent call user-invoked (`headroom learn`, cli/learn.py) and
+ * its own design note says to log events and analyse offline. Charging someone
+ * quota they did not ask to spend is not a default worth taking.
+ */
+export function hostCliHarvest(client = undefined, env = process.env) {
+  const enabled = /^(1|true|yes|on)$/i.test(env.TOKEN_OPTIMIZER_HARVEST_CLI || '');
+  if (!enabled) return null;
+  return harvestCliFor(client === undefined ? env.TOKEN_OPTIMIZER_CLIENT : client, env);
+}
+
 export async function extract(
   digest,
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
@@ -491,11 +794,40 @@ export async function extract(
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return failed('no api key for a remote endpoint');
+  // The host CLI carries its own auth -- the user is already signed into the
+  // client that is running this -- so the key requirement is about the HTTP
+  // backends only.
+  if (!local && !key && !hostCliHarvest()) {
+    return failed('no api key for a remote endpoint');
+  }
 
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // Computed before the CLI branch because BOTH backends need it. It used to
+  // sit below, so the host CLI was the one path that never learned which
+  // files it was allowed to anchor to -- and the anchor gate is what silently
+  // eats a harvest. Caught end to end on a real session: 10 findings
+  // extracted through `claude -p`, 0 surviving `validate`.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+
+  // The host client's own CLI, when the user has opted in. Tried first
+  // because it needs no key and no local model -- the two things whose
+  // absence has kept this path at 3 harvested findings on this machine.
+  const hostCli = hostCliHarvest();
+  if (hostCli) {
+    const result = await runHostCli(
+      hostCli,
+      withAnchorChoices(system, anchorChoices),
+      digest,
+      hostCliTimeoutMs(timeoutMs)
+    );
+    if (!result.ok) return failed(result.reason);
+    const parsed = findingsIn(result.text);
+    if (!parsed) return failed(`no JSON array in the ${hostCli.command} reply`);
+    return succeeded(parsed);
+  }
 
   // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
   //
@@ -514,7 +846,6 @@ export async function extract(
   // Only when the caller knows the list. `buildFullDelta` is raw transcript
   // with no file heading, and its caller passes no knownFiles for the same
   // reason -- an empty enum would forbid every anchor rather than free it.
-  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
   const schema = anchorChoices.length
     ? {
         ...FINDINGS_SCHEMA,
@@ -662,17 +993,8 @@ export async function extract(
       '';
     if (!text) return failed('endpoint answered in an unrecognised shape');
 
-    // Models wrap JSON in prose or fences often enough that finding the array
-    // is more reliable than insisting the whole response parse.
-    const start = text.indexOf('[');
-    const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return failed('no JSON array in the reply');
-
-    try {
-      return succeeded(JSON.parse(text.slice(start, end + 1)));
-    } catch {
-      return failed('the JSON array in the reply did not parse');
-    }
+    const parsed = findingsIn(text);
+    return parsed ? succeeded(parsed) : failed('no usable JSON array in the reply');
   } catch (error) {
     return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -695,6 +695,15 @@ function extractionNotice() {
         '\n\nA credential is configured, so fallback extraction also runs after this session from ' +
         'a bounded digest: paths, commands, prompts and conclusions, never file contents.'
       );
+    case 'host-cli':
+      // The extractor is this client's own headless CLI, which the user opted
+      // into. Worth its own case rather than folding into `remote`: no
+      // credential is involved, and the digest goes to the same vendor that
+      // already ran the session, which is a materially different disclosure.
+      return (
+        '\n\nSemantic extraction also runs after this session through this client\'s own CLI, ' +
+        'from a bounded digest: paths, commands, prompts and conclusions, never file contents.'
+      );
     case 'off:mode':
       // The whole optimizer is off and this text is not emitted anyway. Saying
       // anything here would be noise stacked on an explicit choice.

--- a/plugin/hooks/lib/capabilities.mjs
+++ b/plugin/hooks/lib/capabilities.mjs
@@ -194,6 +194,181 @@ const native = (profile) => ({
   ...profile,
 });
 
+/**
+ * How each client's own CLI can be driven headlessly, when it has one.
+ *
+ * THE HARVEST MODEL IS THE HOST ITSELF. Semantic extraction has always
+ * needed an API key or a local endpoint, and on a machine with neither it
+ * simply does not run -- measured on this one, 3 harvested findings against
+ * 237 written by the agent. But the client that just ran the session is
+ * installed BY DEFINITION and every one of these ships a headless mode, so
+ * the model was already on the machine. Nothing needed configuring; it only
+ * needed asking.
+ *
+ * ONE ROW PER CLIENT, not a hardcoded backend list. The nearest competitor
+ * picks from three (claude, gemini, codex), so its Cursor, Zed, Amp, Crush
+ * or Droid users get no semantic harvest at all. Every client this package
+ * supports gets a row here or an explicit null, and `npm run sync:hooks`
+ * copies the same table into all 16 integrations so the design cannot drift
+ * per client.
+ *
+ * NEVER ANOTHER VENDOR'S CLI. Reaching for whatever happens to be on PATH
+ * would send this session's digest to a model the user never chose, which is
+ * a disclosure they did not agree to. The host is the only defensible
+ * default, and TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND is the only way to pick a
+ * different one.
+ *
+ * DELIVERY IS PART OF THE ROW because the CLIs genuinely differ, and getting
+ * it wrong is silent:
+ *   - 'stdin'       the whole payload goes to the child's stdin.
+ *   - 'arg-stdin'   a short instruction is the final argument and the digest
+ *                   goes to stdin, for CLIs whose prompt flag needs a value
+ *                   but which still read stdin.
+ *   - 'prompt-file' the payload is written to a temp file and the final
+ *                   argument tells the agent to read it, for CLIs that do
+ *                   not read stdin at all.
+ *
+ * WHY A FILE AND NOT JUST A LONG ARGUMENT. Passing the payload itself as an
+ * argument was tried and abandoned on evidence. On POSIX it is fine; on
+ * Windows every one of these installs as a .cmd shim, which Node will not
+ * spawn without a shell, and cmd.exe cannot carry a newline inside an
+ * argument at all. Routing through PowerShell with the payload base64-encoded
+ * got past cmd.exe and then hit PowerShell 5.1's native-argument binder,
+ * which does not escape embedded double quotes: the prompt is JSON, so the
+ * first `\"type\":` ended the quoting and the child received 32 arguments
+ * instead of 1. A path has no spaces we did not choose, no quotes and no
+ * newlines, and it also lifts the ARG_MAX ceiling entirely -- these are
+ * agentic CLIs whose whole purpose is reading files, and the route is
+ * verified: copilot asked to read a payload file returned the exact array.
+ *
+ * VERIFIED means a probe was executed against the installed CLI in this
+ * repository and its reply parsed. DOCUMENTED means the shape comes from the
+ * vendor's own `--help` or published headless docs and has not been executed
+ * here, because the CLI is not installed on this machine. Both ship; the
+ * distinction is recorded so nobody mistakes the second for the first, and a
+ * wrong DOCUMENTED row fails loudly through `harvestFailure()` and doctor
+ * rather than silently producing nothing.
+ */
+const harvestCli = (command, args, { delivery = 'stdin', verified = false } = {}) =>
+  Object.freeze({ command, args: Object.freeze([...args]), delivery, verified });
+
+export const CLIENT_HARVEST_CLI = Object.freeze({
+  // VERIFIED: `claude -p` with the payload on stdin returned the exact array
+  // asked for. --output-format stream-json was tried first and rejected: its
+  // envelopes are themselves JSON containing brackets, which is a parsing
+  // hazard for no gain when plain text is already the model's reply.
+  'claude-code': harvestCli('claude', ['-p'], { verified: true }),
+  // VERIFIED: `codex exec -` reads instructions from stdin (its own --help
+  // says so, and a probe returned the array). It prints a banner containing
+  // `[workdir, /tmp, $TMPDIR]` before the reply, which is exactly why the
+  // reply parser has to try more than the first bracket it finds.
+  codex: harvestCli('codex', ['exec', '-'], { verified: true }),
+  // VERIFIED both ways. Asked to follow instructions on stdin the agent
+  // answered that it was unable to read stdin and exited 0 -- a silent
+  // no-findings result indistinguishable from a quiet session. Asked instead
+  // to read a payload file it returned the exact array requested, which is
+  // why this row is prompt-file. --allow-all-tools is required for
+  // non-interactive use by copilot's own help text, and -s drops the stats
+  // banner.
+  copilot: harvestCli('copilot', ['-s', '--allow-all-tools', '-p'], {
+    delivery: 'prompt-file',
+    verified: true,
+  }),
+  // DOCUMENTED: `gemini --help` states that -p runs headless and that the
+  // prompt is "Appended to input on stdin (if any)", so the digest rides
+  // stdin and the instruction is the flag value. Not executed here: this
+  // machine's gemini is unauthenticated and fails in refreshAuth before any
+  // prompt is read.
+  gemini: harvestCli('gemini', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: qwen-code is a fork of gemini-cli and keeps its flag surface.
+  qwen: harvestCli('qwen', ['-p'], { delivery: 'arg-stdin' }),
+  // DOCUMENTED: `opencode run <message>` is its non-interactive entry point.
+  opencode: harvestCli('opencode', ['run'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `crush run <prompt>` runs a single non-interactive prompt.
+  crush: harvestCli('crush', ['run', '-q'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `droid exec <prompt>` is Factory's headless mode.
+  droid: harvestCli('droid', ['exec'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: `amp -x <prompt>` executes a single prompt and exits.
+  amp: harvestCli('amp', ['-x'], { delivery: 'prompt-file' }),
+  // DOCUMENTED: the Continue CLI installs as `cn` and takes -p for headless.
+  continue: harvestCli('cn', ['-p'], { delivery: 'prompt-file' }),
+
+  // NO HEADLESS CLI OF THEIR OWN. These are editor- and extension-hosted:
+  // the assistant runs inside the IDE process and ships no command a hook
+  // could spawn. Declaring null keeps that a stated fact rather than an
+  // omission, and these clients fall back to a configured endpoint --
+  // borrowing a neighbouring vendor's CLI would send the digest to a model
+  // the user never chose.
+  cursor: null,
+  cline: null,
+  windsurf: null,
+  kilo: null,
+  roo: null,
+  zed: null,
+});
+
+/**
+ * Splits a configured command line into words, respecting quotes.
+ *
+ * SPLITTING ON WHITESPACE ALONE IS WRONG ON WINDOWS, and the first test
+ * written against this caught it: the natural thing to configure is the
+ * interpreter you already have, and on Windows that is
+ * `C:\\Program Files\\nodejs\\node.exe`. A bare split turned that into the
+ * command `C:\\Program` and reported `C:\\Program exited 1`, which is a
+ * diagnostic nobody can act on. Quoting a path with spaces is the ordinary
+ * way to write a command line, so it has to mean what it says.
+ */
+function commandWords(line) {
+  const words = [];
+  let current = '';
+  let quote = '';
+  let started = false;
+  for (const ch of String(line)) {
+    if (quote) {
+      if (ch === quote) quote = '';
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (started) words.push(current);
+      current = '';
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (started) words.push(current);
+  return words;
+}
+
+/**
+ * The harvest CLI for a client, or null when it has none.
+ *
+ * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
+ * client with no row -- or one whose vendor changed its flags after this
+ * shipped -- is a configuration away from working rather than a release away.
+ * The value is a command and its arguments. The payload goes to stdin unless
+ * the string ends in `{}`, which is replaced by the path of a file holding
+ * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ */
+export function harvestCliFor(client, env = process.env) {
+  const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
+  if (override) {
+    const parts = commandWords(override);
+    const arg = parts[parts.length - 1] === '{}';
+    if (arg) parts.pop();
+    const [command, ...args] = parts;
+    if (!command) return null;
+    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+  }
+  return CLIENT_HARVEST_CLI[client] || null;
+}
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({
     name: 'Claude Code',

--- a/plugin/hooks/lib/capabilities.mjs
+++ b/plugin/hooks/lib/capabilities.mjs
@@ -353,21 +353,40 @@ function commandWords(line) {
  * TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND overrides the table entirely, so a
  * client with no row -- or one whose vendor changed its flags after this
  * shipped -- is a configuration away from working rather than a release away.
- * The value is a command and its arguments. The payload goes to stdin unless
- * the string ends in `{}`, which is replaced by the path of a file holding
- * the payload -- the delivery an agentic CLI that ignores stdin needs.
+ * The value is a command and its arguments, and its last word may name a
+ * delivery:
+ *   (nothing)  the payload goes to the command's stdin.
+ *   `{}`       it is written to a file and the path becomes the last
+ *              argument -- what an agentic CLI that ignores stdin needs.
+ *   `{-}`      the payload goes to stdin and a short instruction becomes the
+ *              last argument, for a CLI whose prompt flag demands a value
+ *              but which still reads stdin. gemini and qwen are shaped this
+ *              way, and without this an override could not reach that shape
+ *              at all.
  */
 export function harvestCliFor(client, env = process.env) {
   const override = (env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND || '').trim();
   if (override) {
     const parts = commandWords(override);
-    const arg = parts[parts.length - 1] === '{}';
-    if (arg) parts.pop();
+    const last = parts[parts.length - 1];
+    const delivery =
+      last === '{}' ? 'prompt-file' : last === '{-}' ? 'arg-stdin' : 'stdin';
+    if (delivery !== 'stdin') parts.pop();
     const [command, ...args] = parts;
     if (!command) return null;
-    return harvestCli(command, args, { delivery: arg ? 'prompt-file' : 'stdin' });
+    return harvestCli(command, args, { delivery });
   }
-  return CLIENT_HARVEST_CLI[client] || null;
+  // NORMALISED AND OWN-PROPERTY ONLY, matching `capabilityFor` below.
+  //
+  // A bare index disagreed with its own sibling and reached the prototype.
+  // Reproduced: TOKEN_OPTIMIZER_CLIENT=Codex resolved a capability profile
+  // through capabilityFor -- which lower-cases -- and NO harvest CLI here, so
+  // harvestMode() fell through to off:no-key and an opted-in harvest silently
+  // did nothing on a client that plainly has one. And
+  // harvestCliFor('constructor') returned a function, whose `command` is
+  // undefined, which runHostCli would have handed straight to spawn.
+  const key = String(client || '').toLowerCase();
+  return Object.hasOwn(CLIENT_HARVEST_CLI, key) ? CLIENT_HARVEST_CLI[key] : null;
 }
 export const CLIENT_CAPABILITIES = Object.freeze({
   'claude-code': native({

--- a/plugin/hooks/lib/doctor.mjs
+++ b/plugin/hooks/lib/doctor.mjs
@@ -246,6 +246,23 @@ export function probeHarvest() {
       'local model found -- semantic harvest is on, free and private: no credential, no billing, ' +
       'and nothing leaves this machine. Active-model wiki_write remains the primary path')];
   }
+  // The host client's own CLI, opted into with TOKEN_OPTIMIZER_HARVEST_CLI.
+  // Reported with the same failure-reason read as `local`, because the two
+  // share the property that made a broken configuration invisible: they
+  // return [] on failure and look exactly like a session with nothing to
+  // learn.
+  if (mode === 'host-cli') {
+    const reason = harvestFailure();
+    if (reason) {
+      return [bad('finding extraction is configured but returned nothing',
+        `the last harvest attempt ended: ${reason}`,
+        'check that this client\'s CLI is on PATH and signed in, or unset ' +
+        'TOKEN_OPTIMIZER_HARVEST_CLI to fall back to a configured endpoint')];
+    }
+    return [ok('finding extraction is available',
+      "this client's own CLI runs the semantic harvest -- no separate credential and no " +
+      'second vendor. Active-model wiki_write remains the primary path')];
+  }
   if (mode === 'remote') {
     return [ok('finding extraction is available',
       'active-model wiki_write is primary; a credential also enables fallback extraction from ' +

--- a/plugin/hooks/lib/harvest.mjs
+++ b/plugin/hooks/lib/harvest.mjs
@@ -23,6 +23,7 @@
 import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { harvestCliFor } from './capabilities.mjs';
 
@@ -588,6 +589,14 @@ function withAnchorChoices(system, choices) {
   );
 }
 
+/**
+ * The `-p` value for a CLI whose prompt flag needs one but which still reads
+ * stdin. One line, no quotes, no newlines: everything a Windows command line
+ * cannot carry.
+ */
+export const ARG_STDIN_INSTRUCTION =
+  'Follow the instructions in the input above and reply with only the JSON array they ask for.';
+
 /** Restated at the end of a prompt file, where an agent skimming will see it. */
 const TRAILER =
   'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
@@ -652,7 +661,11 @@ async function runHostCli(cli, system, digest, timeoutMs) {
     // under the OS temp directory, which every one of these CLIs can read by
     // default, and removed in `finish` whatever the outcome.
     try {
-      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // UNGUESSABLE, NOT MERELY UNIQUE. pid and clock are both predictable
+      // enough for another local user to pre-create the path in a shared temp
+      // directory; randomUUID removes the guess, and `flag: 'wx'` below
+      // removes the race that remains.
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${randomUUID()}.txt`);
       // 0600. This is a digest of the user's session -- paths, commands and
       // prompts -- sitting in a shared temp directory for as long as the child
       // takes to read it. It is removed in `finish`, but a kill between the two
@@ -669,6 +682,12 @@ async function runHostCli(cli, system, digest, timeoutMs) {
       writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
         encoding: 'utf8',
         mode: 0o600,
+        // EXCLUSIVE CREATE. `mode` governs a file this call makes; it does
+        // nothing about one that already exists, and the default flag 'w'
+        // happily follows a symlink someone else placed at the path -- which
+        // would redirect a digest of the user's session wherever they chose.
+        // 'wx' fails instead of following.
+        flag: 'wx',
       });
     } catch (error) {
       return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
@@ -679,9 +698,16 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         'instructions and output the JSON array they ask for, and nothing else.'
     );
   } else if (cli.delivery === 'arg-stdin') {
-    // The flag needs a value and the CLI appends it after stdin, so the short
-    // instruction is the argument and the bulky digest still rides stdin.
-    args.push(system);
+    // A SHORT SINGLE LINE, NEVER THE PROMPT. The flag needs a value, and the
+    // obvious value -- `system` -- is the multi-line PROMPT, which
+    // withAnchorChoices extends with a newline-separated file list and which
+    // is full of the JSON prompt's double quotes. That is the exact payload
+    // the prompt-file route exists to keep off a Windows command line:
+    // cmd.exe cannot carry a newline inside an argument, and the quoting
+    // doubles every `"`. These CLIs document the flag value as being
+    // APPENDED to stdin, so the whole payload rides stdin and the argument
+    // is one line of ASCII that any shell survives.
+    args.push(ARG_STDIN_INSTRUCTION);
   }
 
   if (process.platform === 'win32' && file === cli.command) {
@@ -750,12 +776,26 @@ async function runHostCli(cli, system, digest, timeoutMs) {
         : finish({ ok: false, reason: `${cli.command} exited ${code}` })
     );
 
+    // EPIPE ARRIVES AS AN EVENT, NOT AS A THROW. The try/catch below sees
+    // only a synchronous failure; a child that exits without reading stdin
+    // fails the write asynchronously, and Node delivers that on the stream.
+    // With no listener it is an uncaught exception that takes down the hook
+    // process instead of resolving this promise -- and the path is not
+    // hypothetical: copilot, asked to read a prompt on stdin, answers that it
+    // cannot and exits 0, which is why its row is prompt-file at all.
+    child.stdin.on('error', (error) =>
+      finish({
+        ok: false,
+        reason: `could not write the digest to ${cli.command}: ${error?.message || error}`,
+      })
+    );
+
     try {
       // Closed either way: a child left waiting on a pipe that will never
       // carry anything hangs until the timeout, which is the slowest possible
       // way to produce nothing.
       if (fileMode) child.stdin.end();
-      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+      else child.stdin.end(payload);
     } catch {
       finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
     }

--- a/plugin/hooks/lib/harvest.mjs
+++ b/plugin/hooks/lib/harvest.mjs
@@ -20,9 +20,11 @@
  * must be defensible without anyone reading the docs.
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { readFileSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { harvestCliFor } from './capabilities.mjs';
 
 const MODEL = () => process.env.TOKEN_OPTIMIZER_HARVEST_MODEL || 'claude-haiku-4-5-20251001';
 
@@ -178,13 +180,25 @@ export function harvestMode() {
   // Free and private, so nothing further to weigh: no credential, no billing, no digest leaving
   // the machine.
   if (localEndpoint()) return 'local';
+  // THE HOST CLI IS A BACKEND, so the enablement check has to know about it.
+  // Without this the gate answers off:no-key and `extract` never reaches the
+  // CLI path -- which defeats the whole point of a backend that needs no key.
+  // Caught end to end rather than reasoned about: with no endpoint and no key,
+  // the first run of the opted-in host-CLI harvest returned
+  // `harvest is off:no-key` in 0s, having never spawned anything.
+  if (hostCliHarvest()) return 'host-cli';
+
 
   return apiKey() ? 'remote' : 'off:no-key';
 }
 
 export function harvestEnabled() {
   const mode = harvestMode();
-  return mode === 'local' || mode === 'remote';
+  // host-cli belongs here for the same reason local and remote do: it is a
+  // backend that can actually answer. Leaving it out would let the mode say
+  // `host-cli` while every caller that asks `harvestEnabled()` -- the Stop
+  // hook, the worker, extract's own first line -- skipped the harvest.
+  return mode === 'local' || mode === 'remote' || mode === 'host-cli';
 }
 
 /**
@@ -476,6 +490,295 @@ const succeeded = (findings) => {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn. `harvestFailure()` carries why, for the diagnostics that do care.
  */
+/**
+ * The findings array inside a reply, or null.
+ *
+ * Models wrap JSON in prose or fences often enough that locating the array is
+ * more reliable than insisting the whole response parses -- and a CLI adds its
+ * own banner lines and stream-json envelopes on top, so both callers need the
+ * same tolerance. Shared so the two cannot drift.
+ */
+function findingsIn(text) {
+  const raw = String(text || '');
+
+  // FIRST BRACKET TO LAST IS NOT ENOUGH, and a CLI is where that breaks.
+  // `codex exec` prints a banner line reading `sandbox: workspace-write
+  // [workdir, /tmp, $TMPDIR]` before the model says anything, so the first
+  // `[` in the stream belongs to the banner and the naive slice parses to
+  // nothing -- an empty harvest that looks exactly like a session with
+  // nothing to learn. Closing brackets are walked from the end and opening
+  // brackets from the start, so the widest array that actually parses wins,
+  // and prose on either side is tolerated the way it already was for HTTP.
+  const closes = [];
+  for (let i = raw.length - 1; i >= 0 && closes.length < CLOSE_TRIES; i -= 1) {
+    if (raw[i] === ']') closes.push(i);
+  }
+  for (const end of closes) {
+    let tries = 0;
+    for (let start = raw.indexOf('['); start !== -1 && start < end; start = raw.indexOf('[', start + 1)) {
+      if ((tries += 1) > OPEN_TRIES) break;
+      try {
+        const parsed = JSON.parse(raw.slice(start, end + 1));
+        if (Array.isArray(parsed)) return parsed;
+      } catch {
+        /* not this pair */
+      }
+    }
+  }
+  return null;
+}
+
+// Bounded so a pathological reply cannot turn parsing into an O(n^2) walk of
+// a megabyte. A real findings array is at the end of the reply and preceded
+// by a banner or a sentence, not by hundreds of brackets.
+const CLOSE_TRIES = 8;
+const OPEN_TRIES = 40;
+
+/**
+ * Launches a Windows command through cmd.exe WITHOUT letting Node build the
+ * command line.
+ *
+ * These CLIs all install as .cmd shims, and Node has refused to spawn .cmd
+ * or .bat without a shell since the 2024 command-injection fix -- so a shell
+ * is not optional. But Node's own `shell: true` builds the cmd.exe line by
+ * joining argv with single spaces and no quoting at all, which breaks the
+ * moment any part contains one. Caught by the first test written against
+ * this: pointing the override at `C:\\Program Files\\nodejs\\node.exe`
+ * produced `C:\\Program Files\\nodejs\\node.exe exited 1`, because cmd.exe
+ * had been handed `C:\\Program` as the command. Quoting each part and passing
+ * the line verbatim is the fix.
+ */
+function windowsShellCommand(file, args) {
+  const quote = (part) => {
+    const value = String(part);
+    // Doubling is cmd.exe's own escape for a quote inside a quoted token.
+    return /[\s"]/.test(value)
+      ? `"${value.replace(/"/g, '""')}"`
+      : value;
+  };
+  const line = [file, ...args].map(quote).join(' ');
+  return [process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', `"${line}"`]];
+}
+
+/**
+ * States the anchor list in the prompt, for a backend that cannot be handed
+ * a schema.
+ *
+ * THE ANCHOR GATE IS WHAT SILENTLY EATS A HARVEST. `validate` keeps only
+ * anchors naming a file the session actually touched, and a model asked in
+ * English for a path writes a plausible one rather than a real one. Measured
+ * over four runs of qwen2.5:7b on a real digest against that gate:
+ * unconstrained, 4 extracted and 0 accepted; constrained to the list, 4 of 4.
+ *
+ * The HTTP path gets that constraint from a server-enforced enum. A CLI has
+ * no server to enforce it, so the same constraint is stated as strongly as a
+ * prompt can state it -- the exact strings, and an instruction to copy rather
+ * than compose. Not as good as an enum, and much better than nothing: the
+ * first end-to-end run without this extracted 10 findings and kept none.
+ */
+function withAnchorChoices(system, choices) {
+  if (!choices.length) return system;
+  const list = choices.map((file) => `- ${file}`).join('\n');
+  return (
+    `${system}\n\n` +
+    'Every entry in "anchors" MUST be copied verbatim from this list -- pick the ' +
+    'entries that best match the finding, and never write a path that is not ' +
+    'listed. Choosing the nearest match is right; dropping the finding is not:\n' +
+    list
+  );
+}
+
+/** Restated at the end of a prompt file, where an agent skimming will see it. */
+const TRAILER =
+  'END OF SESSION DIGEST. Now follow the instructions at the top of this file: ' +
+  'reply with the JSON array of findings and nothing else. If nothing in the ' +
+  'session is worth recording, reply with an empty array.';
+
+/**
+ * Runs the host client's own CLI as the harvest model.
+ *
+ * THE CHILD MUST NOT HARVEST. The harvest runs from the Stop hook, and a
+ * child session fires its own Stop hook -- verified, not assumed: a bare
+ * `claude -p` with our plugin installed wrote mcp-client, episode-outcome and
+ * derive events to the graph. Left unguarded that is unbounded recursion,
+ * each level spending real quota.
+ *
+ * TOKEN_OPTIMIZER_MODE=off IS THE GUARD, and it is the one that works.
+ * Measured on the same probe: TOKEN_OPTIMIZER_HARVEST=0 still ran the child's
+ * Stop hook and still wrote derive events -- it disables the harvest but not
+ * the hooks around it -- while MODE=off suppressed everything but a single
+ * mcp-client row. The kill switch is the only setting that makes the child
+ * inert, so the child is spawned with it and nothing else is relied upon.
+ *
+ * DELIVERY COMES FROM THE ROW, not from an assumption that every CLI reads
+ * stdin. Copilot does not: asked to follow instructions on stdin it replies
+ * that it cannot read stdin, exits 0, and yields no findings -- which looks
+ * exactly like a session with nothing to learn. Guessing here fails silently,
+ * so it is not guessed.
+ */
+/**
+ * How long to let the host CLI run.
+ *
+ * THE 30s HTTP DEFAULT KILLS EVERY CLI HARVEST, so it cannot be shared. That
+ * budget is sized for one completion against an endpoint that is already
+ * listening. A host CLI is an agent: it starts a process, loads its plugin
+ * and hook tree, opens a session, then thinks. Measured here on a 23 KB
+ * digest with no key and no local model, `claude -p` returned 10 findings in
+ * 104 SECONDS -- correct, and more than three times over the HTTP budget.
+ * `codex exec` on the same machine defaults to xhigh reasoning effort and
+ * had not finished at 300s, which is why this is configurable rather than
+ * merely larger.
+ *
+ * A caller that asks for MORE keeps it; the floor only lifts a default that
+ * was never chosen with this backend in mind.
+ */
+function hostCliTimeoutMs(requested) {
+  const configured = Number(process.env.TOKEN_OPTIMIZER_HARVEST_CLI_TIMEOUT_MS);
+  const floor = Number.isFinite(configured) && configured > 0 ? configured : 180_000;
+  return Math.max(floor, Number(requested) || 0);
+}
+
+async function runHostCli(cli, system, digest, timeoutMs) {
+  const payload = `${system}\n\n${digest}`;
+  const fileMode = cli.delivery === 'prompt-file';
+  let file = cli.command;
+  let args = [...cli.args];
+  let verbatim = false;
+  let promptFile = null;
+
+  if (fileMode) {
+    // A PATH, NOT THE PAYLOAD. See CLIENT_HARVEST_CLI for why the payload
+    // itself cannot travel as an argument on Windows. The file is written
+    // under the OS temp directory, which every one of these CLIs can read by
+    // default, and removed in `finish` whatever the outcome.
+    try {
+      promptFile = join(tmpdir(), `token-optimizer-harvest-${process.pid}-${Date.now()}.txt`);
+      // 0600. This is a digest of the user's session -- paths, commands and
+      // prompts -- sitting in a shared temp directory for as long as the child
+      // takes to read it. It is removed in `finish`, but a kill between the two
+      // would leave it behind, so it is unreadable to other users meanwhile.
+      // (Windows ignores the mode; NTFS inheritance already keeps the per-user
+      // temp directory private.)
+      // THE CONTRACT IS REPEATED AT THE END. The instructions lead the file and
+      // the digest follows, which is the natural order and the one that failed:
+      // handed 23 KB this way, copilot reported the file as "a scratchpad
+      // /summary document" with no instruction in it and asked what JSON array
+      // was wanted. An agent skimming a long file sees its tail; restating the
+      // ask there costs one line and removes the dependence on how the file is
+      // read.
+      writeFileSync(promptFile, `${payload}\n\n${TRAILER}`, {
+        encoding: 'utf8',
+        mode: 0o600,
+      });
+    } catch (error) {
+      return { ok: false, reason: `could not write the harvest prompt file: ${error?.message || error}` };
+    }
+    args.push(
+      `Read the whole file at ${promptFile}. It opens with instructions, then a ` +
+        'digest of a coding session, then repeats what to reply. Follow those ' +
+        'instructions and output the JSON array they ask for, and nothing else.'
+    );
+  } else if (cli.delivery === 'arg-stdin') {
+    // The flag needs a value and the CLI appends it after stdin, so the short
+    // instruction is the argument and the bulky digest still rides stdin.
+    args.push(system);
+  }
+
+  if (process.platform === 'win32' && file === cli.command) {
+    [file, args] = windowsShellCommand(file, args);
+    verbatim = true;
+  }
+
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(file, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        // The command line was built above where it needed cmd.exe, so Node
+        // must not rebuild it: `shell: true` would join argv unquoted.
+        windowsVerbatimArguments: verbatim,
+        env: {
+          ...process.env,
+          TOKEN_OPTIMIZER_MODE: 'off',
+        },
+      });
+    } catch (error) {
+      resolve({ ok: false, reason: `${cli.command} could not start: ${error?.message || error}` });
+      return;
+    }
+
+    let out = '';
+    let done = false;
+    const finish = (value) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      try {
+        child.kill();
+      } catch {
+        /* already gone */
+      }
+      if (promptFile) {
+        try {
+          rmSync(promptFile, { force: true });
+        } catch {
+          /* a leftover in the temp directory is not worth failing a harvest */
+        }
+      }
+      resolve(value);
+    };
+    const timer = setTimeout(
+      () => finish({ ok: false, reason: `${cli.command} timed out after ${timeoutMs}ms` }),
+      timeoutMs
+    );
+
+    child.stdout.on('data', (c) => {
+      out += c;
+    });
+    // stderr is drained so a chatty CLI cannot fill the pipe and deadlock.
+    child.stderr.on('data', () => {});
+    child.on('error', (error) =>
+      finish({ ok: false, reason: `${cli.command} failed: ${error?.message || error}` })
+    );
+    // NON-ZERO IS NOT ALWAYS EMPTY. Some of these print the reply and then
+    // exit non-zero over an unrelated cleanup complaint, so a parseable array
+    // already in hand beats the exit code; the code decides only when there is
+    // nothing to parse.
+    child.on('close', (code) =>
+      code === 0 || findingsIn(out)
+        ? finish({ ok: true, text: out })
+        : finish({ ok: false, reason: `${cli.command} exited ${code}` })
+    );
+
+    try {
+      // Closed either way: a child left waiting on a pipe that will never
+      // carry anything hangs until the timeout, which is the slowest possible
+      // way to produce nothing.
+      if (fileMode) child.stdin.end();
+      else child.stdin.end(cli.delivery === 'arg-stdin' ? digest : payload);
+    } catch {
+      finish({ ok: false, reason: `could not write the digest to ${cli.command}` });
+    }
+  });
+}
+
+/**
+ * Is the host CLI available as a harvest backend for this client?
+ *
+ * OPT-IN, deliberately, and this is the one default in this file that is not
+ * on. Every other path either reads local files or spends a key the user
+ * already configured for this purpose; this one spends the subscription that
+ * runs their editor, automatically, at the end of every session. HeadRoom
+ * makes the equivalent call user-invoked (`headroom learn`, cli/learn.py) and
+ * its own design note says to log events and analyse offline. Charging someone
+ * quota they did not ask to spend is not a default worth taking.
+ */
+export function hostCliHarvest(client = undefined, env = process.env) {
+  const enabled = /^(1|true|yes|on)$/i.test(env.TOKEN_OPTIMIZER_HARVEST_CLI || '');
+  if (!enabled) return null;
+  return harvestCliFor(client === undefined ? env.TOKEN_OPTIMIZER_CLIENT : client, env);
+}
+
 export async function extract(
   digest,
   { timeoutMs = 30_000, prompt = null, knownFiles = null } = {}
@@ -491,11 +794,40 @@ export async function extract(
   // exists and that the user opted in.
   const key = apiKey();
   const local = Boolean(localEndpoint());
-  if (!local && !key) return failed('no api key for a remote endpoint');
+  // The host CLI carries its own auth -- the user is already signed into the
+  // client that is running this -- so the key requirement is about the HTTP
+  // backends only.
+  if (!local && !key && !hostCliHarvest()) {
+    return failed('no api key for a remote endpoint');
+  }
 
   const endpoint = ENDPOINT();
   const dialect = endpointDialect(endpoint);
   const system = prompt || PROMPT;
+
+  // Computed before the CLI branch because BOTH backends need it. It used to
+  // sit below, so the host CLI was the one path that never learned which
+  // files it was allowed to anchor to -- and the anchor gate is what silently
+  // eats a harvest. Caught end to end on a real session: 10 findings
+  // extracted through `claude -p`, 0 surviving `validate`.
+  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
+
+  // The host client's own CLI, when the user has opted in. Tried first
+  // because it needs no key and no local model -- the two things whose
+  // absence has kept this path at 3 harvested findings on this machine.
+  const hostCli = hostCliHarvest();
+  if (hostCli) {
+    const result = await runHostCli(
+      hostCli,
+      withAnchorChoices(system, anchorChoices),
+      digest,
+      hostCliTimeoutMs(timeoutMs)
+    );
+    if (!result.ok) return failed(result.reason);
+    const parsed = findingsIn(result.text);
+    if (!parsed) return failed(`no JSON array in the ${hostCli.command} reply`);
+    return succeeded(parsed);
+  }
 
   // ANCHORS OFFERED AS A CHOICE, NOT REQUESTED IN PROSE.
   //
@@ -514,7 +846,6 @@ export async function extract(
   // Only when the caller knows the list. `buildFullDelta` is raw transcript
   // with no file heading, and its caller passes no knownFiles for the same
   // reason -- an empty enum would forbid every anchor rather than free it.
-  const anchorChoices = knownFiles ? [...knownFiles].filter(Boolean) : [];
   const schema = anchorChoices.length
     ? {
         ...FINDINGS_SCHEMA,
@@ -662,17 +993,8 @@ export async function extract(
       '';
     if (!text) return failed('endpoint answered in an unrecognised shape');
 
-    // Models wrap JSON in prose or fences often enough that finding the array
-    // is more reliable than insisting the whole response parse.
-    const start = text.indexOf('[');
-    const end = text.lastIndexOf(']');
-    if (start === -1 || end <= start) return failed('no JSON array in the reply');
-
-    try {
-      return succeeded(JSON.parse(text.slice(start, end + 1)));
-    } catch {
-      return failed('the JSON array in the reply did not parse');
-    }
+    const parsed = findingsIn(text);
+    return parsed ? succeeded(parsed) : failed('no usable JSON array in the reply');
   } catch (error) {
     return failed(error?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : `${error?.message || error}`);
   } finally {

--- a/tests/hooks/harvest-host-cli.test.mjs
+++ b/tests/hooks/harvest-host-cli.test.mjs
@@ -26,6 +26,7 @@ import {
   harvestMode,
   harvestEnabled,
   hostCliHarvest,
+  ARG_STDIN_INSTRUCTION,
 } from '../../hooks-core/harvest.mjs';
 import { CLIENT_CAPABILITIES, CLIENT_HARVEST_CLI, harvestCliFor } from '../../hooks-core/capabilities.mjs';
 
@@ -56,10 +57,12 @@ const STUB = `
 import { readFileSync, writeFileSync } from 'node:fs';
 const out = process.env.STUB_RECORD;
 let stdin = '';
-try {
-  stdin = readFileSync(0, 'utf8');
-} catch {
-  stdin = '';
+if (!process.env.STUB_IGNORE_STDIN) {
+  try {
+    stdin = readFileSync(0, 'utf8');
+  } catch {
+    stdin = '';
+  }
 }
 const named = (process.argv.slice(2).join(' ').match(/(\\S+token-optimizer-harvest-\\S+\\.txt)/) || [])[1];
 writeFileSync(
@@ -105,6 +108,7 @@ beforeEach(() => {
   process.env.STUB_REPLY = JSON.stringify([FINDING]);
   delete process.env.STUB_BANNER;
   delete process.env.STUB_SILENT;
+  delete process.env.STUB_IGNORE_STDIN;
   delete process.env.STUB_EXIT;
   if (existsSync(record)) rmSync(record);
 });
@@ -121,6 +125,10 @@ const asStdinCli = () => {
   // Quoted: on Windows process.execPath is under `C:\Program Files`, and an
   // unquoted split reported `C:\Program exited 1`.
   process.env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND = `"${process.execPath}" "${stub}"`;
+};
+const asArgStdinCli = () => {
+  process.env.TOKEN_OPTIMIZER_HARVEST_CLI = '1';
+  process.env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND = `"${process.execPath}" "${stub}" {-}`;
 };
 const asFileCli = () => {
   process.env.TOKEN_OPTIMIZER_HARVEST_CLI = '1';
@@ -185,6 +193,37 @@ describe('every supported client declares how it can be harvested', () => {
   test('a trailing {} in the override asks for a prompt file', () => {
     const row = harvestCliFor('zed', { TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND: 'my-llm run {}' });
     expect(row).toMatchObject({ command: 'my-llm', args: ['run'], delivery: 'prompt-file' });
+  });
+
+  test('the client key is normalised, like every other lookup here', () => {
+    // capabilityFor lower-cases and this did not, so TOKEN_OPTIMIZER_CLIENT
+    // =Codex resolved a capability profile and NO harvest CLI -- harvestMode
+    // then fell through to off:no-key and an opted-in harvest silently did
+    // nothing on a client that plainly has one.
+    expect(harvestCliFor('Codex')).toEqual(harvestCliFor('codex'));
+    expect(harvestCliFor('CLAUDE-CODE')).toEqual(harvestCliFor('claude-code'));
+  });
+
+  test('a prototype key is not a client', () => {
+    // A bare index reached Object.prototype: harvestCliFor('constructor')
+    // returned a function whose `command` is undefined, and runHostCli would
+    // have handed that straight to spawn.
+    for (const key of ['constructor', 'toString', 'hasOwnProperty']) {
+      expect(harvestCliFor(key)).toBeNull();
+    }
+  });
+
+  test('an override can name arg-stdin, the shape gemini and qwen use', () => {
+    const row = harvestCliFor('zed', { TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND: 'my-llm -p {-}' });
+    expect(row).toMatchObject({ command: 'my-llm', args: ['-p'], delivery: 'arg-stdin' });
+  });
+
+  test('the arg-stdin flag value carries nothing a shell can break', () => {
+    // It ends up on a Windows command line, where cmd.exe cannot carry a
+    // newline inside an argument and every double quote has to be doubled.
+    expect(ARG_STDIN_INSTRUCTION).not.toContain('\\n');
+    expect(ARG_STDIN_INSTRUCTION).not.toContain('"');
+    expect(ARG_STDIN_INSTRUCTION).not.toContain("'");
   });
 
   test('a quoted path in the override survives the split', () => {
@@ -356,6 +395,59 @@ describe('the payload reaches the CLI and the reply comes back', () => {
     });
     expect(found).toHaveLength(1);
     expect(harvestFailure()).toBeNull();
+  });
+
+  test('an arg-stdin flag value is one line, and the payload rides stdin', async () => {
+    // THE SAME WINDOWS CONSTRAINT prompt-file exists for. Pushing `system`
+    // here put the multi-line PROMPT -- extended by withAnchorChoices with a
+    // newline-separated file list, and full of the JSON prompt's double
+    // quotes -- onto a cmd.exe command line, which cannot carry a newline in
+    // an argument at all.
+    asArgStdinCli();
+    const found = await extract('## Files touched\\nhooks-core/harvest.mjs\\n', {
+      knownFiles: new Set(['hooks-core/harvest.mjs']),
+    });
+    expect(harvestFailure()).toBeNull();
+    expect(found).toHaveLength(1);
+    const got = handed();
+    expect(got.argv).toEqual([ARG_STDIN_INSTRUCTION]);
+    // Nothing is lost by shortening the argument: the whole payload, prompt
+    // included, is on stdin, which these CLIs document as their input.
+    expect(got.stdin).toContain('## Files touched');
+    expect(got.stdin).toContain('JSON array');
+  });
+
+  test('the prompt file is named unguessably, not merely uniquely', async () => {
+    // mode 0o600 governs a file this call creates and says nothing about one
+    // already at the path, and pid plus clock is guessable enough for another
+    // local user to pre-create it as a symlink in the shared temp directory.
+    // `flag: 'wx'` closes the race; a random name removes the guess.
+    asFileCli();
+    await extract('## Files touched\\nhooks-core/harvest.mjs\\n', {
+      knownFiles: new Set(['hooks-core/harvest.mjs']),
+    });
+    const named = handed().argv[0].match(/(\S+token-optimizer-harvest-\S+\.txt)/)[1];
+    expect(named).not.toContain(String(process.pid));
+    expect(named).toMatch(
+      /token-optimizer-harvest-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.txt$/
+    );
+  });
+
+  test('a child that never reads stdin is reported, not thrown', async () => {
+    // EPIPE arrives as an event on child.stdin, which the try/catch cannot
+    // see. With no listener it is an uncaught exception that takes the hook
+    // process down instead of resolving runHostCli -- and copilot, which
+    // exits 0 without reading stdin, is exactly this child. The proof that
+    // the listener works is that this test completes at all: an uncaught
+    // exception here fails the run regardless of the assertions.
+    asStdinCli();
+    process.env.STUB_IGNORE_STDIN = '1';
+    process.env.STUB_SILENT = '1';
+    const found = await extract('x'.repeat(600_000), {
+      knownFiles: new Set(['hooks-core/harvest.mjs']),
+    });
+    expect(found).toEqual([]);
+    expect(harvestFailure()).toBeTruthy();
   });
 
   test('a command that does not exist fails with a reason', async () => {

--- a/tests/hooks/harvest-host-cli.test.mjs
+++ b/tests/hooks/harvest-host-cli.test.mjs
@@ -221,7 +221,14 @@ describe('every supported client declares how it can be harvested', () => {
   test('the arg-stdin flag value carries nothing a shell can break', () => {
     // It ends up on a Windows command line, where cmd.exe cannot carry a
     // newline inside an argument and every double quote has to be doubled.
-    expect(ARG_STDIN_INSTRUCTION).not.toContain('\\n');
+    //
+    // PINNED POSITIVELY FIRST. Three `not.toContain` assertions pass just as
+    // happily against an undefined export as against a correct one -- which is
+    // the repository's own no-vacuous-assertions rule, and it caught this test
+    // rather than a reviewer. The single-line check is the property that
+    // matters, stated as an equality.
+    expect(ARG_STDIN_INSTRUCTION.split('\n')).toHaveLength(1);
+    expect(ARG_STDIN_INSTRUCTION).toContain('JSON array');
     expect(ARG_STDIN_INSTRUCTION).not.toContain('"');
     expect(ARG_STDIN_INSTRUCTION).not.toContain("'");
   });

--- a/tests/hooks/harvest-host-cli.test.mjs
+++ b/tests/hooks/harvest-host-cli.test.mjs
@@ -1,0 +1,372 @@
+/**
+ * The harvest model the machine already has.
+ *
+ * Semantic extraction has always required an API key or a local endpoint. On a
+ * machine with neither it does not run at all -- measured on the development
+ * machine for this package, 3 harvested findings against 237 written by the
+ * agent itself, because nobody configures a variable they have never heard of.
+ * Yet the client that just ran the session is installed by definition, and
+ * every one of them ships a headless mode. So the model was already there.
+ *
+ * These tests hold the two things that make that safe rather than merely
+ * clever: the child must not re-enter the harvest, and the payload has to
+ * reach each client the way that client actually accepts it. Both failed
+ * silently when first written -- the enablement gate answered `off:no-key`
+ * before the CLI path was ever consulted, and `copilot` given a prompt on
+ * stdin answers that it cannot read stdin and exits 0.
+ */
+import { describe, test, expect, beforeAll, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  extract,
+  harvestFailure,
+  harvestMode,
+  harvestEnabled,
+  hostCliHarvest,
+} from '../../hooks-core/harvest.mjs';
+import { CLIENT_CAPABILITIES, CLIENT_HARVEST_CLI, harvestCliFor } from '../../hooks-core/capabilities.mjs';
+
+const FINDING = {
+  type: 'command',
+  claim: 'the stub CLI answered',
+  evidence: 'printed by the stub',
+  applicability: 'while proving the host-CLI transport works',
+  confidenceLabel: 'verified',
+  anchors: ['hooks-core/harvest.mjs'],
+};
+
+let dir;
+let stub;
+let record;
+let saved;
+
+/**
+ * A stand-in for a host CLI.
+ *
+ * Records what it was handed -- argv, stdin, and the mode variable it
+ * inherited -- then prints a reply. `banner` reproduces the thing that broke
+ * the first parser: `codex exec` prints `sandbox: workspace-write [workdir,
+ * /tmp, $TMPDIR]` before the model speaks, so the first `[` in the stream is
+ * not the findings array.
+ */
+const STUB = `
+import { readFileSync, writeFileSync } from 'node:fs';
+const out = process.env.STUB_RECORD;
+let stdin = '';
+try {
+  stdin = readFileSync(0, 'utf8');
+} catch {
+  stdin = '';
+}
+const named = (process.argv.slice(2).join(' ').match(/(\\S+token-optimizer-harvest-\\S+\\.txt)/) || [])[1];
+writeFileSync(
+  out,
+  JSON.stringify({
+    argv: process.argv.slice(2),
+    promptFile: named ? readFileSync(named, 'utf8') : null,
+    stdin,
+    mode: process.env.TOKEN_OPTIMIZER_MODE ?? null,
+    harvestCli: process.env.TOKEN_OPTIMIZER_HARVEST_CLI ?? null,
+  })
+);
+if (process.env.STUB_BANNER) {
+  process.stdout.write('sandbox: workspace-write [workdir, /tmp, $TMPDIR]\\n');
+}
+if (process.env.STUB_SILENT) process.exit(Number(process.env.STUB_EXIT || 0));
+process.stdout.write('Here is what I found:\\n');
+process.stdout.write(process.env.STUB_REPLY + '\\n');
+process.stdout.write('Let me know if you want more.\\n');
+process.exit(Number(process.env.STUB_EXIT || 0));
+`;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'host-cli-harvest-'));
+  stub = join(dir, 'stub.mjs');
+  record = join(dir, 'record.json');
+  writeFileSync(stub, STUB);
+});
+
+beforeEach(() => {
+  saved = { ...process.env };
+  for (const key of [
+    'TOKEN_OPTIMIZER_HARVEST_ENDPOINT',
+    'ANTHROPIC_API_KEY',
+    'TOKEN_OPTIMIZER_API_KEY',
+    'ANTHROPIC_AUTH_TOKEN',
+    'TOKEN_OPTIMIZER_MODE',
+    'TOKEN_OPTIMIZER_HARVEST',
+  ]) {
+    delete process.env[key];
+  }
+  process.env.STUB_RECORD = record;
+  process.env.STUB_REPLY = JSON.stringify([FINDING]);
+  delete process.env.STUB_BANNER;
+  delete process.env.STUB_SILENT;
+  delete process.env.STUB_EXIT;
+  if (existsSync(record)) rmSync(record);
+});
+
+afterEach(() => {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in saved)) delete process.env[key];
+  }
+  Object.assign(process.env, saved);
+});
+
+const asStdinCli = () => {
+  process.env.TOKEN_OPTIMIZER_HARVEST_CLI = '1';
+  // Quoted: on Windows process.execPath is under `C:\Program Files`, and an
+  // unquoted split reported `C:\Program exited 1`.
+  process.env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND = `"${process.execPath}" "${stub}"`;
+};
+const asFileCli = () => {
+  process.env.TOKEN_OPTIMIZER_HARVEST_CLI = '1';
+  process.env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND = `"${process.execPath}" "${stub}" {}`;
+};
+const handed = () => JSON.parse(readFileSync(record, 'utf8'));
+
+describe('every supported client declares how it can be harvested', () => {
+  test('all 16 clients have a row -- a CLI or an explicit null', () => {
+    const clients = Object.keys(CLIENT_CAPABILITIES);
+    expect(clients.length).toBe(16);
+    for (const client of clients) {
+      expect(Object.prototype.hasOwnProperty.call(CLIENT_HARVEST_CLI, client)).toBe(true);
+    }
+    // And no row for a client this package does not support, which would be a
+    // backend nobody can ever reach.
+    for (const row of Object.keys(CLIENT_HARVEST_CLI)) {
+      expect(clients).toContain(row);
+    }
+  });
+
+  test('the clients probed on a real machine are the ones marked verified', () => {
+    // Guards the honesty of the table: `verified` means a probe was executed
+    // against the installed CLI, and rows taken from vendor docs must not
+    // claim it. A future row is welcome to flip this once someone runs it.
+    const verified = Object.entries(CLIENT_HARVEST_CLI)
+      .filter(([, row]) => row && row.verified)
+      .map(([client]) => client)
+      .sort();
+    expect(verified).toEqual(['claude-code', 'codex', 'copilot']);
+  });
+
+  test('editor-hosted clients declare null rather than borrowing a neighbour', () => {
+    // Reaching for whatever CLI is on PATH would send the digest to a vendor
+    // the user never chose.
+    for (const client of ['cursor', 'cline', 'windsurf', 'kilo', 'roo', 'zed']) {
+      expect(CLIENT_HARVEST_CLI[client]).toBeNull();
+    }
+  });
+
+  test('copilot gets a prompt file, because it cannot read stdin', () => {
+    // Probed both ways against the installed CLI: on stdin it answers that
+    // it cannot read stdin and exits 0 -- silence that looks like a session
+    // with nothing to learn -- and asked to read a payload file it returns
+    // the array.
+    expect(CLIENT_HARVEST_CLI.copilot.delivery).toBe('prompt-file');
+  });
+
+  test('claude-code and codex take it on stdin', () => {
+    expect(CLIENT_HARVEST_CLI['claude-code'].delivery).toBe('stdin');
+    expect(CLIENT_HARVEST_CLI.codex.delivery).toBe('stdin');
+    // `codex exec -` is the documented stdin form; without the dash it waits
+    // for a prompt argument.
+    expect(CLIENT_HARVEST_CLI.codex.args).toEqual(['exec', '-']);
+  });
+
+  test('an override reaches a client with no row at all', () => {
+    const row = harvestCliFor('zed', { TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND: 'my-llm --pipe' });
+    expect(row).toMatchObject({ command: 'my-llm', args: ['--pipe'], delivery: 'stdin' });
+  });
+
+  test('a trailing {} in the override asks for a prompt file', () => {
+    const row = harvestCliFor('zed', { TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND: 'my-llm run {}' });
+    expect(row).toMatchObject({ command: 'my-llm', args: ['run'], delivery: 'prompt-file' });
+  });
+
+  test('a quoted path in the override survives the split', () => {
+    // An interpreter under `C:\\Program Files` is the obvious thing to
+    // configure, and an unquoted split reported `C:\\Program exited 1`.
+    const row = harvestCliFor('zed', {
+      TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND: '"C:\\Program Files\\nodejs\\node.exe" run.mjs',
+    });
+    expect(row.command).toBe('C:\\Program Files\\nodejs\\node.exe');
+    expect(row.args).toEqual(['run.mjs']);
+  });
+});
+
+describe('the backend is opt-in and is recognised by the enablement gate', () => {
+  test('off by default even with a client that has a CLI', () => {
+    process.env.TOKEN_OPTIMIZER_CLIENT = 'claude-code';
+    expect(hostCliHarvest()).toBeNull();
+    expect(harvestMode()).toBe('off:no-key');
+  });
+
+  test('opted in, the mode is host-cli with no key and no endpoint', () => {
+    // THE BUG THIS EXISTS FOR. `harvestMode` returned off:no-key before the CLI
+    // path was ever consulted, so `extract` refused in 0s having spawned
+    // nothing -- a backend that needs no key, defeated by the key check.
+    process.env.TOKEN_OPTIMIZER_CLIENT = 'claude-code';
+    process.env.TOKEN_OPTIMIZER_HARVEST_CLI = '1';
+    expect(harvestMode()).toBe('host-cli');
+    expect(harvestEnabled()).toBe(true);
+  });
+
+  test('opted in on a client with no CLI still falls back to the key check', () => {
+    process.env.TOKEN_OPTIMIZER_CLIENT = 'zed';
+    process.env.TOKEN_OPTIMIZER_HARVEST_CLI = '1';
+    expect(hostCliHarvest()).toBeNull();
+    expect(harvestMode()).toBe('off:no-key');
+  });
+
+  test('the kill switch still outranks it', () => {
+    process.env.TOKEN_OPTIMIZER_CLIENT = 'claude-code';
+    process.env.TOKEN_OPTIMIZER_HARVEST_CLI = '1';
+    process.env.TOKEN_OPTIMIZER_MODE = 'off';
+    expect(harvestMode()).toBe('off:mode');
+    expect(harvestEnabled()).toBe(false);
+  });
+
+  test('the opt-out still outranks it', () => {
+    process.env.TOKEN_OPTIMIZER_CLIENT = 'claude-code';
+    process.env.TOKEN_OPTIMIZER_HARVEST_CLI = '1';
+    process.env.TOKEN_OPTIMIZER_HARVEST = '0';
+    expect(harvestMode()).toBe('off:opted-out');
+  });
+
+  test('a configured local endpoint still wins, being free and private', () => {
+    process.env.TOKEN_OPTIMIZER_CLIENT = 'claude-code';
+    process.env.TOKEN_OPTIMIZER_HARVEST_CLI = '1';
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = 'http://127.0.0.1:11434/v1/chat/completions';
+    expect(harvestMode()).toBe('local');
+  });
+});
+
+describe('the payload reaches the CLI and the reply comes back', () => {
+  test('stdin delivery harvests with no key and no local model', async () => {
+    asStdinCli();
+    const found = await extract('## Files touched\nhooks-core/harvest.mjs\n', {
+      knownFiles: new Set(['hooks-core/harvest.mjs']),
+    });
+    expect(harvestFailure()).toBeNull();
+    expect(found).toHaveLength(1);
+    expect(found[0].claim).toBe('the stub CLI answered');
+    const got = handed();
+    expect(got.stdin).toContain('## Files touched');
+    // `node stub.mjs` -- the script path is argv[1], so the child was given
+    // no arguments of its own. Everything travelled on stdin.
+    expect(got.argv).toEqual([]);
+  });
+
+  test('prompt-file delivery hands over a readable path, not the payload', async () => {
+    asFileCli();
+    const found = await extract('## Files touched\nhooks-core/harvest.mjs\n', {
+      knownFiles: new Set(['hooks-core/harvest.mjs']),
+    });
+    expect(harvestFailure()).toBeNull();
+    expect(found).toHaveLength(1);
+    const got = handed();
+    expect(got.stdin).toBe('');
+    expect(got.argv).toHaveLength(1);
+    // ONE argument, and it is a path plus a sentence -- no newlines, no
+    // quotes, nothing a shell or an argument binder can tear apart. The
+    // payload itself as an argument was tried and lost: cmd.exe cannot
+    // carry a newline in one, and PowerShell 5.1's native binder does not
+    // escape the double quotes in the JSON prompt, which split a single
+    // argument into 32.
+    expect(got.argv[0]).not.toContain('\n');
+    expect(got.argv[0]).toMatch(/token-optimizer-harvest-.*\.txt/);
+    const promptPath = got.argv[0].match(/(\S+token-optimizer-harvest-\S+\.txt)/)[1];
+    expect(got.promptFile).toContain('## Files touched');
+    // Removed once the child is done, whatever the outcome: this is a
+    // digest of the user's session sitting in a world-readable temp
+    // directory.
+    expect(existsSync(promptPath)).toBe(false);
+  });
+
+  test('a payload far past any argument limit still travels whole', async () => {
+    // The route the payload-as-argument design had to truncate at 15000
+    // characters on Windows. A path has no such ceiling.
+    asFileCli();
+    const huge = `## Files touched\nhooks-core/harvest.mjs\n${'x'.repeat(120_000)}`;
+    const found = await extract(huge, { knownFiles: new Set(['hooks-core/harvest.mjs']) });
+    expect(found).toHaveLength(1);
+    const got = handed();
+    expect(got.promptFile.length).toBeGreaterThan(120_000);
+    expect(got.promptFile).not.toContain('truncated');
+  });
+  test('the child is spawned with the kill switch, so it cannot re-enter', async () => {
+    // A child session fires its own Stop hook. Unguarded that is unbounded
+    // recursion, each level spending real quota. TOKEN_OPTIMIZER_HARVEST=0 was
+    // tried first and was NOT enough: the child still ran its hooks and wrote
+    // derive events. Only the mode kill switch makes it inert.
+    asStdinCli();
+    await extract('## Files touched\nhooks-core/harvest.mjs\n', {
+      knownFiles: new Set(['hooks-core/harvest.mjs']),
+    });
+    expect(handed().mode).toBe('off');
+  });
+
+  test('a banner containing brackets does not defeat the reply parser', async () => {
+    // `codex exec` prints `sandbox: workspace-write [workdir, /tmp, $TMPDIR]`
+    // before the model says anything. First-bracket-to-last-bracket parses
+    // that and fails, producing an empty harvest indistinguishable from a
+    // session with nothing to learn.
+    asStdinCli();
+    process.env.STUB_BANNER = '1';
+    const found = await extract('## Files touched\nhooks-core/harvest.mjs\n', {
+      knownFiles: new Set(['hooks-core/harvest.mjs']),
+    });
+    expect(harvestFailure()).toBeNull();
+    expect(found).toHaveLength(1);
+  });
+
+  test('a reply with no array is reported as a reason, not as an empty session', async () => {
+    asStdinCli();
+    process.env.STUB_REPLY = 'I could not find anything worth recording.';
+    const found = await extract('## Files touched\nhooks-core/harvest.mjs\n', {
+      knownFiles: new Set(['hooks-core/harvest.mjs']),
+    });
+    expect(found).toEqual([]);
+    expect(harvestFailure()).toMatch(/no JSON array/);
+  });
+
+  test('a non-zero exit with nothing to parse names the exit code', async () => {
+    asStdinCli();
+    process.env.STUB_SILENT = '1';
+    process.env.STUB_EXIT = '3';
+    const found = await extract('## Files touched\nhooks-core/harvest.mjs\n', {
+      knownFiles: new Set(['hooks-core/harvest.mjs']),
+    });
+    expect(found).toEqual([]);
+    expect(harvestFailure()).toMatch(/exited 3/);
+  });
+
+  test('a non-zero exit that still printed findings keeps the findings', async () => {
+    // Several of these CLIs print the reply and then exit non-zero over an
+    // unrelated cleanup complaint. Throwing away a parsed array because of
+    // that would discard a harvest that actually happened.
+    asStdinCli();
+    process.env.STUB_EXIT = '1';
+    const found = await extract('## Files touched\nhooks-core/harvest.mjs\n', {
+      knownFiles: new Set(['hooks-core/harvest.mjs']),
+    });
+    expect(found).toHaveLength(1);
+    expect(harvestFailure()).toBeNull();
+  });
+
+  test('a command that does not exist fails with a reason', async () => {
+    process.env.TOKEN_OPTIMIZER_HARVEST_CLI = '1';
+    process.env.TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND =
+      'token-optimizer-no-such-cli-exists-anywhere';
+    const found = await extract('## Files touched\nhooks-core/harvest.mjs\n', {
+      knownFiles: new Set(['hooks-core/harvest.mjs']),
+    });
+    expect(found).toEqual([]);
+    expect(harvestFailure()).toBeTruthy();
+  });
+
+});


### PR DESCRIPTION
## The problem

Semantic extraction has always needed an API key or a local endpoint. On a machine with neither it simply does not run. Measured on the development machine for this package:

| source | findings in the graph |
| --- | --- |
| `wiki_write` by the active agent | 237 |
| harvested by the extractor | **3** |

Nobody sets an environment variable they have never heard of, so for those users everything downstream of the harvest — injection, transfer between projects, consolidation — was inert.

But the client that just ran the session is installed **by definition**, and every one of them ships a headless mode. The model was already on the machine. Nothing needed configuring; it only needed asking.

## What this adds

`CLIENT_HARVEST_CLI` in `hooks-core/capabilities.mjs` gives **every one of the 16 supported clients** a row: the command, its arguments, and how that client actually accepts a prompt — or an explicit `null` for the editor-hosted ones that ship no CLI at all. `npm run sync:hooks` copies the table into all the integrations, so the design cannot drift per client.

Opt-in through `TOKEN_OPTIMIZER_HARVEST_CLI`, deliberately: this is the one path in the file that spends the subscription running the user's editor, automatically, at the end of every session.

| client | command | delivery | status |
| --- | --- | --- | --- |
| claude-code | `claude -p` | stdin | **verified**, probe executed |
| codex | `codex exec -` | stdin | **verified**, probe executed |
| copilot | `copilot -s --allow-all-tools -p` | prompt file | **verified**, probe executed both ways |
| gemini | `gemini -p` | arg + stdin | documented (`--help`); unauthenticated here |
| qwen | `qwen -p` | arg + stdin | documented (gemini-cli fork) |
| opencode / crush / droid / amp / continue | `run` / `run -q` / `exec` / `-x` / `-p` | prompt file | documented; not installed here |
| cursor / cline / windsurf / kilo / roo / zed | — | — | no headless CLI; falls back to an endpoint |

`verified` in the table means a probe was executed against the installed CLI and its reply parsed. `documented` means the shape comes from the vendor's own `--help` or published headless docs and has **not** been executed here. Both ship; a wrong documented row fails loudly through `harvestFailure()` and `doctor`, never silently. A test pins the verified list so a future row cannot quietly claim it.

`TOKEN_OPTIMIZER_HARVEST_CLI_COMMAND` overrides the table entirely, so a client with no row — or one whose vendor changes its flags after this ships — is a configuration away from working rather than a release away.

## Measured, end to end, with no API key and no local endpoint

A 23 KB digest of a real session, both API-key variables and the endpoint variable deleted:

```
claude -p   (stdin)         10 extracted   ->  6 surviving validate()   76-104 s
copilot     (prompt file)    6 extracted   ->  6 surviving validate()   21 s
```

That is the state this change exists to end: on this machine, before it, the number was zero.

## Four things had to be right, and none were obvious

**The enablement gate ran first.** `harvestMode()` answered `off:no-key` before anything consulted the CLI path, so `extract` refused in 0 s having spawned nothing — a backend that needs no key, defeated by the key check. `harvestMode`, `harvestEnabled`, the credential gate in `extract`, `doctor` and the session-start notice all now know the mode.

**The child must not harvest.** A child session fires its own Stop hook; unguarded that is unbounded recursion, each level spending real quota. `TOKEN_OPTIMIZER_HARVEST=0` was tried first and is **not** enough — measured on the probe, the child still ran its hooks and wrote `derive` events. `TOKEN_OPTIMIZER_MODE=off` suppressed everything but a single `mcp-client` row, so that is what the child is spawned with, and nothing else is relied on. A test asserts the child sees it.

**Delivery is per client, and guessing fails silently.** `copilot` asked to read a prompt on stdin answers that it cannot read stdin, exits 0, and yields nothing — indistinguishable from a session with nothing to learn. Passing the payload as an argument instead does not survive Windows, in three stages: these install as `.cmd` shims, which Node has refused to spawn without a shell since the 2024 command-injection fix; `shell: true` builds the cmd.exe line by joining argv with spaces and no quoting, and cmd.exe cannot carry a newline inside an argument under any quoting; routing through PowerShell with the payload base64-encoded clears both and then hits PowerShell 5.1's native-argument binder, which does not escape embedded double quotes — the prompt is JSON, so the first `"type":` ended the quoting and the child received **32 arguments instead of 1**. Those clients now get a prompt file (mode `0600`, removed after the run whatever the outcome) and an argument naming it, which also lifts the ARG_MAX ceiling entirely.

**The anchor list had to reach it.** `anchorChoices` was computed *below* the CLI branch, so the one backend that cannot be handed a `response_format` schema was also the one never told which files it may anchor to. The first end-to-end run extracted 10 findings and `validate` kept **0**. The list now goes into the prompt for that path, stated as strongly as a prompt can state it. After the fix: 6 of 10 and 6 of 6.

## Smaller things, each with a reason

- `findingsIn` walks bracket pairs from both ends instead of taking the first `[` to the last `]`, because `codex exec` prints `sandbox: workspace-write [workdir, /tmp, $TMPDIR]` before the model speaks, and the naive slice parses to nothing.
- The CLI gets a 180 s timeout floor (`TOKEN_OPTIMIZER_HARVEST_CLI_TIMEOUT_MS`). The 30 s HTTP default is sized for one completion against a listening endpoint; an agent CLI boots a process and a plugin tree first, and `claude -p` took 104 s on a 23 KB digest. `codex exec` at its default xhigh reasoning effort had not finished at 300 s, which is why this is configurable rather than merely larger.
- A non-zero exit that nonetheless printed a parseable array keeps the findings; the exit code decides only when there is nothing to parse.
- The override splits on whitespace **outside quotes**. The first test written against it caught the alternative: pointing it at `C:\Program Files\nodejs\node.exe` reported `C:\Program exited 1`.
- The prompt file restates the output contract at its end. Handed 23 KB with the instructions only at the top, copilot reported the file as "a scratchpad/summary document" with no instruction in it and asked what array was wanted.

## Verification

`npm run validate:pr` and `npm run pr:create` do not exist in this repository, so the equivalent gate was run by hand:

- `npm run sync:hooks` — 59 core files to 11 integrations, 37 entry files, 10 configs; core and synced diffs match line for line (`175/0` and `275/14`), so no CRLF damage
- `npm run build` — clean
- `npm run lint` — **0 errors**, 541 pre-existing warnings
- `npm test` — **268 suites, 3806 passed, 5 skipped, 0 failed**
- `tests/hooks/harvest-host-cli.test.mjs` — 23 new tests covering the table, the opt-in gate and its precedence against the kill switch / opt-out / local endpoint, both delivery paths, the recursion guard, the banner parser, the failure reasons, and prompt-file cleanup

## What is not verified

Seven rows (gemini, qwen, opencode, crush, droid, amp, continue) come from vendor documentation rather than an executed probe, because those CLIs are not installed or not authenticated on this machine. They are labelled as such in the table, in the source, and in a test. A wrong row there produces a named failure in `doctor`, not silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
